### PR TITLE
Add i18n package with pseudotranslate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Each package has its own `README` and documentation describing usage.
 | address | [README](packages/address/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Faddress.svg)](https://badge.fury.io/js/%40shopify%2Faddress) |
 | admin-graphql-api-utilities | [README](packages/admin-graphql-api-utilities/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities) |
 | enzyme-utilities | [README](packages/enzyme-utilities/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities) |
+| i18n | [README](packages/i18n/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fi18n.svg)](https://badge.fury.io/js/%40shopify%2Fi18n) |
 | jest-dom-mocks | [README](packages/jest-dom-mocks/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks) |
 | jest-koa-mocks | [README](packages/jest-koa-mocks/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks) |
 | jest-mock-apollo | [README](packages/jest-mock-apollo/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo) |

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,0 +1,58 @@
+# `@shopify/i18n`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fi18n.svg)](https://badge.fury.io/js/%40shopify%2Fi18n.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/i18n.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/i18n.svg)
+
+Generic i18n-related utilities.
+
+## Installation
+
+```bash
+$ yarn add @shopify/i18n
+```
+
+## Usage
+
+### `pseudotranslate()`
+
+Takes a string and returns a version of it that appears as if it were translated (learn more about [pseudotranslation](https://help.smartling.com/hc/en-us/articles/360000307573-Testing-with-Pseudo-Translation)).
+
+This function accepts a number of arguments to customize the translation:
+
+- `toLocale`: a locale to simulate translation for. This is used primarily to adjust the change in size relative to the original string. When not provided, or when a locale is provided for which no custom size ratio exists, this function slightly increases the string size.
+- `delimiter`, `startDelimiter`, `endDelimiter`: strings used to mark parts of the source string that should not be translated. This can be used, for example, to prevent translation of replacements within a string.
+- `prepend` and `append`: strings to put at the start and end of the resulting string, respectively. This can be used to provide a common set of text around pseudotranslated code that can identify translated strings that are incorrectly joined together.
+
+```ts
+import {pseudotranslate} from '@shopify/react-i18n';
+
+const pseudoOne = pseudoTranslate('cat'); // something like 'ͼααṭ'
+const pseudoTwo = pseudoTranslate('cats: {names}', {
+  toLocale: 'de',
+  startDelimiter: '{',
+  endDelimiter: '}',
+  prepend: '[[!',
+  append: '!]]',
+}); // something like '[[!ͼααṭṡṡ: {names}]]!'
+```
+
+### `regionFromLocale()`
+
+Accepts a locale and extracts the country code as defined in [BCP 47](https://tools.ietf.org/html/rfc5646#section-2.2.4), if it exists. The country code will be normalized to fully uppercase when present.
+
+```ts
+import {regionFromLocale} from '@shopify/i18n';
+
+const regionEn = regionFromLocale('en'); // undefined
+const regionEnCa = regionFromLocale('en-ca'); // 'CA'
+```
+
+### `languageFromLocale()`
+
+Accepts a locale and extracts the language subtag as defined in [BCP 47](https://tools.ietf.org/html/rfc5646#section-2.2.1).
+
+```ts
+import {languageFromLocale} from '@shopify/i18n';
+
+const languageFrCa = languageFromLocale('fr-CA'); // 'fr'
+```

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@shopify/i18n",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Generic i18n-related utilities.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/i18n/README.md",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "typescript": "~3.0.1"
+  }
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,0 +1,2 @@
+export * from './locale';
+export * from './pseudotranslate';

--- a/packages/i18n/src/locale.ts
+++ b/packages/i18n/src/locale.ts
@@ -1,0 +1,8 @@
+export function regionFromLocale(locale: string): string | undefined {
+  const code = locale.split('-')[1];
+  return code && code.toUpperCase();
+}
+
+export function languageFromLocale(locale: string) {
+  return locale.split('-')[0].toLowerCase();
+}

--- a/packages/i18n/src/pseudotranslate.ts
+++ b/packages/i18n/src/pseudotranslate.ts
@@ -1,0 +1,204 @@
+import {languageFromLocale} from './locale';
+
+export interface PseudotranslateOptions {
+  prepend?: string;
+  append?: string;
+  startDelimiter?: string;
+  endDelimiter?: string;
+  delimiter?: string;
+  toLocale?: string;
+}
+
+const LETTERS = new Map<string, string>([
+  ['a', 'α'],
+  ['b', 'ḅ'],
+  ['c', 'ͼ'],
+  ['d', 'ḍ'],
+  ['e', 'ḛ'],
+  ['f', 'ϝ'],
+  ['g', 'ḡ'],
+  ['h', 'ḥ'],
+  ['i', 'ḭ'],
+  ['j', 'ĵ'],
+  ['k', 'ḳ'],
+  ['l', 'ḽ'],
+  ['m', 'ṃ'],
+  ['n', 'ṇ'],
+  ['o', 'ṓ'],
+  ['p', 'ṗ'],
+  ['q', 'ʠ'],
+  ['r', 'ṛ'],
+  ['s', 'ṡ'],
+  ['t', 'ṭ'],
+  ['u', 'ṵ'],
+  ['v', 'ṽ'],
+  ['w', 'ẁ'],
+  ['x', 'ẋ'],
+  ['y', 'ẏ'],
+  ['z', 'ẓ'],
+  ['A', 'Ḁ'],
+  ['B', 'Ḃ'],
+  ['C', 'Ḉ'],
+  ['D', 'Ḍ'],
+  ['E', 'Ḛ'],
+  ['F', 'Ḟ'],
+  ['G', 'Ḡ'],
+  ['H', 'Ḥ'],
+  ['I', 'Ḭ'],
+  ['J', 'Ĵ'],
+  ['K', 'Ḱ'],
+  ['L', 'Ḻ'],
+  ['M', 'Ṁ'],
+  ['N', 'Ṅ'],
+  ['O', 'Ṏ'],
+  ['P', 'Ṕ'],
+  ['Q', 'Ǫ'],
+  ['R', 'Ṛ'],
+  ['S', 'Ṣ'],
+  ['T', 'Ṫ'],
+  ['U', 'Ṳ'],
+  ['V', 'Ṿ'],
+  ['W', 'Ŵ'],
+  ['X', 'Ẋ'],
+  ['Y', 'Ŷ'],
+  ['Z', 'Ż'],
+]);
+
+const DEFAULT_RATIO = 1.15;
+const LOCALE_RATIOS = new Map([
+  ['zh', 0.5],
+  ['ja', 0.5],
+  ['ko', 0.8],
+  ['fr', 1.3],
+  ['it', 1.3],
+  ['de', 1.5],
+  ['nl', 1.5],
+]);
+
+export function sizeRatio({to: locale}: {to?: string}) {
+  if (locale == null) {
+    return DEFAULT_RATIO;
+  }
+
+  return (
+    LOCALE_RATIOS.get(locale) ||
+    LOCALE_RATIOS.get(languageFromLocale(locale)) ||
+    DEFAULT_RATIO
+  );
+}
+
+export function pseudotranslate(
+  string: string,
+  {
+    delimiter,
+    startDelimiter = delimiter,
+    endDelimiter = delimiter,
+    prepend,
+    append,
+    toLocale,
+  }: PseudotranslateOptions = {},
+) {
+  const parts = createParts(string, {startDelimiter, endDelimiter});
+
+  const adjustableCharacters = parts.reduce<number>(
+    (sum, part) =>
+      typeof part === 'string' ? sum + countAdjustableCharacters(part) : sum,
+    0,
+  );
+
+  const charactersToAdjust =
+    Math.ceil(adjustableCharacters * sizeRatio({to: toLocale})) -
+    adjustableCharacters;
+  const adjustEvery = adjustableCharacters / Math.abs(charactersToAdjust);
+  let adjustAt = adjustEvery;
+  let adjustableCharacterIndex = -1;
+
+  const pseudotranslated = parts.reduce<string>((pseudotranslated, part) => {
+    const pseudotranslatedPart =
+      typeof part === 'string'
+        ? [...part]
+            .map(character => {
+              const isAdjustable = isAdjustableCharacter(character);
+
+              if (isAdjustable) {
+                adjustableCharacterIndex++;
+              }
+
+              const newCharacter = LETTERS.get(character) || character;
+              const shouldAdjust =
+                isAdjustable &&
+                adjustableCharacterIndex + 1 === Math.floor(adjustAt);
+
+              if (shouldAdjust) {
+                adjustAt += adjustEvery;
+                return charactersToAdjust < 0 ? '' : newCharacter.repeat(2);
+              } else {
+                return newCharacter;
+              }
+            })
+            .join('')
+        : part[0];
+
+    return pseudotranslated + pseudotranslatedPart;
+  }, '');
+
+  return `${prepend || ''}${pseudotranslated}${append || ''}`;
+}
+
+function isAdjustableCharacter(character: string) {
+  return LETTERS.has(character);
+}
+
+function countAdjustableCharacters(string: string) {
+  return [...string].filter(isAdjustableCharacter).length;
+}
+
+function createParts(
+  string: string,
+  {
+    startDelimiter,
+    endDelimiter,
+  }: Pick<PseudotranslateOptions, 'startDelimiter' | 'endDelimiter'>,
+) {
+  const delimiterRegex =
+    startDelimiter && endDelimiter
+      ? createDelimiterRegex(startDelimiter, endDelimiter)
+      : undefined;
+
+  let lastTokenEndIndex = 0;
+  const parts: (RegExpExecArray | string)[] = [];
+
+  if (delimiterRegex) {
+    let token = delimiterRegex.exec(string);
+
+    while (token) {
+      parts.push(string.substring(lastTokenEndIndex, token.index));
+      parts.push(token);
+
+      lastTokenEndIndex = token.index + token[0].length;
+      token = delimiterRegex.exec(string);
+    }
+  } else {
+    parts.push(string);
+  }
+
+  return parts;
+}
+
+function createDelimiterRegex(startDelimiter: string, endDelimiter: string) {
+  if (startDelimiter.length === 1 && endDelimiter.length === 1) {
+    return new RegExp(
+      `\\${startDelimiter}[^\\${endDelimiter}]*\\${endDelimiter}`,
+      'g',
+    );
+  }
+
+  const escapedStart = [...startDelimiter]
+    .map(character => `\\${character}`)
+    .join('');
+  const escapedEnd = [...endDelimiter]
+    .map(character => `\\${character}`)
+    .join('');
+
+  return new RegExp(`${escapedStart}.*?${escapedEnd}`, 'g');
+}

--- a/packages/i18n/src/test/locale.test.ts
+++ b/packages/i18n/src/test/locale.test.ts
@@ -1,0 +1,21 @@
+import {languageFromLocale, regionFromLocale} from '../locale';
+
+describe('languageFromLocale()', () => {
+  it('returns the language subtag', () => {
+    expect(languageFromLocale('fr-CA')).toBe('fr');
+  });
+});
+
+describe('regionFromLocale()', () => {
+  it('returns undefined when no region exists', () => {
+    expect(regionFromLocale('fr')).toBeUndefined();
+  });
+
+  it('returns the region subtag when it exists', () => {
+    expect(regionFromLocale('fr-CA')).toBe('CA');
+  });
+
+  it('normalizes the region subtag to uppercase', () => {
+    expect(regionFromLocale('fr-ca')).toBe('CA');
+  });
+});

--- a/packages/i18n/src/test/pseudotranslate.test.ts
+++ b/packages/i18n/src/test/pseudotranslate.test.ts
@@ -1,0 +1,127 @@
+import {pseudotranslate} from '../pseudotranslate';
+
+describe('pseudotranslate()', () => {
+  it('changes all ASCII characters', () => {
+    const pseudo = pseudotranslate('cat');
+    expect(pseudo).not.toContain('c');
+    expect(pseudo).not.toContain('a');
+    expect(pseudo).not.toContain('t');
+  });
+
+  describe('prepend', () => {
+    it('is prepended to the pseudotranslated string', () => {
+      expect(pseudotranslate('cat', {prepend: '%%'}).startsWith('%%')).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('append', () => {
+    it('is appended to the pseudotranslated string', () => {
+      expect(pseudotranslate('cat', {append: '%%'}).endsWith('%%')).toBe(true);
+    });
+  });
+
+  describe('delimiters', () => {
+    it('does not replace words in delimiters', () => {
+      const pseudo = pseudotranslate('Hello, {name}. Have a great {day}', {
+        startDelimiter: '{',
+        endDelimiter: '}',
+      });
+      expect(pseudo).toContain('name');
+      expect(pseudo).toContain('day');
+    });
+
+    it('uses the delimiter as both start and end', () => {
+      expect(
+        pseudotranslate('Hello, $name$.', {
+          delimiter: '$',
+        }),
+      ).toContain('name');
+    });
+
+    it('handles multi-character, regex-meaningful delimiters', () => {
+      expect(
+        pseudotranslate('Hello, $$name$$.', {
+          delimiter: '$$',
+        }),
+      ).toContain('name');
+    });
+  });
+
+  describe('length', () => {
+    it('produces a slightly longer string with repeated characters by default', () => {
+      const pseudo = pseudotranslate('dogs');
+      expect(pseudo).toHaveLength(5);
+      expect([...new Set([...pseudo])]).toHaveLength(4);
+    });
+
+    it('does not duplicate whitespace characters', () => {
+      const pseudo = pseudotranslate('c a');
+      expect(pseudo).toHaveLength(4);
+      expect([...pseudo].filter(character => character === ' ')).toHaveLength(
+        1,
+      );
+    });
+
+    it('does not duplicate characters without replacements', () => {
+      expect(pseudotranslate('<>')).toBe('<>');
+    });
+
+    it('produces a 0.5x length string for Chinese', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'zh',
+      });
+      expect(pseudo).toHaveLength(5);
+    });
+
+    it('produces a 0.5x length string for Japanese', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'ja',
+      });
+      expect(pseudo).toHaveLength(5);
+    });
+
+    it('produces a 0.8x length string for Korean', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'ko',
+      });
+      expect(pseudo).toHaveLength(8);
+    });
+
+    it('produces a 1.5x length string for German', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'de',
+      });
+      expect(pseudo).toHaveLength(15);
+    });
+
+    it('produces a 1.5x length string for Dutch', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'nl',
+      });
+      expect(pseudo).toHaveLength(15);
+    });
+
+    it('produces a 1.3x length string for French', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'fr',
+      });
+      expect(pseudo).toHaveLength(13);
+    });
+
+    it('strips out the country code if provided', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'fr-CA',
+      });
+      expect(pseudo).toHaveLength(13);
+    });
+
+    it('produces a 1.3x length string for Italian', () => {
+      const pseudo = pseudotranslate('headphones', {
+        toLocale: 'it',
+      });
+      expect(pseudo).toHaveLength(13);
+    });
+  });
+});

--- a/packages/i18n/tsconfig.build.json
+++ b/packages/i18n/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
This PR starts the work to complete https://github.com/Shopify/quilt/issues/221. It adds a more generic `i18n` package that contains a few utility functions, most notable a `pseudotranslate` function. This takes some cues from the [work done in Web](https://github.com/Shopify/web/blob/master/packages/@shopify/i18n/src/utilities/pseudolocalize.ts), but also takes some from other related projects like Smartling's pseudo localization stuff.

There is a [moderately popular package](https://yarnpkg.com/en/package/pseudoloc-js) for this on NPM, but it does one thing in particular that is IMO very bad: a shared set of options for the module, which could easily break in server environments. It also didn't have a great mechanism for extending/ contracting the string.

Once this package is in, we will consume it in `react-i18n`, and then just have an option for this in the translation manager that will change how the i18n objects translate strings.