### PR TITLE
Revert "✨ Add the ability to set a nonce for comply with script-src CSP"

### DIFF
--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -4,7 +4,6 @@ import load from './load';
 
 export interface Props<Imported = any> {
   source: string;
-  nonce?: string;
   preconnect?: boolean;
   onError(error: Error): void;
   getImport(window: Window): Imported;
@@ -36,10 +35,10 @@ export default class ImportRemote extends React.PureComponent<Props, never> {
   }
 
   async loadRemote() {
-    const {source, nonce = '', getImport, onError, onImported} = this.props;
+    const {source, getImport, onError, onImported} = this.props;
 
     try {
-      const imported = await load(source, getImport, nonce);
+      const imported = await load(source, getImport);
       onImported(imported);
     } catch (error) {
       onError(error);

--- a/packages/react-import-remote/src/load.ts
+++ b/packages/react-import-remote/src/load.ts
@@ -6,7 +6,6 @@ export default function load<
 >(
   source: string,
   getImport: (window: CustomWindow) => Imported,
-  nonce: string,
 ): Promise<Imported> {
   if (typeof window === 'undefined') {
     return Promise.reject(
@@ -20,7 +19,7 @@ export default function load<
     return cachedModule;
   }
 
-  const scriptTag = scriptTagFor(source, nonce);
+  const scriptTag = scriptTagFor(source);
   appendScriptTag(scriptTag);
 
   const promise = new Promise<Imported>((resolve, reject) => {
@@ -48,15 +47,10 @@ export function clearCache() {
   cache.clear();
 }
 
-function scriptTagFor(source: string, nonce: string) {
+function scriptTagFor(source: string) {
   const node = document.createElement('script');
   node.setAttribute('type', 'text/javascript');
   node.setAttribute('src', source);
-
-  if (nonce.length > 0) {
-    node.setAttribute('nonce', nonce);
-  }
-
   return node;
 }
 

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -29,38 +29,18 @@ describe('<ImportRemote />', () => {
 
   describe('source and getImport()', () => {
     it('uses the props as arguments for load()', () => {
-      const nonce = '';
       mount(<ImportRemote {...mockProps} />);
-      expect(load).toHaveBeenCalledWith(
-        mockProps.source,
-        mockProps.getImport,
-        nonce,
-      );
-    });
-
-    it('uses the nonce prop as argument for load()', () => {
-      const nonce = '1a2b3c';
-      mount(<ImportRemote {...mockProps} nonce={nonce} />);
-      expect(load).toHaveBeenCalledWith(
-        mockProps.source,
-        mockProps.getImport,
-        nonce,
-      );
+      expect(load).toHaveBeenCalledWith(mockProps.source, mockProps.getImport);
     });
 
     it('imports a new global if the source changes', () => {
-      const nonce = '';
       const importRemote = mount(<ImportRemote {...mockProps} />);
-      expect(load).toHaveBeenCalledWith(
-        mockProps.source,
-        mockProps.getImport,
-        nonce,
-      );
+      expect(load).toHaveBeenCalledWith(mockProps.source, mockProps.getImport);
 
       const newSource = 'https://bar.com/foo.js';
 
       importRemote.setProps({source: newSource});
-      expect(load).toHaveBeenCalledWith(newSource, mockProps.getImport, nonce);
+      expect(load).toHaveBeenCalledWith(newSource, mockProps.getImport);
     });
   });
 

--- a/packages/react-import-remote/src/test/load.test.ts
+++ b/packages/react-import-remote/src/test/load.test.ts
@@ -3,8 +3,6 @@ import load, {clearCache} from '../load';
 
 describe('load()', () => {
   const mockURL = 'https://foo.com/bar.js';
-  const mockNonce = '1a2b3c';
-  const mockEmptyNonce = '';
 
   beforeEach(() => {
     clearCache();
@@ -16,7 +14,7 @@ describe('load()', () => {
 
   it('creates a script tag with the provided source', async () => {
     const {script, create, append} = spyOnDOM();
-    const promise = load(mockURL, noop, mockNonce);
+    const promise = load(mockURL, noop);
 
     script.triggerEvent('load');
     await promise;
@@ -26,36 +24,9 @@ describe('load()', () => {
     expect(script.setAttribute).toHaveBeenCalledWith('src', mockURL);
   });
 
-  it('does not call setAttribute with nonce when nonce is empty', async () => {
-    const {script, create, append} = spyOnDOM();
-    const promise = load(mockURL, noop, mockEmptyNonce);
-
-    script.triggerEvent('load');
-    await promise;
-
-    expect(create).toHaveBeenCalledWith('script');
-    expect(append).toHaveBeenCalledWith(script);
-    expect(script.setAttribute).not.toHaveBeenCalledWith(
-      'nonce',
-      mockEmptyNonce,
-    );
-  });
-
-  it('creates a script tag with the provided nonce', async () => {
-    const {script, create, append} = spyOnDOM();
-    const promise = load(mockURL, noop, mockNonce);
-
-    script.triggerEvent('load');
-    await promise;
-
-    expect(create).toHaveBeenCalledWith('script');
-    expect(append).toHaveBeenCalledWith(script);
-    expect(script.setAttribute).toHaveBeenCalledWith('nonce', mockNonce);
-  });
-
   it('rejects when the script errors', async () => {
     const {script} = spyOnDOM();
-    const promise = load(mockURL, noop, mockNonce);
+    const promise = load(mockURL, noop);
 
     script.triggerEvent('error');
 
@@ -65,7 +36,7 @@ describe('load()', () => {
   it('calls the getImport() parameter with the window once the script has loaded', async () => {
     const spy = jest.fn();
     const {script} = spyOnDOM();
-    const promise = load(mockURL, spy, mockNonce);
+    const promise = load(mockURL, spy);
 
     expect(spy).not.toHaveBeenCalled();
 
@@ -79,7 +50,7 @@ describe('load()', () => {
     const returnValue = 'foo';
     const spy = jest.fn(() => returnValue);
     const {script} = spyOnDOM();
-    const promise = load(mockURL, spy, mockNonce);
+    const promise = load(mockURL, spy);
 
     script.triggerEvent('load');
     expect(await promise).toBe(returnValue);
@@ -89,11 +60,11 @@ describe('load()', () => {
     const returnValue = 'foo';
     const spy = jest.fn(() => returnValue);
     const {script} = spyOnDOM();
-    const promise = load(mockURL, spy, mockNonce);
+    const promise = load(mockURL, spy);
 
     script.triggerEvent('load');
     expect(await promise).toBe(returnValue);
-    expect(await load(mockURL, spy, mockNonce)).toBe(returnValue);
+    expect(await load(mockURL, spy)).toBe(returnValue);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -102,8 +73,8 @@ describe('load()', () => {
     const spy = jest.fn(() => returnValue);
     const {script, create, append} = spyOnDOM();
 
-    const promiseOne = load(mockURL, spy, mockNonce);
-    const promiseTwo = load(mockURL, spy, mockNonce);
+    const promiseOne = load(mockURL, spy);
+    const promiseTwo = load(mockURL, spy);
 
     script.triggerEvent('load');
     await Promise.all([promiseOne, promiseTwo]);
@@ -116,7 +87,7 @@ describe('load()', () => {
     const spy = jest.fn(() => returnValue);
     const {script, create, append} = spyOnDOM();
 
-    const promiseOne = load(mockURL, spy, mockNonce);
+    const promiseOne = load(mockURL, spy);
 
     script.triggerEvent('error');
     try {
@@ -125,7 +96,7 @@ describe('load()', () => {
     } catch (_) {}
 
     try {
-      await load(mockURL, spy, mockNonce);
+      await load(mockURL, spy);
       // eslint-disable-next-line no-empty
     } catch (_) {}
 
@@ -135,7 +106,7 @@ describe('load()', () => {
 
   it('removes listeners when the script has loaded', async () => {
     const {script} = spyOnDOM();
-    const promise = load(mockURL, noop, mockNonce);
+    const promise = load(mockURL, noop);
 
     script.triggerEvent('load');
     await promise;
@@ -147,7 +118,7 @@ describe('load()', () => {
 
   it('removes listeners when the script has errored', async () => {
     const {script} = spyOnDOM();
-    const promise = load(mockURL, noop, mockNonce);
+    const promise = load(mockURL, noop);
 
     script.triggerEvent('error');
     try {


### PR DESCRIPTION
Reverts Shopify/quilt#325

It is not possible to set the `nonce` at the `script` node creation time. As it would be to easy to simply find the `nonce` and inject a script with that `nonce` which would make an evil script trusted.