### PR TITLE
🐛 render helmet scripts

### DIFF
--- a/packages/react-html/src/HTML.tsx
+++ b/packages/react-html/src/HTML.tsx
@@ -101,10 +101,11 @@ export default function HTML({
       <head>
         {helmet.title.toComponent()}
         {helmet.meta.toComponent()}
+        {helmet.script.toComponent()}
         {helmet.link.toComponent()}
+
         {stylesMarkup}
         {headDataMarkup}
-
         {blockingScriptsMarkup}
       </head>
 

--- a/packages/react-html/src/tests/HTML.test.tsx
+++ b/packages/react-html/src/tests/HTML.test.tsx
@@ -139,6 +139,7 @@ describe('<HTML />', () => {
       const html = mount(<HTML {...mockProps} />);
       expect(html.find('head').contains(link)).toBe(true);
     });
+
     it('includes the script component', () => {
       const script = (
         <script

--- a/packages/react-html/src/tests/HTML.test.tsx
+++ b/packages/react-html/src/tests/HTML.test.tsx
@@ -142,10 +142,7 @@ describe('<HTML />', () => {
 
     it('includes the script component', () => {
       const script = (
-        <script
-          type="text/javascript"
-          dangerouslySetInnerHTML={{__html: 'alert("hi")'}}
-        />
+        <script dangerouslySetInnerHTML={{__html: 'alert("hi")'}} />
       );
       helmetMock.renderStatic.mockImplementation(() =>
         mockHelmet({

--- a/packages/react-html/src/tests/HTML.test.tsx
+++ b/packages/react-html/src/tests/HTML.test.tsx
@@ -139,6 +139,21 @@ describe('<HTML />', () => {
       const html = mount(<HTML {...mockProps} />);
       expect(html.find('head').contains(link)).toBe(true);
     });
+    it('includes the script component', () => {
+      const script = (
+        <script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{__html: 'alert("hi")'}}
+        />
+      );
+      helmetMock.renderStatic.mockImplementation(() =>
+        mockHelmet({
+          script: mockHelmetData('', script),
+        }),
+      );
+      const html = mount(<HTML {...mockProps} />);
+      expect(html.find('head').contains(script)).toBe(true);
+    });
 
     it('includes the htmlAttributes', () => {
       const htmlAttributes = {className: 'hello world', 'data-baz': true};


### PR DESCRIPTION
closes #198 

This PR fixes an oversight where we rendered links, meta, and html attributes from helmet, but not scripts.

We don't want programmatic script tags to be commonly used, but for things like tracking script we make helmet available as an escape hatch.