### PR TITLE
📌 Ensure TS versions stay in sync

### DIFF
--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.11.1",
-    "@types/koa": "^2.0.44"
+    "@types/koa": "^2.0.44",
+    "typescript": "~2.7.2"
   }
 }

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "@types/koa": "^2.0.44",
     "koa": "^2.5.0"
+  },
+  "devDependencies": {
+    "typescript": "~2.7.2"
   }
 }

--- a/test/typescript-version.test.ts
+++ b/test/typescript-version.test.ts
@@ -1,0 +1,40 @@
+import {readdirSync, readFileSync} from 'fs';
+import * as path from 'path';
+
+describe('typescript version', () => {
+  it('the version in each package matches the root version', () => {
+    const rootPackageJSON = require('../package.json');
+    const rootVersion = rootPackageJSON.devDependencies.typescript;
+
+    const packagesPath = path.resolve(__dirname, '..', 'packages');
+    const packageNames = readdirSync(packagesPath);
+
+    for (const packageName of packageNames) {
+      const packageJSONPath = path.join(
+        packagesPath,
+        packageName,
+        'package.json',
+      );
+
+      const packageJSON = JSON.parse(
+        readFileSync(packageJSONPath, {encoding: 'utf8'}),
+      );
+
+      expect(packageJSON).toMatchObject({
+        devDependencies: {
+          typescript: rootVersion,
+        },
+      });
+    }
+  });
+
+  it('the version in the plop file matches the root version', () => {
+    const rootPackageJSON = require('../package.json');
+    const rootVersion = rootPackageJSON.devDependencies.typescript;
+
+    const plopPackageJSON = require('../templates/package.hbs.json');
+    const plopVersion = plopPackageJSON.devDependencies.typescript;
+
+    expect(plopVersion).toBe(rootVersion);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/Shopify/quilt/issues/16

This uses the ts version in the root `package.json` as the source of truth, then ensures the other packages follow its version, as well as the plop file.