### PR TITLE
Changed generator to match conventions

### DIFF
--- a/plopfile.js
+++ b/plopfile.js
@@ -26,27 +26,33 @@ module.exports = function(plop) {
     actions: [
       {
         type: 'add',
-        path: 'packages/{{name}}/package.json',
+        path: 'packages/{{kebabCase name}}/package.json',
         templateFile: 'templates/package.hbs.json',
       },
       {
         type: 'add',
-        path: 'packages/{{name}}/tsconfig.json',
+        path: 'packages/{{kebabCase name}}/tsconfig.json',
         templateFile: 'templates/tsconfig.hbs.json',
       },
       {
         type: 'add',
-        path: 'packages/{{name}}/README.md',
+        path: 'packages/{{kebabCase name}}/README.md',
         templateFile: 'templates/README.hbs.md',
       },
       {
         type: 'add',
-        path: 'packages/{{name}}/src/index.ts',
-        templateFile: 'templates/index.hbs.ts',
+        path: 'packages/{{kebabCase name}}/src/index.ts',
+        templateFile: 'templates/index.hbs',
       },
       {
         type: 'add',
-        path: 'packages/{{name}}/src/test/index.test.ts',
+        path: 'packages/{{kebabCase name}}/src/{{properCase name}}.ts',
+        templateFile: 'templates/my-package.hbs.ts',
+      },
+      {
+        type: 'add',
+        path:
+          'packages/{{kebabCase name}}/src/test/{{properCase name}}.test.ts',
         templateFile: 'templates/test.hbs.ts',
       },
       sharedActions.docs,

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -1,0 +1,3 @@
+import {{properCase name}} from './{{properCase name}}';
+
+export default {{properCase name}};

--- a/templates/index.hbs.ts
+++ b/templates/index.hbs.ts
@@ -1,5 +1,0 @@
-function someFunction() {
-  return 'hello module';
-}
-
-export default someFunction;

--- a/templates/my-package.hbs.ts
+++ b/templates/my-package.hbs.ts
@@ -1,0 +1,3 @@
+export default function someFunction() {
+  return 'Hello {{kebabCase name}}!';
+}


### PR DESCRIPTION
## What problem is this PR solving?
Generator was generating a package structure that did match our conventions. (See issue #135 )

## How is this accomplished?
Changed plop file to add the necessary files and change the test files naming.

![screen shot 2018-09-12 at 10 12 43 am](https://user-images.githubusercontent.com/7542789/45431324-724edd00-b675-11e8-931a-1322876a578d.png)


## Reviewers’ hat-rack 🎩
Ensure that the generator creates the correct file structure for new packages. 
`yarn generate package my-package-name`
