### PR TITLE
✨ run tests without having to build

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,8 +27,6 @@ dev clone quilt
 dev up
 ```
 
-**Note** In order for tests to run properly, you may need to first run `dev build`
-
 [what is dev?](#what-is-dev)
 
 ### Getting productive

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,37 @@
+const {readdirSync, existsSync} = require('fs');
+const path = require('path');
+
+const moduleNameMapper = getPackageNames().reduce((accumulator, name) => {
+  const scopedName = `@shopify/${name}`;
+  accumulator[scopedName] = `<rootDir>/packages/${name}/src/index.ts`;
+  return accumulator;
+}, {});
+
+module.exports = {
+  setupFiles: ['./test/setup.ts'],
+  setupTestFrameworkScriptFile: './test/each-test.ts',
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+    '\\.(gql|graphql)$': 'jest-transform-graphql',
+  },
+  testRegex: '.*\\.test\\.tsx?$',
+  testEnvironmentOptions: {
+    url: 'http://localhost:3000/',
+  },
+  coverageDirectory: './coverage/',
+  collectCoverage: true,
+  moduleNameMapper,
+};
+
+function getPackageNames() {
+  const packagesPath = path.join(__dirname, 'packages');
+  return readdirSync(packagesPath).filter(packageName => {
+    const packageJSONPath = path.join(
+      packagesPath,
+      packageName,
+      'package.json',
+    );
+    return existsSync(packageJSONPath);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -55,26 +55,5 @@
     "ts-jest": "^23.0.0",
     "typescript": "~3.0.1"
   },
-  "dependencies": {},
-  "jest": {
-    "setupFiles": [
-      "./test/setup.ts"
-    ],
-    "setupTestFrameworkScriptFile": "./test/each-test.ts",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest",
-      "\\.(gql|graphql)$": "jest-transform-graphql"
-    },
-    "testRegex": ".*\\.test\\.tsx?$",
-    "testEnvironmentOptions": {
-      "url": "http://localhost:3000/"
-    },
-    "coverageDirectory": "./coverage/",
-    "collectCoverage": true
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
## Summary
This PR creates a dynamic jest config that lets `yarn test` work without having to build first.

## Tophatting
- checkout this branch
- `yarn clean`
- `yarn build`
It should work
