### PR TITLE
💥💅 standardize auth middleware names to match common koa patterns

### DIFF
--- a/packages/koa-shopify-auth/README.md
+++ b/packages/koa-shopify-auth/README.md
@@ -14,39 +14,39 @@ $ yarn add @shopify/koa-shopify-auth
 
 ## Usage
 
-This package exposes `createShopifyAuth` by default, and `createVerifyRequest` as a named export.
+This package exposes `shopifyAuth` by default, and `verifyRequest` as a named export.
 
 ```js
-import createShopifyAuth, {
-  createVerifyRequest,
-} from '@shopify/koa-shopify-auth';
+import shopifyAuth, {verifyRequest} from '@shopify/koa-shopify-auth';
 ```
 
-### createShopifyAuth
+### shopifyAuth
 
 Returns an authentication middleware taking up (by default) the routes `/auth` and `/auth/callback`.
 
-```javascript
-createShopifyAuth({
-  // if specified, mounts the routes off of the given path
-  // eg. /shopify/auth, /shopify/auth/callback
-  // defaults to ''
-  prefix: '/shopify',
-  // your shopify app api key
-  apiKey: SHOPIFY_API_KEY,
-  // your shopify app secret
-  secret: SHOPIFY_SECRET,
-  // scopes to request on the merchants store
-  scopes: ['write_orders, write_products'],
-  // callback for when auth is completed
-  afterAuth(ctx) {
-    const {shop, accessToken} = ctx.session;
+```js
+app.use(
+  shopifyAuth({
+    // if specified, mounts the routes off of the given path
+    // eg. /shopify/auth, /shopify/auth/callback
+    // defaults to ''
+    prefix: '/shopify',
+    // your shopify app api key
+    apiKey: SHOPIFY_API_KEY,
+    // your shopify app secret
+    secret: SHOPIFY_SECRET,
+    // scopes to request on the merchants store
+    scopes: ['write_orders, write_products'],
+    // callback for when auth is completed
+    afterAuth(ctx) {
+      const {shop, accessToken} = ctx.session;
 
-    console.log('We did it!', accessToken);
+      console.log('We did it!', accessToken);
 
-    ctx.redirect('/');
-  },
-}),
+      ctx.redirect('/');
+    },
+  }),
+);
 ```
 
 #### `/auth`
@@ -57,13 +57,13 @@ This route starts the oauth process. It expects a `?shop` parameter and will err
 
 You should never have to manually go here. This route is purely for shopify to send data back during the oauth process.
 
-### createVerifyRequest
+### verifyRequest
 
 Returns a middleware to verify requests before letting them further in the chain.
 
 ```javascript
 app.use(
-  createVerifyRequest({
+  verifyRequest({
     // path to redirect to if verification fails
     // defaults to '/auth'
     authRoute: '/foo/auth',
@@ -81,9 +81,7 @@ import 'isomorphic-fetch';
 
 import Koa from 'koa';
 import session from 'koa-session';
-import createShopifyAuth, {
-  createVerifyRequest,
-} from '@shopify/koa-shopify-auth';
+import shopifyAuth, {verifyRequest} from '@shopify/koa-shopify-auth';
 
 const {SHOPIFY_API_KEY, SHOPIFY_SECRET} = process.env;
 
@@ -96,7 +94,7 @@ app
 
   // sets up shopify auth
   .use(
-    createShopifyAuth({
+    shopifyAuth({
       apiKey: SHOPIFY_API_KEY,
       secret: SHOPIFY_SECRET,
       scopes: ['write_orders, write_products'],
@@ -111,7 +109,7 @@ app
   )
 
   // everything after this point will require authentication
-  .use(createVerifyRequest())
+  .use(verifyRequest())
 
   // application code
   .use(() => {
@@ -127,4 +125,4 @@ This app uses `fetch` to make requests against shopify, and expects you to have 
 
 ### Session
 
-Though you can use `createShopifyAuth` without a session middleware configured, `createVerifyRequest` expects you to have one. If you don't want to use one and have some other solution to persist your credentials, you'll need to build your own verifiction function.
+Though you can use `shopifyAuth` without a session middleware configured, `verifyRequest` expects you to have one. If you don't want to use one and have some other solution to persist your credentials, you'll need to build your own verifiction function.

--- a/packages/koa-shopify-auth/src/index.ts
+++ b/packages/koa-shopify-auth/src/index.ts
@@ -1,7 +1,7 @@
-import createAuthRouter from './auth';
+import shopifyAuth from './auth';
 
-export default createAuthRouter;
+export default shopifyAuth;
 
 export * from './auth';
 
-export {default as createVerifyRequest} from './verify-request';
+export {default as verifyRequest} from './verify-request';

--- a/packages/koa-shopify-auth/src/verify-request/index.ts
+++ b/packages/koa-shopify-auth/src/verify-request/index.ts
@@ -1,3 +1,3 @@
-import createVerifyRequest from './create-verify-request';
+import createVerifyRequest from './verify-request';
 
 export default createVerifyRequest;

--- a/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
+++ b/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
@@ -1,13 +1,13 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
-import createVerifyRequest from '../create-verify-request';
+import verifyRequest from '../verify-request';
 
 describe('verifyRequest', () => {
   it('calls next if there is an accessToken on session', () => {
-    const verifyRequest = createVerifyRequest();
+    const verifyRequestMiddleware = verifyRequest();
     const ctx = createMockContext({session: {accessToken: 'test'}});
     const next = jest.fn();
 
-    verifyRequest(ctx, next);
+    verifyRequestMiddleware(ctx, next);
 
     expect(next).toBeCalled();
   });
@@ -15,27 +15,27 @@ describe('verifyRequest', () => {
   it('redirects to /auth if there is no accessToken but shop is present on query', () => {
     const shop = 'myshop.com';
 
-    const verifyRequest = createVerifyRequest();
+    const verifyRequestMiddleware = verifyRequest();
     const next = jest.fn();
     const ctx = createMockContext({
       url: `/foo?shop=${shop}`,
       redirect: jest.fn(),
     });
 
-    verifyRequest(ctx, next);
+    verifyRequestMiddleware(ctx, next);
 
     expect(ctx.redirect).toBeCalledWith(`/auth?shop=${shop}`);
   });
 
   it('redirects to the /auth when there is no accessToken or known shop', () => {
-    const verifyRequest = createVerifyRequest();
+    const verifyRequestMiddleware = verifyRequest();
 
     const next = jest.fn();
     const ctx = createMockContext({
       redirect: jest.fn(),
     });
 
-    verifyRequest(ctx, next);
+    verifyRequestMiddleware(ctx, next);
 
     expect(ctx.redirect).toBeCalledWith('/auth');
   });
@@ -44,28 +44,28 @@ describe('verifyRequest', () => {
     const shop = 'myshop.com';
     const authRoute = '/my-auth-route';
 
-    const verifyRequest = createVerifyRequest({authRoute});
+    const verifyRequestMiddleware = verifyRequest({authRoute});
     const next = jest.fn();
     const ctx = createMockContext({
       url: `/foo?shop=${shop}`,
       redirect: jest.fn(),
     });
 
-    verifyRequest(ctx, next);
+    verifyRequestMiddleware(ctx, next);
 
     expect(ctx.redirect).toBeCalledWith(`${authRoute}?shop=${shop}`);
   });
 
   it('redirects to the given fallbackRoute when there is no accessToken or known shop', () => {
     const fallbackRoute = '/somewhere-on-the-app';
-    const verifyRequest = createVerifyRequest({fallbackRoute});
+    const verifyRequestMiddleware = verifyRequest({fallbackRoute});
 
     const next = jest.fn();
     const ctx = createMockContext({
       redirect: jest.fn(),
     });
 
-    verifyRequest(ctx, next);
+    verifyRequestMiddleware(ctx, next);
 
     expect(ctx.redirect).toBeCalledWith(fallbackRoute);
   });

--- a/packages/koa-shopify-auth/src/verify-request/verify-request.ts
+++ b/packages/koa-shopify-auth/src/verify-request/verify-request.ts
@@ -7,11 +7,14 @@ export interface Options {
   fallbackRoute?: string;
 }
 
-export default function createVerifyRequest({
+export default function verifyRequest({
   authRoute = '/auth',
   fallbackRoute = '/auth',
 }: Options = {}) {
-  return async function verifyRequest(ctx: Context, next: NextFunction) {
+  return async function verifyRequestMiddleware(
+    ctx: Context,
+    next: NextFunction,
+  ) {
     const {query: {shop}, session} = ctx;
 
     if (session && session.accessToken) {


### PR DESCRIPTION
This is a **breaking change 💥** to `@shopify/koa-shopify-auth` that aims to bring our middleware naming more in line with how the community names koa middleware.

#### What?
- `createShopifyAuth` renamed to `shopifyAuth`
- `createVerifyRequest` renamed to `verifyRequest`
- update docs

#### Why?
Currently in our documentation and named exports we're encouraging a style that is not really inline with how the rest of the koa community is naming things.

Most koa middleware (eg. `koa-session`, `koa-mount`, `koa-router`) use a factory type interface `session({config})`, but do not name themselves anything to do with that.

This makes our middleware factories a bit weird and ugly by comparison, and feels a bit frictiony with the ecosystem (even if it's a bit more correct to what's actually going on).

**This will necessitate a major version bump**
