### PR TITLE
Move koa dependencies to dev-dependencies

### DIFF
--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -22,13 +22,11 @@
     "url": "https://github.com/shopify/quilt/issues"
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/koa-liveness-ping/README.md",
-  "dependencies": {
-    "koa": "^2.5.1"
-  },
   "devDependencies": {
     "@shopify/jest-koa-mocks": "^2.0.12",
-    "@types/koa": "^2.0.45",
+    "@types/koa": "^2.0.44",
     "@types/koa-mount": "^3.0.1",
+    "koa": "^2.5.0",
     "koa-mount": "^3.0.0",
     "typescript": "~3.0.1"
   },

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -23,12 +23,13 @@
   },
   "homepage": "https://github.com/shopify/quilt/blob/master/packages/koa-metrics/README.md",
   "dependencies": {
-    "hot-shots": "^5.4.1",
-    "koa": "^2.5.1"
+    "hot-shots": "^5.4.1"
   },
   "devDependencies": {
     "@shopify/jest-koa-mocks": "^2.0.12",
+    "@types/koa": "^2.0.44",
     "@shopify/with-env": "^1.0.7",
+    "koa": "^2.5.0",
     "typescript": "~3.0.1"
   },
   "sideEffects": false

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -24,14 +24,14 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/koa-shopify-auth/README.md",
   "dependencies": {
     "@shopify/jest-koa-mocks": "^2.0.12",
-    "@types/koa": "^2.0.44",
-    "koa": "^2.5.0",
     "nonce": "^1.0.4",
     "safe-compare": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.0.9",
+    "@types/koa": "^2.0.44",
     "@types/safe-compare": "^1.1.0",
+    "koa": "^2.5.0",
     "typescript": "~3.0.1"
   },
   "sideEffects": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,7 +265,7 @@
   dependencies:
     "@types/koa" "*"
 
-"@types/koa@*", "@types/koa@^2.0.45":
+"@types/koa@*":
   version "2.0.45"
   resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.0.45.tgz#133cbda6cc8d12b73434b5d9663898c833f80aa2"
   dependencies:
@@ -4373,35 +4373,6 @@ koa-mount@^3.0.0:
 koa@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/koa/-/koa-2.5.0.tgz#b0fbe1e195e43b27588a04fd0be0ddaeca2c154c"
-  dependencies:
-    accepts "^1.2.2"
-    content-disposition "~0.5.0"
-    content-type "^1.0.0"
-    cookies "~0.7.0"
-    debug "*"
-    delegates "^1.0.0"
-    depd "^1.1.0"
-    destroy "^1.0.3"
-    error-inject "~1.0.0"
-    escape-html "~1.0.1"
-    fresh "^0.5.2"
-    http-assert "^1.1.0"
-    http-errors "^1.2.8"
-    is-generator-function "^1.0.3"
-    koa-compose "^4.0.0"
-    koa-convert "^1.2.0"
-    koa-is-json "^1.0.0"
-    mime-types "^2.0.7"
-    on-finished "^2.1.0"
-    only "0.0.2"
-    parseurl "^1.3.0"
-    statuses "^1.2.0"
-    type-is "^1.5.5"
-    vary "^1.0.0"
-
-koa@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/koa/-/koa-2.5.1.tgz#79f8b95f8d72d04fe9a58a8da5ebd6d341103f9c"
   dependencies:
     accepts "^1.2.2"
     content-disposition "~0.5.0"


### PR DESCRIPTION
koa-liveness-ping, koa-metrics and koa-shopify-auth only depend upon the
types of koa, they do not use the package directly. Thus it is not a
runtime dependency.

Tweak dependency versions so we use a consistant version across all
packages

---

I'm making this change as @tzvipm mentioned that the changes in https://github.com/Shopify/cloud-node/pull/24 don't depend upon koa so shouldn't have a runtime dependency.

Note shopify-grapghql-proxy already followed this pattern of importing the koa Context and that's working fine without a stating a koa dependency.