### PR TITLE
remove style attribute entirely

### DIFF
--- a/packages/react-html/src/HTML.tsx
+++ b/packages/react-html/src/HTML.tsx
@@ -110,11 +110,7 @@ export default function HTML({
       </head>
 
       <body {...bodyAttributes} style={bodyStyles}>
-        <div
-          id="app"
-          style={{minHeight: '100%'}}
-          dangerouslySetInnerHTML={{__html: markup}}
-        />
+        <div id="app" dangerouslySetInnerHTML={{__html: markup}} />
 
         {dataMarkup}
 


### PR DESCRIPTION
As a follow-up to this PR: https://github.com/Shopify/quilt/pull/304, @lemonmade and I discussed in 🍖 👾 and reached the conclusion that we should remove the style attribute entirely. This will still be a breaking change requiring a 4.0.0 release of `react-html`.