### PR TITLE
🗒️ add badges to package READMEs

### DIFF
--- a/packages/enzyme-utilities/README.md
+++ b/packages/enzyme-utilities/README.md
@@ -1,5 +1,8 @@
 # `@shopify/enzyme-utilities`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities)
+
 Enzyme utilities for testing React components.
 
 ## Installation

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -1,5 +1,8 @@
 # `@shopify/jest-dom-mocks`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks)
+
 Jest mocking utilities for working with the DOM.
 
 ## Installation

--- a/packages/jest-koa-mocks/README.md
+++ b/packages/jest-koa-mocks/README.md
@@ -1,5 +1,8 @@
 # `@shopify/jest-koa-mocks`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks)
+
 Utilities to easily stub Koa context and cookies. The utilities are designed to help you write unit tests for your koa middleware without needing to set up any kind of actual server in your test environment. When test writing is easy and fun you'll want to write more tests. ✨😎
 
 ## Installation

--- a/packages/jest-mock-apollo/README.md
+++ b/packages/jest-mock-apollo/README.md
@@ -1,5 +1,8 @@
 # `@shopify/jest-mock-apollo`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo)
+
 Jest + Enzyme mocks for Apollo 2.x.
 
 ## Installation

--- a/packages/jest-mock-router/README.md
+++ b/packages/jest-mock-router/README.md
@@ -1,5 +1,8 @@
 # `@shopify/jest-mock-router`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-router.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-router)
+
 Jest + Enzyme mocks for React Router 3.x.
 
 ## Installation

--- a/packages/koa-shopify-auth/README.md
+++ b/packages/koa-shopify-auth/README.md
@@ -1,5 +1,8 @@
 # `@shopify/koa-shopify-auth`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth)
+
 Middleware to authenticate a [Koa](http://koajs.com/) application with [Shopify](https://www.shopify.ca/).
 
 Sister module to [`@shopify/shopify-express`](https://www.npmjs.com/package/@shopify/shopify-express), but simplified.

--- a/packages/koa-shopify-graphql-proxy/README.md
+++ b/packages/koa-shopify-graphql-proxy/README.md
@@ -1,5 +1,8 @@
 # `@shopify/koa-shopify-graphql-proxy`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy)
+
 A wrapper around koa-better-http-proxy which allows easy proxying of graphql requests from an embedded shopify app.
 
 ## Installation

--- a/packages/react-compose/README.md
+++ b/packages/react-compose/README.md
@@ -1,5 +1,8 @@
 # `@shopify/react-compose`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-compose.svg)](https://badge.fury.io/js/%40shopify%2Freact-compose) ![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-compose.svg)
+
 Cleanly compose multiple component enhancers together with minimal fuss.
 
 ## Installation

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -1,5 +1,9 @@
 # `@shopify/react-html`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt) [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-html.svg)](https://badge.fury.io/js/%40shopify%2Freact-html)
+
+A component to render your react app with no static HTML.
+
 ## Installation
 
 ```bash

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-html",
   "version": "2.0.7",
   "license": "MIT",
-  "description": "",
+  "description": "A component to render your react app with no static HTML.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -24,9 +24,11 @@
   "homepage": "https://github.com/shopify/quilt/packages/react-html/README.md",
   "dependencies": {
     "@shopify/react-serialize": "^1.0.3",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0"
+  },
+  "peerDependencies": {
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
   },
   "devDependencies": {
     "typescript": "~2.7.2"

--- a/packages/react-serialize/README.md
+++ b/packages/react-serialize/README.md
@@ -1,5 +1,8 @@
 # `@shopify/react-serialize`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-serialize.svg)](https://badge.fury.io/js/%40shopify%2Freact-serialize) ![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-serialize.svg)
+
 Provides an idiomatic way to serialize data for rehydration in a universal react application.
 
 ## Installation

--- a/packages/react-shopify-app-route-propagator/README.md
+++ b/packages/react-shopify-app-route-propagator/README.md
@@ -1,5 +1,8 @@
 # `@shopify/react-shopify-app-route-propagator`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator.svg)](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator) ![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-shopify-app-route-propagator.svg)
+
 `<ShopifyRoutePropagator />` is a simple component to synchronize a Shopify embedded app's client side routing with the outer iframe host.
 
 The component is quite small and can be used with any routing solution.

--- a/packages/with-env/README.md
+++ b/packages/with-env/README.md
@@ -1,5 +1,8 @@
 # `@shopify/with-env`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator.svg)](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator)
+
 A utility for executing code under a specific NODE_ENV.
 
 ## Installation

--- a/plopfile.js
+++ b/plopfile.js
@@ -13,6 +13,11 @@ module.exports = function(plop) {
         name: 'description',
         message: "What should this package's description be?",
       },
+      {
+        type: 'confirm',
+        name: 'usedInBrowser',
+        message: 'Is this package intended for use in the browser?',
+      },
     ],
     actions: [
       {

--- a/templates/README.hbs.md
+++ b/templates/README.hbs.md
@@ -1,5 +1,8 @@
 # `@shopify/{{name}}`
 
+[![CircleCI](https://circleci.com/gh/Shopify/quilt.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2F{{name}}.svg)](https://badge.fury.io/js/%40shopify%2F{{name}}.svg) {{#if usedInBrowser}} [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg) {{/if}}
+
 {{description}}
 
 ## Installation
@@ -7,3 +10,5 @@
 ```bash
 $ yarn add @shopify/{{name}}
 ```
+
+## Usage


### PR DESCRIPTION
closes #122 
closes #116 

This PR does a bit of tidying in our package.jsons and READMEs.

Notably we add badges to our package README's showing the current version, license, and test status (and for client side packages, the minzipped size). This is handy for users because they will likely arrive at the repo from NPM, or even only ever see the README from the npm UI.

![image](https://user-images.githubusercontent.com/4889856/40387870-ee56dba2-5ddb-11e8-8c4e-0b5cbfc91a3b.png)
