### PR TITLE
use min-height instead of height on react root to fix height bug in consumers

### DIFF
--- a/packages/react-html/src/HTML.tsx
+++ b/packages/react-html/src/HTML.tsx
@@ -112,7 +112,7 @@ export default function HTML({
       <body {...bodyAttributes} style={bodyStyles}>
         <div
           id="app"
-          style={{height: '100%'}}
+          style={{minHeight: '100%'}}
           dangerouslySetInnerHTML={{__html: markup}}
         />
 


### PR DESCRIPTION
Setting the `height` on the React root to `100%` has cascading effects on parents and children throughout your application. This forces you to provide a height on all containers that are meant to hold content. Switching this to `min-height` still guarantees the height will always be the height of the window, while allowing it to grow to the height of its children.