### PR TITLE
📌 use versioning to support yarn selective dependency resolution

### DIFF
--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -17,7 +17,7 @@
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
     "apollo-link": "^1.2.1",
-    "graphql": "0.11 - 0.13",
+    "graphql": "^0.13.2",
     "graphql-tool-utilities": "^0.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,17 +2715,17 @@ graphql-tool-utilities@^0.6.2:
     apollo-codegen "0.12.7"
     core-js "^2.4.1"
 
-"graphql@0.11 - 0.13":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
-  dependencies:
-    iterall "^1.2.1"
-
 graphql@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
   dependencies:
     iterall "^1.1.0"
+
+graphql@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+  dependencies:
+    iterall "^1.2.1"
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
https://yarnpkg.com/lang/en/docs/selective-version-resolutions/ suggests a better way to get around the problem of https://github.com/lemonmade/graphql-tools/tree/master/packages/graphql-tool-utilities having stale dependencies. Unfortunately, this wasn't working with the `x - y` version number.