### PR TITLE
✨ create EASDK route propagator

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
       "^.+\\.tsx?$": "ts-jest",
       "\\.(gql|graphql)$": "jest-transform-graphql"
     },
-    "testRegex": ".*\\.test\\.tsx?$"
+    "testRegex": ".*\\.test\\.tsx?$",
+    "testEnvironmentOptions": {
+     "url": "http://localhost:3000/"
+    }
   },
   "dependencies": {
   }

--- a/packages/react-shopify-app-route-propagator/README.md
+++ b/packages/react-shopify-app-route-propagator/README.md
@@ -1,0 +1,99 @@
+# `@shopify/react-shopify-app-route-propagator`
+
+`<EASDKRoutePropagator />` is a simple component to synchronize a Shopify embedded app's client side routing with the outer iframe host.
+
+The component is quite small and can be used with any routing solution.
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-shopify-app-route-propagator
+```
+
+## Usage
+
+The component has the following props signature
+
+```typescript
+export type LocationOrHref =
+  | string
+  | {search: string; hash: string; pathname: string};
+
+export interface Props {
+  location: LocationOrHref;
+}
+```
+
+Allowing you to use it with a string
+
+```javascript
+<EASDKRoutePropagator location="/foo/bar?thing=true" />
+```
+
+Or a location object
+
+```javascript
+<EASDKRoutePropagator location={this.props.location} />
+```
+
+Or even with `window.location` (though then you will need to make sure it rerenders yourself)
+
+```javascript
+<EASDKRoutePropagator location={window.location} />
+```
+
+### With React Router (withRouter)
+
+An easy way to mount the component with minimal configuration in a [react-router](https://github.com/ReactTraining/react-router) application is to first import the `withRouter` Higher-Order-Component and create a wrapped version of the propagator.
+
+```javascript
+import * as React from 'react';
+import { Switch, Route, withRouter } from 'react-router'
+import { BrowserRouter } from 'react-router-dom'
+import EASDKRoutePropagator from '@shopify/react-shopify-app-route-propagator';
+
+const Propagator = withRouter(EASDKRoutePropagator);
+
+export default function() {
+  return (
+    <BrowserRouter>
+      <React.Fragment>
+        <Propagator />
+        <Switch>
+          <Route exact path="/">
+          { /* other routes */ }
+        </Switch>
+      </React.Fragment>
+    </BrowserRouter>
+  );
+}
+```
+
+### With React Router (<Route>)
+
+If you prefer things more explicit you can just get the `location` value to pass in explicitly by using `<Route>`'s children as a render prop.
+
+```javascript
+import * as React from 'react';
+import { Switch, Route, withRouter } from 'react-router'
+import { BrowserRouter } from 'react-router-dom'
+import EASDKRoutePropagator from '@shopify/react-shopify-app-route-propagator;
+
+export default function() {
+  return (
+    <BrowserRouter>
+      <Route>
+        {({location}) => {
+          <React.Fragment>
+            <EASDKRoutePropagator location={location} />
+            <Switch>
+              <Route exact path="/">
+              { /* other routes */ }
+            </Switch>
+          </React.Fragment>
+        }}
+      </Route>
+    </BrowserRouter>
+  );
+}
+```

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@shopify/react-shopify-app-route-propagator",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepublish": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Shopify Inc.",
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
+  "devDependencies": {
+    "enzyme": "^3.3.0",
+    "typescript": "~2.7.2"
+  }
+}

--- a/packages/react-shopify-app-route-propagator/src/globals.ts
+++ b/packages/react-shopify-app-route-propagator/src/globals.ts
@@ -1,0 +1,11 @@
+export function getSelfWindow() {
+  return window.self;
+}
+
+export function getTopWindow() {
+  return window.top;
+}
+
+export function getOrigin() {
+  return location.origin;
+}

--- a/packages/react-shopify-app-route-propagator/src/index.ts
+++ b/packages/react-shopify-app-route-propagator/src/index.ts
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import {getSelfWindow, getTopWindow, getOrigin} from './globals';
+
+export type LocationOrHref =
+  | string
+  | {search: string; hash: string; pathname: string};
+
+export interface Props {
+  location: LocationOrHref;
+}
+
+export const MODAL_IFRAME_NAME = 'app-modal-iframe';
+export const REPLACE_STATE_MESSAGE = 'Shopify.API.replaceState';
+
+export default class ReactShopifyAppRoutePropagator extends React.PureComponent<
+  Props,
+  never
+> {
+  componentDidMount() {
+    this.propagateLocation();
+  }
+
+  componentDidUpdate() {
+    this.propagateLocation();
+  }
+
+  propagateLocation() {
+    const {location} = this.props;
+    const selfWindow = getSelfWindow();
+    const topWindow = getTopWindow();
+
+    const renderedInTheTopWindow = selfWindow === topWindow;
+    const renderedInAModal = selfWindow.name === MODAL_IFRAME_NAME;
+
+    if (renderedInTheTopWindow || renderedInAModal) {
+      return;
+    }
+
+    const normalizedLocation = getNormalizedURL(location);
+
+    /*
+      We delete this param that ends up unnecassarily stuck on
+      the iframe due to oauth when propagating up.
+    */
+    normalizedLocation.searchParams.delete('hmac');
+
+    const {pathname, search, hash} = normalizedLocation;
+
+    const data = JSON.stringify({
+      message: REPLACE_STATE_MESSAGE,
+      data: {location: `${pathname}${search}${hash}`},
+    });
+
+    topWindow.postMessage(data, '*');
+  }
+
+  render() {
+    return null;
+  }
+}
+
+function getNormalizedURL(location: LocationOrHref) {
+  const origin = getOrigin();
+
+  if (typeof location === 'string') {
+    return new URL(location, origin);
+  }
+
+  const {pathname, search, hash} = location;
+  return new URL(`${pathname}${search}${hash}`, origin);
+}

--- a/packages/react-shopify-app-route-propagator/src/test/react-shopify-app-route-propagator.test.tsx
+++ b/packages/react-shopify-app-route-propagator/src/test/react-shopify-app-route-propagator.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import RoutePropagator, {REPLACE_STATE_MESSAGE, MODAL_IFRAME_NAME} from '..';
+
+jest.mock('../globals', () => {
+  return {
+    getOrigin: jest.fn(),
+    getTopWindow: jest.fn(),
+    getSelfWindow: jest.fn(),
+  };
+});
+
+const mockUtilities = require.requireMock('../globals');
+const {getOrigin, getTopWindow, getSelfWindow} = mockUtilities;
+
+describe('@shopify/react-shopify-app-route-propagator', () => {
+  const topWindow = {
+    name: '',
+    postMessage: jest.fn(),
+  };
+  const selfWindow = {
+    name: '',
+  };
+
+  beforeEach(() => {
+    getOrigin.mockImplementation(() => 'https://test.com');
+
+    topWindow.postMessage.mockClear();
+    getTopWindow.mockImplementation(() => topWindow);
+    getSelfWindow.mockImplementation(() => selfWindow);
+  });
+
+  it('sends a post message on mount', () => {
+    const path = '/settings';
+
+    const propagator = mount(<RoutePropagator location={path} />);
+
+    expect(topWindow.postMessage).toBeCalledWith(
+      replaceStateMessage(path),
+      '*',
+    );
+  });
+
+  it('sends a post message when the location updates', () => {
+    const propagator = mount(<RoutePropagator location="/settings" />);
+
+    const path = '/foo';
+    propagator.setProps({location: path});
+    propagator.update();
+
+    expect(topWindow.postMessage).toBeCalledWith(
+      replaceStateMessage(path),
+      '*',
+    );
+  });
+
+  describe('when window is window.top', () => {
+    it('does not send a post message on mount', () => {
+      getSelfWindow.mockImplementation(() => topWindow);
+
+      const propagator = mount(<RoutePropagator location="/settings" />);
+
+      expect(topWindow.postMessage).not.toBeCalled();
+    });
+
+    it('does not send a post message when the location updates', () => {
+      getSelfWindow.mockImplementation(() => topWindow);
+
+      const propagator = mount(<RoutePropagator location="/settings" />);
+
+      const path = '/foo';
+      propagator.setProps({location: path});
+      propagator.update();
+
+      expect(topWindow.postMessage).not.toBeCalled();
+    });
+  });
+
+  describe('when window is an iframe', () => {
+    it('does not send a post message on mount', () => {
+      getSelfWindow.mockImplementation(() => ({
+        name: MODAL_IFRAME_NAME,
+      }));
+      const propagator = mount(<RoutePropagator location="/settings" />);
+
+      expect(topWindow.postMessage).not.toBeCalled();
+    });
+
+    it('does not send a post message when the location updates', () => {
+      getSelfWindow.mockImplementation(() => ({
+        name: MODAL_IFRAME_NAME,
+      }));
+
+      const propagator = mount(<RoutePropagator location="/settings" />);
+
+      propagator.setProps({location: '/foo'});
+      propagator.update();
+
+      expect(topWindow.postMessage).not.toBeCalled();
+    });
+  });
+});
+
+function replaceStateMessage(location: string) {
+  return JSON.stringify({
+    message: REPLACE_STATE_MESSAGE,
+    data: {location},
+  });
+}

--- a/packages/react-shopify-app-route-propagator/tsconfig.json
+++ b/packages/react-shopify-app-route-propagator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5094,6 +5094,15 @@ react@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 read-cmd-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"


### PR DESCRIPTION
## Summary
This PR creates the `@shopify/EASDK-react-route-propagator` package.

It's goal is to keep the outer shopify window's location in synch with the iframe's path. It uses a similar solution to [michelle's solution](https://github.com/Shopify/sell-on-amazon/blob/b9e5468f744f2af55b76f010a1f41f52f5511b64/app/ui/foundation/Router/Router.tsx#L57).

This version is fully generic and doesn't need any specific routing library or depend on Polaris or the EASDK library.

## Questions
- should this be in polaris instead?
- should this depend on a different package?

## Testing this
Is a little involved. It seems that [redefining some window properties recently stopped working for jest](https://github.com/facebook/jest/issues/890), so there's no good way to test this on CI that I could find.

There's also no sample koa app atm, though I have one locally that will soon be in a repo.

That said, adding this to an existing embedded app should be trivial and the [README](https://github.com/Shopify/quilt/blob/4b86b24650b92c5a2213fead0d0da92260ce9411/packages/easdk-react-route-propagator/README.md)'s examples are from my own real experiments.