### PR TITLE
[react-form-state] 🎨 rename FieldDescriptors to Fields

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -7,4 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
+
 - Validators based on `validate` now always succeed for an empty input. The `required` and `requiredString` validators continue to behave the same way they used to.
+- The `FieldDescriptors` type is now named `Fields`.

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -2,16 +2,16 @@ import * as React from 'react';
 import get from 'lodash/get';
 import {memoize, bind} from 'lodash-decorators';
 
-import {FieldDescriptor, FieldDescriptors} from '../types';
+import {Field, Fields} from '../types';
 import {mapObject, replace} from '../utilities';
 
-interface Props<Fields> {
-  field: FieldDescriptor<Fields[]>;
-  children(fields: FieldDescriptors<Fields>, index: number): React.ReactNode;
+interface Props<FieldMap> {
+  field: Field<FieldMap[]>;
+  children(fields: Fields<FieldMap>, index: number): React.ReactNode;
 }
 
-export default class List<Fields> extends React.PureComponent<
-  Props<Fields>,
+export default class List<FieldMap> extends React.PureComponent<
+  Props<FieldMap>,
   never
 > {
   render() {
@@ -21,18 +21,18 @@ export default class List<Fields> extends React.PureComponent<
     } = this.props;
 
     return value.map((fieldValues, index) => {
-      const innerFields: FieldDescriptors<Fields> = mapObject(
+      const innerFields: Fields<FieldMap> = mapObject(
         fieldValues,
-        (value, fieldPath) => {
-          const initialFieldValue = get(initialValue, [index, fieldPath]);
+        (value, key: keyof FieldMap) => {
+          const initialFieldValue = get(initialValue, [index, key]);
           return {
             value,
             onBlur,
-            name: `${name}.${index}.${fieldPath}`,
+            name: `${name}.${index}.${key}`,
             initialValue: initialFieldValue,
             dirty: value !== initialFieldValue,
-            error: get(error, [index, fieldPath]),
-            onChange: this.handleChange({index, key: fieldPath}),
+            error: get(error, [index, key]),
+            onChange: this.handleChange({index, key}),
           };
         },
       );
@@ -48,14 +48,14 @@ export default class List<Fields> extends React.PureComponent<
 
   @memoize()
   @bind()
-  private handleChange<Key extends keyof Fields>({
+  private handleChange<Key extends keyof FieldMap>({
     index,
     key,
   }: {
     index: number;
-    key: any;
+    key: Key;
   }) {
-    return (newValue: Fields[Key]) => {
+    return (newValue: FieldMap[Key]) => {
       const {
         field: {value, onChange},
       } = this.props;

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -2,16 +2,16 @@ import * as React from 'react';
 import get from 'lodash/get';
 import {memoize, bind} from 'lodash-decorators';
 
-import {FieldDescriptor, FieldDescriptors} from '../types';
+import {Field, Fields} from '../types';
 import {mapObject} from '../utilities';
 
-interface Props<Fields> {
-  field: FieldDescriptor<Fields>;
-  children(fields: FieldDescriptors<Fields>): React.ReactNode;
+interface Props<FieldMap> {
+  field: Field<FieldMap>;
+  children(fields: Fields<FieldMap>): React.ReactNode;
 }
 
-export default class Nested<Fields> extends React.PureComponent<
-  Props<Fields>,
+export default class Nested<FieldMap> extends React.PureComponent<
+  Props<FieldMap>,
   never
 > {
   render() {
@@ -20,7 +20,7 @@ export default class Nested<Fields> extends React.PureComponent<
       children,
     } = this.props;
 
-    const innerFields: FieldDescriptors<Fields> = mapObject(
+    const innerFields: Fields<FieldMap> = mapObject(
       value,
       (value, fieldPath) => {
         const initialFieldValue = initialValue[fieldPath];
@@ -41,8 +41,8 @@ export default class Nested<Fields> extends React.PureComponent<
 
   @memoize()
   @bind()
-  private handleChange<Key extends keyof Fields>(key: Key) {
-    return (newValue: Fields[Key]) => {
+  private handleChange<Key extends keyof FieldMap>(key: Key) {
+    return (newValue: FieldMap[Key]) => {
       const {
         field: {value: existingItem, onChange},
       } = this.props;

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -81,8 +81,6 @@ describe('<FormState.List />', () => {
     const newTitle = faker.commerce.productName();
     const newPrice = faker.commerce.price();
 
-    const renderSpy = jest.fn(() => null);
-
     const renderPropSpy = jest.fn(({fields}: any) => {
       return (
         <FormState.List field={fields.products}>

--- a/packages/react-form-state/src/types.ts
+++ b/packages/react-form-state/src/types.ts
@@ -7,11 +7,11 @@ export interface FieldState<Value> {
   error?: any;
 }
 
-export interface FieldDescriptor<Value> extends FieldState<Value> {
+export interface Field<Value> extends FieldState<Value> {
   onChange(newValue: Value): void;
   onBlur(): void;
 }
 
-export type FieldDescriptors<Fields> = {
-  [FieldPath in keyof Fields]: FieldDescriptor<Fields[FieldPath]>
+export type Fields<FieldMap> = {
+  [FieldPath in keyof FieldMap]: Field<FieldMap[FieldPath]>
 };


### PR DESCRIPTION
closes #228 
This PR changes the name of our exported type for the field data passed into the render prop from `FieldDescriptors` to `Fields`.

This is a breaking (for types only) change.

