### PR TITLE
🔧 Adding esModuleInterop to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es5",
+    "esModuleInterop": true,
     "declaration": true,
     "jsx": "react",
     "strictNullChecks": true,


### PR DESCRIPTION
This fixes the issue of synthetic imports being a type-only thing. It ensures that we appropriately import any commonjs modules that don't have a default export.