### PR TITLE
Fix graphql-proxy homepage link

### DIFF
--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },
-  "homepage": "https://github.com/shopify/quilt/packages/koa-shopify-graphql-proxy/README.md",
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/koa-shopify-graphql-proxy/README.md",
   "dependencies": {
     "koa-better-http-proxy": "^0.2.4"
   },


### PR DESCRIPTION
If you go [here](https://www.npmjs.com/package/@shopify/koa-shopify-graphql-proxy) and click 'homepage' it doesn't work. This should fix that.