### PR TITLE
[WIP] Added side effects config options to tracking pixel and preconnect

### DIFF
--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -25,5 +25,6 @@
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.0.8",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -24,5 +24,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/admin-graphql-api-utilities/README.md",
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -28,5 +28,6 @@
   },
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,5 +24,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/i18n/README.md",
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -30,5 +30,6 @@
   },
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -30,5 +30,6 @@
     "@types/express": "^4.11.1",
     "@types/koa": "^2.0.44",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -38,5 +38,6 @@
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.2.4",
     "apollo-client": "^2.3.4"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -34,5 +34,6 @@
       "react-router",
       "@types/react-router"
     ]
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -31,5 +31,6 @@
     "@types/koa-mount": "^3.0.1",
     "koa-mount": "^3.0.0",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -30,5 +30,6 @@
     "@shopify/jest-koa-mocks": "^2.0.11",
     "@shopify/with-env": "^1.0.6",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -33,5 +33,6 @@
     "@shopify/jest-dom-mocks": "^2.0.8",
     "@types/safe-compare": "^1.1.0",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -27,5 +27,6 @@
   },
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,5 +29,6 @@
   },
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -32,5 +32,6 @@
     "@types/enzyme": "^3.1.10",
     "enzyme": "^3.3.0",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -35,5 +35,6 @@
     "enzyme": "^3.3.0",
     "faker": "^4.1.0",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -33,5 +33,6 @@
   "devDependencies": {
     "@shopify/with-env": "^1.0.6",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -31,5 +31,6 @@
     "@types/hoist-non-react-statics": "^3.0.1",
     "hoist-non-react-statics": "^3.0.1",
     "react-tree-walker": "^4.3.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -32,5 +32,6 @@
   },
   "peerDependencies": {
     "react": "^16.4.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-preconnect/package.json
+++ b/packages/react-preconnect/package.json
@@ -31,5 +31,6 @@
   },
   "peerDependencies": {
     "react": "^16.3.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -31,5 +31,6 @@
   "devDependencies": {
     "enzyme": "^3.3.0",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -28,5 +28,6 @@
   "devDependencies": {
     "enzyme": "^3.3.0",
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -27,5 +27,6 @@
   },
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -35,5 +35,6 @@
   },
   "files": [
     "dist/*"
-  ]
+  ],
+  "sideEffects": false
 }

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -24,5 +24,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/with-env/README.md",
   "devDependencies": {
     "typescript": "~3.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -26,6 +26,5 @@
   "devDependencies": {
     "typescript": "~3.0.1"
   },
-  "files": ["dist/*"],
-  "sideEffects": false
+  "files": ["dist/*"]
 }

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -26,5 +26,6 @@
   "devDependencies": {
     "typescript": "~3.0.1"
   },
-  "files": ["dist/*"]
+  "files": ["dist/*"],
+  "sideEffects": false
 }


### PR DESCRIPTION
Added `sideeffects` config option to tracking pixel and preconnect packages (See issue #289 ). 
If this is the correct way to add side effects to our packages, add this config to other Quilt packages, then update generator to add this config to new packages. 