### PR TITLE
🐛 [jest-koa-mocks] Set default response status to be 404

### DIFF
--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -94,6 +94,11 @@ export default function createContext<
   });
 
   const res = httpMocks.createResponse();
+
+  // Koa sets a default status code of 404, not the node default of 200
+  // https://github.com/koajs/koa/blob/master/docs/api/response.md#responsestatus
+  res.statusCode = 404;
+
   // This is to get around an odd behavior in the `cookies` library, where if `res.set` is defined, it will use an internal
   // node function to set headers, which results in them being set in the wrong place.
   // eslint-disable-next-line no-undefined

--- a/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
@@ -13,6 +13,12 @@ describe('create-mock-context', () => {
     expect(context.url).toBe(url);
   });
 
+  it('defaults status to 404', () => {
+    const context = createContext();
+
+    expect(context.status).toBe(404);
+  });
+
   it('includes requestBody on ctx.request', () => {
     const requestBody = 'Hello I am a body';
     const context = createContext({requestBody});

--- a/packages/koa-liveness-ping/src/test/index.test.ts
+++ b/packages/koa-liveness-ping/src/test/index.test.ts
@@ -10,6 +10,7 @@ describe('koa-liveness-ping', () => {
 
     await middleware(ctx, nextFn);
 
+    expect(ctx.status).toBe(404);
     expect(nextFn).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
The node mocks default to a 200 status, but the koa default is 404. We
should follow koa's default as per https://github.com/koajs/koa/blob/master/docs/api/response.md#responsestatus