### PR TITLE
✨Adds the ability to disable tracking

### DIFF
--- a/packages/react-google-analytics/README.md
+++ b/packages/react-google-analytics/README.md
@@ -27,6 +27,7 @@ const UNIVERSAL_GA_ACCOUNT_ID = 'UA-xxxx-xx';
 <Universal
   account={UNIVERSAL_GA_ACCOUNT_ID}
   domain={shopDomain}
+  disableTracking
   debug
   // NOTE: This prop will load and set the debug mode for Google Analytics
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging
@@ -89,7 +90,7 @@ const GA_JS_ACCOUNT_ID = 'UA-xxxx-xx';
 <GaJS
   account={GA_JS_ACCOUNT_ID}
   domain={shopDomain}
-  debug
+  disableTracking
   // NOTE: Disables the tracking snippet from sending data to Google Analytics.
   // https://developers.google.com/analytics/devguides/collection/gajs/#disable
 />;

--- a/packages/react-google-analytics/src/GaJS.tsx
+++ b/packages/react-google-analytics/src/GaJS.tsx
@@ -12,7 +12,7 @@ export interface Props {
   allowHash?: boolean;
   set?: any[][];
   onLoad?(analytics: GaJSAnalytics): void;
-  debug?: boolean;
+  disableTracking?: boolean;
 }
 
 export const SETUP_SCRIPT = `
@@ -31,14 +31,16 @@ export default class GaJSGoogleAnalytics extends React.PureComponent<
   never
 > {
   render() {
-    const {account, debug} = this.props;
+    const {account, disableTracking} = this.props;
 
     return (
       <>
         <script
           id="google-analytics-gtag-script"
           dangerouslySetInnerHTML={{
-            __html: debug ? setupWithDebugScript(account) : SETUP_SCRIPT,
+            __html: disableTracking
+              ? setupWithDebugScript(account)
+              : SETUP_SCRIPT,
           }}
         />
         <ImportRemote

--- a/packages/react-google-analytics/src/Universal.tsx
+++ b/packages/react-google-analytics/src/Universal.tsx
@@ -10,6 +10,7 @@ export interface Props {
   set?: {[key: string]: any};
   onLoad?(analytics: UniversalAnalytics): void;
   debug?: boolean;
+  disableTracking?: boolean;
 }
 
 export const SETUP_SCRIPT = `
@@ -57,6 +58,7 @@ export default class UniversalGoogleAnalytics extends React.PureComponent<
       set: setVariables = {},
       onLoad,
       debug = false,
+      disableTracking = false,
     } = this.props;
 
     const normalizedDomain = getRootDomain(domain);
@@ -66,9 +68,9 @@ export default class UniversalGoogleAnalytics extends React.PureComponent<
       allowLinker: true,
     };
 
-    if (debug) {
-      // The debug version of the analytics.js library
-      // https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging
+    if (debug || disableTracking) {
+      // Prevent data being sent to Google
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging#testing_your_implementation_without_sending_hits
       googleAnalytics('set', 'sendHitTask', null);
     }
 

--- a/packages/react-google-analytics/src/tests/GaJS.test.tsx
+++ b/packages/react-google-analytics/src/tests/GaJS.test.tsx
@@ -26,20 +26,6 @@ describe('<GaJS />', () => {
         gajs.find('script').prop('dangerouslySetInnerHTML'),
       ).toHaveProperty('__html', SETUP_SCRIPT);
     });
-
-    it('renders a script tag with the debug and setup content', () => {
-      const gajs = mount(<GaJS {...mockProps} debug />);
-      expect(
-        gajs.find('script').prop('dangerouslySetInnerHTML'),
-      ).toHaveProperty('__html', setupWithDebugScript(mockProps.account));
-    });
-
-    it('with debug set to false renders a script tag without the debug content', () => {
-      const gajs = mount(<GaJS {...mockProps} debug={false} />);
-      expect(
-        gajs.find('script').prop('dangerouslySetInnerHTML'),
-      ).toHaveProperty('__html', SETUP_SCRIPT);
-    });
   });
 
   describe('<ImportRemote />', () => {
@@ -203,6 +189,32 @@ describe('<GaJS />', () => {
           ]);
         }
       });
+    });
+  });
+
+  describe('disableTracking', () => {
+    it('loads the GA script and injects the setup script when disableTracking is not set', () => {
+      const gajs = mount(<GaJS {...mockProps} />);
+      expect(gajs.find(ImportRemote).prop('source')).toBe(GA_JS_SCRIPT);
+      expect(
+        gajs.find('script').prop('dangerouslySetInnerHTML'),
+      ).toHaveProperty('__html', SETUP_SCRIPT);
+    });
+
+    it('loads the GA script and injects the debug setup script when disableTracking is set to true', () => {
+      const gajs = mount(<GaJS {...mockProps} disableTracking />);
+      expect(gajs.find(ImportRemote).prop('source')).toBe(GA_JS_SCRIPT);
+      expect(
+        gajs.find('script').prop('dangerouslySetInnerHTML'),
+      ).toHaveProperty('__html', setupWithDebugScript(mockProps.account));
+    });
+
+    it('loads the GA script and injects the setup script when disableTracking is set to false', () => {
+      const gajs = mount(<GaJS {...mockProps} disableTracking={false} />);
+      expect(gajs.find(ImportRemote).prop('source')).toBe(GA_JS_SCRIPT);
+      expect(
+        gajs.find('script').prop('dangerouslySetInnerHTML'),
+      ).toHaveProperty('__html', SETUP_SCRIPT);
     });
   });
 

--- a/packages/react-google-analytics/src/tests/Universal.test.tsx
+++ b/packages/react-google-analytics/src/tests/Universal.test.tsx
@@ -7,6 +7,7 @@ import Universal, {
   Props,
   SETUP_SCRIPT,
   UNIVERSAL_GA_SCRIPT,
+  UNIVERSAL_GA_DEBUG_SCRIPT,
 } from '../Universal';
 
 jest.mock('@shopify/react-import-remote', () => () => null);
@@ -138,11 +139,58 @@ describe('<Universal />', () => {
   });
 
   describe('debug', () => {
-    it('sets the debug mode', () => {
+    it('loads the GA script without restrictions when debug is not set', () => {
+      const analytics = mockAnalytics();
+      const universal = mount(<Universal {...mockProps} />);
+      expect(universal.find(ImportRemote).prop('source')).toBe(
+        UNIVERSAL_GA_SCRIPT,
+      );
+      trigger(universal.find(ImportRemote), 'onImported', analytics);
+      expect(analytics).not.toHaveBeenCalledWith('set', 'sendHitTask', null);
+    });
+
+    it('loads the GA debug script and prevent sending data to GA when debug is set to true', () => {
       const analytics = mockAnalytics();
       const universal = mount(<Universal {...mockProps} debug />);
+      expect(universal.find(ImportRemote).prop('source')).toBe(
+        UNIVERSAL_GA_DEBUG_SCRIPT,
+      );
       trigger(universal.find(ImportRemote), 'onImported', analytics);
       expect(analytics).toHaveBeenCalledWith('set', 'sendHitTask', null);
+    });
+
+    it('loads the GA script and does not prevent sending data to GA when debug is set to false', () => {
+      const analytics = mockAnalytics();
+      const universal = mount(<Universal {...mockProps} debug={false} />);
+      expect(universal.find(ImportRemote).prop('source')).toBe(
+        UNIVERSAL_GA_SCRIPT,
+      );
+      trigger(universal.find(ImportRemote), 'onImported', analytics);
+      expect(analytics).not.toHaveBeenCalledWith('set', 'sendHitTask', null);
+    });
+  });
+
+  describe('disableTracking', () => {
+    it('loads the GA script and prevent sending data to GA when disableTracking is set to true', () => {
+      const analytics = mockAnalytics();
+      const universal = mount(<Universal {...mockProps} disableTracking />);
+      expect(universal.find(ImportRemote).prop('source')).toBe(
+        UNIVERSAL_GA_SCRIPT,
+      );
+      trigger(universal.find(ImportRemote), 'onImported', analytics);
+      expect(analytics).toHaveBeenCalledWith('set', 'sendHitTask', null);
+    });
+
+    it('loads the GA script and does not prevent sending data to GA when disableTracking is set to false', () => {
+      const analytics = mockAnalytics();
+      const universal = mount(
+        <Universal {...mockProps} disableTracking={false} />,
+      );
+      expect(universal.find(ImportRemote).prop('source')).toBe(
+        UNIVERSAL_GA_SCRIPT,
+      );
+      trigger(universal.find(ImportRemote), 'onImported', analytics);
+      expect(analytics).not.toHaveBeenCalledWith('set', 'sendHitTask', null);
     });
   });
 });


### PR DESCRIPTION
### Debug vs disableTracking
- The `debug` prop will load `analytics_debug.js`, disable tracking and output verbose logs.
- The `disableTracking` prop will simply disable tracking. This is intended to be used in `development` where we want to run the same GA code in `development` and `production` but don't want to send data to GA.