### PR TITLE
✨ Add the ability to set a nonce for comply with script-src CSP

### DIFF
--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -4,6 +4,7 @@ import load from './load';
 
 export interface Props<Imported = any> {
   source: string;
+  nonce?: string;
   preconnect?: boolean;
   onError(error: Error): void;
   getImport(window: Window): Imported;
@@ -35,10 +36,10 @@ export default class ImportRemote extends React.PureComponent<Props, never> {
   }
 
   async loadRemote() {
-    const {source, getImport, onError, onImported} = this.props;
+    const {source, nonce = '', getImport, onError, onImported} = this.props;
 
     try {
-      const imported = await load(source, getImport);
+      const imported = await load(source, getImport, nonce);
       onImported(imported);
     } catch (error) {
       onError(error);

--- a/packages/react-import-remote/src/load.ts
+++ b/packages/react-import-remote/src/load.ts
@@ -6,6 +6,7 @@ export default function load<
 >(
   source: string,
   getImport: (window: CustomWindow) => Imported,
+  nonce: string,
 ): Promise<Imported> {
   if (typeof window === 'undefined') {
     return Promise.reject(
@@ -19,7 +20,7 @@ export default function load<
     return cachedModule;
   }
 
-  const scriptTag = scriptTagFor(source);
+  const scriptTag = scriptTagFor(source, nonce);
   appendScriptTag(scriptTag);
 
   const promise = new Promise<Imported>((resolve, reject) => {
@@ -47,10 +48,15 @@ export function clearCache() {
   cache.clear();
 }
 
-function scriptTagFor(source: string) {
+function scriptTagFor(source: string, nonce: string) {
   const node = document.createElement('script');
   node.setAttribute('type', 'text/javascript');
   node.setAttribute('src', source);
+
+  if (nonce.length > 0) {
+    node.setAttribute('nonce', nonce);
+  }
+
   return node;
 }
 

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -29,18 +29,38 @@ describe('<ImportRemote />', () => {
 
   describe('source and getImport()', () => {
     it('uses the props as arguments for load()', () => {
+      const nonce = '';
       mount(<ImportRemote {...mockProps} />);
-      expect(load).toHaveBeenCalledWith(mockProps.source, mockProps.getImport);
+      expect(load).toHaveBeenCalledWith(
+        mockProps.source,
+        mockProps.getImport,
+        nonce,
+      );
+    });
+
+    it('uses the nonce prop as argument for load()', () => {
+      const nonce = '1a2b3c';
+      mount(<ImportRemote {...mockProps} nonce={nonce} />);
+      expect(load).toHaveBeenCalledWith(
+        mockProps.source,
+        mockProps.getImport,
+        nonce,
+      );
     });
 
     it('imports a new global if the source changes', () => {
+      const nonce = '';
       const importRemote = mount(<ImportRemote {...mockProps} />);
-      expect(load).toHaveBeenCalledWith(mockProps.source, mockProps.getImport);
+      expect(load).toHaveBeenCalledWith(
+        mockProps.source,
+        mockProps.getImport,
+        nonce,
+      );
 
       const newSource = 'https://bar.com/foo.js';
 
       importRemote.setProps({source: newSource});
-      expect(load).toHaveBeenCalledWith(newSource, mockProps.getImport);
+      expect(load).toHaveBeenCalledWith(newSource, mockProps.getImport, nonce);
     });
   });
 


### PR DESCRIPTION
Adds the ability to set the [`nonce`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src) attribute to the script tag.

```jsx
<ImportRemote source={...} nonce="1a2b3c"  />
```