### PR TITLE
🐛 fix redirect page for when app is in an iframe

### DIFF
--- a/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
+++ b/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
@@ -39,8 +39,9 @@ export default function createOAuthStart({
     }
 
     const formattedQueryString = querystring.stringify(redirectParams);
-    const redirectTo = `https://${shop}/admin/oauth/authorize?${formattedQueryString}`;
-
-    ctx.body = redirectionPage(redirectTo);
+    ctx.body = redirectionPage({
+      origin: `https://${shop}`,
+      path: `/admin/oauth/authorize?${formattedQueryString}`,
+    });
   };
 }

--- a/packages/koa-shopify-auth/src/auth/redirection-page.ts
+++ b/packages/koa-shopify-auth/src/auth/redirection-page.ts
@@ -1,4 +1,5 @@
-export default function redirectionScript(redirectTo: string) {
+export default function redirectionScript({origin, path}) {
+  const redirectTo = `${origin}${path}`;
   return `
     <script type="text/javascript">
       document.addEventListener('DOMContentLoaded', function() {
@@ -12,7 +13,7 @@ export default function redirectionScript(redirectTo: string) {
             data: { location: '${redirectTo}' }
           });
 
-          window.parent.postMessage(data, targetInfo.myshopifyUrl);
+          window.parent.postMessage(data, '${origin}');
         }
       });
     </script>

--- a/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
@@ -15,7 +15,8 @@ const query = querystring.stringify.bind(querystring);
 const fakeNonce = 'fakenonce';
 const baseUrl = 'myapp.com/auth';
 const shop = 'shop1.myshopify.io';
-const redirectionURL = `https://${shop}/admin/oauth/authorize`;
+const shopOrigin = 'https://shop1.myshopify.io';
+const redirectionURL = `/admin/oauth/authorize`;
 
 const baseConfig = {
   apiKey: 'myapikey',
@@ -59,7 +60,10 @@ describe('OAuthStart', () => {
     oAuthStart(ctx);
 
     expect(ctx.body).toBe(
-      redirectionPage(`${redirectionURL}?${query(queryData)}`),
+      redirectionPage({
+        path: `${redirectionURL}?${query(queryData)}`,
+        origin: shopOrigin,
+      }),
     );
   });
 
@@ -88,6 +92,11 @@ describe('OAuthStart', () => {
 
     // eslint-disable-next-line camelcase
     const grantQuery = query({...queryData, 'grant_options[]': 'per-user'});
-    expect(ctx.body).toBe(redirectionPage(`${redirectionURL}?${grantQuery}`));
+    expect(ctx.body).toBe(
+      redirectionPage({
+        path: `${redirectionURL}?${grantQuery}`,
+        origin: shopOrigin,
+      }),
+    );
   });
 });


### PR DESCRIPTION
Previously auth would work fine when run from the app's domain, but not when run inside an iframe from core. This means that for my test app I could log in fine the first time and install the app, but if I deleted my cookies it would break.

This change also brings us more in line with `shopify_app`.