### PR TITLE
React shortcuts context refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/jest": "^23.3.5",
     "@types/react-helmet": "^5.0.6",
+    "@types/react": "16.3.18",
     "codecov": "^3.0.2",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
@@ -55,6 +56,9 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^23.10.4",
     "typescript": "~3.0.1"
+  },
+  "resolutions": {
+    "@types/react": "16.3.18"
   },
   "dependencies": {}
 }

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {contextTypes} from '../ShortcutProvider';
+import {Consumer, Context} from '../ShortcutProvider';
 import Key, {ModifierKey} from '../keys';
 
 export interface Props {
@@ -15,15 +15,22 @@ export interface Subscription {
   unsubscribe(): void;
 }
 
-export default class Shortcut extends React.Component<Props, never> {
-  static contextTypes = contextTypes;
+export default function Shortcut(props: Props) {
+  return (
+    <Consumer>
+      {(context: Context) => <ShortcutConsumer {...props} {...context} />}
+    </Consumer>
+  );
+}
+
+class ShortcutConsumer extends React.Component<Props & Context, never> {
   public data = {
     node: this.props.node,
     ordered: this.props.ordered,
     held: this.props.held,
     ignoreInput: this.props.ignoreInput || false,
     onMatch: this.props.onMatch,
-    allowDefault: this.props.allowDefault,
+    allowDefault: this.props.allowDefault || false,
   };
   public subscription!: Subscription;
 
@@ -34,7 +41,10 @@ export default class Shortcut extends React.Component<Props, never> {
       return;
     }
 
-    const {shortcutManager} = this.context;
+    const {shortcutManager} = this.props;
+    if (shortcutManager == null) {
+      return;
+    }
     this.subscription = shortcutManager.subscribe(this.data);
   }
 

--- a/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
+++ b/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
@@ -19,10 +19,10 @@ export default class ShortcutProvider extends React.Component<Props, never> {
   }
 
   render() {
-    const appContext: Context = {
+    const context: Context = {
       shortcutManager: this.shortcutManager,
     };
 
-    return <Provider value={appContext}>{this.props.children}</Provider>;
+    return <Provider value={context}>{this.props.children}</Provider>;
   }
 }

--- a/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
+++ b/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
@@ -18,13 +18,11 @@ export default class ShortcutProvider extends React.Component<Props, never> {
     this.shortcutManager.setup();
   }
 
-  get childContext() {
-    return {
+  render() {
+    const appContext: Context = {
       shortcutManager: this.shortcutManager,
     };
-  }
 
-  render() {
-    return <Provider value={this.childContext}>{this.props.children}</Provider>;
+    return <Provider value={appContext}>{this.props.children}</Provider>;
   }
 }

--- a/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
+++ b/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
@@ -1,34 +1,30 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import ShortcutManager from '../ShortcutManager';
 
-export const contextTypes = {
-  shortcutManager: PropTypes.instanceOf(ShortcutManager),
-};
-
 export interface Context {
-  shortcutManager: ShortcutManager;
+  shortcutManager?: ShortcutManager;
 }
 
 export interface Props {
   children?: React.ReactNode;
 }
 
+export const {Provider, Consumer} = React.createContext<Context>({});
+
 export default class ShortcutProvider extends React.Component<Props, never> {
-  static childContextTypes = contextTypes;
   private shortcutManager = new ShortcutManager();
 
   componentDidMount() {
     this.shortcutManager.setup();
   }
 
-  getChildContext() {
+  get childContext() {
     return {
       shortcutManager: this.shortcutManager,
     };
   }
 
   render() {
-    return this.props.children;
+    return <Provider value={this.childContext}>{this.props.children}</Provider>;
   }
 }

--- a/packages/react-shortcuts/src/ShortcutProvider/index.ts
+++ b/packages/react-shortcuts/src/ShortcutProvider/index.ts
@@ -1,4 +1,4 @@
 import ShortcutProvider from './ShortcutProvider';
 
-export {Props, Context, contextTypes} from './ShortcutProvider';
+export {Props, Context, Consumer} from './ShortcutProvider';
 export default ShortcutProvider;

--- a/packages/react-shortcuts/src/index.ts
+++ b/packages/react-shortcuts/src/index.ts
@@ -4,7 +4,6 @@ export {
   default as ShortcutProvider,
   Props as ProviderProps,
   Context,
-  contextTypes,
 } from './ShortcutProvider';
 
 export {default as ShortcutManager} from './ShortcutManager';

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,10 +370,12 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.0.2":
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.1.tgz#6f6aaffaf7dba502ff5ca15e4aa18caee9b04995"
-  integrity sha512-bDni2+bq90eBYPAUbElpx5Lm0Cgbyo7oqrxIjrOSnyEb2QBjmLWKdfr1hYNhlamA5x4oKRZETED59q4/oe7ZBQ==
+"@types/react@*", "@types/react@16.3.18", "@types/react@^16.0.2":
+  version "16.3.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.18.tgz#bf195aed4d77dc86f06e4c9bb760214a3b822b8d"
+  integrity sha512-aWTvLHzKqbVWCiee8huwf5x7Ob4n4gxDwgJT/X31HqjGVZpeUeFeSFYH5Gvi5Dmm5HKF+s+dQkwa/nnEVVzzzg==
+  dependencies:
+    csstype "^2.2.0"
 
 "@types/safe-compare@^1.1.0":
   version "1.1.0"
@@ -1887,6 +1889,11 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   integrity sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
+  integrity sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This pr refactors react-shortcuts to use the new React16.3+ context API. Resolves #196. 

Should be good to go after #347 is merged👍