### PR TITLE
[react-form-state] never validate empty fields unless using the required validator

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and from `v0.2.6`, this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -42,6 +42,22 @@ describe('validation helpers', () => {
       expect(alwaysPassValidator(input)).toBeUndefined();
       expect(alwaysFailValidator(input)).toBe(error(input));
     });
+
+    it('returns a function that returns void when the input is empty', () => {
+      function error(input: string) {
+        return `${input} error`;
+      }
+
+      const alwaysPassValidator = validate(trueMatcher, error);
+      const alwaysFailValidator = validate(falseMatcher, error);
+
+      expect(alwaysPassValidator('')).toBeUndefined();
+      expect(alwaysFailValidator('')).toBeUndefined();
+      expect(alwaysPassValidator(null)).toBeUndefined();
+      expect(alwaysFailValidator(null)).toBeUndefined();
+      expect(alwaysPassValidator(undefined)).toBeUndefined();
+      expect(alwaysFailValidator(undefined)).toBeUndefined();
+    });
   });
 
   describe('validateObject', () => {
@@ -170,7 +186,7 @@ describe('validation helpers', () => {
       it('returns a function that returns errorContent when input.length <= length', () => {
         const error = faker.lorem.word();
         const validator = validators.lengthMoreThan(10, error);
-        expect(validator({length: 0})).toBe(error);
+        expect(validator({length: 2})).toBe(error);
       });
     });
 

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -110,7 +110,10 @@ export function validate<Input, Fields = never>(
   return (input: Input, fields: Fields) => {
     const matches = matcher(input, fields);
 
-    // always mark empty fields valid if they are strings
+    /*
+      always mark empty fields valid to match Polaris guidelines
+      https://polaris.shopify.com/patterns/error-messages#section-form-validation
+    */
     if (isEmpty(input)) {
       return;
     }

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -110,6 +110,11 @@ export function validate<Input, Fields = never>(
   return (input: Input, fields: Fields) => {
     const matches = matcher(input, fields);
 
+    // always mark empty fields valid if they are strings
+    if (isEmpty(input)) {
+      return;
+    }
+
     if (matches) {
       return;
     }
@@ -137,16 +142,40 @@ const validators = {
     return validate(isNumericString, errorContent);
   },
 
-  requiredString(errorContent: ErrorContent) {
-    return validate(not(isEmptyString), errorContent);
-  },
-
   nonNumericString(errorContent: ErrorContent) {
     return validate(not(isNumericString), errorContent);
   },
 
+  requiredString(errorContent: ErrorContent) {
+    return (input: string) => {
+      if (not(isEmptyString)(input)) {
+        return;
+      }
+
+      if (typeof errorContent === 'function') {
+        // eslint-disable-next-line consistent-return
+        return errorContent(toString(input));
+      }
+
+      // eslint-disable-next-line consistent-return
+      return errorContent;
+    };
+  },
+
   required(errorContent: ErrorContent) {
-    return validate(not(isEmpty), errorContent);
+    return (input: any) => {
+      if (not(isEmpty)(input)) {
+        return;
+      }
+
+      if (typeof errorContent === 'function') {
+        // eslint-disable-next-line consistent-return
+        return errorContent(toString(input));
+      }
+
+      // eslint-disable-next-line consistent-return
+      return errorContent;
+    };
   },
 };
 


### PR DESCRIPTION
closes #218 
closes #211 
closes #297 

This PR makes it so that any validator created using `validate` will automatically pass if the given input is empty. It also rewrites `required` and `requiredString` to skip using the helper, allowing them to continue to work as expected.

**Edit** with the validators handling bailing on empty inputs we are free to remove the `if  (!dirty)` check form our `validateFieldValue` method so that cases like @darrenhebner pointed out work as expected.