### PR TITLE
⚡ remove unnecessary lodash functions for tiny local implementations

### DIFF
--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import isEqual from 'lodash/isEqual';
-import isArray from 'lodash/isArray';
 import set from 'lodash/set';
+
 import {memoize, bind} from 'lodash-decorators';
 
-import {mapObject} from './utilities';
+import {mapObject, deepEqual} from './utilities';
 import {FieldDescriptors, FieldState} from './types';
 import {List, Nested} from './components';
 
@@ -77,7 +76,7 @@ export default class FormState<
     }
 
     const oldInitialValues = initialValuesFromFields(oldState.fields);
-    const shouldReinitialize = !isEqual(oldInitialValues, newInitialValues);
+    const shouldReinitialize = !deepEqual(oldInitialValues, newInitialValues);
 
     if (shouldReinitialize) {
       return createFormState(newInitialValues);
@@ -199,7 +198,7 @@ export default class FormState<
   ) {
     this.setState<any>(({fields, dirtyFields}: State<Fields>) => {
       const field = fields[fieldPath];
-      const dirty = !isEqual(value, field.initialValue);
+      const dirty = !deepEqual(value, field.initialValue);
 
       const updatedField = this.getUpdatedField({
         fieldPath,
@@ -320,7 +319,7 @@ export default class FormState<
       return validate(value, fields);
     }
 
-    if (!isArray(validate)) {
+    if (!Array.isArray(validate)) {
       return;
     }
 
@@ -344,10 +343,19 @@ export default class FormState<
             return accumulator;
           }
 
+<<<<<<< HEAD
           return set(accumulator, field, message);
         },
         {},
       );
+=======
+        if (Array.isArray(field)) {
+          return {message, field: field.join('.')};
+        }
+
+        return {message, field};
+      });
+>>>>>>> ⚡ remove unnecessary lodash functions for tiny local implementations
 
       return {
         errors,

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -343,19 +343,10 @@ export default class FormState<
             return accumulator;
           }
 
-<<<<<<< HEAD
           return set(accumulator, field, message);
         },
         {},
       );
-=======
-        if (Array.isArray(field)) {
-          return {message, field: field.join('.')};
-        }
-
-        return {message, field};
-      });
->>>>>>> ⚡ remove unnecessary lodash functions for tiny local implementations
 
       return {
         errors,

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -1,3 +1,61 @@
+export function deepEqual(first: any, second: any, maxDepth = 20, depth = 0) {
+  const newDepth = depth + 1;
+
+  if (newDepth > maxDepth) {
+    throw new Error('Maximum comparison depth reached.');
+  }
+
+  if (first === second) {
+    return true;
+  }
+
+  if (typeof first !== typeof second) {
+    return false;
+  }
+
+  if (first === null || second === null) {
+    return false;
+  }
+
+  if (Array.isArray(first)) {
+    return arrayEqual(first, second, depth, maxDepth);
+  }
+
+  if (typeof first === 'object') {
+    return objectEqual(first, second, depth, maxDepth);
+  }
+
+  return first.valueOf() === second.valueOf();
+}
+
+function arrayEqual(
+  first: any[],
+  second: any[],
+  depth: number,
+  maxDepth: number,
+) {
+  if (first.length !== second.length) return false;
+
+  return first.every((valueOfFirst, index) =>
+    deepEqual(valueOfFirst, second[index], depth, maxDepth),
+  );
+}
+
+function objectEqual(first: any, second: any, depth, maxDepth) {
+  const firstKeys = Object.keys(first);
+  const secondKeys = Object.keys(second);
+
+  if (firstKeys.length !== secondKeys.length) {
+    return false;
+  }
+
+  return firstKeys.every(
+    key =>
+      Object.prototype.hasOwnProperty.call(second, key) &&
+      !deepEqual(first[key], second[key], depth, maxDepth),
+  );
+}
+
 export function mapObject<Input, Output>(
   input: Input,
   mapper: (value: any, key: keyof Input) => any,

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -1,4 +1,4 @@
-export function deepEqual(first: any, second: any, maxDepth = 20, depth = 0) {
+export function deepEqual(first: any, second: any, maxDepth = 2000, depth = 0) {
   const newDepth = depth + 1;
 
   if (newDepth > maxDepth) {
@@ -18,11 +18,11 @@ export function deepEqual(first: any, second: any, maxDepth = 20, depth = 0) {
   }
 
   if (Array.isArray(first)) {
-    return arrayEqual(first, second, depth, maxDepth);
+    return arrayEqual(first, second, maxDepth, depth);
   }
 
   if (typeof first === 'object') {
-    return objectEqual(first, second, depth, maxDepth);
+    return objectEqual(first, second, maxDepth, depth);
   }
 
   return first.valueOf() === second.valueOf();
@@ -31,17 +31,17 @@ export function deepEqual(first: any, second: any, maxDepth = 20, depth = 0) {
 function arrayEqual(
   first: any[],
   second: any[],
-  depth: number,
   maxDepth: number,
+  depth: number,
 ) {
   if (first.length !== second.length) return false;
 
   return first.every((valueOfFirst, index) =>
-    deepEqual(valueOfFirst, second[index], depth, maxDepth),
+    deepEqual(valueOfFirst, second[index], maxDepth, depth),
   );
 }
 
-function objectEqual(first: any, second: any, depth, maxDepth) {
+function objectEqual(first: any, second: any, maxDepth: number, depth: number) {
   const firstKeys = Object.keys(first);
   const secondKeys = Object.keys(second);
 
@@ -52,7 +52,7 @@ function objectEqual(first: any, second: any, depth, maxDepth) {
   return firstKeys.every(
     key =>
       Object.prototype.hasOwnProperty.call(second, key) &&
-      !deepEqual(first[key], second[key], depth, maxDepth),
+      deepEqual(first[key], second[key], maxDepth, depth),
   );
 }
 

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -13,10 +13,6 @@ export function deepEqual(first: any, second: any, maxDepth = 2000, depth = 0) {
     return false;
   }
 
-  if (first === null || second === null) {
-    return false;
-  }
-
   if (Array.isArray(first)) {
     return arrayEqual(first, second, maxDepth, depth);
   }
@@ -25,7 +21,7 @@ export function deepEqual(first: any, second: any, maxDepth = 2000, depth = 0) {
     return objectEqual(first, second, maxDepth, depth);
   }
 
-  return first.valueOf() === second.valueOf();
+  return Object.is(first, second);
 }
 
 function arrayEqual(
@@ -34,7 +30,9 @@ function arrayEqual(
   maxDepth: number,
   depth: number,
 ) {
-  if (first.length !== second.length) return false;
+  if (first.length !== second.length) {
+    return false;
+  }
 
   return first.every((valueOfFirst, index) =>
     deepEqual(valueOfFirst, second[index], maxDepth, depth),
@@ -51,7 +49,7 @@ function objectEqual(first: any, second: any, maxDepth: number, depth: number) {
 
   return firstKeys.every(
     key =>
-      Object.prototype.hasOwnProperty.call(second, key) &&
+      second.hasOwnProperty(key) &&
       deepEqual(first[key], second[key], maxDepth, depth),
   );
 }


### PR DESCRIPTION
part of #182 

This PR removes two of our lodash function imports from `<FormState />` in favour of less heavy implementations. In the case of `isArray` we just use `Array.isArray`. In the case of `isEqual` we implement a less crufty version of the algorithm ourselves.