### PR TITLE
✨ add react-serialize package

### DIFF
--- a/packages/react-serialize/README.md
+++ b/packages/react-serialize/README.md
@@ -1,0 +1,9 @@
+# `@shopify/react-serialize`
+
+Provides an idiomatic way to serialize data for rehydration in a universal react application.
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-serialize
+```

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@shopify/react-serialize",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Provides an idiomatic way to serialize data for rehydration in a universal react application.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepublish": "yarn run build"
+  },
+  "publishConfig": {
+    "@shopify:registry": "https://packages.shopify.io/shopify/node/npm/"
+  },
+  "author": "Shopify Inc.",
+  "dependencies": {
+    "serialize-javascript": "^1.5.0"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
+  "devDependencies": {
+    "enzyme": "^3.3.0",
+    "typescript": "~2.7.2"
+  }
+}

--- a/packages/react-serialize/src/Serializer.tsx
+++ b/packages/react-serialize/src/Serializer.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import serialize from 'serialize-javascript';
+import {serializedID} from './utilities';
+
+export interface Props {
+  id: string;
+  data: any;
+  details?: {[key: string]: any};
+}
+
+export default function Serializer({id, data, details}: Props) {
+  const additionalProps = details
+    ? {'data-serialized-details': serialize(details)}
+    : {};
+
+  return (
+    <script
+      type="text/json"
+      id={serializedID(id)}
+      dangerouslySetInnerHTML={{__html: serialize(data)}}
+      {...additionalProps}
+    />
+  );
+}

--- a/packages/react-serialize/src/index.ts
+++ b/packages/react-serialize/src/index.ts
@@ -1,0 +1,2 @@
+export {default as Serializer} from './Serializer';
+export {getSerialized, Serialized} from './utilities';

--- a/packages/react-serialize/src/tests/Serializer.test.tsx
+++ b/packages/react-serialize/src/tests/Serializer.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import {shallow} from 'enzyme';
+import serialize from 'serialize-javascript';
+
+import Serializer from '../Serializer';
+import {serializedID} from '../utilities';
+
+describe('<Serializer />', () => {
+  const id = 'MyData';
+
+  it('generates a script tag with a JSON content type', () => {
+    const serializer = shallow(<Serializer id={id} data={{}} />);
+    expect(serializer.find('script')).toHaveLength(1);
+    expect(serializer.find('script').prop('type')).toBe('text/json');
+  });
+
+  describe('id', () => {
+    it('is used as part of the ID for the script', () => {
+      const serializer = shallow(<Serializer id={id} data={{}} />);
+      expect(serializer.find('script').prop('id')).toBe(serializedID(id));
+    });
+  });
+
+  describe('data', () => {
+    it('serializes the content as the child contents of the script tag', () => {
+      const data = {
+        foo: {bar: {baz: 'window.location = "http://dangerous.com"'}},
+      };
+
+      const serializer = shallow(<Serializer id={id} data={data} />);
+      expect(
+        serializer.find('script').prop('dangerouslySetInnerHTML'),
+      ).toHaveProperty('__html', serialize(data));
+    });
+  });
+
+  describe('details', () => {
+    it('does not include a data attribute with details if none are passed', () => {
+      const serializer = shallow(<Serializer id={id} data={{}} />);
+      expect(
+        serializer.find('script').prop('data-serialized-details'),
+      ).toBeUndefined();
+    });
+
+    it('includes a data attribute with the serialized details', () => {
+      const details = {
+        foo: {bar: {baz: 'window.location = "http://dangerous.com"'}},
+      };
+
+      const serializer = shallow(
+        <Serializer id={id} data={{}} details={details} />,
+      );
+      expect(serializer.find('script').prop('data-serialized-details')).toBe(
+        serialize(details),
+      );
+    });
+  });
+});

--- a/packages/react-serialize/src/tests/utilities.test.ts
+++ b/packages/react-serialize/src/tests/utilities.test.ts
@@ -1,0 +1,53 @@
+import serialize from 'serialize-javascript';
+import {getSerialized, serializedID} from '../utilities';
+
+describe('getSerialized()', () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = jest.spyOn(document, 'getElementById');
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it('queries for the serialized ID', () => {
+    spy.mockReturnValue(createFakeSerializedNode());
+    getSerialized('MyData');
+    expect(spy).toHaveBeenCalledWith(serializedID('MyData'));
+  });
+
+  it('throws if no node is found matching the ID', () => {
+    spy.mockReturnValue(null);
+    expect(() => getSerialized('MyData')).toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining('MyData'),
+      }),
+    );
+  });
+
+  it('returns the deserialized data', () => {
+    const data = {foo: 'window.location = "http://dangerous.com"'};
+    spy.mockReturnValue(createFakeSerializedNode(data));
+    expect(getSerialized('MyData').data).toMatchObject(data);
+  });
+
+  it('returns the empty details when none were provided', () => {
+    spy.mockReturnValue(createFakeSerializedNode());
+    expect(getSerialized('MyData').details).toEqual({});
+  });
+
+  it('returns the deserialized details', () => {
+    const details = {foo: 'window.location = "http://dangerous.com"'};
+    spy.mockReturnValue(createFakeSerializedNode({}, details));
+    expect(getSerialized('MyData').details).toMatchObject(details);
+  });
+});
+
+function createFakeSerializedNode(data: any = {}, details?: any) {
+  return {
+    innerHTML: serialize(data),
+    dataset: details ? {serializedDetails: serialize(details)} : {},
+  };
+}

--- a/packages/react-serialize/src/utilities.ts
+++ b/packages/react-serialize/src/utilities.ts
@@ -1,0 +1,24 @@
+export interface Serialized<Data, Details> {
+  data: Data;
+  details: Details;
+}
+
+export function getSerialized<Data = {}, Details = {}>(
+  id: string,
+): Serialized<Data, Details> {
+  const node = document.getElementById(serializedID(id));
+  if (node == null) {
+    throw new Error(`No serialized data found with the id '${id}'`);
+  }
+
+  const {serializedDetails} = node.dataset;
+
+  return {
+    data: JSON.parse(node.innerHTML),
+    details: serializedDetails ? JSON.parse(serializedDetails) : {},
+  };
+}
+
+export function serializedID(id: string) {
+  return `SerializedData-${id}`;
+}

--- a/packages/react-serialize/tsconfig.json
+++ b/packages/react-serialize/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5094,6 +5094,15 @@ react@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 read-cmd-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
@@ -5466,6 +5475,10 @@ sentence-case@^2.1.0:
   dependencies:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
+
+serialize-javascript@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This is actually a line-for-line port of the [web repo's serialize component](https://github.com/Shopify/neutron/blob/master/packages/%40shopify/react-serialize/Serializer.tsx#L7). 

Didn't have to change anything.

Required dependency of the `<HTML>` component, which I'll need pulled out before unite.