### PR TITLE
🗒️ [react-form-state] add a better final example to the guide

### DIFF
--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -503,7 +503,9 @@ export function ProductPage() {
 
 ## Putting it all together
 
-The following example shows how you can use everything this documentation covered to build a full [Polaris](https://polaris.shopify.com) styled page.'s
+The following example shows how you can use everything this documentation covered to build a full [Polaris](https://polaris.shopify.com) styled page.
+
+[Try it out in codesandbox](https://codesandbox.io/s/zx387x0vmx)
 
 ```typescript
 import * as React from 'react';
@@ -530,7 +532,11 @@ import FormState, {
 
 const {required, numericString, nonNumericString, lengthMoreThan} = validators;
 
-interface State {}
+interface Variant {
+  option: string;
+  value: string;
+  price: string;
+}
 
 interface Props {
   initialValues: {
@@ -538,21 +544,12 @@ interface Props {
     description: string;
     sku: string;
     quantity: string;
-    firstVariant: string;
-      option: string;
-      value: string;
-      price: string;
-    };
-    variants: {
-      option: string;
-      value: string;
-      price: string;
-    }[];
-  },
-  productUpdate,
+    firstVariant: Variant;
+    variants: Variant[];
+  };
 }
 
-export default function Playground({initialValues, updateProduct}: Props) {
+function CreateProductPage({initialValues}: Props) {
   return (
     <AppProvider>
       <FormState
@@ -570,7 +567,13 @@ export default function Playground({initialValues, updateProduct}: Props) {
             price: numericString('value must be numeric'),
           }),
         }}
-        onSubmit={updateProduct}
+        onSubmit={({fields}) => {
+          /*
+            In a real project you would make some kind of asynchronous call here
+            such as a graphQL mutation or a POST request, and return an array of errors if you encounter any.
+          */
+          return [{message: 'server error'}];
+        }}
       >
         {formDetails => {
           const {
@@ -578,7 +581,6 @@ export default function Playground({initialValues, updateProduct}: Props) {
             dirty,
             reset,
             submit,
-            valid,
             submitting,
             errors,
           } = formDetails;
@@ -662,11 +664,11 @@ export default function Playground({initialValues, updateProduct}: Props) {
                       <FormLayout>
                         <FormState.Nested field={firstVariant}>
                           {({option, value, price}) => (
-                            <>
+                            <React.Fragment>
                               <TextField label="option" {...option} />
                               <TextField label="value" {...value} />
                               <TextField label="price" {...price} />
-                            </>
+                            </React.Fragment>
                           )}
                         </FormState.Nested>
                       </FormLayout>
@@ -676,11 +678,11 @@ export default function Playground({initialValues, updateProduct}: Props) {
                       <FormLayout>
                         <FormState.List field={variants}>
                           {({option, value, price}) => (
-                            <>
+                            <React.Fragment>
                               <TextField label="option" {...option} />
                               <TextField label="value" {...value} />
                               <TextField label="price" {...price} />
-                            </>
+                            </React.Fragment>
                           )}
                         </FormState.List>
                         <ButtonGroup>


### PR DESCRIPTION
This PR updates the `building-forms` guide for `<FormState />` to link out to a working codesandbox example, and updates the code to the exact code from the sandbox.