### PR TITLE
💅 rename script apis

### DIFF
--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -64,7 +64,7 @@ The children to be rendered inside the `#app` div.
 Descriptors for any style tags you want to include in the HEAD of the document.
 
 **scripts**
-Descriptors for any deferred script tags you want to include at the end of the document.
+Descriptors for any script tags you want to include in your document. All scripts passed to this property will be deferred by appending them to the end of the document. We encourage this as a default, although you may use `blockingScripts` for any scripts that must be included in the HEAD of the document.
 
 **blockingScripts**
 Descriptors for any script tags you want to include in the HEAD of the document. These will block HTML parsing until they are evaluated, so use them carefully.

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -36,8 +36,8 @@ The component will automatically propagate any usage of the `react-helmet` modul
 export interface Props {
   children?: React.ReactNode;
   styles?: Asset[];
-  synchronousScripts?: Asset[];
-  deferedScripts?: Asset[];
+  scripts?: Asset[];
+  blockingScripts?: Asset[];
   headData?: {[id: string]: any};
   data?: {[id: string]: any};
 }
@@ -63,11 +63,11 @@ The children to be rendered inside the `#app` div.
 **styles**
 Descriptors for any style tags you want to include in the HEAD of the document.
 
-**synchronousScripts**
-Descriptors for any script tags you want to include in the HEAD of the document.
-
-**deferredScripts**
+**scripts**
 Descriptors for any deferred script tags you want to include at the end of the document.
+
+**blockingScripts**
+Descriptors for any script tags you want to include in the HEAD of the document. These will block HTML parsing until they are evaluated, so use them carefully.
 
 ### Serializers
 

--- a/packages/react-html/src/HTML.tsx
+++ b/packages/react-html/src/HTML.tsx
@@ -28,16 +28,16 @@ export interface Browser {
 export interface Props {
   children?: React.ReactNode;
   styles?: Asset[];
-  synchronousScripts?: Asset[];
-  deferedScripts?: Asset[];
+  blockingScripts?: Asset[];
+  scripts?: Asset[];
   headData?: {[id: string]: any};
   data?: {[id: string]: any};
 }
 
 export default function HTML({
   children = '',
-  deferedScripts = [],
-  synchronousScripts = [],
+  blockingScripts = [],
+  scripts = [],
   styles = [],
   data = {},
   headData = {},
@@ -59,7 +59,7 @@ export default function HTML({
     );
   });
 
-  const synchronousScriptsMarkup = synchronousScripts.map(script => {
+  const blockingScriptsMarkup = blockingScripts.map(script => {
     return (
       <Script
         key={script.path}
@@ -70,7 +70,7 @@ export default function HTML({
     );
   });
 
-  const deferedScriptsMarkup = deferedScripts.map(script => {
+  const deferredScriptsMarkup = scripts.map(script => {
     return (
       <Script
         key={script.path}
@@ -84,7 +84,7 @@ export default function HTML({
 
   /* eslint-disable no-process-env, no-undefined */
   const bodyStyles =
-    process.env.NODE_ENV === 'development' && deferedScripts.length > 0
+    process.env.NODE_ENV === 'development' && blockingScripts.length > 0
       ? {display: 'none'}
       : undefined;
   /* eslint-enable no-process-env, no-undefined */
@@ -106,7 +106,7 @@ export default function HTML({
         {stylesMarkup}
         {headDataMarkup}
 
-        {synchronousScriptsMarkup}
+        {blockingScriptsMarkup}
       </head>
 
       <body {...bodyAttributes} style={bodyStyles}>
@@ -118,7 +118,7 @@ export default function HTML({
 
         {dataMarkup}
 
-        {deferedScriptsMarkup}
+        {deferredScriptsMarkup}
       </body>
     </html>
   );

--- a/packages/react-html/src/tests/HTML.test.tsx
+++ b/packages/react-html/src/tests/HTML.test.tsx
@@ -36,15 +36,15 @@ describe('<HTML />', () => {
     expect(styles && styles.display).not.toBe('none');
   });
 
-  it('is not styled `display: none` on the host node when there are no deferred scripts', () => {
+  it('is not styled `display: none` on the host node when there are no scripts', () => {
     const app = withEnv('development', () => mount(<HTML {...mockProps} />));
     const styles = app.find('#app').prop('style');
     expect(styles && styles.display).not.toBe('none');
   });
 
-  it('sets the display to none on the document body in development when there are deferred scripts to prevent the flash of unstyled content', () => {
+  it('sets the display to none on the document body in development when there are scripts to prevent the flash of unstyled content', () => {
     const app = withEnv('development', () =>
-      mount(<HTML {...mockProps} deferedScripts={[{path: 'foo.js'}]} />),
+      mount(<HTML {...mockProps} blockingScripts={[{path: 'foo.js'}]} />),
     );
     expect(app.find('body').prop('style')).toMatchObject({
       display: 'none',
@@ -66,7 +66,7 @@ describe('<HTML />', () => {
   describe('deferedScripts', () => {
     it('generates a script tag in the body with the `defer` attribute', () => {
       const scripts = [{path: 'foo.js'}, {path: 'bar.js'}];
-      const html = mount(<HTML {...mockProps} deferedScripts={scripts} />);
+      const html = mount(<HTML {...mockProps} scripts={scripts} />);
       const body = html.find('body');
 
       for (const script of scripts) {
@@ -80,10 +80,10 @@ describe('<HTML />', () => {
     });
   });
 
-  describe('synchronousScripts', () => {
+  describe('blockingScripts', () => {
     it('generates a script tag in the head without the `defer` attribute', () => {
       const scripts = [{path: 'foo.js'}, {path: 'bar.js'}];
-      const html = mount(<HTML {...mockProps} synchronousScripts={scripts} />);
+      const html = mount(<HTML {...mockProps} blockingScripts={scripts} />);
       const head = html.find('head');
 
       for (const script of scripts) {
@@ -196,7 +196,7 @@ describe('<HTML />', () => {
         <HTML
           {...mockProps}
           headData={headData}
-          synchronousScripts={[{path: 'foo.js'}]}
+          blockingScripts={[{path: 'foo.js'}]}
         />,
       );
       const headContents = html.find('head').children();
@@ -241,7 +241,7 @@ describe('<HTML />', () => {
     it('renders the serializers in the body before the defered scripts', () => {
       const data = {foo: {bar: 'baz'}};
       const html = mount(
-        <HTML {...mockProps} data={data} deferedScripts={[{path: 'foo.js'}]} />,
+        <HTML {...mockProps} data={data} scripts={[{path: 'foo.js'}]} />,
       );
       const bodyContents = html.find('body').children();
       const serializerIndex = findIndex(


### PR DESCRIPTION
closes #96 

This PR is a **breaking change** 💥  to the `<HTML>` component. We make some changes to the naming on the api of the HTML component.

#### What?
- `deferredScripts` renamed to `scripts`
- `synchronousScripts` renamed to `blockingScripts`

#### Why?
- The current naming for `deferedScripts` and `synchronousScripts` is not really as clear as it could be. 
- `deferedScripts` is a typo
- We want to encourage people to think of deferred scripts as the default, and synchronous scripts as blocking.

**This will necessitate a major version bump**