### PR TITLE
Pass whole form data into submit

### DIFF
--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -114,7 +114,7 @@ There is also nothing to stop you from using your own custom inputs.
 Forms usually need some mechanism of submission. `<FormState />` is not opinionated about how this is done, but does provide a built-in mechanism for managing loading state and updating based on errors from the submission process. Most of this is done through the `onSubmit` property.
 
 ```typescript
-  onSubmit={async (fields) => {
+  onSubmit={async ({fields}: FormData<Fields>) => {
     const result = await updateProduct(fields);
 
     if (isErrorResult(result)) {

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -523,7 +523,7 @@ describe('<FormState />', () => {
   });
 
   describe('field submit', () => {
-    it('calls onSubmit() with the current field state when submit() is called', () => {
+    it('calls onSubmit() with the current formDetails, other than the submit function, when submit() is called', () => {
       const renderPropSpy = jest.fn(() => null);
       const onSubmitSpy = jest.fn();
       const product = faker.commerce.productName();
@@ -534,16 +534,15 @@ describe('<FormState />', () => {
         </FormState>,
       );
 
-      const {fields, submit} = lastCallArgs(renderPropSpy);
+      const {submit, submitting, reset, ...formData} = lastCallArgs(
+        renderPropSpy,
+      );
+
       submit();
 
-      expect(lastCallArgs(onSubmitSpy)).toMatchObject({
-        product: {
-          value: fields.product.value,
-          initialValue: fields.product.initialValue,
-          dirty: false,
-        },
-      });
+      expect(onSubmitSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining(formData),
+      );
     });
 
     it('when onSubmit() returns a promise, re-renders with submitting true while waiting for it to resolve/reject', () => {


### PR DESCRIPTION
fixes #188
This PR changes the api of `<FormState />`'s submit handler such that it  passes in all the state information that the render prop gets, except for `submitting`, `reset`, and `submit` since they are not useful in that context.

It also burns some state regeneration logic that didn't really make sense