### PR TITLE
⬆️ TypeScript 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-helmet": "^5.2.0",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.0.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "dependencies": {},
   "jest": {

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/address/README.md",
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.0.7",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -27,6 +27,6 @@
     "lodash": "^4.17.5"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -29,6 +29,6 @@
     "lolex": "^2.3.2"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@types/express": "^4.11.1",
     "@types/koa": "^2.0.44",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -33,7 +33,7 @@
     "apollo-client": "^2.3.4",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.2.4",

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -27,7 +27,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router": "^3.2.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "greenkeeper": {
     "ignore": [

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -30,6 +30,6 @@
     "@types/koa": "^2.0.45",
     "@types/koa-mount": "^3.0.1",
     "koa-mount": "^3.0.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@shopify/jest-koa-mocks": "^2.0.9",
     "@shopify/with-env": "^1.0.5",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.0.7",
     "@types/safe-compare": "^1.1.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -26,6 +26,6 @@
     "koa-better-http-proxy": "^0.2.4"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -28,6 +28,6 @@
     "pretty-ms": "^3.2.0"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "@types/enzyme": "^3.1.10",
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -34,6 +34,6 @@
     "@types/enzyme": "^3.1.10",
     "enzyme": "^3.3.0",
     "faker": "^4.1.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@shopify/with-env": "^1.0.5",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-i18n/README.md",
   "devDependencies": {
     "intl-pluralrules": "^0.2.1",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "dependencies": {
     "@types/hoist-non-react-statics": "^3.0.1",

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@shopify/javascript-utilities": "^2.1.0",
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "peerDependencies": {
     "react": "^16.4.1"

--- a/packages/react-preconnect/package.json
+++ b/packages/react-preconnect/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "enzyme": "^3.3.0",
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -26,6 +26,6 @@
     "react": "^16.3.2"
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/with-env/README.md",
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -25,6 +25,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "typescript": "~2.9.2"
+    "typescript": "~3.0.1"
   }
 }

--- a/test/typescript-version.test.ts
+++ b/test/typescript-version.test.ts
@@ -7,7 +7,9 @@ describe('typescript version', () => {
     const rootVersion = rootPackageJSON.devDependencies.typescript;
 
     const packagesPath = path.resolve(__dirname, '..', 'packages');
-    const packageNames = readdirSync(packagesPath);
+    const packageNames = readdirSync(packagesPath).filter(
+      file => !file.includes('.'),
+    );
 
     for (const packageName of packageNames) {
       const packageJSONPath = path.join(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6712,9 +6712,9 @@ typescript-eslint-parser@17.0.1:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@~2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
closes #248

This PR updates all packages in quilt to use TS 3.0.1. I also snuck in a small QoL fix to the TS version test so that it doesn't yell at me for VSCode creating dotfiles in `/packages` anymore.

## 🎩 instructions
To test a package (eg. react-html) still works in a consuming project (eg. web):
- `yarn build && cd packages/react-html && yarn link`
- `dev cd web && yarn link @shopify/react-html && dev test && dev server`
