### PR TITLE
[react-form-state] 🐛 fix unmounting FormState during submission throwing errors

### DIFF
--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -166,9 +166,14 @@ export default class FormState<
 
     this.setState({submitting: true});
 
-    const result = await onSubmit(formData);
-    if (result) {
-      this.updateRemoteErrors(result);
+    const errors = await onSubmit(formData);
+
+    if (!mounted) {
+      return;
+    }
+
+    if (errors) {
+      this.updateRemoteErrors(errors);
     }
 
     this.setState({submitting: false});

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -600,7 +600,7 @@ describe('<FormState />', () => {
         return Promise.resolve(submitErrors);
       }
 
-      const form = mount(
+      mount(
         <FormState initialValues={{product}} onSubmit={onSubmit}>
           {renderPropSpy}
         </FormState>,
@@ -628,7 +628,7 @@ describe('<FormState />', () => {
         return Promise.resolve(submitErrors);
       }
 
-      const form = mount(
+      mount(
         <FormState
           initialValues={{product: faker.commerce.productName()}}
           onSubmit={onSubmit}
@@ -659,7 +659,7 @@ describe('<FormState />', () => {
         return Promise.resolve(submitErrors);
       }
 
-      const form = mount(
+      mount(
         <FormState
           initialValues={{product: faker.commerce.productName()}}
           onSubmit={onSubmit}
@@ -674,6 +674,28 @@ describe('<FormState />', () => {
 
       const {fields: updatedFields} = lastCallArgs(renderPropSpy);
       expect(updatedFields.product.error).not.toBe(message);
+    });
+
+    it('does not error when component is unmounted before submit resolves', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const onSubmitSpy = jest.fn();
+      const product = faker.commerce.productName();
+
+      const form = mount(
+        <FormState initialValues={{product}} onSubmit={onSubmitSpy}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit, submitting, reset, ...formData} = lastCallArgs(
+        renderPropSpy,
+      );
+
+      const submissionPromise = submit();
+      form.unmount();
+      expect(async () => {
+        await submissionPromise();
+      }).not.toThrow();
     });
   });
 


### PR DESCRIPTION
closes #215 

This PR fixes cases where unmounting during a submission handler would cause the component to throw.