### PR TITLE
Fix display: none styling on HTML component

### DIFF
--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -47,6 +47,7 @@ export interface Props {
   blockingScripts?: Asset[];
   headData?: {[id: string]: any};
   data?: {[id: string]: any};
+  hideForInitialLoad?: boolean;
 }
 
 interface Asset {
@@ -75,6 +76,9 @@ Descriptors for any script tags you want to include in your document. All script
 
 **blockingScripts**
 Descriptors for any script tags you want to include in the HEAD of the document. These will block HTML parsing until they are evaluated, so use them carefully.
+
+**hideForInitialLoad**
+Sets the body contents to be hidden for the initial render. Use this using Sewing Kit/ Webpack to inject styles dynamically in development in order to prevent a flash of unstyled content.
 
 ### Serializers
 

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -78,7 +78,7 @@ Descriptors for any script tags you want to include in your document. All script
 Descriptors for any script tags you want to include in the HEAD of the document. These will block HTML parsing until they are evaluated, so use them carefully.
 
 **hideForInitialLoad**
-Sets the body contents to be hidden for the initial render. Use this using Sewing Kit/ Webpack to inject styles dynamically in development in order to prevent a flash of unstyled content.
+Sets the body contents to be hidden for the initial render. Use this when injecting stylesheets dynamically in development in order to prevent a flash of unstyled content.
 
 ### Serializers
 

--- a/packages/react-html/src/HTML.tsx
+++ b/packages/react-html/src/HTML.tsx
@@ -32,6 +32,7 @@ export interface Props {
   scripts?: Asset[];
   headData?: {[id: string]: any};
   data?: {[id: string]: any};
+  hideForInitialLoad?: boolean;
 }
 
 export default function HTML({
@@ -41,6 +42,7 @@ export default function HTML({
   styles = [],
   data = {},
   headData = {},
+  hideForInitialLoad,
 }: Props) {
   const markup = renderToString(children);
   const helmet = Helmet.renderStatic();
@@ -83,10 +85,7 @@ export default function HTML({
   });
 
   /* eslint-disable no-process-env, no-undefined */
-  const bodyStyles =
-    process.env.NODE_ENV === 'development' && blockingScripts.length > 0
-      ? {display: 'none'}
-      : undefined;
+  const bodyStyles = hideForInitialLoad ? {display: 'none'} : undefined;
   /* eslint-enable no-process-env, no-undefined */
 
   const headDataMarkup = Object.keys(headData).map(id => {

--- a/packages/react-html/src/HTML.tsx
+++ b/packages/react-html/src/HTML.tsx
@@ -84,9 +84,9 @@ export default function HTML({
     );
   });
 
-  /* eslint-disable no-process-env, no-undefined */
+  /* eslint-disable no-undefined */
   const bodyStyles = hideForInitialLoad ? {display: 'none'} : undefined;
-  /* eslint-enable no-process-env, no-undefined */
+  /* eslint-enable no-undefined */
 
   const headDataMarkup = Object.keys(headData).map(id => {
     return <Serializer key={id} id={id} data={headData[id]} />;

--- a/packages/react-html/src/tests/HTML.test.tsx
+++ b/packages/react-html/src/tests/HTML.test.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {mount, CommonWrapper} from 'enzyme';
 import {HelmetData} from 'react-helmet';
 import {Serializer} from '@shopify/react-serialize';
-import withEnv from '@shopify/with-env';
 
 import {Script, Style} from '../components';
 import HTML, {Props} from '../HTML';
@@ -30,24 +29,18 @@ describe('<HTML />', () => {
     expect(html.find('html').prop('lang')).toBe('en');
   });
 
-  it('is not styled `display: none` on host node in production', () => {
-    const app = withEnv('production', () => mount(<HTML {...mockProps} />));
-    const styles = app.find('#app').prop('style');
-    expect(styles && styles.display).not.toBe('none');
-  });
+  describe('hideForInitialLoad', () => {
+    it('does not hide the contents by default', () => {
+      const app = mount(<HTML {...mockProps} />);
+      const styles = app.find('#app').prop('style') || {};
+      expect(styles).not.toHaveProperty('display');
+    });
 
-  it('is not styled `display: none` on the host node when there are no scripts', () => {
-    const app = withEnv('development', () => mount(<HTML {...mockProps} />));
-    const styles = app.find('#app').prop('style');
-    expect(styles && styles.display).not.toBe('none');
-  });
-
-  it('sets the display to none on the document body in development when there are scripts to prevent the flash of unstyled content', () => {
-    const app = withEnv('development', () =>
-      mount(<HTML {...mockProps} blockingScripts={[{path: 'foo.js'}]} />),
-    );
-    expect(app.find('body').prop('style')).toMatchObject({
-      display: 'none',
+    it('hides the contents when true', () => {
+      const app = mount(<HTML {...mockProps} hideForInitialLoad />);
+      expect(app.find('body').prop('style')).toMatchObject({
+        display: 'none',
+      });
     });
   });
 


### PR DESCRIPTION
Will fix https://github.com/Shopify/web/issues/4527. When this was brought over, the condition on when to hide the body was incorrectly set to be based on blocking scripts. This PR fixes this by having an explicit prop for it instead, which makes this a little less magical and a little more flexible for consumers.

cc/ @ismail-syed when I applied this locally it fixed the issue /shrug