### PR TITLE
✨ Validate whole form on submit, expose `validateForm`

### DIFF
--- a/documentation/FAQ.md
+++ b/documentation/FAQ.md
@@ -1,3 +1,28 @@
 # Frequently asked questions (FAQ)
 
+## I want to invoke all my validators whenever I want, how can I do this?
+
+You can do this by setting a `ref` on your `<FormState />`, and calling `validateForm` on the instance passed in.
+
+```typescript
+// use `createRef` and validate imperatively later
+class MyComponent extends React.Component {
+  formState = React.createRef();
+
+  render() {
+    return (
+      <FormState
+        initialValues={fields}
+        ref={this.formState}
+      />
+      <button onClick={() => this.formState.current.validateForm()}>validate</button>
+    );
+  }
+}
+```
+
+If you need to do something immediately on mount you could also use old fashioned [callback refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs).
+
+## More questions
+
 Have a question that you think should be included in our FAQ? Please help us by creating an [issue](https://github.com/Shopify/quilt/issues/new?template=ENHANCEMENT.md) or opening a pull request.

--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- The `validateOnSubmit` prop can be used to have validators run before the `onSubmit` function is called and will prevent `onSubmit` from being called if any fail.
+
 ## [0.2.10]
 
 ### Fixed

--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -27,6 +27,7 @@ interface Props<Fields> {
   initialValues: Fields;
   validators?: Partial<ValidatorDictionary<Fields>>;
   onSubmit?: SubmitHandler<Fields>;
+  validateOnSubmit?: boolean;
   children(form: FormDetails<Fields>): React.ReactNode;
 }
 ```

--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -355,6 +355,47 @@ function MyComponent() {
 }
 ```
 
+### validateOnSubmit
+
+You can configure `<FormState />` to run all validators on the form before executing `onSubmit` by passing it the `validateOnSubmit` prop. If any of the validators return an error, the submit is cancelled and `onSubmit` is not run.
+
+```typescript
+import {TextField, Form, Button} from '@shopify/polaris';
+import FormState, {validators} from '@shopify/react-form-state';
+
+function MyComponent() {
+  return (
+    <FormState
+      validateOnSubmit
+      initialValues={{
+        title: 'Cool title',
+      }}
+      validators={{
+        title(input) {
+          if (input.length > 10) {
+            return 'That title is too long';
+          }
+        },
+      }}
+      onSubmit={() => {
+        console.log('I will not be run if title is too long');
+      }}
+    >
+      {formDetails => {
+        const {fields, submit} = formDetails;
+
+        return (
+          <Form onSubmit={submit}>
+            <TextField label="Title" {...fields.title} />
+            <Button type="submit">Submit</Button>
+          </Form>
+        );
+      }}
+    </FormState>
+  );
+}
+```
+
 To learn more about building validators, and the built in functions exposed by this package, check out the [validators guide](validators.md).
 
 ## Compound fields

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -26,10 +26,10 @@ interface SubmitHandler<Fields> {
     | MaybePromise<void>;
 }
 
-export type ValidatorDictionary<Fields> = {
-  [FieldPath in keyof Fields]: MaybeArray<
-    ValidationFunction<Fields[FieldPath], Fields>
-  >
+export type Validator<T, F> = MaybeArray<ValidationFunction<T, F>>;
+
+export type ValidatorDictionary<FieldMap> = {
+  [FieldPath in keyof FieldMap]: Validator<FieldMap[FieldPath], FieldMap>
 };
 
 interface ValidationFunction<Value, Fields> {
@@ -53,6 +53,7 @@ interface Props<Fields> {
   initialValues: Fields;
   validators?: Partial<ValidatorDictionary<Fields>>;
   onSubmit?: SubmitHandler<Fields>;
+  validateOnSubmit?: boolean;
   children(form: FormDetails<Fields>): React.ReactNode;
 }
 
@@ -122,19 +123,29 @@ export default class FormState<
     };
   }
 
+  public validateForm() {
+    return new Promise(resolve => {
+      this.setState(runAllValidators, () => resolve());
+    });
+  }
+
   private get dirty() {
     return this.state.dirtyFields.length > 0;
   }
 
   private get valid() {
-    const {errors, fields} = this.state;
+    const {errors} = this.state;
 
-    const fieldsWithErrors = Object.keys(fields).filter(fieldPath => {
-      const {error} = fields[fieldPath];
-      return error != null;
+    return !this.hasClientErrors && errors.length === 0;
+  }
+
+  private get hasClientErrors() {
+    const {fields} = this.state;
+
+    return Object.keys(fields).some(fieldPath => {
+      const field = fields[fieldPath];
+      return field.error != null;
     });
-
-    return fieldsWithErrors.length === 0 && errors.length === 0;
   }
 
   private get fields() {
@@ -149,7 +160,7 @@ export default class FormState<
 
   @bind()
   private async submit(event?: Event) {
-    const {onSubmit} = this.props;
+    const {onSubmit, validateOnSubmit} = this.props;
     const {formData, mounted} = this;
 
     if (!mounted) {
@@ -165,6 +176,14 @@ export default class FormState<
     }
 
     this.setState({submitting: true});
+
+    if (validateOnSubmit) {
+      await this.validateForm();
+
+      if (this.hasClientErrors) {
+        return;
+      }
+    }
 
     const errors = await onSubmit(formData);
 
@@ -321,27 +340,9 @@ export default class FormState<
 
     const {validators = {}} = this.props;
     const {fields} = this.state;
-    const validate = validators[fieldPath];
-
-    if (typeof validate === 'function') {
-      // eslint-disable-next-line consistent-return
-      return validate(value, fields);
-    }
-
-    if (!isArray(validate)) {
-      return;
-    }
-
-    const errors = validate
-      .map(validator => validator(value, fields))
-      .filter(input => input != null);
-
-    if (errors.length === 0) {
-      return;
-    }
 
     // eslint-disable-next-line consistent-return
-    return errors;
+    return runValidator(validators[fieldPath], value, fields);
   }
 
   private updateRemoteErrors(errors: RemoteError[]) {
@@ -389,4 +390,56 @@ function createFormState<Fields>(values: Fields): State<Fields> {
 
 function initialValuesFromFields<Fields>(fields: FieldStates<Fields>): Fields {
   return mapObject(fields, ({initialValue}) => initialValue);
+}
+
+function runValidator<T, F>(
+  validate: Validator<T, F> = () => {},
+  value: T,
+  fields: FieldStates<F>,
+) {
+  if (typeof validate === 'function') {
+    // eslint-disable-next-line consistent-return
+    return validate(value, fields);
+  }
+
+  if (!isArray(validate)) {
+    // eslint-disable-next-line consistent-return
+    return;
+  }
+
+  const errors = validate
+    .map(validator => validator(value, fields))
+    .filter(input => input != null);
+
+  if (errors.length === 0) {
+    // eslint-disable-next-line consistent-return
+    return;
+  }
+
+  // eslint-disable-next-line consistent-return
+  return errors;
+}
+
+function runAllValidators<FieldMap>(
+  state: State<FieldMap>,
+  props: Props<FieldMap>,
+) {
+  const {fields} = state;
+  const {validators} = props;
+
+  if (!validators) {
+    return null;
+  }
+
+  const updatedFields = mapObject(fields, (field, path) => {
+    return {
+      ...field,
+      error: runValidator(validators[path], field.value, fields),
+    };
+  });
+
+  return {
+    ...state,
+    fields: updatedFields,
+  } as State<FieldMap>;
 }


### PR DESCRIPTION
#299 
#286 

This PR adds the `validateOnSubmit` prop to `<FormState>`. This prop allows you to run all your validators at submit and bail without hitting the server if any fail.

This PR also adds the public instance method `validateForm`, giving consumers the ability to validate the entire form at once, regardless of dirty state. This should only be used as an escape hatch when doing non-standard form flows.

### 🎩  instructions
- clone branch
- `yarn install && yarn build`
- `cd packages/react-form-state`
- `yarn link`
- go to your own project
- `yarn link @shopify/react-form-state`
- try it out :)