### PR TITLE
✨ added `@shopify/admin-graphql-api-utilities` which contain a set of…

### DIFF
--- a/packages/admin-graphql-api-utilities/README.md
+++ b/packages/admin-graphql-api-utilities/README.md
@@ -1,0 +1,78 @@
+# `@shopify/admin-graphql-api-utilities`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/admin-graphql-api-utilities.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/admin-graphql-api-utilities.svg)
+
+A set of utilities to use when consuming Shopify’s admin graphql api.
+
+## Installation
+
+```bash
+$ yarn add @shopify/admin-graphql-api-utilities
+```
+
+## API Reference
+
+### `function parseGid(gid: string): string`
+
+Given a Gid string, parse out the id.
+
+#### Example Usage
+
+```typescript
+import {parseGid} from '@shopify/admin-graphql-api-utilities';
+
+parseGid('gid://shopify/Customer/12345');
+// → '12345'
+```
+
+### `function composeGid(key: string, id: number | string): string`
+
+Given a key and id, compose a Gid string.
+
+#### Example Usage
+
+```typescript
+import {composeGid} from '@shopify/admin-graphql-api-utilities';
+
+composeGid('Customer', 12345);
+// → 'gid://shopify/Customer/12345'
+
+composeGid('Customer', '67890');
+// → 'gid://shopify/Customer/67890'
+```
+
+### `function nodesFromEdges(edges)`
+
+Given an array of edges, return the nodes.
+
+#### Example Usage
+
+```typescript
+import {nodesFromEdges} from '@shopify/admin-graphql-api-utilities';
+
+nodesFromEdges([
+  {node: {id: '1', title: 'title one'}},
+  {node: {id: '2', title: 'title two'}},
+]);
+// → [{id: '1', title: 'title one'}, {id: '2', title: 'title two'}]
+```
+
+### `function keyFromEdges(edges, key)`
+
+Given an array of edges, return a new array of only the specific key from those nodes.
+
+#### Example Usage
+
+```typescript
+import {keyFromEdges} from '@shopify/admin-graphql-api-utilities';
+
+keyFromEdges(
+  [
+    {node: {id: '1', title: 'title one'}},
+    {node: {id: '2', title: 'title two'}},
+  ],
+  'title',
+);
+// → ['title one', 'title two']
+```

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@shopify/admin-graphql-api-utilities",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A set of utilities to use when consuming Shopify’s admin graphql api.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/admin-graphql-api-utilities/README.md",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "typescript": "~2.9.2"
+  }
+}

--- a/packages/admin-graphql-api-utilities/src/index.ts
+++ b/packages/admin-graphql-api-utilities/src/index.ts
@@ -1,0 +1,30 @@
+const GID_REGEXP = /\/(\w+(-\w+)*)$/;
+
+export function parseGid(gid: string): string {
+  // appends forward slash to help identify invalid id
+  const id = `/${gid}`;
+  const matches = id.match(GID_REGEXP);
+  if (matches && matches[1] !== undefined) {
+    return matches[1];
+  }
+  throw new Error(`Invalid gid: ${gid}`);
+}
+
+export function composeGid(key: string, id: number | string): string {
+  return `gid://shopify/${key}/${id}`;
+}
+
+interface Edge<T> {
+  node: T;
+}
+
+export function nodesFromEdges<T>(edges: Edge<T>[]): T[] {
+  return edges.map(({node}) => node);
+}
+
+export function keyFromEdges<T, K extends keyof T>(
+  edges: Edge<T>[],
+  key: K,
+): T[K][] {
+  return edges.map(({node}) => node[key]);
+}

--- a/packages/admin-graphql-api-utilities/src/test/index.test.ts
+++ b/packages/admin-graphql-api-utilities/src/test/index.test.ts
@@ -1,0 +1,84 @@
+import {v4} from 'uuid';
+import {parseGid, composeGid, nodesFromEdges, keyFromEdges} from '..';
+
+describe('admin-graphql-api-utilities', () => {
+  describe('parseGid()', () => {
+    it('throw Error for an invalid id', () => {
+      const key = 'gid://shopify/Section/';
+      ['@', '-1', '!1'].forEach(id =>
+        expect(() => parseGid(`${key}/${id}`)).toThrow(
+          `Invalid gid: ${key}/${id}`,
+        ),
+      );
+    });
+
+    it('returns the id portion of an unprefixed gid', () => {
+      ['1', '1a', v4()].forEach(id => expect(parseGid(id)).toEqual(id));
+    });
+
+    it('returns the id portion of a gid for integer ids', () => {
+      const id = '12';
+      const gid = `gid://shopify/Section/${id}`;
+      expect(parseGid(gid)).toEqual(id);
+    });
+
+    it('returns the id portion of a gid for uuids', () => {
+      const id = v4();
+      const gid = `gid://shopify/Section/${id}`;
+      expect(parseGid(gid)).toEqual(id);
+    });
+  });
+
+  describe('composeGid()', () => {
+    it('returns the composed Gid using key and number id', () => {
+      const id = 123;
+      const key = 'Section';
+      expect(composeGid(key, id)).toEqual(`gid://shopify/${key}/${id}`);
+    });
+
+    it('returns the composed Gid using key and string id', () => {
+      const id = '456';
+      const key = 'Section';
+      expect(composeGid(key, id)).toEqual(`gid://shopify/${key}/${id}`);
+    });
+
+    it('returns the composed Gid using key and uuid', () => {
+      const id = v4();
+      const key = 'Section';
+      expect(composeGid(key, id)).toEqual(`gid://shopify/${key}/${id}`);
+    });
+  });
+
+  describe('nodesFromEdges()', () => {
+    it('returns the node for each edge', () => {
+      const nodeOne = Symbol('Node One');
+      const nodeTwo = Symbol('Node Two');
+      const edges = [{node: nodeOne}, {node: nodeTwo}];
+      expect(nodesFromEdges(edges)).toEqual([nodeOne, nodeTwo]);
+    });
+  });
+
+  describe('keyFromEdges()', () => {
+    it('returns the specify key from each edge', () => {
+      const titleOne = 'title one';
+      const titleTwo = 'title two';
+      const edges = [{node: {title: titleOne}}, {node: {title: titleTwo}}];
+      expect(keyFromEdges(edges, 'title')).toEqual([titleOne, titleTwo]);
+    });
+
+    it('returns the specify key from each edge, and undeinfed if not found', () => {
+      const titleOne = 'title one';
+      const titleThree = 'title three';
+      const edges = [
+        {node: {title: titleOne}},
+        {node: {}},
+        {node: {title: titleThree}},
+      ];
+      expect(keyFromEdges<{title?: string}, 'title'>(edges, 'title')).toEqual([
+        titleOne,
+        undefined,
+        titleThree,
+      ]);
+    });
+  });
+});

--- a/packages/admin-graphql-api-utilities/tsconfig.json
+++ b/packages/admin-graphql-api-utilities/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
… utilities to use when consuming Shopify’s admin graphql api.

Moving over `parseGid`, `composeGid`, `nodesFromEdges`, and `keyFromEdges` from web.
Anyone can think of more utility that should be move over?