### PR TITLE
✨ Create jest-koa-mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ This package uses a monorepo approach. Links to individual packages can be found
 
 ## Packages
 
-| package            |                                               |                                                                                                                                      |
-| ------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `jest-dom-mocks`   | [README](packages/jest-dom-mocks/README.md)   | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks)     |
-| `jest-mock-apollo` | [README](packages/jest-mock-apollo/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo) |
-| `jest-mock-router` | [README](packages/jest-mock-router/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-router.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-router) |
-| `koa-shopify-auth` | [README](packages/koa-shopify-auth/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth) |
+| package            |                                                                                          |                                                                                                                                      |
+| ------------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `jest-dom-mocks`   | [README](packages/jest-dom-mocks/README.md)                                              | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks)     |
+| `jest-mock-apollo` | [README](packages/jest-mock-apollo/README.md)                                            | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo) |
+| `jest-mock-router` | [README](packages/jest-mock-router/README.md)                                            | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-router.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-router) |
+| `jest-koa-mocks`   | [README](https://github.com/Shopify/quilt/blob/master/packages/jest-koa-mocks/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks)     |
+| `koa-shopify-auth` | [README](packages/koa-shopify-auth/README.md)                                            | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth) |
 
 ## Contribute
 

--- a/packages/jest-koa-mocks/README.md
+++ b/packages/jest-koa-mocks/README.md
@@ -1,0 +1,45 @@
+# `@shopify/jest-koa-mocks`
+
+## Installation
+
+```bash
+$ yarn add @shopify/jest-koa-mocks
+```
+
+## Usage
+
+### createContext
+
+This function allows you to create fully stubbable koa contexts for your tests. Using this you can test middleware without actually having to setup an app or http mocks in your tests.
+
+```typescript
+  interface Options extends Dictionary<any> {
+    url?: string;
+    method?: RequestMethod;
+    statusCode?: number;
+    session?: Dictionary<any>;
+    headers?: Dictionary<string>;
+    [key: string]: any;
+  }
+
+  createContext(options: Options)
+```
+
+**simple example**
+
+```typescript
+import SillyViewCounterMiddleware from "../silly-view-counter";
+import { createContext } from "jest-mock-koa";
+
+describe("silly-view-counter", () => {
+  it("iterates and displays new ctx.state.views", async () => {
+    const ctx = createContext({ state: { views: 31 } });
+
+    await SillyViewCounterMiddleware(ctx);
+
+    expect(ctx.state.views).toBe(32);
+    expect(ctx.status).toBe(200);
+    expect(ctx.body).toBe({ view: 32 });
+  });
+});
+```

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@shopify/jest-mock-koa",
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prepublish": "yarn run build"
+  },
+  "author": "Shopify Inc.",
+  "dependencies": {
+    "koa": "^2.5.0",
+    "node-mocks-http": "^1.5.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.11.1",
+    "@types/koa": "^2.0.44"
+  }
+}

--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -1,0 +1,68 @@
+import httpMocks, {RequestMethod} from 'node-mocks-http';
+import stream from 'stream';
+import Koa, {Context} from 'koa';
+
+import createMockCookies, {MockCookies} from '../create-mock-cookies';
+
+export interface Dictionary<T> {
+  [key: string]: T;
+}
+
+export interface MockContext extends Context {
+  cookies: MockCookies;
+}
+
+export interface Options extends Dictionary<any> {
+  url?: string;
+  method?: RequestMethod;
+  statusCode?: number;
+  session?: Dictionary<any>;
+  headers?: Dictionary<string>;
+  cookies?: Dictionary<string>;
+  [key: string]: any;
+}
+
+export default function createContext(options: Options = {}): MockContext {
+  const app = new Koa();
+  app.proxy = true;
+
+  const {
+    url,
+    cookies,
+    method,
+    statusCode,
+    session,
+    headers,
+    ...customFields
+  } = options;
+  const extensions = {...customFields, session};
+
+  Object.keys(extensions).forEach(key => {
+    app.context[key] = extensions[key];
+  });
+
+  const req = httpMocks.createRequest({
+    url,
+    method,
+    statusCode,
+    session,
+    headers,
+  });
+
+  // Some functions we call in the implementations will perform checks for `req.encrypted`, which delegates to the socket.
+  // MockRequest doesn't set a fake socket itself, so we create one here.
+  req.socket = new stream.Duplex() as any;
+
+  const res = httpMocks.createResponse();
+
+  // This is to get around an odd behavior in the `cookies` library, where if `res.set` is defined, it will use an internal
+  // node function to set headers, which results in them being set in the wrong place.
+  // eslint-disable-next-line no-undefined
+  res.set = undefined as any;
+
+  const context = app.createContext(req, res) as Context;
+
+  context.cookies = createMockCookies(cookies);
+
+  return context as any;
+}

--- a/packages/jest-koa-mocks/src/create-mock-context/index.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/index.ts
@@ -1,0 +1,5 @@
+import createMockContext from './create-mock-context';
+
+export * from './create-mock-context';
+
+export default createMockContext;

--- a/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
@@ -1,0 +1,62 @@
+import createContext from '../create-mock-context';
+
+describe('create-mock-context', () => {
+  it('includes custom method and url', () => {
+    const method = 'PUT';
+    const url = 'http://mystore.com/admin';
+    const context = createContext({method, url});
+
+    expect(context.method).toBe(method);
+    expect(context.url).toBe(url);
+  });
+
+  it('includes custom cookies', () => {
+    const cookies = {
+      test: '1',
+    };
+
+    const context = createContext({cookies});
+
+    expect(context.cookies.requestStore.get('test')).toBe(cookies.test);
+  });
+
+  it('includes custom session data', () => {
+    const session = {
+      shop: 'shop1',
+    };
+    const context = createContext({session});
+
+    expect(context.session.shop).toBe(session.shop);
+  });
+
+  it('includes custom headers', () => {
+    const headers = {
+      referrer: 'shop1',
+    };
+
+    const context = createContext({
+      headers,
+    });
+
+    expect(context.headers.referrer).toBe(headers.referrer);
+  });
+
+  it('includes custom state', () => {
+    const state = {
+      productName: 'Fabulous robot',
+    };
+
+    const context = createContext({
+      state,
+    });
+
+    expect(context.state.productName).toBe(context.state.produ);
+  });
+
+  it('supports arbitrary custom properties', () => {
+    const totallyNotARegularProperty = '👌✨';
+    const context = createContext({totallyNotARegularProperty});
+
+    expect(context.totallyNotARegularProperty).toBe(totallyNotARegularProperty);
+  });
+});

--- a/packages/jest-koa-mocks/src/create-mock-cookies/create-mock-cookies.ts
+++ b/packages/jest-koa-mocks/src/create-mock-cookies/create-mock-cookies.ts
@@ -1,0 +1,36 @@
+import {Context} from 'koa';
+
+export type Cookies = Context['cookies'];
+
+export interface Dictionary<T> {
+  [key: string]: T;
+}
+
+export interface MockCookies extends Cookies {
+  requestStore: Map<string, string>;
+  responseStore: Map<string, string>;
+}
+
+export default function createMockCookies(
+  cookies = {},
+  secure = true,
+): MockCookies {
+  const cookieEntries = Object.keys(cookies).map(
+    key => [key, cookies[key]] as [string, string],
+  );
+
+  const requestStore = new Map<string, string>(cookieEntries);
+  const responseStore = new Map<string, string>(cookieEntries);
+
+  return {
+    set: jest.fn((key, value) => {
+      return responseStore.set(key, value);
+    }),
+    get: jest.fn(key => {
+      return requestStore.get(key);
+    }),
+    requestStore,
+    responseStore,
+    secure,
+  } as any;
+}

--- a/packages/jest-koa-mocks/src/create-mock-cookies/index.ts
+++ b/packages/jest-koa-mocks/src/create-mock-cookies/index.ts
@@ -1,0 +1,5 @@
+import createMockCookies from './create-mock-cookies';
+
+export * from './create-mock-cookies';
+
+export default createMockCookies;

--- a/packages/jest-koa-mocks/src/create-mock-cookies/test/create-mock-cookies.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-cookies/test/create-mock-cookies.test.ts
@@ -1,0 +1,57 @@
+import createMockCookies from '../create-mock-cookies';
+
+describe('create-mock-cookies', () => {
+  it('includes maps for response and request cookie stores', () => {
+    const cookies = createMockCookies();
+    expect(cookies.requestStore).toBeInstanceOf(Map);
+    expect(cookies.responseStore).toBeInstanceOf(Map);
+  });
+
+  it('adds all given cookies to the requestStore', () => {
+    const values = {
+      sessionID: 'something something',
+      store: 'shop1',
+      referrer: 'somewhere.io',
+    };
+
+    const cookies = createMockCookies(values);
+
+    Object.keys(values).forEach(key => {
+      const value = values[key];
+      expect(cookies.requestStore.get(key)).toBe(value);
+    });
+  });
+
+  it('sets secure to true by default', () => {
+    const secureCookies = createMockCookies();
+    expect(secureCookies.secure).toBe(true);
+  });
+
+  it('sets secure to the given value', () => {
+    const secureCookies = createMockCookies({}, true);
+    expect(secureCookies.secure).toBe(true);
+
+    const insecureCookies = createMockCookies({}, false);
+    expect(insecureCookies.secure).toBe(false);
+  });
+
+  describe('set', () => {
+    it('adds to responseStore', () => {
+      const cookies = createMockCookies();
+
+      cookies.set('foo', 'bar');
+
+      expect(cookies.responseStore.get('foo')).toBe('bar');
+    });
+  });
+
+  describe('get', () => {
+    it('returns value from requestStore', () => {
+      const cookies = createMockCookies({foo: 'bar'});
+
+      cookies.set('foo', 'bar');
+
+      expect(cookies.responseStore.get('foo')).toBe('bar');
+    });
+  });
+});

--- a/packages/jest-koa-mocks/src/index.ts
+++ b/packages/jest-koa-mocks/src/index.ts
@@ -1,0 +1,2 @@
+export {default as createMockContext} from './create-mock-context';
+export {default as createMockCookies} from './create-mock-context';

--- a/packages/jest-koa-mocks/tsconfig.json
+++ b/packages/jest-koa-mocks/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,7 +133,7 @@
     "@types/events" "*"
     "@types/node" "*"
 
-"@types/express@*":
+"@types/express@*", "@types/express@^4.11.1":
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.11.1.tgz#f99663b3ab32d04cb11db612ef5dd7933f75465b"
   dependencies:
@@ -244,7 +244,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-accepts@^1.2.2:
+accepts@^1.2.2, accepts@^1.3.3:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
@@ -4177,6 +4177,10 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
+merge-descriptors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
@@ -4190,6 +4194,10 @@ merge2@^1.2.1:
 merge@^1.1.3, merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+
+methods@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
@@ -4236,6 +4244,10 @@ mime-types@^2.0.7, mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, m
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime@^1.3.4:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -4346,6 +4358,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+net@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/net/-/net-1.0.2.tgz#d1757ec9a7fb2371d83cf4755ce3e27e10829388"
+
 no-case@^2.2.0, no-case@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -4362,6 +4378,21 @@ node-fetch@^1.0.1, node-fetch@^1.5.3:
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+
+node-mocks-http@^1.5.8:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.5.8.tgz#cbcc6dc8278861f96522c51ae858cf62806e2f80"
+  dependencies:
+    accepts "^1.3.3"
+    depd "^1.1.0"
+    fresh "^0.5.2"
+    merge-descriptors "^1.0.1"
+    methods "^1.1.2"
+    mime "^1.3.4"
+    net "^1.0.2"
+    parseurl "^1.3.1"
+    range-parser "^1.2.0"
+    type-is "^1.6.14"
 
 node-notifier@^5.2.1:
   version "5.2.1"
@@ -4710,7 +4741,7 @@ parse5@^3.0.1:
   dependencies:
     "@types/node" "*"
 
-parseurl@^1.3.0:
+parseurl@^1.3.0, parseurl@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
@@ -4973,6 +5004,10 @@ randomatic@^1.1.3:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+range-parser@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.6"
@@ -5968,7 +6003,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@^1.5.5:
+type-is@^1.5.5, type-is@^1.6.14:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:


### PR DESCRIPTION
Closes #10 

Creates the `jest-mock-koa` package.

I had to change the implementation quite a bit from the one in the `web` project because it seemed like it didn't actually support most of the fields that it's type definition said it did. This is due to the way it's using `node-mocks-http`.

I'll enhance the documentation further in a subsequent PR.