### PR TITLE
💚 don't include tests in build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
     ]
   },
   "exclude": [
-    "./node_modules"
+    "./node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
   ]
 }


### PR DESCRIPTION
The deploy failures for `shopify-koa-auth` seem to have been due to `devDependencies` not being included. 

The scalable fix for this is to just not try to build our test files when we're deploying. To accomplish this we just add to the `"excludes"` array in our base tsconfig.