### PR TITLE
⬆️ 🏗️ [RFC] Use TS 3 project references

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-helmet": "^5.2.0",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.0.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "dependencies": {},
   "jest": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "scripts": {
     "publish": "lerna publish",
-    "prebuild": "yarn run clean",
-    "build": "lerna run build",
+    "build": "tsc -b packages",
     "lint": "yarn eslint '**/*.{ts,tsx}'",
     "ci:lint-docs": "yarn generate docs && test -z \"$(git status --porcelain)\" || echo 'The root README has not been updated. Run `yarn generate docs` in the root of your quilt directory and try again.'",
+    "ci:lint-tsconfig": "yarn generate tsconfig && test -z \"$(git status --porcelain)\" || echo 'packages/tsconfig.json has not been updated. Run `yarn generate tsconfig` in the root of your quilt directory and try again.'",
     "test": "jest --maxWorkers=3",
     "check": "lerna run check",
     "release": "lerna publish && git push --follow-tags",
@@ -75,6 +75,11 @@
       "url": "http://localhost:3000/"
     },
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "globals": {
+      "ts-jest": {
+        "tsConfigFile": "tsconfig.test.json"
+      }
+    }
   }
 }

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/address/README.md",
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.0.7",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -10,7 +10,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "author": "Shopify Inc.",

--- a/packages/address/tsconfig.json
+++ b/packages/address/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/admin-graphql-api-utilities/tsconfig.json
+++ b/packages/admin-graphql-api-utilities/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -27,6 +27,6 @@
     "lodash": "^4.17.5"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -10,7 +10,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "author": "Shopify Inc.",

--- a/packages/enzyme-utilities/tsconfig.json
+++ b/packages/enzyme-utilities/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -29,6 +29,6 @@
     "lolex": "^2.3.2"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -10,7 +10,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "author": "Shopify Inc.",

--- a/packages/jest-dom-mocks/src/match-media.ts
+++ b/packages/jest-dom-mocks/src/match-media.ts
@@ -6,7 +6,8 @@ export interface MediaMatching {
 
 export default class MatchMedia {
   private isUsingMockMatchMedia = false;
-  originalMatchMedia: (mediaQuery: string) => MediaQueryList;
+  originalMatchMedia: (mediaQuery: string) => MediaQueryList =
+    window.matchMedia;
 
   mock(media: MediaMatching = defaultMatcher) {
     if (this.isUsingMockMatchMedia) {

--- a/packages/jest-dom-mocks/tsconfig.json
+++ b/packages/jest-dom-mocks/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@types/express": "^4.11.1",
     "@types/koa": "^2.0.44",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -10,7 +10,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "author": "Shopify Inc.",

--- a/packages/jest-koa-mocks/tsconfig.json
+++ b/packages/jest-koa-mocks/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -33,7 +33,7 @@
     "apollo-client": "^2.3.4",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.2.4",

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -10,7 +10,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "author": "Shopify Inc.",

--- a/packages/jest-mock-apollo/tsconfig.json
+++ b/packages/jest-mock-apollo/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -27,7 +27,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router": "^3.2.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "greenkeeper": {
     "ignore": [

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -10,7 +10,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "author": "Shopify Inc.",

--- a/packages/jest-mock-router/tsconfig.json
+++ b/packages/jest-mock-router/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -30,6 +30,6 @@
     "@types/koa": "^2.0.45",
     "@types/koa-mount": "^3.0.1",
     "koa-mount": "^3.0.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/koa-liveness-ping/tsconfig.json
+++ b/packages/koa-liveness-ping/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@shopify/jest-koa-mocks": "^2.0.9",
     "@shopify/with-env": "^1.0.5",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/koa-metrics/tsconfig.json
+++ b/packages/koa-metrics/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.0.7",
     "@types/safe-compare": "^1.1.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -10,7 +10,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "author": "Shopify Inc.",

--- a/packages/koa-shopify-auth/tsconfig.json
+++ b/packages/koa-shopify-auth/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -26,6 +26,6 @@
     "koa-better-http-proxy": "^0.2.4"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/koa-shopify-graphql-proxy/tsconfig.json
+++ b/packages/koa-shopify-graphql-proxy/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -28,6 +28,6 @@
     "pretty-ms": "^3.2.0"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "@types/enzyme": "^3.1.10",
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -34,6 +34,6 @@
     "@types/enzyme": "^3.1.10",
     "enzyme": "^3.3.0",
     "faker": "^4.1.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-form-state/tsconfig.json
+++ b/packages/react-form-state/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@shopify/with-env": "^1.0.5",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-html/tsconfig.json
+++ b/packages/react-html/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [{"path": "../react-serialize"}]
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-i18n/README.md",
   "devDependencies": {
     "intl-pluralrules": "^0.2.1",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "dependencies": {
     "@types/hoist-non-react-statics": "^3.0.1",

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build",
     "test": "jest --config ./config/jest/config.json"
   },

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -1,19 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
-    "rootDir": "./src",
-    "downlevelIteration": true,
-    "lib": [
-      "dom",
-      "es2015",
-      "es2016",
-      "es2017",
-      "es2018",
-      "esnext.asynciterable"
-    ]
+    "rootDir": "./src"
   },
-  "include": ["../../config/typescript/**/*", "./src/**/*.ts", "./src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@shopify/javascript-utilities": "^2.1.0",
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "peerDependencies": {
     "react": "^16.4.1"

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-import-remote/tsconfig.json
+++ b/packages/react-import-remote/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [{"path": "../react-preconnect"}]
 }

--- a/packages/react-preconnect/package.json
+++ b/packages/react-preconnect/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/react-preconnect/package.json
+++ b/packages/react-preconnect/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-preconnect/tsconfig.json
+++ b/packages/react-preconnect/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-serialize/tsconfig.json
+++ b/packages/react-serialize/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-shopify-app-route-propagator/tsconfig.json
+++ b/packages/react-shopify-app-route-propagator/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -26,6 +26,6 @@
     "react": "^16.3.2"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/react-shortcuts/tsconfig.json
+++ b/packages/react-shortcuts/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../tsconfig.base.json",
+  "references": [
+    {"path": "address"},
+    {"path": "admin-graphql-api-utilities"},
+    {"path": "enzyme-utilities"},
+    {"path": "jest-dom-mocks"},
+    {"path": "jest-koa-mocks"},
+    {"path": "jest-mock-apollo"},
+    {"path": "jest-mock-router"},
+    {"path": "koa-liveness-ping"},
+    {"path": "koa-metrics"},
+    {"path": "koa-shopify-auth"},
+    {"path": "koa-shopify-graphql-proxy"},
+    {"path": "logger"},
+    {"path": "react-compose"},
+    {"path": "react-form-state"},
+    {"path": "react-html"},
+    {"path": "react-i18n"},
+    {"path": "react-import-remote"},
+    {"path": "react-preconnect"},
+    {"path": "react-serialize"},
+    {"path": "react-shopify-app-route-propagator"},
+    {"path": "react-shortcuts"},
+    {"path": "with-env"}
+  ]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
+  "files": [],
   "references": [
     {"path": "address"},
     {"path": "admin-graphql-api-utilities"},

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/with-env/README.md",
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {

--- a/packages/with-env/tsconfig.json
+++ b/packages/with-env/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/plopfile.js
+++ b/plopfile.js
@@ -48,28 +48,11 @@ module.exports = function(plop) {
     ],
   });
 
-  // docs generator
   plop.setGenerator('docs', {
     description: 'Generate root repo documentation',
     prompts: [],
     actions(data) {
-      const {
-        readdirSync,
-        existsSync,
-        readFileSync,
-        writeFileSync,
-      } = require('fs');
-      const path = require('path');
-
-      const packagesPath = path.join(__dirname, 'packages');
-      const packageNames = readdirSync(packagesPath).filter(packageName => {
-        const packageJSONPath = path.join(
-          packagesPath,
-          packageName,
-          'package.json',
-        );
-        return existsSync(packageJSONPath);
-      });
+      const packageNames = getPackageNames();
 
       return [
         {
@@ -82,4 +65,37 @@ module.exports = function(plop) {
       ];
     },
   });
+
+  plop.setGenerator('tsconfig', {
+    description: 'Generate package level tsconfig',
+    prompts: [],
+    actions(data) {
+      const packageNames = getPackageNames();
+
+      return [
+        {
+          type: 'add',
+          path: 'packages/tsconfig.json',
+          templateFile: 'templates/packages-tsconfig.hbs.json',
+          force: true,
+          data: {packageNames},
+        },
+      ];
+    },
+  });
 };
+
+function getPackageNames() {
+  const {readdirSync, existsSync, readFileSync, writeFileSync} = require('fs');
+  const path = require('path');
+
+  const packagesPath = path.join(__dirname, 'packages');
+  return readdirSync(packagesPath).filter(packageName => {
+    const packageJSONPath = path.join(
+      packagesPath,
+      packageName,
+      'package.json',
+    );
+    return existsSync(packageJSONPath);
+  });
+}

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -25,6 +25,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "yarn run build"
   },
   "publishConfig": {
@@ -22,8 +22,7 @@
     "url": "https://github.com/shopify/quilt/issues"
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/{{name}}/README.md",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "typescript": "~3.0.1"
   }

--- a/templates/packages-tsconfig.hbs.json
+++ b/templates/packages-tsconfig.hbs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "references": [
+    {{#each packageNames}}
+      { "path": "{{this}}" }{{#if @last}}{{else}},{{/if}}
+    {{/each}}
+  ]
+}

--- a/templates/tsconfig.hbs.json
+++ b/templates/tsconfig.hbs.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "compileOnSave": false,
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./src",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/test/typescript-version.test.ts
+++ b/test/typescript-version.test.ts
@@ -10,6 +10,10 @@ describe('typescript version', () => {
     const packageNames = readdirSync(packagesPath);
 
     for (const packageName of packageNames) {
+      if (packageName.includes('.')) {
+        continue;
+      }
+
       const packageJSONPath = path.join(
         packagesPath,
         packageName,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,7 @@
 {
+  "compileOnSave": false,
   "compilerOptions": {
+    "strict": true,
     "moduleResolution": "node",
     "target": "es5",
     "downlevelIteration": true,
@@ -13,6 +15,7 @@
     "experimentalDecorators": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
+    "composite": true,
     "lib": [
       "dom",
       "es2015",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6712,9 +6712,9 @@ typescript-eslint-parser@17.0.1:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@~2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
closes #248 
helps with #243  (hopefully, maybe)

## Summary
This PR ups us to TS 3.0.1, sets up [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) and fixes up our config a bit.

### TS 3.0
The changes I had to make to get TS 3.0 working were very minimal, just updating it in all the `package.json`s and the `yarn.lock`, and changing one spot that used an uninitialized class property.

### Project References

#### pros
-  `yarn build` no longer relies on lerna, just `tsc` itself. 
- `yarn build` is now guaranteed to build things in the right order (previously it could in theory have failed with one package depending on another that is not built)
- `yarn link`ing a single package while working on multiple will now work better, even if you are making changes to packages it depends on, since `tsc -b` will also rebuild those.

#### cons
- `ts-jest` [does not support composite projects](https://github.com/kulshekhar/ts-jest/issues/669) yet, so we still have the same clunkiness for running tests that depend on a package that needs to be built
- the output from `tsc -b packages` is slightly less useful than `lerna run yarn build` was, since we no longer get output sorted by package
- we now have to add an entry to `references` for any in-repo (non-dev) dependency of a package or `yarn build` will fail
- we have one more config file we need to regenerate whenever we add  a new package to the repo (we can probably just get `yarn generate package` to update these though)

## 🎩instructions
### basics
- `g checkout TS-3`
- `yarn run build`
- `yarn test`

### linking
- `g checkout TS-3`
- `cd packages/react-html`
- `yarn link`
- (in another tab) `dev cd web && yarn link @shopify/react-html`
- (in your quilt tab) add `console.log('foo bar baz')` to `packages/react-serialize/src/index.ts`
- (in your quilt tab) run `yarn run build` inside `packages/react-html`
- (in web tab) run `dev run dev`, **you should see your console log when compilation finishes**

## Concerns
I'm not sure how much value this actually adds without working for tests. We may want to hold off on it until it does since it does add some extra complexity to our config. On the other hand, it does bring us a bit closer to not actually needing `lerna`. It's possible that at some point we will be able to just use TS and yarn workspaces to handle the monorepo on their own.
