### PR TITLE
Adds proper typings for fetch mock

### DIFF
--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -15,6 +15,7 @@
   "author": "Shopify Inc.",
   "dependencies": {
     "@shopify/javascript-utilities": "^2.1.0",
+    "@types/fetch-mock": "^6.0.1",
     "fetch-mock": "^6.3.0",
     "lolex": "^2.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,6 +156,10 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/fetch-mock@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-6.0.1.tgz#df4e9f3a12fc81fae173f018ea17ad79441c10ba"
+
 "@types/graphql@^0.9.1":
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.4.tgz#cdeb6bcbef9b6c584374b81aa7f48ecf3da404fa"


### PR DESCRIPTION
Makes sure that `fetch` is properly types by including the typings for the underlying `fetch-mock` library.