### PR TITLE
✅ Add more tests for trigger in enzyme-utilities

### DIFF
--- a/packages/enzyme-utilities/src/test/index.test.tsx
+++ b/packages/enzyme-utilities/src/test/index.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
+import {noop} from '@shopify/javascript-utilities/other';
 
 import {trigger, findById} from '..';
 
@@ -36,6 +37,35 @@ describe('enzyme-utilities', () => {
 
       await promise;
       expect(toggle.find('button').text()).toBe('inactive');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('throws an error if wrapper has no matching nodes', () => {
+      function MyComponent() {
+        return <div />;
+      }
+      const myComponent = mount(<MyComponent />);
+
+      expect(() => trigger(myComponent.find(Toggle), 'onAction')).toThrowError(
+        'You tried to trigger onAction on a React wrapper with no matching nodes. This generally happens because you have either filtered your React components incorrectly, or the component you are looking for is not rendered because of the props on your component, or there is some error during one of your component’s render methods.',
+      );
+    });
+
+    it('throws an error if no callback found', () => {
+      const action = mount(
+        <Action
+          handler={{
+            name: 'noop',
+            onAction: noop,
+          }}
+        />,
+      );
+
+      expect(() =>
+        trigger(action.find('button'), 'onNonExistantAction'),
+      ).toThrowError(
+        "No callback found at keypath 'onNonExistantAction'. Available props: type, onClick",
+      );
     });
   });
 


### PR DESCRIPTION
fixes #129

Add tests for the two error cases for trigger in enzyme-utilities, bringing test coverage up to 100%.

Before:
<img width="805" alt="screen shot 2018-10-08 at 12 10 08 pm" src="https://user-images.githubusercontent.com/1470768/46622426-8e209400-caf8-11e8-90c1-ef7104e49358.png">

After:
<img width="807" alt="screen shot 2018-10-08 at 12 41 02 pm" src="https://user-images.githubusercontent.com/1470768/46622427-8e209400-caf8-11e8-8897-5fcbdec2d810.png">
