### PR TITLE
[react-form-state] Adds support for arrays of validators to validateNested

### DIFF
--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -83,6 +83,25 @@ describe('validation helpers', () => {
 
       expect(result).toBeUndefined();
     });
+
+    it('accepts arrays of validators', () => {
+      const compoundValidator = validateNested({
+        title: [alwaysPassValidator, alwaysPassValidator, alwaysPassValidator],
+        product: [alwaysPassValidator, alwaysFailValidator],
+      });
+
+      const data = {
+        title: faker.lorem.words(),
+        product: faker.commerce.product(),
+      };
+
+      const result = compoundValidator(data, {});
+
+      expect(result).toMatchObject({
+        title: alwaysPassValidator(data.title),
+        product: [alwaysFailValidator(data)],
+      });
+    });
   });
 
   describe('validateArray', () => {

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -48,27 +48,30 @@ export function validateNested<Input extends Object, Fields>(
   // eslint-disable-next-line consistent-return
   return (input: Input, fields: Fields) => {
     const errors = mapObject<Input, any>(input, (value, field) => {
-      if (validatorDictionary[field]) {
-        if (typeof validatorDictionary[field] === 'function') {
-          return validatorDictionary[field](value, fields);
-        }
-        if (!isArray(validatorDictionary[field])) {
-          // eslint-disable-next-line consistent-return
-          return;
-        }
+      const validate = validatorDictionary[field];
 
-        const errors = validatorDictionary[field]
-          .map(validator => validator(value, fields))
-          .filter(input => input != null);
-
-        if (errors.length === 0) {
-          // eslint-disable-next-line consistent-return
-          return;
-        }
-        return errors;
+      if (validate == null) {
+        return null;
       }
-      // eslint-disable-next-line
-      return;
+
+      if (typeof validate === 'function') {
+        return validate(value, fields);
+      }
+
+      if (!isArray(validate)) {
+        // eslint-disable-next-line consistent-return
+        return;
+      }
+
+      const errors = validate
+        .map(validator => validator(value, fields))
+        .filter(input => input != null);
+
+      if (errors.length === 0) {
+        // eslint-disable-next-line consistent-return
+        return;
+      }
+      return errors;
     });
 
     const anyErrors = Object.keys(errors)

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -53,7 +53,8 @@ export function validateNested<Input extends Object, Fields>(
           return validatorDictionary[field](value, fields);
         }
         if (!isArray(validatorDictionary[field])) {
-          return null;
+          // eslint-disable-next-line consistent-return
+          return;
         }
 
         const errors = validatorDictionary[field]
@@ -61,11 +62,13 @@ export function validateNested<Input extends Object, Fields>(
           .filter(input => input != null);
 
         if (errors.length === 0) {
-          return null;
+          // eslint-disable-next-line consistent-return
+          return;
         }
         return errors;
       }
-      return null;
+      // eslint-disable-next-line
+      return;
     });
 
     const anyErrors = Object.keys(errors)


### PR DESCRIPTION
was just trying out this great new library and noticed that this:

```js
validateNested({
  field: [validator1, validator2],
});
```

was throwing a TypeError, so thought I'd put up a quick PR to add support for arrays of validators to `validateNested`. I basically just copied the functionality from [validateFieldValue](https://github.com/Shopify/quilt/blob/2e4c911cbb74391225c6d5ca61f16b9f0d1406e5/packages/react-form-state/src/FormState.ts#L306).