### PR TITLE
Added `react` & `prop-types` as dependency to `react-i18n`

### DIFF
--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -30,6 +30,8 @@
   "dependencies": {
     "@types/hoist-non-react-statics": "^3.0.1",
     "hoist-non-react-statics": "^3.0.1",
+    "prop-types": "^15.6.2",
+    "react": "^16.2.0",
     "react-tree-walker": "^4.3.0"
   },
   "sideEffects": false


### PR DESCRIPTION
This pr adds missing dependencies from [`react-i18n`](https://github.com/Shopify/quilt/tree/master/packages/react-i18n).

- [prop-types](https://yarnpkg.com/en/package/prop-types)
- [react](https://yarnpkg.com/en/package/react)

Should also fix #288. 

Here is the current badge error: 
![image](https://user-images.githubusercontent.com/13720087/45572645-dae5b780-b837-11e8-8dfa-28b554f1b64e.png)


Screenshot of error from [Bundlephobia](https://bundlephobia.com/result?p=@shopify/react-i18n):
![image](https://user-images.githubusercontent.com/13720087/45572690-010b5780-b838-11e8-8336-bc21d1c0fcf0.png)
 