### PR TITLE
🐛Fix broken Validator guide markdown link

### DIFF
--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -355,7 +355,7 @@ function MyComponent() {
 }
 ```
 
-To learn more about building validators, and the built in functions exposed by this package, check out the [validators guide](/validators.md).
+To learn more about building validators, and the built in functions exposed by this package, check out the [validators guide](validators.md).
 
 ## Compound fields
 


### PR DESCRIPTION
The link to the Validator guide was broken because it was an absolute path, linking to the root of Quilt. Change it to a relative path so it correctly links to this page:
https://github.com/Shopify/quilt/blob/master/packages/react-form-state/docs/validators.md