### PR TITLE
Return middleware from proxy package

### DIFF
--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -8,45 +8,47 @@ export interface SessionContext extends Context {
 export const PROXY_BASE_PATH = '/graphql';
 export const GRAPHQL_PATH = '/admin/api/graphql.json';
 
-export default async function shopifyGraphQLProxy(
-  ctx: SessionContext,
-  next: () => Promise<any>,
-) {
-  const {session = {}} = ctx;
-  const {accessToken, shop} = session;
+export default function shopifyGraphQLProxy() {
+  return async function shopifyGraphQLProxyMiddleware(
+    ctx: SessionContext,
+    next: () => Promise<any>,
+  ) {
+    const {session = {}} = ctx;
+    const {accessToken, shop} = session;
 
-  if (ctx.path !== PROXY_BASE_PATH || ctx.method !== 'POST') {
-    await next();
-    return;
-  }
+    if (ctx.path !== PROXY_BASE_PATH || ctx.method !== 'POST') {
+      await next();
+      return;
+    }
 
-  if (accessToken == null || shop == null) {
-    ctx.throw(403, 'Unauthorized');
-    return;
-  }
+    if (accessToken == null || shop == null) {
+      ctx.throw(403, 'Unauthorized');
+      return;
+    }
 
-  await proxy(shop, {
-    https: true,
-    parseReqBody: false,
-    // Setting request header here, not response. That's why we don't use ctx.set()
-    // proxy middleware will grab this request header
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Shopify-Access-Token': accessToken,
-    },
-    proxyReqPathResolver() {
-      return `https://${shop}${GRAPHQL_PATH}`;
-    },
-  })(
-    ctx,
+    await proxy(shop, {
+      https: true,
+      parseReqBody: false,
+      // Setting request header here, not response. That's why we don't use ctx.set()
+      // proxy middleware will grab this request header
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Shopify-Access-Token': accessToken,
+      },
+      proxyReqPathResolver() {
+        return `https://${shop}${GRAPHQL_PATH}`;
+      },
+    })(
+      ctx,
 
-    /*
-      We want this middleware to terminate, not fall through to the next in the chain,
-      but sadly it doesn't support not passing a `next` function. To get around this we
-      just pass our own dummy `next` that resolves immediately.
-    */
-    noop,
-  );
+      /*
+        We want this middleware to terminate, not fall through to the next in the chain,
+        but sadly it doesn't support not passing a `next` function. To get around this we
+        just pass our own dummy `next` that resolves immediately.
+      */
+      noop,
+    );
+  };
 }
 
 async function noop() {}

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -17,18 +17,21 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('throws when no session is provided', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
       method: 'POST',
       throw: jest.fn(),
     });
 
-    await koaShopifyGraphQLProxy(ctx, jest.fn());
+    await koaShopifyGraphQLProxyMiddleware(ctx, jest.fn());
 
     expect(ctx.throw).toBeCalledWith(403, 'Unauthorized');
   });
 
   it('throws when no accessToken is on session', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
       method: 'POST',
@@ -36,12 +39,13 @@ describe('koa-shopify-graphql-proxy', () => {
       session: {shop: 'shop1.myshopify.com'},
     });
 
-    await koaShopifyGraphQLProxy(ctx, jest.fn());
+    await koaShopifyGraphQLProxyMiddleware(ctx, jest.fn());
 
     expect(ctx.throw).toBeCalledWith(403, 'Unauthorized');
   });
 
   it('throws when no shop is on session', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
       method: 'POST',
@@ -49,12 +53,13 @@ describe('koa-shopify-graphql-proxy', () => {
       session: {accessToken: 'sdfasdf'},
     });
 
-    await koaShopifyGraphQLProxy(ctx, jest.fn());
+    await koaShopifyGraphQLProxyMiddleware(ctx, jest.fn());
 
     expect(ctx.throw).toBeCalledWith(403, 'Unauthorized');
   });
 
   it('bails and calls next if method is not POST', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const ctx = createMockContext({
       url: '/graphql',
       method: 'GET',
@@ -63,13 +68,14 @@ describe('koa-shopify-graphql-proxy', () => {
     });
     const nextSpy = jest.fn();
 
-    await koaShopifyGraphQLProxy(ctx, nextSpy);
+    await koaShopifyGraphQLProxyMiddleware(ctx, nextSpy);
 
     expect(nextSpy).toBeCalled();
     expect(proxyFactory).not.toBeCalled();
   });
 
   it('bails and calls next if path does not start with the base url', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const ctx = createMockContext({
       url: '/not/graphql',
       throw: jest.fn(),
@@ -77,13 +83,14 @@ describe('koa-shopify-graphql-proxy', () => {
     });
     const nextSpy = jest.fn();
 
-    await koaShopifyGraphQLProxy(ctx, nextSpy);
+    await koaShopifyGraphQLProxyMiddleware(ctx, nextSpy);
 
     expect(nextSpy).toBeCalled();
     expect(proxyFactory).not.toBeCalled();
   });
 
   it('does not bail or throw when request is for the graphql api', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
       method: 'POST',
@@ -92,13 +99,14 @@ describe('koa-shopify-graphql-proxy', () => {
     });
     const nextSpy = jest.fn();
 
-    await koaShopifyGraphQLProxy(ctx, nextSpy);
+    await koaShopifyGraphQLProxyMiddleware(ctx, nextSpy);
 
     expect(nextSpy).not.toBeCalled();
     expect(ctx.throw).not.toBeCalledWith(403, 'Unauthorized');
   });
 
   it('configures a custom koa-better-http-proxy', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const accessToken = 'asdfasdf';
     const shop = 'i-sell-things.myshopify.com';
 
@@ -109,7 +117,7 @@ describe('koa-shopify-graphql-proxy', () => {
       session: {accessToken, shop},
     });
 
-    await koaShopifyGraphQLProxy(ctx, jest.fn());
+    await koaShopifyGraphQLProxyMiddleware(ctx, jest.fn());
 
     const [host, config] = proxyFactory.mock.calls[0];
     expect(host).toBe(shop);
@@ -125,6 +133,7 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('passes a proxyReqPathResolver that returns full shop url', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const shop = 'some-shop.myshopify.com';
 
     const ctx = createMockContext({
@@ -134,13 +143,14 @@ describe('koa-shopify-graphql-proxy', () => {
       session: {accessToken: 'sdfasdf', shop},
     });
 
-    await koaShopifyGraphQLProxy(ctx, jest.fn());
+    await koaShopifyGraphQLProxyMiddleware(ctx, jest.fn());
 
     const {proxyReqPathResolver} = proxyFactory.mock.calls[0][1];
     expect(proxyReqPathResolver(ctx)).toBe(`https://${shop}${GRAPHQL_PATH}`);
   });
 
   it('terminates middleware chain when proxying (does not call next)', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const shop = 'some-shop.myshopify.com';
 
     const ctx = createMockContext({
@@ -151,7 +161,7 @@ describe('koa-shopify-graphql-proxy', () => {
     });
     const nextSpy = jest.fn();
 
-    await koaShopifyGraphQLProxy(ctx, nextSpy);
+    await koaShopifyGraphQLProxyMiddleware(ctx, nextSpy);
     expect(nextSpy).not.toBeCalled();
   });
 });


### PR DESCRIPTION
In effort to maintain a consistent interface for the quilt koa middleware, this PR wraps the `shopify-graphql-poxy` in a function that returns the actual middleware itself.

**Note** this is a breaking change. Usage of the middleware will change as follows:

```
const app = new Koa()

// old way
app.use(graphQLProxy)

// new way
app.use(graphQLProxy())
```

Open to criticism against this change as well.

cc/ @leo-shopify