### PR TITLE
✨ optimistically regenerate form initial values on successful submit

### DIFF
--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -523,36 +523,14 @@ import {
 } from '@shopify/polaris';
 import FormState, {
   validators,
-  validateArray,
-  validateObject,
+  validateList,
+  validateNested,
   arrayUtils,
 } from '@shopify/react-form-state';
 
 const {required, numericString, nonNumericString, lengthMoreThan} = validators;
 
-interface State {}
-
-interface Props {
-  initialValues: {
-    title: string;
-    description: string;
-    sku: string;
-    quantity: string;
-    firstVariant: string;
-      option: string;
-      value: string;
-      price: string;
-    };
-    variants: {
-      option: string;
-      value: string;
-      price: string;
-    }[];
-  },
-  productUpdate,
-}
-
-export default function Playground({initialValues, updateProduct}: Props) {
+export default function Playground({initialValues, updateProduct}) {
   return (
     <AppProvider>
       <FormState
@@ -561,11 +539,11 @@ export default function Playground({initialValues, updateProduct}: Props) {
           title: required('Required'),
           quantity: numericString('Must be a number'),
           sku: lengthMoreThan(3, 'Must  be longer than 3 characters'),
-          firstVariant: validateObject({
+          firstVariant: validateNested({
             option: required('required'),
             price: numericString('value must be numeric'),
           }),
-          variants: validateArray({
+          variants: validateList({
             option: nonNumericString('option must be nonNumeric'),
             price: numericString('value must be numeric'),
           }),

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -176,7 +176,6 @@ export default class FormState<
     }
   }
 
-  @bind
   private makeClean() {
     this.setState(({fields}) => createFormState(valuesFromFields(fields)));
   }

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -166,12 +166,19 @@ export default class FormState<
 
     this.setState({submitting: true});
 
-    const result = await onSubmit(formData);
-    if (result) {
-      this.updateRemoteErrors(result);
-    }
+    const errors = await onSubmit(formData);
 
-    this.setState({submitting: false});
+    if (errors) {
+      this.setState({submitting: false});
+      this.updateRemoteErrors(errors);
+    } else {
+      this.makeClean();
+    }
+  }
+
+  @bind
+  private makeClean() {
+    this.setState(({fields}) => createFormState(valuesFromFields(fields)));
   }
 
   @bind()
@@ -381,4 +388,8 @@ function createFormState<Fields>(values: Fields): State<Fields> {
 
 function initialValuesFromFields<Fields>(fields: FieldStates<Fields>): Fields {
   return mapObject(fields, ({initialValue}) => initialValue);
+}
+
+function valuesFromFields<Fields>(fields: FieldStates<Fields>): Fields {
+  return mapObject(fields, ({value}) => value);
 }

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -587,6 +587,36 @@ describe('<FormState />', () => {
       expect(submitting).toBe(false);
     });
 
+    it('when onSubmit() does not produce errors, regenerates form state with current values as initialValues', async () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName(),
+          }}
+          onSubmit={onSubmit}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const product = faker.commerce.productName();
+      const formDetails = lastCallArgs(renderPropSpy);
+      formDetails.fields.product.onChange(product);
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      await submit();
+
+      const {fields, dirty} = lastCallArgs(renderPropSpy);
+      expect(fields.product.initialValue).toBe(product);
+      expect(dirty).toBe(false);
+    });
+
     it('updates errors when errors are returned from onSubmit', async () => {
       const renderPropSpy = jest.fn(() => null);
       const product = faker.commerce.productName();
@@ -628,7 +658,7 @@ describe('<FormState />', () => {
         return Promise.resolve(submitErrors);
       }
 
-      const form = mount(
+      mount(
         <FormState
           initialValues={{product: faker.commerce.productName()}}
           onSubmit={onSubmit}
@@ -659,7 +689,7 @@ describe('<FormState />', () => {
         return Promise.resolve(submitErrors);
       }
 
-      const form = mount(
+      mount(
         <FormState
           initialValues={{product: faker.commerce.productName()}}
           onSubmit={onSubmit}


### PR DESCRIPTION
fixes #216 

## what this
When a submit handler is successful we always want the form to be marked clean and have it's initial values updated as soon as possible. In some cases this might not be able to happen implicitly if the submit function does not also update

## worries
Weird stuff could happen if you do the update and then somehow the parent component is re-rendered and gives us new initialValues that don't match (as we would reinitialize the form again). I can't think of a state where that's wrong though.

## how 2 test
- checkout repo and branch
- yarn build && yarn link
- go to your consuming project
- yarn link `@shopify/react-form-state`