### PR TITLE
Revert #234 

### DIFF
--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -42,22 +42,6 @@ describe('validation helpers', () => {
       expect(alwaysPassValidator(input)).toBeUndefined();
       expect(alwaysFailValidator(input)).toBe(error(input));
     });
-
-    it('returns a function that returns void when the input is empty', () => {
-      function error(input: string) {
-        return `${input} error`;
-      }
-
-      const alwaysPassValidator = validate(trueMatcher, error);
-      const alwaysFailValidator = validate(falseMatcher, error);
-
-      expect(alwaysPassValidator('')).toBeUndefined();
-      expect(alwaysFailValidator('')).toBeUndefined();
-      expect(alwaysPassValidator(null)).toBeUndefined();
-      expect(alwaysFailValidator(null)).toBeUndefined();
-      expect(alwaysPassValidator(undefined)).toBeUndefined();
-      expect(alwaysFailValidator(undefined)).toBeUndefined();
-    });
   });
 
   describe('validateObject', () => {
@@ -186,7 +170,7 @@ describe('validation helpers', () => {
       it('returns a function that returns errorContent when input.length <= length', () => {
         const error = faker.lorem.word();
         const validator = validators.lengthMoreThan(10, error);
-        expect(validator({length: 2})).toBe(error);
+        expect(validator({length: 0})).toBe(error);
       });
     });
 

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -110,14 +110,6 @@ export function validate<Input, Fields = never>(
   return (input: Input, fields: Fields) => {
     const matches = matcher(input, fields);
 
-    /*
-      always mark empty fields valid to match Polaris guidelines
-      https://polaris.shopify.com/patterns/error-messages#section-form-validation
-    */
-    if (isEmpty(input)) {
-      return;
-    }
-
     if (matches) {
       return;
     }
@@ -145,40 +137,16 @@ const validators = {
     return validate(isNumericString, errorContent);
   },
 
+  requiredString(errorContent: ErrorContent) {
+    return validate(not(isEmptyString), errorContent);
+  },
+
   nonNumericString(errorContent: ErrorContent) {
     return validate(not(isNumericString), errorContent);
   },
 
-  requiredString(errorContent: ErrorContent) {
-    return (input: string) => {
-      if (not(isEmptyString)(input)) {
-        return;
-      }
-
-      if (typeof errorContent === 'function') {
-        // eslint-disable-next-line consistent-return
-        return errorContent(toString(input));
-      }
-
-      // eslint-disable-next-line consistent-return
-      return errorContent;
-    };
-  },
-
   required(errorContent: ErrorContent) {
-    return (input: any) => {
-      if (not(isEmpty)(input)) {
-        return;
-      }
-
-      if (typeof errorContent === 'function') {
-        // eslint-disable-next-line consistent-return
-        return errorContent(toString(input));
-      }
-
-      // eslint-disable-next-line consistent-return
-      return errorContent;
-    };
+    return validate(not(isEmpty), errorContent);
   },
 };
 


### PR DESCRIPTION
 Reverts  "[react-form-state] never validate empty fields unless using the required validator (#234)".

We're just doing this so we can ship upcoming breaking changes and this as one big major bump rather than multiple.