### PR TITLE
✨ Introducing the new location mock from web

### DIFF
--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "@shopify:registry": "https://packages.shopify.io/shopify/node/npm/"
   },


### PR DESCRIPTION
I notice that we made some updates in `web`. We'll need to include these here in order for `jest-dom-mocks` to be useable there.