### PR TITLE
Replaced SupportedLocale type with string

### DIFF
--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
+## 2.2.0 - 2018-10-01
+
+- Replaced `SupportedLocale` type by string. Default to english, if locale does not exist. ([#](https://github.com/Shopify/quilt/pull/xxx))
+
+## 2.1.0 - 2018-09-28
+
+- Created `SupportedLocale` type ([#311](https://github.com/Shopify/quilt/pull/311))
+- Created `SupportedCountry` type ([#311](https://github.com/Shopify/quilt/pull/311))
+- `AddressFormatter` now accepts `SupportedLocale` as locale instead of `string` ([#311](https://github.com/Shopify/quilt/pull/311))
+
 ## 2.0.0 - 2018-09-19
 
 ### Enhancements
@@ -17,6 +27,3 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 - Changed `address2Key: string` type to `ZipKey` type ([#274](https://github.com/Shopify/quilt/pull/274))
 - Removed `attributes` key from Country type ([#274](https://github.com/Shopify/quilt/pull/274))
 - Changed `format` key to `formatting` in Country type ([#274](https://github.com/Shopify/quilt/pull/274))
-- Created `SupportedLocale` type ([#311](https://github.com/Shopify/quilt/pull/311))
-- Created `SupportedCountry` type ([#311](https://github.com/Shopify/quilt/pull/311))
-- `AddressFormatter` now accepts `SupportedLocale` as locale instead of `string` ([#311](https://github.com/Shopify/quilt/pull/311))

--- a/packages/address/README.md
+++ b/packages/address/README.md
@@ -16,11 +16,11 @@ $ yarn add @shopify/address
 
 - `country` field in Address is expected to be of format ISO 3166-1 alpha-2, eg. CA / FR / JP
 
-#### `constructor(private locale: SupportedLocale)`
+#### `constructor(private locale: string)`
 
 Instantiate the AddressFormatter by passing it a locale.
 
-#### `updateLocale(locale: SupportedLocale)`
+#### `updateLocale(locale: string)`
 
 Update the locale of the formatter. Following requests will be in the given locale.
 

--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -1,10 +1,4 @@
-import {
-  Address,
-  FieldName,
-  Country,
-  SupportedLocale,
-  SupportedCountry,
-} from './types';
+import {Address, FieldName, Country, SupportedCountry} from './types';
 import {renderLineTemplate, FIELDS_MAPPING} from './utilities';
 import {loadCountry, loadCountries} from './loader';
 
@@ -26,12 +20,12 @@ const COUNTRIES_CACHE: {
 } = {};
 
 export default class AddressFormatter {
-  constructor(private locale: SupportedLocale) {
+  constructor(private locale: string) {
     this.locale = locale;
     COUNTRIES_CACHE[this.locale] = {};
   }
 
-  updateLocale(locale: SupportedLocale) {
+  updateLocale(locale: string) {
     this.locale = locale;
     COUNTRIES_CACHE[this.locale] = {};
   }

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -4,7 +4,6 @@ import {
   LoadCountryResponse,
   ResponseError,
   SupportedCountry,
-  SupportedLocale,
 } from './types';
 import query from './graphqlQuery';
 
@@ -19,9 +18,7 @@ const HEADERS = {
   'Access-Control-Allow-Origin': '*',
 };
 
-export async function loadCountries(
-  locale: SupportedLocale,
-): Promise<Country[]> {
+export async function loadCountries(locale: string): Promise<Country[]> {
   const response = await fetch(GRAPHQL_ENDPOINT, {
     method: 'POST',
     headers: HEADERS,
@@ -44,7 +41,7 @@ export async function loadCountries(
 }
 
 export async function loadCountry(
-  locale: SupportedLocale,
+  locale: string,
   countryCode: SupportedCountry,
 ): Promise<Country> {
   const response = await fetch(GRAPHQL_ENDPOINT, {
@@ -74,8 +71,26 @@ class CountryLoaderError extends Error {
   }
 }
 
-function toSupportedLocale(locale: SupportedLocale) {
+const DEFAULT_LOCALE = 'EN';
+const SUPPORTED_LOCALES = [
+  'DA',
+  'DE',
+  'EN',
+  'ES',
+  'FR',
+  'IT',
+  'JA',
+  'NL',
+  'PT',
+  'PT_BR',
+];
+
+function toSupportedLocale(locale: string) {
   const supportedLocale = locale.replace(/-/, '_').toUpperCase();
 
-  return supportedLocale;
+  if (SUPPORTED_LOCALES.includes(supportedLocale)) {
+    return supportedLocale;
+  } else {
+    return DEFAULT_LOCALE;
+  }
 }

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -1,5 +1,5 @@
 import {fetch} from '@shopify/jest-dom-mocks';
-import {Address, FieldName, SupportedLocale} from '../types';
+import {Address, FieldName} from '../types';
 import AddressFormatter from '..';
 import {
   countriesJa,
@@ -141,9 +141,9 @@ describe('getCountries()', () => {
   });
 
   it('should not call the API again for the countries if the locale is the same.', async () => {
-    mockAPICall('countries', countriesEn, 'YY');
+    mockAPICall('countries', countriesEn, 'PT_BR');
     // Bypass the cache by using a non existant locale
-    const addressFormatter = new AddressFormatter('yy' as SupportedLocale);
+    const addressFormatter = new AddressFormatter('pt-br');
     await addressFormatter.getCountries();
     await addressFormatter.getCountries();
 
@@ -151,12 +151,12 @@ describe('getCountries()', () => {
   });
 
   it('should call the API again for the countries if the locale has been updated.', async () => {
-    mockAPICall('countries', countriesEn, 'ZZ');
-    mockAPICall('countries', countriesJa, 'XX');
+    mockAPICall('countries', countriesEn, 'NL');
+    mockAPICall('countries', countriesJa, 'IT');
 
-    const addressFormatter = new AddressFormatter('zz' as SupportedLocale);
+    const addressFormatter = new AddressFormatter('nl');
     await addressFormatter.getCountries();
-    addressFormatter.updateLocale('xx' as SupportedLocale);
+    addressFormatter.updateLocale('it');
     await addressFormatter.getCountries();
 
     expect(fetch.calls()).toHaveLength(2);
@@ -277,11 +277,20 @@ describe('toSupportedLocale', () => {
   });
 
   it('replaces - with _ and returns the locale in uppercase', async () => {
-    mockAPICall('country', countryJpJa, 'PT_BR');
+    mockAPICall('country', countryJpJa, 'DE');
 
-    const addressFormatter = new AddressFormatter('pt-br' as SupportedLocale);
+    const addressFormatter = new AddressFormatter('de');
     const result = await addressFormatter.getCountry('JP');
 
     expect(result).toEqual(countryJpJa.data.country);
+  });
+
+  it('Returns default locale if locale is not supported', async () => {
+    mockAPICall('country', countryJpEn, 'EN');
+
+    const addressFormatter = new AddressFormatter('xx');
+    const result = await addressFormatter.getCountry('JP');
+
+    expect(result).toEqual(countryJpEn.data.country);
   });
 });

--- a/packages/address/src/types.ts
+++ b/packages/address/src/types.ts
@@ -78,18 +78,6 @@ export interface ResponseError {
   }[];
 }
 
-export type SupportedLocale =
-  | 'da'
-  | 'de'
-  | 'en'
-  | 'es'
-  | 'fr'
-  | 'it'
-  | 'ja'
-  | 'nl'
-  | 'pt'
-  | 'pt-BR';
-
 export type SupportedCountry =
   | 'AD'
   | 'AE'


### PR DESCRIPTION
- Replaced `SupportedLocale` with type `string`, to make sure no error is triggered if an unsupported locale is passed. We default to English instead.