### PR TITLE
🎉 [New Package] create @shopify/react-form-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository uses [lerna](https://github.com/lerna/lerna) to manage it's pack
 | koa-shopify-graphql-proxy | [README](packages/koa-shopify-graphql-proxy/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy) |
 | logger | [README](packages/logger/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Flogger.svg)](https://badge.fury.io/js/%40shopify%2Flogger) |
 | react-compose | [README](packages/react-compose/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-compose.svg)](https://badge.fury.io/js/%40shopify%2Freact-compose) |
+| react-form-state | [README](packages/react-form-state/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
 | react-html | [README](packages/react-html/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-html.svg)](https://badge.fury.io/js/%40shopify%2Freact-html) |
 | react-preconnect | [README](packages/react-preconnect/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-preconnect.svg)](https://badge.fury.io/js/%40shopify%2Freact-preconnect) |
 | react-serialize | [README](packages/react-serialize/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-serialize.svg)](https://badge.fury.io/js/%40shopify%2Freact-serialize) |

--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -1,0 +1,54 @@
+# `@shopify/react-form-state`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-formwell.svg)](https://badge.fury.io/js/%40shopify%2Freact-formwell.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-formwell.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-formwell.svg)
+
+Manage react forms tersely and safely-typed with no magic.
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-form-state
+```
+
+## Usage
+
+### `<FormState />`
+
+The default component exported by this library is `<FormState />`.
+
+```typescript
+import FormState from '@shopify/react-form-state';
+```
+
+```typescript
+// Fields here refers to the inferred type of your initialValues object
+interface Props<Fields> {
+  initialValues: Fields;
+  validators?: Partial<ValidatorDictionary<Fields>>;
+  onSubmit?: SubmitHandler<Fields>;
+  children(form: FormDetails<Fields>): React.ReactNode;
+}
+```
+
+Its only mandatory props are `initialValues` and `children`. The `initialValues` prop is used to infer all the types for the rest of the component, and to generate handlers and field state objects. The `children` prop expects a function of the current state of the form, which is represented by a `FormDetails` object.
+
+```typescript
+<FormState initialValues={myInitialValues}>
+  {({fields, dirty, valid, submitting, errors, reset, submit}) => {
+    return /* some cool ui */;
+  }}
+</FormState>
+```
+
+For detailed explanations of how to use `<FormState />` check out [the guide](/docs/building-forms.md).
+
+### `validators`
+
+The library also makes a number of validation factory functions available out of the box that should help with common use cases, as well as some tools to make building reusable custom validators easy.
+
+```typescript
+import {validate, validators} from '@shopify/react-form-state';
+```
+
+For detailed explanations of the validation uitilities, check out [the validation docs](/docs/validation.md).

--- a/packages/react-form-state/docs/FAQ.md
+++ b/packages/react-form-state/docs/FAQ.md
@@ -1,0 +1,16 @@
+# FAQ
+
+## Another form library?
+
+Good forms in React are surprisingly tough. A good API needs to support complex usecases with large numbers of fields split up across multiple components and explicit validation. It also needs to be quick to get started with and work for the simplest of forms cleanly. In meeting these goals, a package needs to balance developer experience, flexibility, and performance.
+
+At Shopify we wanted our form solution to be true to the Web Foundations team's core values. We wanted it to be [explicit, type-safe](https://github.com/Shopify/web-foundation/blob/master/Principles/3%20-%20Explicit%20over%20automatic.md), and to [prioritize user experience](https://github.com/Shopify/web-foundation/blob/master/Principles/1%20-%20User%20over%20team%20over%20self.md) while keeping code quality and developer happiness high.
+
+Several popular community packages sit at different places on the spectrum for these requirements, and all are solid choices for many projects. While we find it valuable to [use and contribute to community libraries,](https://github.com/Shopify/web-foundation/blob/master/Principles/5%20-%20Community%20over%20ownership.md) in this case we felt that we were better off going our own way.
+
+- [formik](https://github.com/jaredpalmer/formik) offers a declarative way of managing form state with minimal dependencies. Unfortunately since it uses a single set of handlers across all a form's fields we found it insufficiently type safe.
+- [redux-form](https://redux-form.com/7.4.2/) offers a redux integrated solution that can be quite magical and gives you the power of the redux dev tools for debugging broken states. Not all react apps need or want redux, and the library is fairly heavy, so we found it unsuitable for our uses.
+
+As such the main difference in our solution is the explicit, declarative api. Form fields are given explicit handlers generated individually for each field and made available through a [render prop](https://reactjs.org/docs/render-props.html). To reduce boilerplate we've kept the generated `field` objects as easy to use as possible. Usually you can just splat them onto your inputs. We'll go into this in more detail in the [usage guide](/usage-guide.md). Creating handlers for each field instead of having one that you share or inject using a higher order component means we are fully type safe, with editor autocomplete able to show a developer exactly what fields are available, and compilation breaking when someone tries to use a field that doesn't exist.
+
+`<FormState />` also differs in that it's validation behavior is based around the [Polaris form validation guidelines](https://polaris.shopify.com/patterns/error-messages#section-form-validation) out of the box. This allows us to provide consistent feedback across all pages that use it without developers having to think about it.

--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -1,0 +1,710 @@
+# Building forms with FormState
+
+## Basic
+
+When using `<FormState>`, you express your form's component tree as a function of the generated field state objects provided by `<FormState />` into its `children` function as `formDetails`.
+
+```typescript
+interface FormDetails<Fields> {
+  fields: FieldDescriptors<Fields>;
+  dirty: boolean;
+  valid: boolean;
+  submitting: boolean;
+  errors: ClientError[];
+  reset(): void;
+  submit(): void;
+}
+```
+
+The `formDetails` object passed into `children` contains a `fields` dictionary, which includes all the state and handlers you need to render your form.
+
+```typescript
+interface FieldState<Value> {
+  name: string;
+  initialValue: Value;
+  value: Value;
+  dirty: boolean;
+  error?: any;
+  onBlur(): void;
+}
+```
+
+The simplest way to use `<FormState />` is to pass it some `initialValues` and render some `input`s in its `children` render prop.
+
+```typescript
+import FormState from '@shopify/react-form-state';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={{
+        title: 'Cool title',
+        description: 'Cool product',
+      }}
+    >
+      {formDetails => {
+        const {fields} = formDetails;
+        const {title, description} = fields;
+
+        return (
+          <form>
+            <label htmlFor={title.name}>Title</label>
+            <input
+              {...title}
+              id={title.name}
+              onChange={({currentTarget}) => {
+                // our onChange expects just a value, no event needed
+                title.onChange(currentTarget.value);
+              }}
+            />
+
+            <label htmlFor={description.name}>Title</label>
+            <input
+              {...description}
+              id={title.name}
+              onChange={({currentTarget}) => {
+                description.onChange(currentTarget.value);
+              }}
+            />
+          </form>
+        );
+      }}
+    </FormState>
+  );
+}
+```
+
+## Reducing boilerplate with custom inputs
+
+The previous example has a fair amount of repetition around passing the right handlers to the right inputs. It also doesn't handle rendering errors. We can eliminate this boilerplate by using a custom component with props which match our field descriptor objects.
+
+[@shopify/polaris](https://polaris.shopify.com/components/forms/text-field)'s `<TextField />` component expects props that match our API. So, using `<TextField />` and ES6 [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) syntax we can greatly simplify our forms. The Polaris inputs also support `error` props, allowing us to surface error messages to our users at the field level once we set up validation.
+
+```typescript
+import {TextField} from '@shopify/polaris';
+import FormState from '@shopify/react-form-state';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={{
+        title: 'Cool title',
+        description: 'Cool product',
+      }}
+    >
+      {formDetails => {
+        const {fields} = formDetails;
+
+        return (
+          <form>
+            <TextField label="Title" {...fields.title} />
+            <TextField label="Description" {...fields.description} />
+          </form>
+        );
+      }}
+    </FormState>
+  );
+}
+```
+
+There is also nothing to stop you from using your own custom inputs.
+
+## Submission
+
+Forms usually need some mechanism of submission. `<FormState />` is not opinionated about how this is done, but does provide a built-in mechanism for managing loading state and updating based on errors from the submission process. Most of this is done through the `onSubmit` property.
+
+```typescript
+  onSubmit={async (fields) => {
+    const result = await updateProduct(fields);
+
+    if (isErrorResult(result)) {
+      return result.errors;
+    }
+  }}
+```
+
+When given an [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) function (or one that returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function), the `children` function will be rerendered with `submitting: true` until the promise resolves or rejects. Once it has returned the function will be re-rendered with `submitting: false` and `errors` either `[]` (if the promise resolved with no value), or with an array of `{field?: string, error: string}` if the promise resolved with an error list.
+
+```typescript
+// api.ts
+
+const fakeErrorResult = {error: [{message: 'api is not real'}]};
+
+// simple async function that fakes a failing api call
+export function fakeApiCall(data: any) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(fakeErrorResult);
+    }, 2000);
+  });
+}
+```
+
+```typescript
+// MyPage.ts
+import {fakeApiCall} from './api';
+import {TextField, Button, Banner, FormLayout, Spinner} from '@shopify/polaris';
+import FormState from '@shopify/react-form-state';
+
+export function MyPage() {
+  return (
+    <FormState
+      initialValues={{email: '', password: ''}}
+      onSubmit={async () => {
+        const results = await fakeApiCall();
+        if (results.error) {
+          return results.error;
+        }
+      }}
+    >
+      {({fields, submitting, errors, submit, valid}) => {
+        return (
+          <form onSubmit={submit}>
+            {submitting && <Spinner size="large" color="teal" />}
+
+            {!valid && (
+              <Banner status="critical">
+                <ul>
+                  {errors.map(error => (
+                    <li key={`${error.message}${error.field}`}>
+                      {error.message}
+                    </li>
+                  ))}
+                </ul>
+              </Banner>
+            )}
+
+            <FormLayout>
+              <TextField label="Email" {...fields.email} />
+              <TextField label="Password" {...fields.password} />
+            </FormLayout>
+
+            <Button primary type="submit" disabled={submitting}>
+              Save
+            </Button>
+          </form>
+        );
+      }}
+    </FormState>
+  );
+}
+```
+
+## Resetting
+
+Most forms need to expose a way to reset all fields to their initial values. The `reset()` function passed into `children()` allows you to easily make this available to a user.
+
+```typescript
+// MyPage.ts
+import {TextField, Button} from '@shopify/polaris';
+import FormState from '@shopify/react-form-state';
+
+export function MyPage() {
+  return (
+    <FormState
+      initialValues={{email: '', password: ''}}
+    >
+      {({fields, reset, dirty}) => {
+        return (
+          <form>
+            <FormLayout>
+              <TextField label="Email" {...fields.email} />
+              <TextField label="Password" {...fields.password} />
+            </FormLayout>
+
+            <Button
+              onClick={reset}
+              disabled={!dirty}
+            >
+              Reset
+            </Button>
+          </form>
+        );
+      }}
+    </FormState>
+  );
+```
+
+## Dirty Tracking
+
+Often you want to change some UI behavior based on whether a form has changed from its initial values. `<FormState />` supports this both on the form and individual field level.
+
+```typescript
+// MyPage.ts
+import {TextField, Button} from '@shopify/polaris';
+import FormState from '@shopify/react-form-state';
+
+export function MyPage() {
+  return (
+    <FormState
+      initialValues={{email: '', password: ''}}
+    >
+      {({fields, dirty}) => {
+        const dirtyMarkup = fields.password.dirty && (
+          <p>you have edited this</p>
+        );
+
+        return (
+          <form>
+            <FormLayout>
+              <TextField label="Email" {...fields.email} />
+              <TextField label="Password" {...fields.password} />
+              {dirtyMarkup}
+            </FormLayout>
+
+            <Button
+              primary
+              type="submit"
+              disabled={!dirty}
+            >
+              Save
+            </Button>
+          </form>
+        );
+      }}
+    </FormState>
+  );
+```
+
+# Validation
+
+`<FormState />` supports client-side validation through the `validators` prop.
+
+```typescript
+export type ValidatorDictionary<Fields> = {
+  [FieldPath in keyof Fields]: MaybeArray<
+    ValidationFunction<Fields[FieldPath], Fields>
+  >
+};
+
+interface ValidationFunction<Value, Fields> {
+  (value: Value, fields: FieldStates<Fields>): any;
+}
+```
+
+To define validators use the `validators` prop and pass it a partial dictionary of validation functions.
+
+```typescript
+  validators={{
+    title(input) {
+      if (input === 'foo') {
+        return 'title cannot be foo';
+      }
+    },
+  }}
+```
+
+To run multiple functions on the same field you can also use an array of functions.
+
+```typescript
+  validators={{
+    password: [
+      (input) => {
+        if (input.length > 20) {
+          return 'too big';
+        }
+      },
+      (input) => {
+        if (input.length < 3) {
+          return 'too small';
+        }
+      },
+  ]}}
+```
+
+`<FormState />` generates handlers that follow the [Polaris form validation guidelines](https://polaris.shopify.com/patterns/error-messages#section-form-validation). When you blur an input, or when you change it and it already has an error, any defined validators for that field will be invoked.
+
+```typescript
+import {TextField} from '@shopify/polaris';
+import FormState, {validators} from '@shopify/react-form-state';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={{
+        title: 'Cool title',
+        description: 'Cool product',
+        quantity: 0,
+      }}
+      validators={{
+        title(input) {
+          if (input.length > 10) {
+            return 'That title is too long';
+          }
+        },
+        quantity() {
+          if (!/[^0-9.,]/g.test(input)) {
+            return 'Quantity must be a number';
+          }
+        },
+      }}
+    >
+      {formDetails => {
+        const {fields} = formDetails;
+
+        return (
+          <form>
+            <TextField label="Title" {...fields.title} />
+            <TextField label="Description" {...fields.description} />
+            <TextField label="Quantity" {...fields.quantity} />
+          </form>
+        );
+      }}
+    </FormState>
+  );
+}
+```
+
+To learn more about building validators, and the built in functions exposed by this package, check out the [validators guide](/validators.md).
+
+## Compound fields
+
+The default API for generating handlers with `<FormState />` is very simple, but real world apps are often very complex. You will often have to represent editing many resources with one form. This can mean needing support for arrays of fields, fields that are nested objects, or both. `<FormState />` allows passing these complex values into `initialValues` and having your own special sub-components that use the handlers, but for most cases it's recommended to use the sub-components `<FormState.List />` and `<FormState.Nested />`.
+
+### `<FormState.Nested />`
+
+Sometimes your data might be best represented using a sub-object.
+
+```typescript
+initialValues={{
+  firstVariant: {
+    option: 'size',
+    value: 'enormous',
+    price: '2.00',
+    sku: 'mc23',
+  }
+  /* other fields */
+}}
+```
+
+Passing this directly into `<FormState />` will generate one field description object for the entire object, just like any other field.
+
+This might work for some usecases if you have some kind of custom component that you just want to pass an updater to, but this can make collection values back for submission, validation, and other subtleties a pain to manage.
+
+In cases like this you can use `<FormState.Nested />` to generate individual field descriptors for the sub-fields.
+
+```typescript
+// ProductPage.ts
+import {TextField} from '@shopify/polaris';
+import FormState from '@shopify/react-form-state';
+
+export function ProductPage() {
+  return (
+    <FormState
+      initialValues={{
+        name: '',
+        description: '',
+        firstVariant: {
+          option: 'size',
+          value: 'enormous',
+          price: '2.00',
+          sku: 'mc23',
+        }
+      }}
+    >
+    {({fields}) => {
+      return (
+        <form>
+          <div>
+            <TextField label="Name" {...fields.name} />
+            <TextField label="Description" {...fields.description} />
+
+            <FormState.Nested field={fields.firstVariant}>
+              {(fields) => {
+                <TextField label="Option" {...fields.option} />
+                <TextField label="Value" {...fields.value} />
+                <TextField label="SKU" {...fields.sku} />
+                <TextField label="Price" {...fields.price} />
+              }}
+            </FormState.Nested>
+          </div>
+        </form>
+      )
+    }}
+    </FormState>
+  );
+}
+```
+
+### `<FormState.List />`
+
+Sometimes your data might be best represented using an array of objects.
+
+```typescript
+initialValues={{
+  variants: [{
+    option: 'size',
+    value: 'enormous',
+    price: '2.00',
+    sku: 'mc23',
+  }, {
+    option: 'size',
+    value: 'teensy',
+    price: '0.20',
+    sku: 'mc25',
+  }]
+  /* other fields */
+}}
+```
+
+Passing this directly into `<FormState />` will generate one field description object for the entire array, just like any other field.
+
+This might work for some usecases if you have some kind of custom component that you just want to pass an updater to, but this can make collecting values back for submission, validation, and other subtleties a pain to manage. It can also make adding and removing fields quite code intensive.
+
+In cases like this you can use `<FormState.List />` to generate individual field descriptors for the sub-fields of each object in the array. `<FormState.List />` will render the `children` function you give it once for each item in the `field` array you give it, passing in a `fields` object with the same type of signature as `<FormState.Nested />`.
+
+```typescript
+// ProductPage.ts
+import {TextField} from '@shopify/polaris';
+import FormState from '@shopify/react-form-state';
+
+export function ProductPage() {
+  return (
+    <FormState
+      initialValues={{
+        name: '',
+        description: '',
+        variants: [{
+          option: 'size',
+          value: 'enormous',
+          price: '2.00',
+          sku: 'mc23',
+        }, {
+          option: 'size',
+          value: 'teensy',
+          price: '0.20',
+          sku: 'mc25',
+        }],
+      }}
+    >
+    {({fields}) => {
+      return (
+        <form>
+          <div>
+            <TextField label="Name" {...fields.name} />
+            <TextField label="Description" {...fields.description} />
+
+            <FormState.List field={fields.variants}>
+              {(fields) => {
+                <TextField label="Option" {...fields.option} />
+                <TextField label="Value" {...fields.value} />
+                <TextField label="SKU" {...fields.sku} />
+                <TextField label="Price" {...fields.price} />
+              }}
+            </FormState.List>
+          </div>
+        </form>
+      )
+    }}
+    </FormState>
+  );
+}
+```
+
+## Putting it all together
+
+The following example shows how you can use everything this documentation covered to build a full [Polaris](https://polaris.shopify.com) styled page.'s
+
+```typescript
+import * as React from 'react';
+import {
+  AppProvider,
+  Page,
+  TextField,
+  FormLayout,
+  PageActions,
+  Spinner,
+  Banner,
+  Stack,
+  Card,
+  Layout,
+  ButtonGroup,
+  Button,
+} from '@shopify/polaris';
+import FormState, {
+  validators,
+  validateArray,
+  validateObject,
+  arrayUtils,
+} from '@shopify/react-form-state';
+
+const {required, numericString, nonNumericString, lengthMoreThan} = validators;
+
+interface State {}
+
+interface Props {
+  initialValues: {
+    title: string;
+    description: string;
+    sku: string;
+    quantity: string;
+    firstVariant: string;
+      option: string;
+      value: string;
+      price: string;
+    };
+    variants: {
+      option: string;
+      value: string;
+      price: string;
+    }[];
+  },
+  productUpdate,
+}
+
+export default function Playground({initialValues, updateProduct}: Props) {
+  return (
+    <AppProvider>
+      <FormState
+        initialValues={initialValues}
+        validators={{
+          title: required('Required'),
+          quantity: numericString('Must be a number'),
+          sku: lengthMoreThan(3, 'Must  be longer than 3 characters'),
+          firstVariant: validateObject({
+            option: required('required'),
+            price: numericString('value must be numeric'),
+          }),
+          variants: validateArray({
+            option: nonNumericString('option must be nonNumeric'),
+            price: numericString('value must be numeric'),
+          }),
+        }}
+        onSubmit={updateProduct}
+      >
+        {formDetails => {
+          const {
+            fields,
+            dirty,
+            reset,
+            submit,
+            valid,
+            submitting,
+            errors,
+          } = formDetails;
+          const {
+            title,
+            description,
+            sku,
+            quantity,
+            variants,
+            firstVariant,
+          } = fields;
+
+          const submitAction = {
+            content: 'Save',
+            onAction: submit,
+            disabled: !dirty || submitting,
+            loading: submitting,
+          };
+
+          const resetAction = {
+            content: 'Reset',
+            onAction: reset,
+            disabled: !dirty || submitting,
+          };
+
+          const errorBanner = errors.length > 0 && (
+            <Banner status="critical">
+              <ul>
+                {errors.map(error => (
+                  <li key={`${error.message}${error.field}`}>
+                    {error.message}
+                  </li>
+                ))}
+              </ul>
+            </Banner>
+          );
+
+          function addVariant() {
+            variants.onChange(
+              arrayUtils.push(variants.value, {
+                option: '',
+                value: '',
+                price: '0',
+              }),
+            );
+          }
+
+          return (
+            <Page
+              title="Products"
+              primaryAction={submitAction}
+              secondaryActions={[resetAction]}
+            >
+              <Layout>
+                <Layout.Section>{errorBanner}</Layout.Section>
+
+                <Layout.Section>
+                  <Stack distribution="center">
+                    {submitting && <Spinner />}
+                  </Stack>
+
+                  <Card>
+                    <Card.Section>
+                      <FormLayout>
+                        <TextField label="Title" {...title} />
+                        <TextField label="Description" {...description} />
+                        <TextField label="SKU" {...sku} />
+                        <TextField
+                          type="number"
+                          label="Quantity"
+                          {...quantity}
+                        />
+                      </FormLayout>
+                    </Card.Section>
+                  </Card>
+                </Layout.Section>
+
+                <Layout.Section>
+                  <Card title="Variants">
+                    <Card.Section title="Default">
+                      <FormLayout>
+                        <FormState.Nested field={firstVariant}>
+                          {({option, value, price}) => (
+                            <>
+                              <TextField label="option" {...option} />
+                              <TextField label="value" {...value} />
+                              <TextField label="price" {...price} />
+                            </>
+                          )}
+                        </FormState.Nested>
+                      </FormLayout>
+                    </Card.Section>
+
+                    <Card.Section>
+                      <FormLayout>
+                        <FormState.List field={variants}>
+                          {({option, value, price}) => (
+                            <>
+                              <TextField label="option" {...option} />
+                              <TextField label="value" {...value} />
+                              <TextField label="price" {...price} />
+                            </>
+                          )}
+                        </FormState.List>
+                        <ButtonGroup>
+                          <Button onClick={addVariant} primary>
+                            Add variant
+                          </Button>
+                        </ButtonGroup>
+                      </FormLayout>
+                    </Card.Section>
+                  </Card>
+                </Layout.Section>
+
+                <Layout.Section>
+                  <PageActions
+                    primaryAction={submitAction}
+                    secondaryActions={[resetAction]}
+                  />
+                </Layout.Section>
+              </Layout>
+            </Page>
+          );
+        }}
+      </FormState>
+    </AppProvider>
+  );
+}
+```

--- a/packages/react-form-state/docs/validators.md
+++ b/packages/react-form-state/docs/validators.md
@@ -1,0 +1,208 @@
+# Validators
+
+## Built in validator functions
+
+The library makes a number of validation factory functions available out of the box that should help with common use cases.
+
+```typescript
+import {validators} from '@shopify/react-form-state';
+```
+
+```typescript
+  // input has a length > the given number
+  lengthMoreThan(length: number, errorContent: ErrorContent): Validator
+  // input has a length < the given number
+  lengthLessThan(length: number, errorContent: ErrorContent): Validator
+  // input is a numeric string
+  numericString(errorContent: ErrorContent): Validator
+  // input must be a non-empty string
+  requiredString(errorContent: ErrorContent): Validator
+  // input cannot be null/undefined
+  required(errorContent: ErrorContent): Validator
+```
+
+We can pass these directly into the `validators` prop of `<FormState />`.
+
+```typescript
+import {TextField} from '@shopify/polaris';
+import FormState, {validators} from '@shopify/react-form-state';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={{
+        title: 'Cool title',
+        description: 'Cool product',
+        quantity: 0,
+      }}
+      validators={{
+        title: validators.lengthLessThan(10, 'That title is too long')
+
+        quantity: [
+          validators.required('Products must have a quantity'),
+          validators.numericString('Quantity must be numeric'),
+        ],
+      }}
+    >
+      {formDetails => {
+        const {fields} = formDetails;
+
+        return (
+          <form>
+            <TextField label="Title" {...fields.title} />
+            <TextField label="Description" {...fields.description} />
+            <TextField label="Quantity" {...fields.description} />
+          </form>
+        );
+      }}
+    </FormState>
+  );
+}
+```
+
+## Building reusable validators
+
+As the number of custom validators in your app grows, you'll likely want to reuse them. This can be tricky because you'll usually want to support custom error messages depending on context.
+
+`@shopify/react-form-state` ships with a small DSL for building your own validators.
+
+```typescript
+import {validate} from '@shopify/react-form-state';
+```
+
+the `validate` function takes a `Matcher` function and some error content, and returns a `Validator` that works with `FormState`'s `validators` prop.
+
+```typescript
+export function validate<Input>(
+  matcher: Matcher<Input>,
+  errorContent: ErrorContent,
+): (input: Input) => ErrorContent | void;
+```
+
+You can use `validate` to generate handlers cleanly from your own functions.
+
+```typescript
+//utilities.ts
+export function isValidEmail(input: string) {
+  // example only
+  return /+\@.+\..+/.test(string);
+}
+```
+
+```typescript
+//MyPage.ts
+import FormState from '@shopify/react-form-state';
+import {isValidEmail} from './utilities';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={email: ''}
+      validators={{
+        email: validate(isValidEmail, 'invalid email')
+      }}
+    >
+      {/* ...some ui */}
+    </FormState>
+  );
+}
+```
+
+Or take it a step further by making a generic shared validator.
+
+```typescript
+//custom-validators.ts
+import {validate, ErrorContent} from '@shopify/react-form-state';
+
+export function validEmail(input: string, errorContent: ErrorContent) {
+  // example only
+  return validate(input => /+\@.+\..+/.test(input), errorContent);
+}
+```
+
+```typescript
+// MyPage.ts
+import FormState from '@shopify/react-form-state';
+import {validEmail} from './custom-validators';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={email: ''}
+      validators={{
+        email: validEmail('Email is invalid'),
+      }}
+    >
+      {/* ...some ui */}
+    </FormState>
+  );
+}
+```
+
+`validate`-generated functions also support taking an error-generating functions as their last parameter. Suppose we want to include the current field value in our error message; we could update the above example to use this technique.
+
+```typescript
+// MyPage.ts
+import {validEmail} from './custom-validators';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={email: ''}
+      validators={{
+        email: validEmail((input) => `${input} is not a valid email`),
+      }}
+    >
+      {/* ...some ui */}
+    </FormState>
+  );
+}
+```
+
+## Compound validators
+
+All of the validation we've done so far has been concerned with scalar value fields. Its possible to write validators for arrays and objects using the syntax described above, but it would be difficult to handle passing errors down intelligently. Its great for things like checking that there are a set number of items in the array, but terrible for checking individual subfield values.
+
+```typescript
+validators={{
+  variants(input) {
+    if (input.length > 10) {
+      return 'too many variants!';
+    }
+  }
+}}
+```
+
+Because of these difficulties, this package also contains some helpers for writing validators for complex fields that work with `<FormState.Nested />` and `<FormState.List />` to let us propagate errors down the same way as we do for regular fields.
+
+### `validateNested()`
+
+```typescript
+import {validateNested} form '@shopify/react-form-state';
+```
+
+The validation helper companion for `<FormState.Nested />` lets you define field level validations for nested fields using the same API as you would use for flat scalar fields.
+
+```typescript
+  validators={{
+    firstVariant: validateNested({
+      price: validators.numericString('variant price should be a number'),
+      sku: validators.lengthLessthan(3, 'variant SKU must be shorter than 3 characters');
+    });
+  }}
+```
+
+### `validateList()`
+
+```typescript
+import {validateList} form '@shopify/react-form-state';
+```
+
+```typescript
+  validators={{
+    variants: validateList({
+      price: validators.numericString('variant price should be a number'),
+      sku: validators.lengthLessthan(3, 'variant SKU must be shorter than 3 characters');
+    });
+  }}
+```

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@shopify/react-form-state",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Manage react forms tersely and type-safe with no magic.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-form-state/README.md",
+  "dependencies": {
+    "lodash-decorators": "^6.0.0",
+    "lodash-es": "^4.17.10"
+  },
+  "peerDependencies": {
+    "react": "^16.4.1"
+  },
+  "devDependencies": {
+    "@types/enzyme": "^3.1.10",
+    "enzyme": "^3.3.0",
+    "faker": "^4.1.0",
+    "typescript": "~2.9.2"
+  }
+}

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -1,0 +1,331 @@
+import * as React from 'react';
+import isEqual from 'lodash/isEqual';
+import isArray from 'lodash/isArray';
+import {memoize, bind} from 'lodash-decorators';
+
+import {mapObject} from './utilities';
+import {FieldDescriptors, ClientError, FieldState} from './types';
+import {List, Nested} from './components';
+
+interface RemoteError {
+  field: string[] | null;
+  message: string;
+}
+
+export type FormError = RemoteError | ClientError;
+
+export type FieldStates<Fields> = {
+  [FieldPath in keyof Fields]: FieldState<Fields[FieldPath]>
+};
+
+type MaybeArray<T> = T | T[];
+type MaybePromise<T> = T | Promise<T>;
+
+interface SubmitHandler<Fields> {
+  (fields: FieldStates<Fields>): MaybePromise<FormError[]> | MaybePromise<void>;
+}
+
+export type ValidatorDictionary<Fields> = {
+  [FieldPath in keyof Fields]: MaybeArray<
+    ValidationFunction<Fields[FieldPath], Fields>
+  >
+};
+
+interface ValidationFunction<Value, Fields> {
+  (value: Value, fields: FieldStates<Fields>): any;
+}
+
+export interface FormDetails<Fields> {
+  fields: FieldDescriptors<Fields>;
+  dirty: boolean;
+  valid: boolean;
+  submitting: boolean;
+  errors: ClientError[];
+  reset(): void;
+  submit(): void;
+}
+
+interface Props<Fields> {
+  initialValues: Fields;
+  validators?: Partial<ValidatorDictionary<Fields>>;
+  onSubmit?: SubmitHandler<Fields>;
+  children(form: FormDetails<Fields>): React.ReactNode;
+}
+
+interface State<Fields> {
+  submitting: boolean;
+  errors: ClientError[];
+  dirtyFields: (keyof Fields)[];
+  fields: FieldStates<Fields>;
+}
+
+export default class FormState<
+  Fields extends Object
+> extends React.PureComponent<Props<Fields>, State<Fields>> {
+  static List = List;
+  static Nested = Nested;
+
+  static getDerivedStateFromProps<T>(newProps: Props<T>, oldState?: State<T>) {
+    const newInitialValues = newProps.initialValues;
+
+    if (oldState == null) {
+      return createFormState(newInitialValues);
+    }
+
+    const oldInitialValues = initialValuesFromFields(oldState.fields);
+    const shouldReinitialize = !isEqual(oldInitialValues, newInitialValues);
+
+    if (shouldReinitialize) {
+      return createFormState(newInitialValues);
+    }
+
+    return null;
+  }
+
+  state = createFormState(this.props.initialValues);
+  private mounted = false;
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  render() {
+    const {children} = this.props;
+    const {submitting, errors} = this.state;
+    const {fields, reset, submit, dirty, valid} = this;
+
+    return children({
+      submit,
+      reset,
+      submitting,
+      dirty,
+      valid,
+      errors,
+      fields,
+    });
+  }
+
+  private get dirty() {
+    return this.state.dirtyFields.length > 0;
+  }
+
+  private get valid() {
+    return this.allErrors.length === 0;
+  }
+
+  private get fields() {
+    const {fields} = this.state;
+
+    const fieldDescriptors: FieldDescriptors<Fields> = mapObject(
+      fields,
+      (field, path) => {
+        return {
+          name: path,
+          ...field,
+          ...this.getHandlersForField(path),
+        };
+      },
+    );
+
+    return fieldDescriptors;
+  }
+
+  private get allErrors(): ClientError[] {
+    const {errors, fields} = this.state;
+
+    const fieldErrors = Object.keys(fields)
+      .map(field => {
+        const {error: message} = fields[field];
+        return {message, field};
+      })
+      .filter(error => {
+        return error.field != null && error.message != null;
+      }) as ClientError[];
+
+    return [...errors, ...fieldErrors];
+  }
+
+  @bind
+  private async submit(event?: Event) {
+    if (!this.mounted) {
+      return;
+    }
+
+    if (event && !event.defaultPrevented) {
+      event.preventDefault();
+    }
+
+    const {onSubmit} = this.props;
+    const {fields} = this.state;
+
+    if (onSubmit == null) {
+      return;
+    }
+
+    this.setState({
+      ...createFormState(valuesFromFields(fields)),
+      submitting: true,
+    });
+
+    const result = await onSubmit(fields);
+
+    if (result) {
+      this.updateErrors(result);
+    }
+
+    this.setState({submitting: false});
+  }
+
+  @bind
+  private reset() {
+    this.setState(createFormState(this.props.initialValues));
+  }
+
+  @memoize
+  private getHandlersForField(path: keyof FieldStates<Fields>) {
+    return {
+      onChange: this.updateField.bind(this, path),
+      onBlur: this.blurField.bind(this, path),
+    };
+  }
+  private updateField<K extends keyof Fields>(fieldPath: K, value: Fields[K]) {
+    this.setState<any>(({fields, dirtyFields}: State<Fields>) => {
+      const field = fields[fieldPath];
+      const {error} = field;
+
+      const dirty = !isEqual(value, field.initialValue);
+      const newDirtyFields = new Set(dirtyFields);
+
+      if (dirty) {
+        newDirtyFields.add(fieldPath);
+      } else {
+        newDirtyFields.delete(fieldPath);
+      }
+
+      const newFieldData = Object.assign({}, field, {
+        value,
+        dirty,
+      });
+
+      /*
+        We only want to update errors as the user types if they
+        already have an error.
+        https://polaris.shopify.com/patterns/error-messages#section-form-validation
+      */
+      const shouldUpdateError = error != null;
+
+      const newError = shouldUpdateError
+        ? this.validateFieldValue(fieldPath, newFieldData)
+        : // eslint-disable-next-line no-undefined
+          undefined;
+
+      return {
+        dirtyFields: [...Array.from(newDirtyFields)],
+        fields: Object.assign({}, fields, {
+          [fieldPath]: Object.assign({}, newFieldData, {error: newError}),
+        }),
+      };
+    });
+  }
+
+  private blurField<Key extends keyof Fields>(fieldPath: Key) {
+    const {fields} = this.state;
+    const field = fields[fieldPath];
+    const error = this.validateFieldValue<Key>(fieldPath, field);
+
+    if (error == null) {
+      return;
+    }
+
+    this.setState(state => ({
+      fields: Object.assign({}, state.fields, {
+        [fieldPath]: Object.assign({}, state.fields[fieldPath], {error}),
+      }),
+    }));
+  }
+
+  private validateFieldValue<Key extends keyof Fields>(
+    fieldPath: Key,
+    {value, dirty}: FieldState<Fields[Key]>,
+  ) {
+    if (!dirty) {
+      return;
+    }
+
+    const {validators = {}} = this.props;
+    const {fields} = this.state;
+    const validate = validators[fieldPath];
+
+    if (typeof validate === 'function') {
+      // eslint-disable-next-line consistent-return
+      return validate(value, fields);
+    }
+
+    if (!isArray(validate)) {
+      return;
+    }
+
+    const errors = validate
+      .map(validator => validator(value, fields))
+      .filter(input => input != null);
+
+    if (errors.length === 0) {
+      return;
+    }
+
+    // eslint-disable-next-line consistent-return
+    return errors;
+  }
+
+  private updateErrors(newErrors: FormError[]) {
+    this.setState(({fields}: State<Fields>) => {
+      const newFields = {...(fields as any)};
+
+      const errors: ClientError[] = newErrors.map(({message, field}) => {
+        if (field == null) {
+          return {message};
+        }
+
+        if (isArray(field)) {
+          return {message, field: field.join('.')};
+        }
+
+        return {message, field};
+      });
+
+      return {
+        errors,
+        fields: newFields,
+      };
+    });
+  }
+}
+
+function createFormState<Fields>(values: Fields): State<Fields> {
+  const fields: FieldStates<Fields> = mapObject(values, value => {
+    return {
+      value,
+      initialValue: value,
+      dirty: false,
+    };
+  });
+
+  return {
+    dirtyFields: [],
+    errors: [],
+    fields,
+    submitting: false,
+  };
+}
+
+function valuesFromFields<Fields>(fields: FieldStates<Fields>): Fields {
+  return mapObject(fields, ({value}) => value);
+}
+
+function initialValuesFromFields<Fields>(fields: FieldStates<Fields>): Fields {
+  return mapObject(fields, ({initialValue}) => initialValue);
+}

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import get from 'lodash/get';
+import {memoize, bind} from 'lodash-decorators';
+
+import {FieldDescriptor, FieldDescriptors} from '../types';
+import {mapObject, replace} from '../utilities';
+
+interface Props<Fields> {
+  field: FieldDescriptor<Fields[]>;
+  children(fields: FieldDescriptors<Fields>, index: number): React.ReactNode;
+}
+
+export default class List<Fields> extends React.PureComponent<
+  Props<Fields>,
+  never
+> {
+  render() {
+    const {
+      field: {value, initialValue, error, onBlur},
+      children,
+    } = this.props;
+
+    return value.map((fieldValues, index) => {
+      const innerFields: FieldDescriptors<Fields> = mapObject(
+        fieldValues,
+        (value, fieldPath) => {
+          const initialFieldValue = get(initialValue, [index, fieldPath]);
+          return {
+            value,
+            onBlur,
+            name: `${name}.${index}.${fieldPath}`,
+            initialValue: initialFieldValue,
+            dirty: value !== initialFieldValue,
+            error: get(error, [index, fieldPath]),
+            onChange: this.handleChange(index, fieldPath),
+          };
+        },
+      );
+
+      return (
+        // eslint-disable-next-line
+        <React.Fragment key={index}>
+          {children(innerFields, index)}
+        </React.Fragment>
+      );
+    });
+  }
+
+  @memoize
+  @bind
+  private handleChange<Key extends keyof Fields>(index: number, key: Key) {
+    return (newValue: Fields[Key]) => {
+      const {
+        field: {value, onChange},
+      } = this.props;
+
+      const existingItem = value[index];
+      const newItem = {
+        ...(existingItem as any),
+        [key]: newValue,
+      };
+
+      onChange(replace(value, index, newItem));
+    };
+  }
+}

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import get from 'lodash/get';
+import {memoize, bind} from 'lodash-decorators';
+
+import {FieldDescriptor, FieldDescriptors} from '../types';
+import {mapObject} from '../utilities';
+
+interface Props<Fields> {
+  field: FieldDescriptor<Fields>;
+  children(fields: FieldDescriptors<Fields>): React.ReactNode;
+}
+
+export default class Nested<Fields> extends React.PureComponent<
+  Props<Fields>,
+  never
+> {
+  render() {
+    const {
+      field: {value, onBlur, initialValue, error},
+      children,
+    } = this.props;
+
+    const innerFields: FieldDescriptors<Fields> = mapObject(
+      value,
+      (value, fieldPath) => {
+        const initialFieldValue = initialValue[fieldPath];
+        return {
+          value,
+          onBlur,
+          name: `${name}.${fieldPath}`,
+          initialValue: initialFieldValue,
+          dirty: value !== initialFieldValue,
+          error: get(error, [fieldPath]),
+          onChange: this.handleChange(fieldPath),
+        };
+      },
+    );
+
+    return children(innerFields);
+  }
+
+  @memoize
+  @bind
+  private handleChange<Key extends keyof Fields>(key: Key) {
+    return (newValue: Fields[Key]) => {
+      const {
+        field: {value: existingItem, onChange},
+      } = this.props;
+
+      const newItem = {
+        ...(existingItem as any),
+        [key]: newValue,
+      };
+
+      onChange(newItem);
+    };
+  }
+}

--- a/packages/react-form-state/src/components/index.ts
+++ b/packages/react-form-state/src/components/index.ts
@@ -1,0 +1,2 @@
+export {default as List} from './List';
+export {default as Nested} from './Nested';

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import faker from 'faker';
+import {mount} from 'enzyme';
+
+import Input from './components/Input';
+import FormState from '../..';
+
+const ARBITRARY_SEED = 1337;
+
+describe('<FormState.List />', () => {
+  beforeEach(() => {
+    faker.seed(ARBITRARY_SEED);
+  });
+
+  it('passes form state into child function for each index of the given array', () => {
+    const renderPropSpy = jest.fn(() => null);
+
+    const products = [
+      {title: faker.commerce.productName()},
+      {title: faker.commerce.productName()},
+      {title: faker.commerce.productName()},
+    ];
+
+    mount(
+      <FormState initialValues={{products}}>
+        {({fields}) => {
+          return (
+            <FormState.List field={fields.products}>
+              {renderPropSpy}
+            </FormState.List>
+          );
+        }}
+      </FormState>,
+    );
+
+    const calls = renderPropSpy.mock.calls;
+    expect(calls).toHaveLength(products.length);
+
+    calls.forEach(([fields], index) => {
+      const expectedTitle = products[index].title;
+
+      expect(fields.title.value).toBe(expectedTitle);
+      expect(fields.title.initialValue).toBe(expectedTitle);
+      expect(fields.title.dirty).toBe(false);
+    });
+  });
+
+  it("updates the top level FormState's array when an inner field is updated", () => {
+    const products = [{title: faker.commerce.productName()}];
+    const newTitle = faker.commerce.productName();
+
+    const renderPropSpy = jest.fn(({fields}: any) => {
+      return (
+        <>
+          <FormState.List field={fields.products}>
+            {(fields: any) => {
+              return <Input {...fields.title} />;
+            }}
+          </FormState.List>
+        </>
+      );
+    });
+
+    const form = mount(
+      <FormState initialValues={{products}}>{renderPropSpy}</FormState>,
+    );
+
+    form
+      .find(Input)
+      .props()
+      .onChange(newTitle);
+
+    form.update();
+
+    const {fields} = lastCallArgs(renderPropSpy);
+
+    expect(fields.products.value[0].title).toBe(newTitle);
+  });
+
+  it('tracks individual subfield dirty state', () => {
+    const products = [{title: faker.commerce.productName()}];
+    const newTitle = faker.commerce.productName();
+
+    const renderSpy = jest.fn(() => null);
+
+    const form = mount(
+      <FormState initialValues={{products}}>
+        {({fields}) => {
+          return (
+            <>
+              <FormState.List field={fields.products}>
+                {renderSpy}
+              </FormState.List>
+            </>
+          );
+        }}
+      </FormState>,
+    );
+
+    const {title} = lastCallArgs(renderSpy);
+    title.onChange(newTitle);
+
+    form.update();
+
+    const updatedFields = lastCallArgs(renderSpy);
+    expect(updatedFields.title.dirty).toBe(true);
+  });
+
+  it('passes errors down to inner fields', () => {
+    const products = [
+      {
+        title: faker.commerce.productName(),
+        department: faker.commerce.department(),
+      },
+      {
+        title: faker.commerce.productName(),
+        department: faker.commerce.department(),
+      },
+    ];
+
+    const field = {
+      name: 'products',
+      value: products,
+      initialValue: products,
+      onChange: jest.fn(),
+      onBlur: jest.fn(),
+      dirty: false,
+      changed: false,
+      error: [
+        {
+          title: faker.lorem.words(5),
+        },
+        {
+          department: faker.lorem.words(5),
+        },
+      ],
+    };
+
+    const renderSpy = jest.fn(() => null);
+    mount(<FormState.List field={field}>{renderSpy}</FormState.List>);
+
+    renderSpy.mock.calls.forEach(([fields], index) => {
+      const {title, department} = fields;
+
+      expect(title.error).toBe(field.error[index].title);
+      expect(department.error).toBe(field.error[index].department);
+    });
+  });
+});
+
+function lastCallArgs(spy: jest.Mock) {
+  const calls = spy.mock.calls;
+  return calls[calls.length - 1][0];
+}

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import faker from 'faker';
+import {mount} from 'enzyme';
+
+import {Input} from './components';
+import FormState from '../..';
+
+const ARBITRARY_SEED = 1337;
+
+describe('<Nested />', () => {
+  beforeEach(() => {
+    faker.seed(ARBITRARY_SEED);
+  });
+
+  it('passes field state into child function', () => {
+    const renderPropSpy = jest.fn(() => null);
+
+    const product = {
+      title: faker.commerce.productName(),
+      adjective: faker.commerce.productAdjective(),
+    };
+
+    mount(
+      <FormState initialValues={{product}}>
+        {({fields}) => {
+          return (
+            <FormState.Nested field={fields.product}>
+              {renderPropSpy}
+            </FormState.Nested>
+          );
+        }}
+      </FormState>,
+    );
+
+    expect(renderPropSpy).toBeCalledWith({
+      title: {
+        name: 'nodejs.title',
+        dirty: false,
+        // eslint-disable-next-line no-undefined
+        error: undefined,
+        initialValue: product.title,
+        value: product.title,
+        onChange: expect.any(Function),
+        onBlur: expect.any(Function),
+      },
+      adjective: {
+        name: 'nodejs.adjective',
+        dirty: false,
+        // eslint-disable-next-line no-undefined
+        error: undefined,
+        initialValue: product.adjective,
+        value: product.adjective,
+        onChange: expect.any(Function),
+        onBlur: expect.any(Function),
+      },
+    });
+  });
+
+  it("updates the top level FormState's array when an inner field is updated", () => {
+    const product = {title: faker.commerce.productName()};
+    const newTitle = faker.commerce.productName();
+
+    const renderPropSpy = jest.fn(({fields: {product}}: any) => {
+      return (
+        <>
+          <FormState.Nested field={product}>
+            {({title}: any) => {
+              return <Input label="title" {...title} />;
+            }}
+          </FormState.Nested>
+        </>
+      );
+    });
+
+    const form = mount(
+      <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+    );
+
+    form
+      .find(Input)
+      .props()
+      .onChange(newTitle);
+    form.update();
+
+    const {fields} = lastCallArgs(renderPropSpy);
+
+    expect(fields.product.value.title).toBe(newTitle);
+  });
+
+  it('tracks field dirty state', () => {
+    const product = {title: faker.commerce.productName()};
+    const newTitle = faker.commerce.productName();
+
+    const renderSpy = jest.fn(() => null);
+
+    const form = mount(
+      <FormState initialValues={{product}}>
+        {({fields}) => {
+          return (
+            <>
+              <FormState.Nested field={fields.product}>
+                {renderSpy}
+              </FormState.Nested>
+            </>
+          );
+        }}
+      </FormState>,
+    );
+
+    const {title} = lastCallArgs(renderSpy);
+    title.onChange(newTitle);
+
+    form.update();
+
+    const updatedFields = lastCallArgs(renderSpy);
+    expect(updatedFields.title.dirty).toBe(true);
+  });
+
+  it('passes errors down to inner fields', () => {
+    const product = {
+      title: faker.commerce.productName(),
+      department: faker.commerce.department(),
+    };
+
+    const field = {
+      name: 'product',
+      value: product,
+      initialValue: product,
+      onChange: jest.fn(),
+      onBlur: jest.fn(),
+      dirty: false,
+      changed: false,
+      error: {
+        title: faker.lorem.words(5),
+        department: faker.lorem.words(5),
+      },
+    };
+
+    const renderSpy = jest.fn(() => null);
+    mount(<FormState.Nested field={field}>{renderSpy}</FormState.Nested>);
+
+    const renderPropArgs = lastCallArgs(renderSpy);
+
+    expect(renderPropArgs.title.error).toBe(field.error.title);
+    expect(renderPropArgs.department.error).toBe(field.error.department);
+  });
+});
+
+function lastCallArgs(spy: jest.Mock) {
+  const calls = spy.mock.calls;
+  return calls[calls.length - 1][0];
+}
+
+function TextField({onChange, ...props}: any) {
+  return <input {...props} />;
+}

--- a/packages/react-form-state/src/components/tests/components/Input.tsx
+++ b/packages/react-form-state/src/components/tests/components/Input.tsx
@@ -1,0 +1,18 @@
+import React, {InputHTMLAttributes} from 'react';
+
+export interface Props {
+  onChange(value: string): void;
+}
+
+export default function Input({
+  onChange,
+  ...inputProps
+}: Props & InputHTMLAttributes<any>) {
+  return (
+    <input
+      // eslint-disable-next-line react/jsx-no-bind
+      onChange={({currentTarget}) => onChange(currentTarget.value)}
+      {...inputProps}
+    />
+  );
+}

--- a/packages/react-form-state/src/components/tests/components/index.ts
+++ b/packages/react-form-state/src/components/tests/components/index.ts
@@ -1,0 +1,1 @@
+export {default as Input, Props as InputProps} from './Input';

--- a/packages/react-form-state/src/index.ts
+++ b/packages/react-form-state/src/index.ts
@@ -1,0 +1,11 @@
+import FormState from './FormState';
+
+import {push, replace, remove} from './utilities';
+
+export const arrayUtils = {push, replace, remove};
+
+export {default as validators} from './validators';
+export * from './validators';
+
+export * from './FormState';
+export default FormState;

--- a/packages/react-form-state/src/test/FormState.test.tsx
+++ b/packages/react-form-state/src/test/FormState.test.tsx
@@ -1,0 +1,660 @@
+import React from 'react';
+import faker from 'faker';
+import {mount} from 'enzyme';
+import FormState from '..';
+
+const ARBITRARY_SEED = 1337;
+
+describe('<FormState />', () => {
+  beforeEach(() => {
+    faker.seed(ARBITRARY_SEED);
+  });
+
+  it('passes form state into child function', () => {
+    const renderPropSpy = jest.fn(() => null);
+
+    mount(<FormState initialValues={{}}>{renderPropSpy}</FormState>);
+
+    const args = renderPropSpy.mock.calls[0][0];
+    expect(args).toHaveProperty('fields');
+    expect(args).toHaveProperty('errors');
+    expect(args).toHaveProperty('dirty');
+    expect(args).toHaveProperty('valid');
+    expect(args).toHaveProperty('submitting');
+    expect(args).toHaveProperty('submit');
+  });
+
+  describe('initialValues', () => {
+    it('bases initial field objects passed into render prop on initialValues', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      mount(<FormState initialValues={{product}}>{renderPropSpy}</FormState>);
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields).toMatchObject({
+        product: {
+          value: product,
+          initialValue: product,
+          dirty: false,
+        },
+      });
+    });
+
+    it('resets field objects values to new initialValues when prop is updated', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      const otherProduct = faker.commerce.productName();
+      form.setProps({initialValues: {product: otherProduct}});
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields).toMatchObject({
+        product: {
+          value: otherProduct,
+          initialValue: otherProduct,
+          dirty: false,
+        },
+      });
+    });
+
+    it('does not reset field objects values when non-initialValues props are updated', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      const otherProduct = faker.commerce.productName();
+      formDetails.fields.product.onChange(otherProduct);
+      form.update();
+
+      form.setProps({validators: {}});
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields).toMatchObject({
+        product: {
+          value: otherProduct,
+          initialValue: product,
+          dirty: true,
+        },
+      });
+    });
+  });
+
+  describe('reset()', () => {
+    it('resets all fields to their initial values', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      const {reset} = lastCallArgs(renderPropSpy);
+      reset();
+
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      reset();
+      expect(fields).toMatchObject({
+        product: {
+          value: product,
+          initialValue: product,
+          dirty: false,
+        },
+      });
+    });
+  });
+
+  describe('dirty', () => {
+    it('defaults to false', () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName(),
+            color: faker.commerce.productName(),
+          }}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {dirty} = lastCallArgs(renderPropSpy);
+
+      expect(dirty).toBe(false);
+    });
+
+    it("is set to false if every field's value is equal to it's initialValue", () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+      const color = faker.commerce.color();
+
+      const form = mount(
+        <FormState initialValues={{product, color}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      formDetails.fields.color.onChange(faker.commerce.color());
+      form.update();
+
+      formDetails.fields.product.onChange(product);
+      formDetails.fields.color.onChange(color);
+      form.update();
+
+      const {dirty} = lastCallArgs(renderPropSpy);
+      expect(dirty).toBe(false);
+    });
+
+    it("is set to true if any field's value is not equal to it's initialValue", () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+      const color = faker.commerce.color();
+
+      const form = mount(
+        <FormState initialValues={{product, color}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      const {dirty} = lastCallArgs(renderPropSpy);
+      expect(dirty).toBe(true);
+    });
+  });
+
+  describe('field onChange', () => {
+    it('updates field.value', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      const otherProduct = faker.commerce.productName();
+      formDetails.fields.product.onChange(otherProduct);
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields.product.value).toBe(otherProduct);
+    });
+
+    it('does not change field.initialValue', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields.product.initialValue).toBe(product);
+    });
+
+    it('sets field.dirty to true if the new value is different from initialValue', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields.product.dirty).toBe(true);
+    });
+
+    it('sets field.dirty to false if the new value is the same as initialValue', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(product);
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields.product.dirty).toBe(false);
+    });
+
+    it('sets global dirty to true if the new value is different from initialValue', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      const {dirty} = lastCallArgs(renderPropSpy);
+      expect(dirty).toBe(true);
+    });
+
+    it('sets global dirty to false if the new value is the same as initialValue and no other field is dirty', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+      const description = faker.lorem.words();
+
+      const form = mount(
+        <FormState initialValues={{product, description}}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(product);
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields.product.dirty).toBe(false);
+    });
+
+    it('keeps global dirty true if the new value is the same as initialValue and another field is dirty', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+      const description = faker.lorem.words();
+
+      const form = mount(
+        <FormState initialValues={{product, description}}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(product);
+      form.update();
+      formDetails.fields.description.onChange(faker.lorem.words());
+      form.update();
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields.product.dirty).toBe(false);
+    });
+  });
+
+  describe('validation', () => {
+    it('runs validation when an onBlur() is called', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const productValidatorSpy = jest.fn();
+
+      const form = mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName(),
+          }}
+          validators={{product: productValidatorSpy}}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const product = faker.commerce.productName();
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(product);
+      form.update();
+
+      formDetails.fields.product.onBlur();
+
+      expect(productValidatorSpy).toBeCalledWith(product, {
+        product: {
+          dirty: true,
+          // eslint-disable-next-line no-undefined
+          error: undefined,
+          initialValue: 'Gorgeous Rubber Keyboard',
+          value: 'Intelligent Plastic Towels',
+        },
+      });
+    });
+
+    it("skips validation on a field when it's onBlur() is called and the form is not dirty", () => {
+      const renderPropSpy = jest.fn(() => null);
+      const validatorSpy = jest.fn();
+
+      mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          validators={{product: validatorSpy}}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onBlur();
+
+      expect(validatorSpy).not.toBeCalled();
+    });
+
+    it('runs validation on a field when it already has an error and onChange() is called', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const validatorSpy = jest.fn(() => faker.lorem.sentence());
+
+      const form = mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          validators={{product: validatorSpy}}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      formDetails.fields.product.onBlur();
+      form.update();
+
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      form.update();
+
+      expect(validatorSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("sets field.error to the result of it's validator", () => {
+      const renderPropSpy = jest.fn(() => null);
+      const error = faker.lorem.sentence();
+      const validatorSpy = jest.fn(() => error);
+
+      const form = mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          validators={{product: validatorSpy}}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const product = faker.commerce.productName();
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(product);
+      form.update();
+
+      formDetails.fields.product.onBlur();
+
+      const updatedFormDetails = lastCallArgs(renderPropSpy);
+      expect(updatedFormDetails.fields.product.error).toBe(error);
+    });
+
+    it("sets field.error to an array of the results of all it's validators if an array is given", () => {
+      const renderPropSpy = jest.fn(() => null);
+      const error = faker.lorem.sentence();
+      const otherError = faker.lorem.sentence();
+      const validatorSpy = jest.fn(() => error);
+      const otherValidatorSpy = jest.fn(() => otherError);
+
+      const form = mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          validators={{product: [validatorSpy, otherValidatorSpy]}}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const product = faker.commerce.productName();
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(product);
+      form.update();
+
+      formDetails.fields.product.onBlur();
+
+      const updatedFormDetails = lastCallArgs(renderPropSpy);
+      expect(updatedFormDetails.fields.product.error).toEqual([
+        error,
+        otherError,
+      ]);
+    });
+
+    it('does not run validation on a field when it has no error and onChange() is called', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const validatorSpy = jest.fn();
+
+      const form = mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          validators={{product: validatorSpy}}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onBlur();
+      form.update();
+
+      const otherProduct = faker.commerce.productName();
+      formDetails.fields.product.onChange(otherProduct);
+      form.update();
+
+      expect(validatorSpy).not.toHaveBeenCalledTimes(2);
+    });
+
+    it('sets valid to false when any field fails validation', () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      const form = mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName(),
+            sku: faker.random.uuid(),
+          }}
+          validators={{
+            // eslint-disable-next-line no-undefined
+            product: () => undefined,
+            sku: () => faker.lorem.sentence(),
+          }}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(faker.commerce.productName());
+      formDetails.fields.sku.onChange(faker.commerce.product());
+      form.update();
+
+      formDetails.fields.product.onBlur();
+      formDetails.fields.sku.onBlur();
+      form.update();
+
+      const {valid} = lastCallArgs(renderPropSpy);
+      expect(valid).toBe(false);
+    });
+
+    it('sets valid to true when every field passes validation', () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      const form = mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName(),
+            sku: faker.random.uuid(),
+          }}
+          validators={{
+            // eslint-disable-next-line no-undefined
+            product: () => undefined,
+            // eslint-disable-next-line no-undefined
+            sku: () => undefined,
+          }}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onBlur();
+      formDetails.fields.sku.onBlur();
+      form.update();
+
+      const {valid} = lastCallArgs(renderPropSpy);
+      expect(valid).toBe(true);
+    });
+  });
+
+  describe('field submit', () => {
+    it('calls onSubmit() with the current field state when submit() is called', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const onSubmitSpy = jest.fn();
+      const product = faker.commerce.productName();
+
+      mount(
+        <FormState initialValues={{product}} onSubmit={onSubmitSpy}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {fields, submit} = lastCallArgs(renderPropSpy);
+      submit();
+
+      expect(lastCallArgs(onSubmitSpy)).toMatchObject({
+        product: {
+          value: fields.product.value,
+          initialValue: fields.product.initialValue,
+          dirty: false,
+        },
+      });
+    });
+
+    it('when onSubmit() returns a promise, rerenders with submitting true while waiting for it to resolve/reject', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState initialValues={{product}} onSubmit={onSubmit}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      submit();
+
+      const {submitting} = lastCallArgs(renderPropSpy);
+      expect(submitting).toBe(true);
+    });
+
+    it('when onSubmit() returns a promise, rerenders with submitting false when promise resolves', async () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState initialValues={{product}} onSubmit={onSubmit}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      await submit();
+
+      const {submitting} = lastCallArgs(renderPropSpy);
+      expect(submitting).toBe(false);
+    });
+
+    it('updates errors when errors are returned from onSubmit', async () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const submitErrors = [
+        {message: faker.lorem.sentences()},
+        {message: faker.lorem.sentences()},
+      ];
+
+      function onSubmit() {
+        return Promise.resolve(submitErrors);
+      }
+
+      const form = mount(
+        <FormState initialValues={{product}} onSubmit={onSubmit}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      await submit();
+      form.update();
+
+      const {errors} = lastCallArgs(renderPropSpy);
+      expect(errors).toEqual(errors);
+    });
+
+    it('converts array values for error fields to keypaths', async () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      const submitErrors = [
+        {message: faker.lorem.sentences(), field: ['title', 'foo']},
+        {message: faker.lorem.sentences(), field: ['description', 'bar']},
+      ];
+
+      function onSubmit() {
+        return Promise.resolve(submitErrors);
+      }
+
+      const form = mount(
+        <FormState initialValues={{}} onSubmit={onSubmit}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      await submit();
+      form.update();
+
+      const {
+        errors: [titleError, descriptionError],
+      } = lastCallArgs(renderPropSpy);
+
+      expect(titleError.field).toEqual(submitErrors[0].field.join('.'));
+      expect(titleError.message).toEqual(submitErrors[0].message);
+      expect(descriptionError.field).toEqual(submitErrors[1].field.join('.'));
+      expect(descriptionError.message).toEqual(submitErrors[1].message);
+    });
+  });
+});
+
+function lastCallArgs(spy: jest.Mock) {
+  const calls = spy.mock.calls;
+  return calls[calls.length - 1][0];
+}

--- a/packages/react-form-state/src/test/array-utilities.test.tsx
+++ b/packages/react-form-state/src/test/array-utilities.test.tsx
@@ -1,0 +1,73 @@
+import faker from 'faker';
+import {push, replace, remove} from '../utilities';
+
+describe('array-utilities', () => {
+  describe('push', () => {
+    it('returns array with new member appended', () => {
+      const array = [faker.address.latitude()];
+
+      const newItem = faker.address.latitude();
+      const newArray = push(array, newItem);
+
+      expect(newArray).toEqual(array.concat([newItem]));
+    });
+
+    it('does not mutate original array', () => {
+      const array = [faker.address.latitude()];
+      const newItem = faker.address.latitude();
+
+      const newArray = push(array, newItem);
+
+      expect(newArray).not.toBe(array);
+      expect(array).not.toEqual(array.concat([newItem]));
+    });
+  });
+
+  describe('replace', () => {
+    it('returns array with new value replacing given index', () => {
+      const array = [
+        faker.address.latitude(),
+        faker.address.latitude(),
+        faker.address.latitude(),
+      ];
+
+      const newItem = faker.address.latitude();
+      const newArray = replace(array, 1, newItem);
+
+      expect(newArray).toEqual([array[0], newItem, array[2]]);
+    });
+
+    it('does not mutate original array', () => {
+      const array = [faker.address.latitude()];
+      const newItem = faker.address.latitude();
+
+      const newArray = replace(array, 0, newItem);
+
+      expect(newArray).not.toBe(array);
+      expect(array).not.toEqual([newItem]);
+    });
+  });
+
+  describe('remove', () => {
+    it('returns array with value at given index removed', () => {
+      const array = [
+        faker.address.latitude(),
+        faker.address.latitude(),
+        faker.address.latitude(),
+      ];
+
+      const newArray = remove(array, 1);
+
+      expect(newArray).toEqual([array[0], array[2]]);
+    });
+
+    it('does not mutate original array', () => {
+      const array = [faker.address.latitude()];
+
+      const newArray = remove(array, 0);
+
+      expect(newArray).not.toBe(array);
+      expect(array).not.toEqual([]);
+    });
+  });
+});

--- a/packages/react-form-state/src/test/validators.test.tsx
+++ b/packages/react-form-state/src/test/validators.test.tsx
@@ -1,0 +1,247 @@
+import faker from 'faker';
+import {validate, validateNested, validateList, validators} from '..';
+
+describe('validation helpers', () => {
+  function trueMatcher() {
+    return true;
+  }
+  function falseMatcher() {
+    return false;
+  }
+
+  describe('validate', () => {
+    it("returns a function that returns void if matcher returns true on it's input", () => {
+      const error = faker.lorem.word();
+      const alwaysPassValidator = validate(trueMatcher, error);
+      const alwaysFailValidator = validate(falseMatcher, error);
+
+      const input = faker.lorem.word();
+      expect(alwaysPassValidator(input)).toBeUndefined();
+      expect(alwaysFailValidator(input)).not.toBeUndefined();
+    });
+
+    it("returns a function that returns the errorContent when matcher returns true on it's input ", () => {
+      const error = faker.lorem.word();
+      const alwaysPassValidator = validate(trueMatcher, error);
+      const alwaysFailValidator = validate(falseMatcher, error);
+
+      const input = faker.lorem.word();
+      expect(alwaysPassValidator(input)).toBeUndefined();
+      expect(alwaysFailValidator(input)).toBe(error);
+    });
+
+    it("returns a function that returns the result of errorContent(input) when matcher returns true on it's input and errorContent is a function ", () => {
+      function error(input: string) {
+        return `${input} error`;
+      }
+
+      const alwaysPassValidator = validate(trueMatcher, error);
+      const alwaysFailValidator = validate(falseMatcher, error);
+
+      const input = faker.lorem.word();
+      expect(alwaysPassValidator(input)).toBeUndefined();
+      expect(alwaysFailValidator(input)).toBe(error(input));
+    });
+  });
+
+  describe('validateObject', () => {
+    const defaultError = faker.lorem.word();
+    const alwaysPassValidator = validate(trueMatcher, defaultError);
+    const alwaysFailValidator = validate(falseMatcher, defaultError);
+
+    it('returns a function that returns an error dictionary for validators that fail', () => {
+      const compoundValidator = validateNested({
+        title: alwaysPassValidator,
+        product: alwaysFailValidator,
+      });
+
+      const data = {
+        title: faker.lorem.words(),
+        product: faker.commerce.product(),
+      };
+
+      const result = compoundValidator(data, {});
+
+      expect(result).toMatchObject({
+        title: alwaysPassValidator(data.title),
+        product: alwaysFailValidator(data),
+      });
+    });
+
+    it('returns a function that returns void when no validator fails', () => {
+      const compoundValidator = validateNested({
+        title: alwaysPassValidator,
+        product: alwaysPassValidator,
+      });
+
+      const data = {
+        title: faker.lorem.words(),
+        product: faker.commerce.product(),
+      };
+
+      const result = compoundValidator(data, {});
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('validateArray', () => {
+    const defaultError = faker.lorem.word();
+    const alwaysPassValidator = validate(trueMatcher, defaultError);
+    const alwaysFailValidator = validate(falseMatcher, defaultError);
+
+    it('returns a function that returns an array of error dictionaries for any validators that fail', () => {
+      const compoundValidator = validateList({
+        title: alwaysPassValidator,
+        product: alwaysFailValidator,
+      });
+
+      const data = [
+        {
+          title: faker.lorem.words(),
+          product: faker.commerce.product(),
+        },
+        {
+          title: faker.lorem.words(),
+          product: faker.commerce.product(),
+        },
+      ];
+
+      const results = compoundValidator(data, {});
+
+      results.forEach((result, index) => {
+        expect(result).toMatchObject({
+          title: alwaysPassValidator(data[index].title),
+          product: alwaysFailValidator(data[index].product),
+        });
+      });
+    });
+
+    it('returns a function that returns void when no item in the array fails any validators', () => {
+      const compoundValidator = validateList({
+        title: alwaysPassValidator,
+        product: alwaysPassValidator,
+      });
+
+      const data = [
+        {
+          title: faker.lorem.words(),
+          product: faker.commerce.product(),
+        },
+        {
+          title: faker.lorem.words(),
+          product: faker.commerce.product(),
+        },
+      ];
+
+      const result = compoundValidator(data, {});
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('validators', () => {
+    describe('lengthMoreThan', () => {
+      it('returns a function that returns undefined when input.length > length', () => {
+        const error = faker.lorem.word();
+        const validator = validators.lengthMoreThan(0, error);
+        expect(validator({length: 10})).toBeUndefined();
+      });
+
+      it('returns a function that returns errorContent when input.length <= length', () => {
+        const error = faker.lorem.word();
+        const validator = validators.lengthMoreThan(10, error);
+        expect(validator({length: 0})).toBe(error);
+      });
+    });
+
+    describe('lengthLessThan', () => {
+      const error = faker.lorem.word();
+
+      it('returns a function that returns undefined when input.length < length', () => {
+        const validator = validators.lengthLessThan(10, error);
+        expect(validator({length: 0})).toBeUndefined();
+      });
+
+      it('returns a function that returns errorContent when input.length >= length', () => {
+        const validator = validators.lengthLessThan(0, error);
+        expect(validator({length: 10})).toBe(error);
+      });
+    });
+
+    describe('numericString', () => {
+      const error = faker.lorem.word();
+
+      it('returns a function that returns undefined when the input is a numeric string', () => {
+        const validator = validators.numericString(error);
+        expect(validator('2')).toBeUndefined();
+      });
+
+      it('returns a function that returns errorContent when the input is a non-numeric string', () => {
+        const validator = validators.numericString(error);
+        expect(validator(faker.lorem.words())).toBe(error);
+      });
+    });
+
+    describe('nonNumericString', () => {
+      const error = faker.lorem.word();
+
+      it('returns a function that returns errorContent when the input is a non-numeric string', () => {
+        const validator = validators.numericString(error);
+        expect(validator(faker.lorem.words())).toBe(error);
+      });
+
+      it('returns a function that returns undefined when the input is a numeric string', () => {
+        const validator = validators.numericString(error);
+        expect(validator('2')).toBeUndefined();
+      });
+    });
+
+    describe('required', () => {
+      const error = faker.lorem.word();
+
+      it('returns a function that returns errorContent when the input is null', () => {
+        const validator = validators.required(error);
+        expect(validator(null)).toBe(error);
+      });
+
+      it('returns a function that returns errorContent when the input is undefined', () => {
+        const validator = validators.required(error);
+        // eslint-disable-next-line no-undefined
+        expect(validator(undefined)).toBe(error);
+      });
+
+      it('returns a function that returns errorContent when the input has a length of 0', () => {
+        const validator = validators.required(error);
+        expect(validator('')).toBe(error);
+      });
+
+      it('returns a function that returns undefined when the input is a non-falsey value with a length > 0', () => {
+        const validator = validators.required(error);
+
+        expect(validator([1, 2])).toBeUndefined();
+        expect(validator(faker.lorem.words())).toBeUndefined();
+        expect(validator({length: 1})).toBeUndefined();
+      });
+    });
+
+    describe('requiredString', () => {
+      const error = faker.lorem.word();
+
+      it('returns a function that returns undefined when the input is not empty', () => {
+        const validator = validators.requiredString(error);
+        expect(validator(faker.lorem.words())).toBeUndefined();
+      });
+
+      it('returns a function that returns errorContent when the input is empty', () => {
+        const validator = validators.requiredString(error);
+        expect(validator('')).toBe(error);
+      });
+
+      it('returns a function that returns errorContent when the input is only whitespace', () => {
+        const validator = validators.requiredString(error);
+        expect(validator('                      ')).toBe(error);
+      });
+    });
+  });
+});

--- a/packages/react-form-state/src/types.ts
+++ b/packages/react-form-state/src/types.ts
@@ -1,0 +1,22 @@
+export interface ClientError {
+  field?: string;
+  message: string;
+}
+
+export interface FieldState<Value> {
+  name: string;
+  initialValue: Value;
+  value: Value;
+  dirty: boolean;
+  changed: boolean;
+  error?: any;
+}
+
+export interface FieldDescriptor<Value> extends FieldState<Value> {
+  onChange(newValue: Value): void;
+  onBlur(): void;
+}
+
+export type FieldDescriptors<Fields> = {
+  [FieldPath in keyof Fields]: FieldDescriptor<Fields[FieldPath]>
+};

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -1,0 +1,29 @@
+export function mapObject<Input, Output>(
+  input: Input,
+  mapper: (value: any, key: keyof Input) => any,
+) {
+  return Object.keys(input)
+    .map(key => [key, input[key]])
+    .reduce((accumulator: any, [key, value]) => {
+      accumulator[key] = mapper(value, key as keyof Input);
+      return accumulator;
+    }, {}) as Output;
+}
+
+export function push<T>(array: T[], ...values: T[]) {
+  return array.concat(values);
+}
+
+export function remove<T>(array: T[], targetIndex: number) {
+  return array.filter((_, index) => index !== targetIndex);
+}
+
+export function replace<T>(array: T[], targetIndex: number, newValue: T) {
+  return array.map((value, index) => {
+    if (index !== targetIndex) {
+      return value;
+    }
+
+    return newValue;
+  });
+}

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -1,0 +1,132 @@
+import {toString} from 'lodash';
+import {mapObject} from './utilities';
+
+interface Matcher<Input> {
+  (input: Input): boolean;
+}
+
+interface Matcher<Input, Fields = never> {
+  (input: Input, fields: Fields): boolean;
+}
+
+interface StringMapper {
+  (input: string): any;
+}
+
+type ErrorContent = string | StringMapper;
+
+export function lengthMoreThan(length: number) {
+  return (input: {length: number}) => input.length > length;
+}
+
+export function lengthLessThan(length: number) {
+  return (input: {length: number}) => input.length < length;
+}
+
+export function isNumericString(input: string) {
+  return input !== '' && (input.match(/[^0-9.,]/g) || []).length === 0;
+}
+
+export function isEmpty(input: any) {
+  // eslint-disable-next-line no-undefined
+  return input === null || input === undefined || input.length === 0;
+}
+
+export function isEmptyString(input: string) {
+  return input.trim().length < 1;
+}
+
+export function not<Input>(matcher: Matcher<Input>): Matcher<Input>;
+
+export function not<Input, Fields>(matcher: Matcher<Input, Fields>) {
+  return (input: Input, fields: Fields) => !matcher(input, fields);
+}
+
+export function validateNested<Input extends Object, Fields>(
+  validatorDictionary: any,
+) {
+  // eslint-disable-next-line consistent-return
+  return (input: Input, fields: Fields) => {
+    const errors = mapObject<Input, any>(input, (value, field) => {
+      return (
+        validatorDictionary[field] && validatorDictionary[field](value, fields)
+      );
+    });
+
+    const anyErrors = Object.keys(errors)
+      .map(key => errors[key])
+      .some(value => value != null);
+
+    if (anyErrors) {
+      return errors;
+    }
+  };
+}
+
+export function validateList<Input extends Object, Fields>(
+  validatorDictionary: any,
+) {
+  const validateItem = validateNested(validatorDictionary);
+  // eslint-disable-next-line consistent-return
+  return (input: Input[], fields: Fields) => {
+    const errors = input.map(item => validateItem(item, fields));
+
+    if (errors.some(error => error != null)) {
+      return errors;
+    }
+  };
+}
+
+export function validate<Input>(
+  matcher: Matcher<Input>,
+  errorContent: ErrorContent,
+): (input: Input) => ErrorContent | void;
+
+export function validate<Input, Fields = never>(
+  matcher: Matcher<Input, Fields>,
+  errorContent: ErrorContent,
+) {
+  return (input: Input, fields: Fields) => {
+    const matches = matcher(input, fields);
+
+    if (matches) {
+      return;
+    }
+
+    if (typeof errorContent === 'function') {
+      // eslint-disable-next-line consistent-return
+      return errorContent(toString(input));
+    }
+
+    // eslint-disable-next-line consistent-return
+    return errorContent;
+  };
+}
+
+const validators = {
+  lengthMoreThan(length: number, errorContent: ErrorContent) {
+    return validate(lengthMoreThan(length), errorContent);
+  },
+
+  lengthLessThan(length: number, errorContent: ErrorContent) {
+    return validate(lengthLessThan(length), errorContent);
+  },
+
+  numericString(errorContent: ErrorContent) {
+    return validate(isNumericString, errorContent);
+  },
+
+  requiredString(errorContent: ErrorContent) {
+    return validate(not(isEmptyString), errorContent);
+  },
+
+  nonNumericString(errorContent: ErrorContent) {
+    return validate(not(isNumericString), errorContent);
+  },
+
+  required(errorContent: ErrorContent) {
+    return validate(not(isEmpty), errorContent);
+  },
+};
+
+export default validators;

--- a/packages/react-form-state/tsconfig.json
+++ b/packages/react-form-state/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,6 +2503,10 @@ eyes@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
+faker@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
+
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
@@ -4528,6 +4532,16 @@ lodash-decorators@^4.3.5:
   resolved "https://registry.yarnpkg.com/lodash-decorators/-/lodash-decorators-4.5.0.tgz#a4bb63dfbb512f0dd9409f7af452e4e2edcb80f4"
   dependencies:
     tslib "^1.7.1"
+
+lodash-decorators@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lodash-decorators/-/lodash-decorators-6.0.0.tgz#4e0639ba639d738e5f4993acf54bf292cc95d851"
+  dependencies:
+    tslib "^1.9.2"
+
+lodash-es@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -6615,6 +6629,10 @@ ts-jest@^22.4.2:
 tslib@^1.7.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
+tslib@^1.9.2:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
closes #17 

## Create `@shopify/react-form-state`

This PR is absolutely ginormous and I'm sorry. Part a port of `with-form`, part a rewrite of it, part a set of guidelines for how to use it properly. This thing should serve as a solid base for our react forms going forward. 

One nice thing is the vast majority of the PR is actually tests and documentation, which makes me feel all warm and tingly inside.

The PR is already huge, so I really don't want to make any additive changes to it. We also already had some pseudo review cycles on the RFC and the demo PR on our internal repos.

OFC subtractive changes and neutral changes are good :).

For an understanding of all the things this lets you do, check out the README. It's real big and thorough.

@loic-d  @michelleyschen  @9at8  you all wanted to take a look at the final PR for this too.

## Future / Questions
- currently the setup causes some react warnings due to polaris inputs passing stuff like `dirty`, `initialValue` down. I'm not *sure* we actually need to pass those down, so maybe I should filter them off before passing them into the render prop?
- probably we need to change our validation strategy to validate all fields whenever one field is cahnged, @loic-d  did some work on that we can port to here
- we may want to pull out the validator helpers into a second module so that the minimum size for this goes down
- maybe we can make smaller versions of the lodash functions I used here