### PR TITLE
🗒️ [react-form-state] export types for field descriptors

### DIFF
--- a/packages/react-form-state/src/index.ts
+++ b/packages/react-form-state/src/index.ts
@@ -7,5 +7,7 @@ export const arrayUtils = {push, replace, remove};
 export {default as validators} from './validators';
 export * from './validators';
 
+export * from './types';
+
 export * from './FormState';
 export default FormState;


### PR DESCRIPTION
Really simple change, we weren't exporting the types for field objects. This makes it annoying to write custom compound fields that take the entire field object.