### PR TITLE
✅ test package name validity

### DIFF
--- a/test/consistent-package-names.ts
+++ b/test/consistent-package-names.ts
@@ -1,0 +1,23 @@
+import {readdirSync, readFileSync} from 'fs';
+import * as path from 'path';
+
+describe('package name', () => {
+  it('matches the path name', () => {
+    const packagesPath = path.resolve(__dirname, '..', 'packages');
+    const packageNames = readdirSync(packagesPath);
+
+    for (const packageName of packageNames) {
+      const packageJSONPath = path.join(
+        packagesPath,
+        packageName,
+        'package.json',
+      );
+
+      const packageJSON = JSON.parse(
+        readFileSync(packageJSONPath, {encoding: 'utf8'}),
+      );
+
+      expect(packageJSON.name).toBe(packageName);
+    }
+  });
+});

--- a/test/consistent-package-names.ts
+++ b/test/consistent-package-names.ts
@@ -1,4 +1,4 @@
-import {readdirSync, readFileSync} from 'fs';
+import {readdirSync, readFileSync, existsSync} from 'fs';
 import * as path from 'path';
 
 describe('package name', () => {
@@ -12,6 +12,10 @@ describe('package name', () => {
         packageName,
         'package.json',
       );
+
+      if (!existsSync(packageJSONPath)) {
+        continue;
+      }
 
       const packageJSON = JSON.parse(
         readFileSync(packageJSONPath, {encoding: 'utf8'}),

--- a/test/typescript-version.test.ts
+++ b/test/typescript-version.test.ts
@@ -2,7 +2,7 @@ import {readdirSync, readFileSync} from 'fs';
 import * as path from 'path';
 
 describe('typescript version', () => {
-  it('the version in each package matches the root version', () => {
+  it('matches the root version', () => {
     const rootPackageJSON = require('../package.json');
     const rootVersion = rootPackageJSON.devDependencies.typescript;
 


### PR DESCRIPTION
closes #37 

This PR adds a test to make sure that package names in the repo match their directory name. This should prevent our releases from failing by stopping people from merging packages with malformed setups.