### PR TITLE
Changed lodash version for tracking pixel

### DIFF
--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-tracking-pixel/README.md",
   "dependencies": {
     "@shopify/react-preconnect": "^0.1.2",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "enzyme": "^3.3.0",


### PR DESCRIPTION
Changed lodash version for `@shopify/react-tracking-pixel` to match lodash version used in Web. 