### PR TITLE
🔥 custom dev command

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,11 +4,6 @@ up:
   - node:
       version: v8.10.0
       yarn: true
-  - custom:
-      name: lerna bootstrap
-      met?: 'false'
-      meet: yarnpkg run lerna bootstrap
-
 commands:
   __default__: start
   build: yarnpkg build


### PR DESCRIPTION
This PR fixes the `dev up` flow to not give misleading error messages. We do this simply by removing our custom dev command. It seems that we didn't need to run`lerna bootstrap` anyway since we are using yarn workspaces.

## 🎩 instructions
- `dev clone quilt`
- `dev up`
- `dev build && dev test`