### PR TITLE
Koa Auth Tests and Refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: circleci/node:8.9.4
     steps:
       - checkout
+      - run: printf "@shopify:registry=https://packages.shopify.io/shopify/node/npm/\\n//packages.shopify.io/shopify/node/npm/:_authToken=$NODEJS_PACKAGECLOUD_TOKEN" >> ~/.npmrc
       - run: yarn install --production=false
       - run: yarn lint
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
     "publish": "lerna publish",
     "prebuild": "yarn run clean",
     "build": "lerna run build",
-    "lint": "yarn eslint **/*.{ts,tsx} ",
-    "pretest": "yarn build",
-    "test": "jest",
+    "lint": "yarn eslint '**/*.{ts,tsx}'",
+    "test": "jest --maxWorkers=3",
     "check": "lerna run check",
     "release": "lerna publish && git push --follow-tags",
     "clean": "rimraf './packages/**/*.{js,d.ts}'",
@@ -47,7 +46,8 @@
     "react-dom": "^16.2.0",
     "rimraf": "^2.6.2",
     "ts-jest": "^22.4.2",
-    "typescript": "~2.7.2"
+    "typescript": "~2.7.2",
+    "isomorphic-fetch": "^2.2.1"
   },
   "jest": {
     "setupFiles": [
@@ -63,5 +63,7 @@
       "\\.(gql|graphql)$": "jest-transform-graphql"
     },
     "testRegex": ".*\\.test\\.tsx?$"
+  },
+  "dependencies": {
   }
 }

--- a/packages/jest-koa-mocks/README.md
+++ b/packages/jest-koa-mocks/README.md
@@ -29,7 +29,7 @@ This function allows you to create fully stubbable koa contexts for your tests. 
 
 ```typescript
 import SillyViewCounterMiddleware from '../silly-view-counter';
-import {createContext} from 'jest-koa-mocks';
+import {createMockContext} from '@shopify/jest-koa-mocks';
 
 describe('silly-view-counter', () => {
   it('iterates and displays new ctx.state.views', async () => {

--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -1,3 +1,4 @@
+import {URL} from 'url';
 import httpMocks, {RequestMethod} from 'node-mocks-http';
 import stream from 'stream';
 import Koa, {Context} from 'koa';
@@ -19,39 +20,54 @@ export interface Options extends Dictionary<any> {
   session?: Dictionary<any>;
   headers?: Dictionary<string>;
   cookies?: Dictionary<string>;
+  encrypted?: boolean;
+  host?: string;
   [key: string]: any;
 }
 
 export default function createContext(options: Options = {}): MockContext {
   const app = new Koa();
-  app.proxy = true;
 
   const {
-    url,
+    url = '',
     cookies,
     method,
     statusCode,
     session,
-    headers,
+    headers = {},
+    encrypted = false,
+    host = 'test.com',
     ...customFields
   } = options;
+
   const extensions = {...customFields, session};
 
   Object.keys(extensions).forEach(key => {
     app.context[key] = extensions[key];
   });
 
+  const protocolFallback = encrypted ? 'https' : 'http';
+  const urlObject = new URL(url, `${protocolFallback}://${host}`);
+
   const req = httpMocks.createRequest({
-    url,
+    url: urlObject.toString(),
     method,
     statusCode,
     session,
-    headers,
+    headers: {
+      // Koa determines protocol based on the `Host` header.
+      Host: urlObject.host,
+      ...headers,
+    },
   });
 
   // Some functions we call in the implementations will perform checks for `req.encrypted`, which delegates to the socket.
   // MockRequest doesn't set a fake socket itself, so we create one here.
   req.socket = new stream.Duplex() as any;
+  Object.defineProperty(req.socket, 'encrypted', {
+    writable: false,
+    value: urlObject.protocol === 'https:',
+  });
 
   const res = httpMocks.createResponse();
 
@@ -61,7 +77,6 @@ export default function createContext(options: Options = {}): MockContext {
   res.set = undefined as any;
 
   const context = app.createContext(req, res) as Context;
-
   context.cookies = createMockCookies(cookies);
 
   return context as any;

--- a/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
@@ -1,13 +1,83 @@
 import createContext from '../create-mock-context';
 
+const STORE_URL = 'http://mystore.com/admin';
+
 describe('create-mock-context', () => {
   it('includes custom method and url', () => {
     const method = 'PUT';
-    const url = 'http://mystore.com/admin';
+    const url = STORE_URL;
     const context = createContext({method, url});
 
     expect(context.method).toBe(method);
     expect(context.url).toBe(url);
+  });
+
+  it('sets url segment aliases correctly', () => {
+    const context = createContext({url: STORE_URL});
+
+    const {url, originalUrl, host, origin, path, protocol} = context;
+    expect(url).toBe(STORE_URL);
+    expect(originalUrl).toBe(STORE_URL);
+    expect(host).toBe('mystore.com');
+    expect(path).toBe('/admin');
+    expect(protocol).toBe('http');
+    expect(origin).toBe('http://mystore.com');
+  });
+
+  it('defaults url segments when no origin is given', () => {
+    const context = createContext({url: '/foo'});
+
+    const {url, originalUrl, host, origin, path, protocol} = context;
+    expect(url).toBe('http://test.com/foo');
+    expect(originalUrl).toBe('http://test.com/foo');
+    expect(host).toBe('test.com');
+    expect(path).toBe('/foo');
+    expect(protocol).toBe('http');
+    expect(origin).toBe('http://test.com');
+  });
+
+  it('determines protocol based on `encrypted`', () => {
+    const {protocol} = createContext({
+      encrypted: true,
+      url: '/foo',
+    });
+
+    expect(protocol).toBe('https');
+  });
+
+  it('determines protocol based on `encrypted`', () => {
+    const {protocol} = createContext({
+      encrypted: true,
+      url: '/foo',
+    });
+
+    expect(protocol).toBe('https');
+  });
+
+  it('generates the same url from segments as a full url', () => {
+    const explicitSegments = createContext({
+      url: '/foo/bar',
+      host: 'www.foobarbaz.com',
+      encrypted: true,
+    });
+
+    const fullyQualifiedUrl = createContext({
+      url: 'https://www.foobarbaz.com/foo/bar',
+    });
+
+    expect(explicitSegments.originalUrl).toBe(fullyQualifiedUrl.originalUrl);
+  });
+
+  it('prefers fully qualified url over explicit segments', () => {
+    const expectedUrl = 'https://www.foobarbaz.com/foo/bar';
+
+    const {originalUrl} = createContext({
+      url: 'https://www.foobarbaz.com/foo/bar',
+      host: 'someotherplace.com',
+      encrypted: false,
+    });
+
+    expect(originalUrl).toBe(expectedUrl);
   });
 
   it('includes custom cookies', () => {
@@ -15,7 +85,10 @@ describe('create-mock-context', () => {
       test: '1',
     };
 
-    const context = createContext({cookies});
+    const context = createContext({
+      url: STORE_URL,
+      cookies,
+    });
 
     expect(context.cookies.requestStore.get('test')).toBe(cookies.test);
   });
@@ -24,7 +97,11 @@ describe('create-mock-context', () => {
     const session = {
       shop: 'shop1',
     };
-    const context = createContext({session});
+
+    const context = createContext({
+      url: STORE_URL,
+      session,
+    });
 
     expect(context.session.shop).toBe(session.shop);
   });
@@ -35,6 +112,7 @@ describe('create-mock-context', () => {
     };
 
     const context = createContext({
+      url: STORE_URL,
       headers,
     });
 
@@ -47,6 +125,7 @@ describe('create-mock-context', () => {
     };
 
     const context = createContext({
+      url: STORE_URL,
       state,
     });
 
@@ -55,7 +134,10 @@ describe('create-mock-context', () => {
 
   it('supports arbitrary custom properties', () => {
     const totallyNotARegularProperty = '👌✨';
-    const context = createContext({totallyNotARegularProperty});
+    const context = createContext({
+      url: STORE_URL,
+      totallyNotARegularProperty,
+    });
 
     expect(context.totallyNotARegularProperty).toBe(totallyNotARegularProperty);
   });

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -13,10 +13,14 @@
   },
   "author": "Shopify Inc.",
   "dependencies": {
+    "@shopify/jest-koa-mocks": "^1.0.4",
     "@types/koa": "^2.0.44",
-    "koa": "^2.5.0"
+    "koa": "^2.5.0",
+    "safe-compare": "^1.1.2"
   },
   "devDependencies": {
+    "@shopify/jest-dom-mocks": "^2.0.0-0",
+    "@types/safe-compare": "^1.1.0",
     "typescript": "~2.7.2"
   }
 }

--- a/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
+++ b/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
@@ -1,29 +1,29 @@
 import {Context} from 'koa';
 import querystring from 'querystring';
 
+import redirectionPage from './redirection-page';
 import {Options} from './types';
+import Error from './errors';
 
 export default function createOAuthStart({
-  scopes,
+  scopes = [],
   apiKey,
-  prefix,
   accessMode,
 }: Options) {
   return function oAuthStart(ctx: Context) {
-    const {query, originalUrl} = ctx;
+    const {query, host, path} = ctx;
     const {shop} = query;
 
     if (shop == null) {
-      ctx.throw(400, 'shop parameter required');
+      ctx.throw(400, Error.ShopParamMissing);
       return;
     }
 
     /* eslint-disable camelcase */
     const redirectParams = {
-      baseUrl: prefix,
-      scope: scopes,
+      scope: scopes.join(' '),
       client_id: apiKey,
-      redirect_uri: `${originalUrl}/callback`,
+      redirect_uri: `https://${host}${path}/callback`,
     };
     /* eslint-enable camelcase */
 
@@ -34,27 +34,6 @@ export default function createOAuthStart({
     const formattedQueryString = querystring.stringify(redirectParams);
     const redirectTo = `https://${shop}/admin/oauth/authorize?${formattedQueryString}`;
 
-    ctx.body = `
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <script type="text/javascript">
-            document.addEventListener('DOMContentLoaded', function() {
-              if (window.top === window.self) {
-                // If the current window is the 'parent', change the URL by setting location.href
-                window.location.href = '${redirectTo}';
-              } else {
-                // If the current window is the 'child', change the parent's URL with postMessage
-                data = JSON.stringify({
-                  message: 'Shopify.API.remoteRedirect',
-                  data: { location: '${redirectTo}' }
-                });
-
-                window.parent.postMessage(data, targetInfo.myshopifyUrl);
-              }
-            });
-          </script>
-        </head>
-      </html>`;
+    ctx.body = redirectionPage(redirectTo);
   };
 }

--- a/packages/koa-shopify-auth/src/auth/errors.ts
+++ b/packages/koa-shopify-auth/src/auth/errors.ts
@@ -1,0 +1,7 @@
+enum Error {
+  ShopParamMissing = 'Expected a shop query parameter',
+  InvalidHMAC = 'HMAC validation failed',
+  AccessTokenError = 'Could not fetch access token',
+}
+
+export default Error;

--- a/packages/koa-shopify-auth/src/auth/index.ts
+++ b/packages/koa-shopify-auth/src/auth/index.ts
@@ -2,13 +2,15 @@ import {Context} from 'koa';
 
 import createOAuthStart from './create-oauth-start';
 import createOAuthCallback from './create-oauth-callback';
-import {Options} from './types';
+import {Options, AccessMode} from './types';
+
+const DEFAULT_ACCESS_MODE: AccessMode = 'online';
 
 export default function createShopifyAuth(options: Options) {
   const config = {
     scopes: [],
-    accessMode: 'online',
     prefix: '',
+    accessMode: DEFAULT_ACCESS_MODE,
     ...options,
   };
 
@@ -31,3 +33,6 @@ export default function createShopifyAuth(options: Options) {
     }
   };
 }
+
+export {default as Error} from './errors';
+export {default as validateHMAC} from './validate-hmac';

--- a/packages/koa-shopify-auth/src/auth/redirection-page.ts
+++ b/packages/koa-shopify-auth/src/auth/redirection-page.ts
@@ -1,0 +1,20 @@
+export default function redirectionScript(redirectTo: string) {
+  return `
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', function() {
+        if (window.top === window.self) {
+          // If the current window is the 'parent', change the URL by setting location.href
+          window.location.href = '${redirectTo}';
+        } else {
+          // If the current window is the 'child', change the parent's URL with postMessage
+          data = JSON.stringify({
+            message: 'Shopify.API.remoteRedirect',
+            data: { location: '${redirectTo}' }
+          });
+
+          window.parent.postMessage(data, targetInfo.myshopifyUrl);
+        }
+      });
+    </script>
+  `;
+}

--- a/packages/koa-shopify-auth/src/auth/test/oauth-callback.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-callback.test.ts
@@ -1,17 +1,191 @@
+import querystring from 'querystring';
+import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
+import {createMockContext} from '@shopify/jest-koa-mocks';
+
+import createOAuthCallback from '../create-oauth-callback';
+import {AuthConfig} from '../types';
+import Error from '../errors';
+
+jest.mock('../validate-hmac', () => jest.fn(() => true));
+const validateHmac = require.requireMock('../validate-hmac');
+
+const baseConfig: AuthConfig = {
+  apiKey: 'myapikey',
+  secret: 'mysecret',
+};
+
+const queryData = {
+  shop: 'shop1.myshopify.io',
+  hmac: 'abc',
+  code: 'def',
+};
+
+const baseUrl = 'myapp.com/auth/callback';
+
+// eslint-disable-next-line camelcase
+const basicResponse = {status: 200, body: {access_token: 'made up token'}};
+
 describe('OAuthCallback', () => {
-  // pending koa mocks being merged
-  pending();
-  it('throws a 400 if the hmac is invalid', async () => {});
+  beforeEach(() => {
+    validateHmac.mockReset();
+    validateHmac.mockImplementation(() => true);
+  });
 
-  it('throws a 400 if the shop query parameter is not present', async () => {});
+  afterEach(async () => {
+    await fetchMock.flush();
+    fetchMock.restore();
+  });
 
-  it('fetches an access token', async () => {});
+  it('throws a 400 if the shop query parameter is not present', () => {
+    fetchMock.mock('*', basicResponse);
 
-  it('throws a 401 if the token request fails', async () => {});
+    const oAuthCallback = createOAuthCallback(baseConfig);
+    const ctx = createMockContext({
+      url: baseUrl,
+      throw: jest.fn(),
+    });
 
-  it('includes the shop and accessToken on session if the token request succeeds', async () => {});
+    oAuthCallback(ctx);
 
-  it('includes the shop and accesstoken on state if the token request succeeds', async () => {});
+    expect(ctx.throw).toBeCalledWith(400, Error.ShopParamMissing);
+  });
 
-  it('calls afterAuth with ctx when the token request succeeds', async () => {});
+  it('throws a 400 if the hmac is invalid', async () => {
+    fetchMock.mock('*', basicResponse);
+
+    validateHmac.mockImplementation(() => false);
+
+    const oAuthCallback = createOAuthCallback(baseConfig);
+    const ctx = createMockContext({
+      url: `${baseUrl}?${querystring.stringify(queryData)}`,
+      throw: jest.fn(),
+    });
+
+    await oAuthCallback(ctx);
+
+    expect(validateHmac).toBeCalled();
+    expect(ctx.throw).toBeCalledWith(400, Error.InvalidHMAC);
+  });
+
+  it('does not throw a 400 when hmac is valid and shop parameter is supplied', async () => {
+    fetchMock.mock('*', basicResponse);
+
+    const oAuthCallback = createOAuthCallback(baseConfig);
+    const ctx = createMockContext({
+      url: `${baseUrl}?${querystring.stringify(queryData)}`,
+      throw: jest.fn(),
+    });
+
+    await oAuthCallback(ctx);
+
+    expect(ctx.throw).not.toBeCalledWith(400, Error.ShopParamMissing);
+    expect(ctx.throw).not.toBeCalledWith(400, Error.InvalidHMAC);
+  });
+
+  it("fetches an access token with the app's credentials", async () => {
+    // eslint-disable-next-line camelcase
+    fetchMock.mock('*', {status: 200, body: {access_token: 'abc'}});
+
+    const oAuthCallback = createOAuthCallback(baseConfig);
+    const ctx = createMockContext({
+      url: `${baseUrl}?${querystring.stringify(queryData)}`,
+    });
+
+    await oAuthCallback(ctx);
+
+    const {secret, apiKey} = baseConfig;
+    const {code} = queryData;
+
+    expect(fetchMock.lastCall()).toEqual([
+      'https://shop1.myshopify.io/admin/oauth/access_token',
+      {
+        body: querystring.stringify({
+          code,
+          // eslint-disable-next-line camelcase
+          client_id: apiKey,
+          // eslint-disable-next-line camelcase
+          client_secret: secret,
+        }),
+        headers: {
+          'Content-Length': '50',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        method: 'POST',
+      },
+    ]);
+  });
+
+  it('throws a 401 if the token request fails', async () => {
+    // eslint-disable-next-line camelcase
+    fetchMock.mock('*', {status: 401, body: {access_token: 'abc'}});
+
+    const oAuthCallback = createOAuthCallback(baseConfig);
+    const ctx = createMockContext({
+      url: `${baseUrl}?${querystring.stringify(queryData)}`,
+      throw: jest.fn(),
+    });
+
+    await oAuthCallback(ctx);
+
+    expect(ctx.throw).toBeCalledWith(401, Error.AccessTokenError);
+  });
+
+  it('includes the shop and accessToken on session if the token request succeeds and session exists', async () => {
+    const accessToken = 'abc';
+
+    // eslint-disable-next-line camelcase
+    fetchMock.mock('*', {status: 200, body: {access_token: accessToken}});
+
+    const oAuthCallback = createOAuthCallback(baseConfig);
+    const ctx = createMockContext({
+      url: `${baseUrl}?${querystring.stringify(queryData)}`,
+      session: {},
+    });
+
+    await oAuthCallback(ctx);
+
+    expect(ctx.session).toMatchObject({
+      shop: queryData.shop,
+      accessToken,
+    });
+  });
+
+  it('includes the shop and accesstoken on state if the token request succeeds', async () => {
+    const accessToken = 'abc';
+
+    // eslint-disable-next-line camelcase
+    fetchMock.mock('*', {status: 200, body: {access_token: accessToken}});
+
+    const oAuthCallback = createOAuthCallback(baseConfig);
+    const ctx = createMockContext({
+      url: `${baseUrl}?${querystring.stringify(queryData)}`,
+      session: {},
+    });
+
+    await oAuthCallback(ctx);
+
+    expect(ctx.state.shopify).toMatchObject({
+      shop: queryData.shop,
+      accessToken,
+    });
+  });
+
+  it('calls afterAuth with ctx when the token request succeeds', async () => {
+    const afterAuth = jest.fn();
+
+    // eslint-disable-next-line camelcase
+    fetchMock.mock('*', {status: 200, body: {access_token: 'abc'}});
+
+    const oAuthCallback = createOAuthCallback({
+      ...baseConfig,
+      afterAuth,
+    });
+    const ctx = createMockContext({
+      url: `myapp.com/auth?shop=shop1.myshopify.io&hmac=noreal&code=nothing`,
+    });
+
+    await oAuthCallback(ctx);
+
+    expect(afterAuth).toBeCalledWith(ctx);
+  });
 });

--- a/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
@@ -1,9 +1,69 @@
+import querystring from 'querystring';
+import {createMockContext} from '@shopify/jest-koa-mocks';
+
+import createOAuthStart from '../create-oauth-start';
+import redirectionPage from '../redirection-page';
+import Error from '../errors';
+
+const query = querystring.stringify.bind(querystring);
+
+const baseUrl = 'myapp.com/auth';
+const shop = 'shop1.myshopify.io';
+const redirectionURL = `https://${shop}/admin/oauth/authorize`;
+
+const baseConfig = {
+  apiKey: 'myapikey',
+  secret: 'mysecret',
+  scopes: ['write_orders, write_products'],
+};
+
+const queryData = {
+  scope: 'write_orders, write_products',
+  // eslint-disable-next-line camelcase
+  client_id: baseConfig.apiKey,
+  // eslint-disable-next-line camelcase
+  redirect_uri: `https://${baseUrl}/callback`,
+};
+
 describe('OAuthStart', () => {
-  // pending koa mocks being merged
-  pending();
-  it('sets body to a redirect page for the given shop', async () => {});
+  it('throws a 400 when no shop query parameter is given', async () => {
+    const oAuthStart = createOAuthStart(baseConfig);
+    const ctx = createMockContext({
+      url: `https://${baseUrl}`,
+      throw: jest.fn(),
+    });
 
-  it('redirect page includes per-user grant for accessMode: online', async () => {});
+    await oAuthStart(ctx);
+    expect(ctx.throw).toBeCalledWith(400, Error.ShopParamMissing);
+  });
 
-  it('throws a 400 when no shop query parameter is given', async () => {});
+  it('sets body to a redirect page for the given shop', () => {
+    const oAuthStart = createOAuthStart(baseConfig);
+    const ctx = createMockContext({
+      url: `https://${baseUrl}?${query({shop})}`,
+    });
+
+    oAuthStart(ctx);
+
+    expect(ctx.body).toBe(
+      redirectionPage(`${redirectionURL}?${query(queryData)}`),
+    );
+  });
+
+  it('redirect page includes per-user grant for accessMode: online', () => {
+    const oAuthStart = createOAuthStart({
+      ...baseConfig,
+      accessMode: 'online',
+    });
+
+    const ctx = createMockContext({
+      url: 'https://myapp.com/auth?shop=shop1.myshopify.io',
+    });
+
+    oAuthStart(ctx);
+
+    // eslint-disable-next-line camelcase
+    const grantQuery = query({...queryData, 'grant_options[]': 'per-user'});
+    expect(ctx.body).toBe(redirectionPage(`${redirectionURL}?${grantQuery}`));
+  });
 });

--- a/packages/koa-shopify-auth/src/auth/test/validate-hmac.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/validate-hmac.test.ts
@@ -1,0 +1,43 @@
+import validateHmac from '../validate-hmac';
+
+jest.mock('crypto', () => {
+  return {
+    createHmac() {
+      return {
+        update() {
+          return this;
+        },
+        digest() {
+          return 'somehmac';
+        },
+      };
+    },
+  };
+});
+
+jest.mock('safe-compare', () => {
+  return jest.fn((first: string, second: string) => first === second);
+});
+
+const safeCompare = require.requireMock('safe-compare');
+const data = {foo: 'bar'};
+const secret = 'somehmac';
+
+describe('validateHmac', () => {
+  beforeEach(() => {});
+
+  it('returns true when digest matches input', () => {
+    const hmac = 'somehmac';
+    expect(validateHmac(hmac, secret, data)).toBe(true);
+  });
+
+  it('returns false when digests does not match input', () => {
+    const hmac = 'some invalid hmac';
+    expect(validateHmac(hmac, secret, data)).toBe(false);
+  });
+
+  it('compares using safeCompare', () => {
+    const hmac = 'some invalid hmac';
+    expect(safeCompare).toBeCalledWith('somehmac', hmac);
+  });
+});

--- a/packages/koa-shopify-auth/src/auth/types.ts
+++ b/packages/koa-shopify-auth/src/auth/types.ts
@@ -1,10 +1,12 @@
 import {Context} from 'koa';
 
+export type AccessMode = 'online' | 'offline';
+
 export interface AuthConfig {
   secret: string;
   apiKey: string;
-  accessMode: 'online' | 'offline';
-  afterAuth(ctx: Context): void;
+  accessMode?: 'online' | 'offline';
+  afterAuth?(ctx: Context): void;
 }
 
 export interface Options extends AuthConfig {

--- a/packages/koa-shopify-auth/src/auth/validate-hmac.ts
+++ b/packages/koa-shopify-auth/src/auth/validate-hmac.ts
@@ -1,0 +1,22 @@
+import {Context} from 'koa';
+import querystring from 'querystring';
+import safeCompare from 'safe-compare';
+import crypto from 'crypto';
+
+export default function validateHmac(
+  hmac: string,
+  secret: string,
+  query: Context['query'],
+) {
+  const map = {...query};
+  delete map.signature;
+  delete map.hmac;
+
+  const message = querystring.stringify(map);
+  const generatedHash = crypto
+    .createHmac('sha256', secret)
+    .update(message)
+    .digest('hex');
+
+  return safeCompare(generatedHash, hmac);
+}

--- a/packages/koa-shopify-auth/src/index.ts
+++ b/packages/koa-shopify-auth/src/index.ts
@@ -2,4 +2,6 @@ import createAuthRouter from './auth';
 
 export default createAuthRouter;
 
+export * from './auth';
+
 export {default as createVerifyRequest} from './verify-request';

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,5 @@
 import './console-wrapper';
-
+import 'isomorphic-fetch';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,10 @@
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.1.tgz#6f6aaffaf7dba502ff5ca15e4aa18caee9b04995"
 
+"@types/safe-compare@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/safe-compare/-/safe-compare-1.1.0.tgz#47ed9b9ca51a3a791b431cd59b28f47fa9bf1224"
+
 "@types/serve-static@*":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.1.tgz#1d2801fa635d274cd97d4ec07e26b21b44127492"
@@ -881,6 +885,21 @@ bser@^2.0.0:
 buf-compare@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
+
+buffer-alloc-unsafe@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz#ffe1f67551dd055737de253337bfe853dfab1a6a"
+
+buffer-alloc@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.1.0.tgz#05514d33bf1656d3540c684f65b1202e90eca303"
+  dependencies:
+    buffer-alloc-unsafe "^0.1.0"
+    buffer-fill "^0.1.0"
+
+buffer-fill@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-0.1.1.tgz#76d825c4d6e50e06b7a31eb520c04d08cc235071"
 
 buffer-from@^1.0.0:
   version "1.0.0"
@@ -3354,7 +3373,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -5402,6 +5421,12 @@ rxjs@^5.5.2:
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-compare@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/safe-compare/-/safe-compare-1.1.2.tgz#bb6f18f222fbc52c8aaa4a60db596dfb3e03006a"
+  dependencies:
+    buffer-alloc "^1.1.0"
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR adds some unit tests to `koa-shopify-auth` and also does a bit of refactoring there. We'll still want to add some more tests in the future but this is a solid start.

It ended up being a bit of a rabbithole because `jest-koa-mocks` wasn't properly setting all of the url segment related fields of it's request object, so I fixed that and added tests there as well.