### PR TITLE
Fix Nested and List race condition

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -8,3 +8,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Validators based on `validate` now always succeed for an empty input. The `required` and `requiredString` validators continue to behave the same way they used to.
+- Fixed Nested and List component race condition. Nested and List now pass a function to their `onChange` prop instead of an object so that the data object will be created within `setState`.

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -4,8 +4,8 @@ import isArray from 'lodash/isArray';
 import set from 'lodash/set';
 import {memoize, bind} from 'lodash-decorators';
 
-import {mapObject, replace} from './utilities';
-import {FieldDescriptors, FieldState} from './types';
+import {mapObject} from './utilities';
+import {FieldDescriptors, FieldState, ValueMapper} from './types';
 import {List, Nested} from './components';
 
 export interface RemoteError {
@@ -200,21 +200,12 @@ export default class FormState<
 
   private updateField<Key extends keyof Fields>(
     fieldPath: Key,
-    value: Fields[Key],
-    nested?: {key: string; index?: number},
+    value: Fields[Key] | ValueMapper<Fields[Key]>,
   ) {
     this.setState<any>(({fields, dirtyFields}: State<Fields>) => {
       const field = fields[fieldPath];
-      let newValue = value;
 
-      if (nested && nested.key) {
-        const {value: fieldValue} = field;
-        newValue = this.getNewNestedItem({
-          nested,
-          fieldValue,
-          value,
-        });
-      }
+      const newValue = typeof value === 'function' ? value(field.value) : value;
 
       const dirty = !isEqual(newValue, field.initialValue);
 
@@ -242,32 +233,6 @@ export default class FormState<
               },
       };
     });
-  }
-
-  private getNewNestedItem<Key extends keyof Fields>({
-    nested,
-    fieldValue,
-    value,
-  }: {
-    nested: {key: string; index?: number};
-    fieldValue: Fields[Key];
-    value: Fields[Key];
-  }) {
-    // List (has index)
-    if (nested.index || nested.index === 0) {
-      const existingItem = fieldValue[nested.index];
-      const updated = {
-        ...(existingItem as any),
-        [nested.key]: value,
-      };
-      return replace(fieldValue as any, nested.index, updated);
-    }
-
-    // Nested
-    return {
-      ...(fieldValue as any),
-      [nested.key]: value,
-    };
   }
 
   private getUpdatedDirtyFields<Key extends keyof Fields>({

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import {memoize, bind} from 'lodash-decorators';
 
 import {FieldDescriptor, FieldDescriptors} from '../types';
-import {mapObject, replace} from '../utilities';
+import {mapObject} from '../utilities';
 
 interface Props<Fields> {
   field: FieldDescriptor<Fields[]>;
@@ -57,16 +57,10 @@ export default class List<Fields> extends React.PureComponent<
   }) {
     return (newValue: Fields[Key]) => {
       const {
-        field: {value, onChange},
+        field: {onChange},
       } = this.props;
 
-      const existingItem = value[index];
-      const newItem = {
-        ...(existingItem as any),
-        [key]: newValue,
-      };
-
-      onChange(replace(value, index, newItem));
+      onChange(newValue as any, {key, index});
     };
   }
 }

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import {memoize, bind} from 'lodash-decorators';
 
 import {FieldDescriptor, FieldDescriptors} from '../types';
-import {mapObject} from '../utilities';
+import {mapObject, replace} from '../utilities';
 
 interface Props<Fields> {
   field: FieldDescriptor<Fields[]>;
@@ -60,7 +60,14 @@ export default class List<Fields> extends React.PureComponent<
         field: {onChange},
       } = this.props;
 
-      onChange(newValue as any, {key, index});
+      onChange(value => {
+        const existingItem = value[index];
+        const newItem = {
+          ...(existingItem as any),
+          [key]: newValue,
+        };
+        return replace(value, index, newItem);
+      });
     };
   }
 }

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -47,7 +47,12 @@ export default class Nested<Fields> extends React.PureComponent<
         field: {onChange},
       } = this.props;
 
-      onChange(newValue as any, {key: key as string});
+      onChange(value => {
+        return {
+          ...(value as any),
+          [key]: newValue,
+        };
+      });
     };
   }
 }

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -44,15 +44,10 @@ export default class Nested<Fields> extends React.PureComponent<
   private handleChange<Key extends keyof Fields>(key: Key) {
     return (newValue: Fields[Key]) => {
       const {
-        field: {value: existingItem, onChange},
+        field: {onChange},
       } = this.props;
 
-      const newItem = {
-        ...(existingItem as any),
-        [key]: newValue,
-      };
-
-      onChange(newItem);
+      onChange(newValue as any, {key: key as string});
     };
   }
 }

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -180,4 +180,43 @@ describe('<FormState.List />', () => {
       expect(department.error).toBe(field.error[index].department);
     });
   });
+
+  it('Does not have race condition with multiple onChange calls', () => {
+    const products = [
+      {
+        title: faker.commerce.productName(),
+        department: faker.commerce.department(),
+      },
+    ];
+
+    const renderSpy = jest.fn(({title, department}) => {
+      return (
+        <>
+          <Input label="title" {...title} />
+          <Input label="department" {...department} />
+        </>
+      );
+    });
+
+    const renderPropSpy = jest.fn(({fields}: any) => {
+      return (
+        <FormState.List field={fields.products}>{renderSpy}</FormState.List>
+      );
+    });
+
+    mount(<FormState initialValues={{products}}>{renderPropSpy}</FormState>);
+
+    const {title, department} = lastCallArgs(renderSpy);
+
+    const newTitle = faker.commerce.productName();
+    const newDepartment = faker.commerce.department();
+
+    title.onChange(newTitle);
+    department.onChange(newDepartment);
+
+    const updatedFields = lastCallArgs(renderSpy);
+
+    expect(updatedFields.title.value).toBe(newTitle);
+    expect(updatedFields.department.value).toBe(newDepartment);
+  });
 });

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -130,4 +130,45 @@ describe('<Nested />', () => {
     expect(renderPropArgs.title.error).toBe(field.error.title);
     expect(renderPropArgs.department.error).toBe(field.error.department);
   });
+
+  it('Does not have race condition with multiple onChange calls', () => {
+    const product = {
+      title: faker.commerce.productName(),
+      department: faker.commerce.department(),
+    };
+
+    const renderSpy = jest.fn(({title, department}) => {
+      return (
+        <>
+          <Input label="title" {...title} />
+          <Input label="department" {...department} />
+        </>
+      );
+    });
+
+    mount(
+      <FormState initialValues={{product}}>
+        {({fields}) => {
+          return (
+            <FormState.Nested field={fields.product}>
+              {renderSpy}
+            </FormState.Nested>
+          );
+        }}
+      </FormState>,
+    );
+
+    const {title, department} = lastCallArgs(renderSpy);
+
+    const newTitle = faker.commerce.productName();
+    const newDepartment = faker.commerce.department();
+
+    title.onChange(newTitle);
+    department.onChange(newDepartment);
+
+    const updatedFields = lastCallArgs(renderSpy);
+
+    expect(updatedFields.title.value).toBe(newTitle);
+    expect(updatedFields.department.value).toBe(newDepartment);
+  });
 });

--- a/packages/react-form-state/src/types.ts
+++ b/packages/react-form-state/src/types.ts
@@ -8,10 +8,14 @@ export interface FieldState<Value> {
 }
 
 export interface FieldDescriptor<Value> extends FieldState<Value> {
-  onChange(newValue: Value, nested?: {key: string; index?: number}): void;
+  onChange(newValue: Value | ValueMapper<Value>): void;
   onBlur(): void;
 }
 
 export type FieldDescriptors<Fields> = {
   [FieldPath in keyof Fields]: FieldDescriptor<Fields[FieldPath]>
 };
+
+export interface ValueMapper<Value> {
+  (value: Value): Value;
+}

--- a/packages/react-form-state/src/types.ts
+++ b/packages/react-form-state/src/types.ts
@@ -8,7 +8,7 @@ export interface FieldState<Value> {
 }
 
 export interface FieldDescriptor<Value> extends FieldState<Value> {
-  onChange(newValue: Value): void;
+  onChange(newValue: Value, nested?: {key: string; index?: number}): void;
   onBlur(): void;
 }
 


### PR DESCRIPTION
I encountered a race condition when using two components within a `FormState.Nested` where one depended on the other and they would both have their state updated when a certain action occurred. Because the updated `Nested` `field item` was created outside of the `setState` function, when the two `onChange's` were called from within the same `Nested` component the second `field` object didn't include the updated values from the first `onChange` because `setState` is asynchronous.

To solve this, I moved the creation of the `Nested` `field item` object into the setState function to ensure it is done atomically. That way if consecutive `onChange` function calls are made, the `Nested` `field item` object will include the previous changes.

The `Nested` component will call the `onChange` function with the new optional `nested` parameter with an object containing the `key` to the field that was updated.

This same issue also occurs in the `FormState.List` component for exactly the same reasons and was fixed in a similar manner. `List` calls the `onChange` function with an object containing the `key` and `index` for the update.

Note: I'm kinda new to TypeScript so if my typings need to be better let me know.