### PR TITLE
Add troubleshooting note for withRouter type issues

### DIFF
--- a/packages/react-shopify-app-route-propagator/README.md
+++ b/packages/react-shopify-app-route-propagator/README.md
@@ -72,6 +72,14 @@ export default function() {
 }
 ```
 
+#### `react-router` typescript issues
+
+`withRouter` has a strict type definition for the component it wraps. The component is expected to require the entire WithRouterProps prop definition. If you're getting a type error on the `ShopifyRoutePropagator` component, you can cast it to `any` when passing it in to withRouter.
+
+```javascript
+const Propagator = withRouter(ShopifyRoutePropagator as any);
+```
+
 ### With React Router (`<Route>`)
 
 If you prefer things more explicit you can just get the `location` value to pass in explicitly by using `<Route>`'s children as a render prop.


### PR DESCRIPTION
`withRouter` is overly strict about its type definition for wrapped component. Just adding a note in the README to work around this. Hopefully, we can get a fix in `react-router` to loosen the type on the wrapped component.