### PR TITLE
🐛 Make modifier keys work in react-shortcuts

### DIFF
--- a/packages/react-shortcuts/README.md
+++ b/packages/react-shortcuts/README.md
@@ -45,6 +45,10 @@ export interface Props {
   */
   keys: Key[];
   /*
+    keys that need to be kept pressed along with `keys` to trigger `onMatch`
+  */
+  modifierKeys?: ModifierKey[];
+  /*
     a callback that will trigger when the key combination is pressed
   */
   onMatch(keys: Key[]): void;
@@ -57,7 +61,7 @@ export interface Props {
   */
   ignoreInput?: boolean;
   /*
-    a boolean that lets you opt out of swalloing the key event and let it propagate
+    a boolean that lets you opt out of swallowing the key event and let it propagate
   */
   allowDefault?: boolean;
 }
@@ -75,7 +79,7 @@ export default function MyComponent() {
   return (
     <div>
       {/* some app markup here */}
-      <Shortcut key={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
+      <Shortcut keys={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
     </div>
   );
 }
@@ -94,7 +98,8 @@ export default function MyComponent() {
     <div>
       {/* some app markup here */}
       <Shortcut
-        key={['ctrlKey', 'shiftKey', 'b']}
+        modifierKeys={['Control', 'Shift']}
+        keys={['B']}
         onMatch={() => console.log('bar!')}
       />
     </div>
@@ -122,7 +127,7 @@ class MyComponent extends React.Component {
         <button ref={node => this.setState({fooNode: node})} />
         <Shortcut
           node={fooNode}
-          key={['f', 'o', 'o']}
+          keys={['f', 'o', 'o']}
           onMatch={() => console.log('foo')}
         />
       </div>
@@ -146,7 +151,7 @@ export default function MyComponent() {
   return (
     <div>
       {/* some app markup here */}
-      <Shortcut key={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
+      <Shortcut keys={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
     </div>
   );
 }
@@ -171,7 +176,7 @@ describe('my-component', () => {
 
     const shortcut = component.find(Shortcut);
 
-    expect(shortcut.prop('key')).toEqual(['f', 'o', 'o']);
+    expect(shortcut.prop('keys')).toEqual(['f', 'o', 'o']);
   });
 });
 ```

--- a/packages/react-shortcuts/README.md
+++ b/packages/react-shortcuts/README.md
@@ -43,15 +43,15 @@ export interface Props {
   /*
     keys that, when pressed sequentially, will trigger `onMatch`
   */
-  keys: Key[];
+  ordered: Key[];
   /*
     keys that need to be kept pressed along with `keys` to trigger `onMatch`
   */
-  modifierKeys?: ModifierKey[];
+  held?: ModifierKey[];
   /*
     a callback that will trigger when the key combination is pressed
   */
-  onMatch(keys: Key[]): void;
+  onMatch(matched: {ordered: Key[]; held?: ModifierKey[]}): void;
   /*
     a node that, when supplied, will be used to only fire `onMatch` when it is focused
   */
@@ -79,7 +79,7 @@ export default function MyComponent() {
   return (
     <div>
       {/* some app markup here */}
-      <Shortcut keys={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
+      <Shortcut ordered={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
     </div>
   );
 }
@@ -98,8 +98,8 @@ export default function MyComponent() {
     <div>
       {/* some app markup here */}
       <Shortcut
-        modifierKeys={['Control', 'Shift']}
-        keys={['B']}
+        held={['Control', 'Shift']}
+        ordered={['B']}
         onMatch={() => console.log('bar!')}
       />
     </div>
@@ -127,7 +127,7 @@ class MyComponent extends React.Component {
         <button ref={node => this.setState({fooNode: node})} />
         <Shortcut
           node={fooNode}
-          keys={['f', 'o', 'o']}
+          ordered={['f', 'o', 'o']}
           onMatch={() => console.log('foo')}
         />
       </div>
@@ -151,7 +151,7 @@ export default function MyComponent() {
   return (
     <div>
       {/* some app markup here */}
-      <Shortcut keys={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
+      <Shortcut ordered={['f', 'o', 'o']} onMatch={() => console.log('foo')} />
     </div>
   );
 }
@@ -176,7 +176,7 @@ describe('my-component', () => {
 
     const shortcut = component.find(Shortcut);
 
-    expect(shortcut.prop('keys')).toEqual(['f', 'o', 'o']);
+    expect(shortcut.prop('ordered')).toEqual(['f', 'o', 'o']);
   });
 });
 ```

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -3,8 +3,8 @@ import {contextTypes} from '../ShortcutProvider';
 import Key, {ModifierKey} from '../keys';
 
 export interface Props {
-  keys: Key[];
-  modifierKeys?: ModifierKey[];
+  ordered: Key[];
+  held?: ModifierKey[];
   node?: HTMLElement | null;
   ignoreInput?: boolean;
   onMatch(keys: Key[]): void;
@@ -19,8 +19,8 @@ export default class Shortcut extends React.Component<Props, never> {
   static contextTypes = contextTypes;
   public data = {
     node: this.props.node,
-    keys: this.props.keys,
-    modifierKeys: this.props.modifierKeys,
+    ordered: this.props.ordered,
+    held: this.props.held,
     ignoreInput: this.props.ignoreInput || false,
     onMatch: this.props.onMatch,
     allowDefault: this.props.allowDefault,

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import {contextTypes} from '../ShortcutProvider';
-import Key from '../keys';
+import Key, {ModifierKey} from '../keys';
 
 export interface Props {
   keys: Key[];
+  modifierKeys?: ModifierKey[];
   node?: HTMLElement | null;
   ignoreInput?: boolean;
   onMatch(keys: Key[]): void;
@@ -19,6 +20,7 @@ export default class Shortcut extends React.Component<Props, never> {
   public data = {
     node: this.props.node,
     keys: this.props.keys,
+    modifierKeys: this.props.modifierKeys,
     ignoreInput: this.props.ignoreInput || false,
     onMatch: this.props.onMatch,
     allowDefault: this.props.allowDefault,

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -7,7 +7,7 @@ export interface Props {
   held?: ModifierKey[];
   node?: HTMLElement | null;
   ignoreInput?: boolean;
-  onMatch(keys: Key[]): void;
+  onMatch(matched: {ordered: Key[]; held?: ModifierKey[]}): void;
   allowDefault?: boolean;
 }
 

--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -4,8 +4,8 @@ const ON_MATCH_DELAY = 500;
 
 export interface Data {
   node: HTMLElement | null | undefined;
-  keys: Key[];
-  modifierKeys?: ModifierKey[];
+  ordered: Key[];
+  held?: ModifierKey[];
   ignoreInput: boolean;
   onMatch(): void;
   allowDefault: boolean;
@@ -66,21 +66,18 @@ export default class ShortcutManager {
       this.shortcutsMatched.length > 0 ? this.shortcutsMatched : this.shortcuts;
 
     this.shortcutsMatched = shortcuts.filter(
-      ({keys, modifierKeys, node, ignoreInput}) => {
+      ({ordered, held, node, ignoreInput}) => {
         if (isFocusedInput() && !ignoreInput) {
           return false;
         }
 
-        if (
-          modifierKeys &&
-          !modifierKeys.every(key => event.getModifierState(key))
-        ) {
+        if (held && !held.every(key => event.getModifierState(key))) {
           return false;
         }
 
         const partiallyMatching = arraysMatch(
           this.keysPressed,
-          keys.slice(0, this.keysPressed.length),
+          ordered.slice(0, this.keysPressed.length),
         );
 
         if (node) {
@@ -94,8 +91,8 @@ export default class ShortcutManager {
   }
 
   private callMatchedShortcut(event: Event) {
-    const longestMatchingShortcut = this.shortcutsMatched.find(({keys}) =>
-      arraysMatch(keys, this.keysPressed),
+    const longestMatchingShortcut = this.shortcutsMatched.find(({ordered}) =>
+      arraysMatch(ordered, this.keysPressed),
     );
 
     if (!longestMatchingShortcut) {

--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -7,7 +7,7 @@ export interface Data {
   ordered: Key[];
   held?: ModifierKey[];
   ignoreInput: boolean;
-  onMatch(): void;
+  onMatch(matched: {ordered: Key[]; held?: ModifierKey[]}): void;
   allowDefault: boolean;
 }
 
@@ -103,7 +103,10 @@ export default class ShortcutManager {
       event.preventDefault();
     }
 
-    longestMatchingShortcut.onMatch();
+    longestMatchingShortcut.onMatch({
+      ordered: longestMatchingShortcut.ordered,
+      held: longestMatchingShortcut.held,
+    });
 
     clearTimeout(this.timer);
 

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -23,8 +23,8 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut key="foo" keys={['f', 'o', 'o']} onMatch={fooSpy} />
-        <Shortcut key="bar" keys={['b', 'a', 'r']} onMatch={barSpy} />
+        <Shortcut key="foo" ordered={['f', 'o', 'o']} onMatch={fooSpy} />
+        <Shortcut key="bar" ordered={['b', 'a', 'r']} onMatch={barSpy} />
       </ShortcutProvider>,
     );
 
@@ -40,8 +40,8 @@ describe('ShortcutManager', () => {
     const barSpy = jest.fn();
     mount(
       <ShortcutProvider>
-        <Shortcut key="foo" keys={['f', 'o', 'o']} onMatch={fooSpy} />
-        <Shortcut key="bar" keys={['b', 'a', 'r']} onMatch={barSpy} />
+        <Shortcut key="foo" ordered={['f', 'o', 'o']} onMatch={fooSpy} />
+        <Shortcut key="bar" ordered={['b', 'a', 'r']} onMatch={barSpy} />
       </ShortcutProvider>,
     );
 
@@ -64,9 +64,9 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['f', 'o', 'o']} onMatch={fooSpy} />
-        <Shortcut keys={['f', 'o']} onMatch={foSpy} />
-        <Shortcut keys={['f']} onMatch={fSpy} />
+        <Shortcut key="foo" ordered={['f', 'o', 'o']} onMatch={fooSpy} />
+        <Shortcut key="fo" ordered={['f', 'o']} onMatch={foSpy} />
+        <Shortcut key="f" ordered={['f']} onMatch={fSpy} />
       </ShortcutProvider>,
     );
 
@@ -86,7 +86,7 @@ describe('ShortcutManager', () => {
     const spy = jest.fn();
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['b', 'a', 'r']} onMatch={spy} />
+        <Shortcut ordered={['b', 'a', 'r']} onMatch={spy} />
       </ShortcutProvider>,
     );
 
@@ -105,8 +105,8 @@ describe('ShortcutManager', () => {
     const spy = jest.fn();
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['f', 'o', 'o']} onMatch={spy} />
-        <Shortcut keys={['f']} onMatch={spy} />
+        <Shortcut key="foo" ordered={['f', 'o', 'o']} onMatch={spy} />
+        <Shortcut key="f" ordered={['f']} onMatch={spy} />
       </ShortcutProvider>,
     );
 
@@ -136,8 +136,8 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['f', 'o', 'o']} onMatch={spy} />
-        <Shortcut keys={['f', 'o', 'o']} onMatch={spy} />
+        <Shortcut key="foo-1" ordered={['f', 'o', 'o']} onMatch={spy} />
+        <Shortcut key="foo-2" ordered={['f', 'o', 'o']} onMatch={spy} />
       </ShortcutProvider>,
     );
 
@@ -154,8 +154,8 @@ describe('ShortcutManager', () => {
 
     const app = mount(
       <ShortcutProvider>
-        <Shortcut keys={['b', 'a', 'r']} onMatch={spy} />
-        <Shortcut keys={['f', 'o', 'o']} onMatch={spy} />
+        <Shortcut key="bar" ordered={['b', 'a', 'r']} onMatch={spy} />
+        <Shortcut key="foo" ordered={['f', 'o', 'o']} onMatch={spy} />
       </ShortcutProvider>,
     );
 
@@ -177,7 +177,7 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['?']} onMatch={spy} />
+        <Shortcut ordered={['?']} onMatch={spy} />
       </ShortcutProvider>,
     );
 
@@ -196,7 +196,7 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['a']} onMatch={spy} allowDefault />
+        <Shortcut ordered={['a']} onMatch={spy} allowDefault />
       </ShortcutProvider>,
     );
 
@@ -214,7 +214,7 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['a']} onMatch={spy} />
+        <Shortcut ordered={['a']} onMatch={spy} />
       </ShortcutProvider>,
     );
 
@@ -227,16 +227,16 @@ describe('ShortcutManager', () => {
   describe('modifier keys', () => {
     it('matches shortcut when all modifier keys are pressed', () => {
       const fooSpy = jest.fn();
-      const modifierKeys: ModifierKey[] = ['Control', 'Shift', 'Alt', 'Meta'];
+      const held: ModifierKey[] = ['Control', 'Shift', 'Alt', 'Meta'];
 
       mount(
         <ShortcutProvider>
-          <Shortcut modifierKeys={modifierKeys} keys={['/']} onMatch={fooSpy} />
+          <Shortcut held={held} ordered={['/']} onMatch={fooSpy} />
         </ShortcutProvider>,
       );
 
       keydown('/', document, {
-        getModifierState: key => modifierKeys.includes(key),
+        getModifierState: key => held.includes(key),
       });
 
       expect(fooSpy).toHaveBeenCalled();
@@ -244,27 +244,18 @@ describe('ShortcutManager', () => {
 
     it('doesn’t match shortcut when all modifier keys not pressed', () => {
       const fooSpy = jest.fn();
-      const modifierKeysToCheck: ModifierKey[] = [
-        'Control',
-        'Shift',
-        'Alt',
-        'Meta',
-      ];
+      const heldToCheck: ModifierKey[] = ['Control', 'Shift', 'Alt', 'Meta'];
 
       mount(
         <ShortcutProvider>
-          <Shortcut
-            modifierKeys={modifierKeysToCheck}
-            keys={['/']}
-            onMatch={fooSpy}
-          />
+          <Shortcut held={heldToCheck} ordered={['/']} onMatch={fooSpy} />
         </ShortcutProvider>,
       );
 
-      const modifierKeysPressed: ModifierKey[] = ['Control', 'Shift', 'Hyper'];
+      const heldPressed: ModifierKey[] = ['Control', 'Shift', 'Hyper'];
 
       keydown('/', document, {
-        getModifierState: key => modifierKeysPressed.includes(key),
+        getModifierState: key => heldPressed.includes(key),
       });
 
       expect(fooSpy).not.toHaveBeenCalled();

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -35,23 +35,6 @@ describe('ShortcutManager', () => {
     expect(fooSpy).toHaveBeenCalled();
   });
 
-  it('works with modifier keys', () => {
-    const fooSpy = jest.fn();
-    const modifierKeys: ModifierKey[] = ['Control', 'Shift', 'Alt', 'Meta'];
-
-    mount(
-      <ShortcutProvider>
-        <Shortcut modifierKeys={modifierKeys} keys={['/']} onMatch={fooSpy} />
-      </ShortcutProvider>,
-    );
-
-    keydown('/', document, {
-      getModifierState: key => modifierKeys.includes(key),
-    });
-
-    expect(fooSpy).toHaveBeenCalled();
-  });
-
   it('calls multiple shortcuts', () => {
     const fooSpy = jest.fn();
     const barSpy = jest.fn();
@@ -239,6 +222,53 @@ describe('ShortcutManager', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(event.preventDefault).toBeCalled();
+  });
+
+  describe('modifier keys', () => {
+    it('matches shortcut when all modifier keys are pressed', () => {
+      const fooSpy = jest.fn();
+      const modifierKeys: ModifierKey[] = ['Control', 'Shift', 'Alt', 'Meta'];
+
+      mount(
+        <ShortcutProvider>
+          <Shortcut modifierKeys={modifierKeys} keys={['/']} onMatch={fooSpy} />
+        </ShortcutProvider>,
+      );
+
+      keydown('/', document, {
+        getModifierState: key => modifierKeys.includes(key),
+      });
+
+      expect(fooSpy).toHaveBeenCalled();
+    });
+
+    it('doesn’t match shortcut when all all modifier keys not pressed', () => {
+      const fooSpy = jest.fn();
+      const modifierKeysToCheck: ModifierKey[] = [
+        'Control',
+        'Shift',
+        'Alt',
+        'Meta',
+      ];
+
+      mount(
+        <ShortcutProvider>
+          <Shortcut
+            modifierKeys={modifierKeysToCheck}
+            keys={['/']}
+            onMatch={fooSpy}
+          />
+        </ShortcutProvider>,
+      );
+
+      const modifierKeysPressed: ModifierKey[] = ['Control', 'Shift', 'Hyper'];
+
+      keydown('/', document, {
+        getModifierState: key => modifierKeysPressed.includes(key),
+      });
+
+      expect(fooSpy).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -37,18 +37,17 @@ describe('ShortcutManager', () => {
 
   it('works with modifier keys', () => {
     const fooSpy = jest.fn();
-    const barSpy = jest.fn();
+    const modifierKeys: ModifierKey[] = ['Control', 'Shift', 'Alt', 'Meta'];
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['Control', 'Shift', 'Alt', 'Meta']} onMatch={fooSpy} />
+        <Shortcut modifierKeys={modifierKeys} keys={['/']} onMatch={fooSpy} />
       </ShortcutProvider>,
     );
 
-    keydown('Control');
-    keydown('Shift');
-    keydown('Alt');
-    keydown('Meta');
+    keydown('/', document, {
+      getModifierState: key => modifierKeys.includes(key),
+    });
 
     expect(fooSpy).toHaveBeenCalled();
   });
@@ -201,9 +200,9 @@ describe('ShortcutManager', () => {
 
     keydown('Shift');
     keydown('a');
-    keydown('\\');
+    keydown('?');
 
-    expect(spy).toHaveBeenCalledTimes(0);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('allows default event to occur', () => {
@@ -214,11 +213,11 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['Shift']} onMatch={spy} allowDefault />
+        <Shortcut keys={['a']} onMatch={spy} allowDefault />
       </ShortcutProvider>,
     );
 
-    keydown('Shift', document, event);
+    keydown('a', document, event);
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(event.preventDefault).not.toBeCalled();
@@ -232,11 +231,11 @@ describe('ShortcutManager', () => {
 
     mount(
       <ShortcutProvider>
-        <Shortcut keys={['Shift']} onMatch={spy} />
+        <Shortcut keys={['a']} onMatch={spy} />
       </ShortcutProvider>,
     );
 
-    keydown('Shift', document, event);
+    keydown('a', document, event);
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(event.preventDefault).toBeCalled();

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -242,7 +242,7 @@ describe('ShortcutManager', () => {
       expect(fooSpy).toHaveBeenCalled();
     });
 
-    it('doesn’t match shortcut when all all modifier keys not pressed', () => {
+    it('doesn’t match shortcut when all modifier keys not pressed', () => {
       const fooSpy = jest.fn();
       const modifierKeysToCheck: ModifierKey[] = [
         'Control',

--- a/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
@@ -30,7 +30,7 @@ export default class ShortcutWithFocus extends React.Component<Props, State> {
     return (
       <div className="app">
         <button type="button" ref={this.setRef} />
-        <Shortcut keys={['z']} onMatch={spy} node={node} />
+        <Shortcut ordered={['z']} onMatch={spy} node={node} />
       </div>
     );
   }

--- a/packages/react-shortcuts/tsconfig.json
+++ b/packages/react-shortcuts/tsconfig.json
@@ -4,15 +4,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
-    "rootDir": "./src",
-    "lib": [
-      "dom",
-      "es2015",
-      "es2016",
-      "es2017",
-      "esnext.asynciterable",
-      "dom.iterable"
-    ]
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/react-shortcuts/tsconfig.json
+++ b/packages/react-shortcuts/tsconfig.json
@@ -9,7 +9,9 @@
       "dom",
       "es2015",
       "es2016",
-      "es2017"
+      "es2017",
+      "esnext.asynciterable",
+      "dom.iterable"
     ]
   },
   "include": [

--- a/packages/react-shortcuts/tsconfig.json
+++ b/packages/react-shortcuts/tsconfig.json
@@ -9,9 +9,7 @@
       "dom",
       "es2015",
       "es2016",
-      "es2017",
-      "esnext.asynciterable",
-      "dom.iterable"
+      "es2017"
     ]
   },
   "include": [


### PR DESCRIPTION
Fixes #133 

We weren't checking for modifier keys properly using `getModifierState`, but just checking `event.key` instead. This doesn't always work, as the user would need to press the modifier keys in that particular order. (which shouldn't be the case, example: `Cmd + Option + c` equals `Option + Cmd + c`)

Doing what we did also meant that the user couldn't perform an `onMatch` by holding the modifier keys and then repeatedly pressing a normal key. (example: `Cmd (hold) + v + v + v` pastes thrice, but it would work only once if we use the current version of react-shortcuts)

Considering all these problems, I think that separating the `keys` prop into `modifierKeys` prop and `keys` prop made most sense.

Also, I'll push this and #171 together, and then release.