### PR TITLE
No, but really

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,6 +1,6 @@
 ci:
   require:
-    - continuous-integration/travis-ci
+    - continuous-integration/travis-ci/push
 dependencies:
   post:
     - yarn run build


### PR DESCRIPTION
So, it turns out that shipit does indeed require a complete check name, and not just a prefix like github does.