### PR TITLE
Explicitly set registry

### DIFF
--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -10,7 +10,8 @@
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
   "dependencies": {

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -10,7 +10,8 @@
     "prepublish": "yarn run build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
   "dependencies": {

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -10,7 +10,8 @@
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
   "dependencies": {

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -10,7 +10,8 @@
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
   "peerDependencies": {

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -10,7 +10,8 @@
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
   "devDependencies": {

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -10,7 +10,8 @@
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
   "dependencies": {


### PR DESCRIPTION
The private registry from previous lerna deploys is being cached and used as the registry for deploys. This PR explicitly sets the registry to the public one. 

In previous experiences we learned that lerna was setting the default registry to the public npm registry [here](https://github.com/lerna/lerna/blob/9c24a25d4e9053ee613f8c9111b1f053cbd1d008/utils/npm-conf/lib/defaults.js#L139). With that we assumed that the monorepo packages would be deployed to the public registry. 

Moving forward I strongly suggest we should update the [lerna shipit stack](https://github.com/Shopify/shipit-engine/blob/master/app/models/shipit/deploy_spec/lerna_discovery.rb#L57) to automate the public/private deploy like we do in the [npm shipit stack](https://github.com/Shopify/shipit-engine/blob/master/app/models/shipit/deploy_spec/npm_discovery.rb#L160)