### PR TITLE
Add type definition for phoneNumberPrefix

### DIFF
--- a/packages/address/src/tests/fixtures/CA_en.ts
+++ b/packages/address/src/tests/fixtures/CA_en.ts
@@ -5,6 +5,7 @@ const data = {
     code: 'CA',
     zoneKey: 'province',
     zipKey: 'postalCode',
+    phoneNumberPrefix: 1,
     format: {
       edit:
         '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',

--- a/packages/address/src/tests/fixtures/CA_fr.ts
+++ b/packages/address/src/tests/fixtures/CA_fr.ts
@@ -5,6 +5,7 @@ const data = {
     code: 'CA',
     zoneKey: 'province',
     zipKey: 'postalCode',
+    phoneNumberPrefix: 1,
     format: {
       edit:
         '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',

--- a/packages/address/src/tests/fixtures/FR_fr.ts
+++ b/packages/address/src/tests/fixtures/FR_fr.ts
@@ -5,6 +5,7 @@ const data = {
     code: 'FR',
     zoneKey: 'region',
     zipKey: 'postalCode',
+    phoneNumberPrefix: 33,
     format: {
       edit:
         '{firstName}{lastName}_{company}_{address1}_{address2}_{country}{zip}{city}_{phone}',

--- a/packages/address/src/tests/fixtures/JP_ja.ts
+++ b/packages/address/src/tests/fixtures/JP_ja.ts
@@ -5,6 +5,7 @@ const data = {
     code: 'JP',
     zoneKey: 'prefecture',
     zipKey: 'postalCode',
+    phoneNumberPrefix: 81,
     format: {
       edit:
         '{company}_{lastName}{firstName}_{zip}_{country}_{province}{city}_{address1}_{address2}_{phone}',

--- a/packages/address/src/types.ts
+++ b/packages/address/src/types.ts
@@ -36,6 +36,7 @@ export interface Country {
   attributes: {
     code: string;
     name: string;
+    phoneNumberPrefix: number;
     format: {
       edit: string;
       show: string;


### PR DESCRIPTION
Add type definition for `phoneNumberPrefix` for `Country` to reflect [changes in the country_service API](https://github.com/Shopify/country-service/pull/42/files)