### PR TITLE
Fix types in jest-koa-mocks

### DIFF
--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -11,7 +11,7 @@ export interface Dictionary<T> {
 
 export interface MockContext extends Context {
   cookies: MockCookies;
-  request: Context['Request'] & {
+  request: Context['request'] & {
     body?: any;
     session?: any;
   };


### PR DESCRIPTION
This only kinda worked before. It used to output an `any` type, because `Context` had a `string -> any` key signature. That signature was recently removed from the `@types/koa` package across a patch version, which broke some consuming packages of `jest-koa-mocks`.