### PR TITLE
🚀 do not accidentally bring in all of lodash

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- No longer accidentally import all of lodash.
+
 ## [0.2.8]
 
 ### Changed
@@ -13,4 +19,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed Nested and List component race condition. Nested and List now pass a function to their `onChange` prop instead of an object so that the data object will be created within `setState`.
-- No longer accidentally import all of lodash.

--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -13,3 +13,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed Nested and List component race condition. Nested and List now pass a function to their `onChange` prop instead of an object so that the data object will be created within `setState`.
+- No longer accidentally import all of lodash.

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -1,4 +1,5 @@
-import {toString, isArray} from 'lodash';
+import toString from 'lodash/toString';
+import isArray from 'lodash/isArray';
 import {mapObject} from './utilities';
 
 interface Matcher<Input> {


### PR DESCRIPTION
This PR tweaks the import syntax in form-state such that we can avoid bringing in all of lodash and potentially clobbering global lodash settings.