### PR TITLE
🐛[react-form-state] Fix FormState.List memoize bug

### DIFF
--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -32,7 +32,7 @@ export default class List<Fields> extends React.PureComponent<
             initialValue: initialFieldValue,
             dirty: value !== initialFieldValue,
             error: get(error, [index, fieldPath]),
-            onChange: this.handleChange(index, fieldPath),
+            onChange: this.handleChange({index, key: fieldPath}),
           };
         },
       );
@@ -48,7 +48,13 @@ export default class List<Fields> extends React.PureComponent<
 
   @memoize()
   @bind()
-  private handleChange<Key extends keyof Fields>(index: number, key: Key) {
+  private handleChange<Key extends keyof Fields>({
+    index,
+    key,
+  }: {
+    index: number;
+    key: any;
+  }) {
     return (newValue: Fields[Key]) => {
       const {
         field: {value, onChange},

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -66,6 +66,53 @@ describe('<FormState.List />', () => {
     expect(fields.products.value[0].title).toBe(newTitle);
   });
 
+  it('updates multiple sub-field properties', () => {
+    const products = [
+      {
+        title: faker.commerce.productName(),
+        price: faker.commerce.price(),
+      },
+      {
+        title: faker.commerce.productName(),
+        price: faker.commerce.price(),
+      },
+    ];
+
+    const newTitle = faker.commerce.productName();
+    const newPrice = faker.commerce.price();
+
+    const renderSpy = jest.fn(() => null);
+
+    const renderPropSpy = jest.fn(({fields}: any) => {
+      return (
+        <FormState.List field={fields.products}>
+          {(fields: any) => {
+            return (
+              <>
+                <Input {...fields.title} />
+                <Input {...fields.price} />
+              </>
+            );
+          }}
+        </FormState.List>
+      );
+    });
+
+    const form = mount(
+      <FormState initialValues={{products}}>{renderPropSpy}</FormState>,
+    );
+
+    const titleInput = form.find(Input).first();
+    trigger(titleInput, 'onChange', newTitle);
+
+    const priceInput = form.find(Input).at(1);
+    trigger(priceInput, 'onChange', newPrice);
+
+    const {fields} = lastCallArgs(renderPropSpy);
+    expect(fields.products.value[0].title).toBe(newTitle);
+    expect(fields.products.value[0].price).toBe(newPrice);
+  });
+
   it('tracks individual sub-field dirty state', () => {
     const products = [{title: faker.commerce.productName()}];
     const newTitle = faker.commerce.productName();


### PR DESCRIPTION
While using `FormState.List`, I noticed that it wasn’t updating the state correctly. For an initialState like this:

```js
{
  products: [
    {
      id: '',
      title: '',
    },
  ],
}
```

rendered like this:

```jsx
<FormState>
  {formData => {
    const {products} = formData.fields;
    return (
      <FormState.List field={products}>
        ...
      </FormState.List>
    );
  }}
</FormState>

…`FormState` would only run the memoized `handleChange` function in `List.tsx` once, even though the inputs are different. So every input handler would edit the first property in the object, in this case `id`.

It looks like the `@memoize` decorator only understands a single argument, so I changed the function signature of `handleChange` to use a single destructured object instead of multiple args, which fixed the issue.