### PR TITLE
🐛 Fixing dependencies and typing metadata in package.json

### DIFF
--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "Jest + Enzyme mocks for Apollo 2.x.",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "@shopify:registry": "https://packages.shopify.io/shopify/node/npm/"
   },
@@ -16,7 +17,7 @@
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
     "apollo-link": "^1.2.1",
-    "graphql": "^0.13.2",
+    "graphql": "0.11 - 0.13",
     "graphql-tool-utilities": "^0.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2711,17 +2711,17 @@ graphql-tool-utilities@^0.6.2:
     apollo-codegen "0.12.7"
     core-js "^2.4.1"
 
+"graphql@0.11 - 0.13":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+  dependencies:
+    iterall "^1.2.1"
+
 graphql@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
   dependencies:
     iterall "^1.1.0"
-
-graphql@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
-  dependencies:
-    iterall "^1.2.1"
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This is intended to resolve some errors in using `jest-mock-apollo`:

1. people had to import from `/dist` (`types` fixes this) - closes https://github.com/Shopify/quilt/issues/42
2. some projects had issues with mismatched versions of `graphql` (reduce the dependency to a lower required version).