### PR TITLE
Fix race condition when using multiple levels of Nested and List

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed using multiple layers deep of Nested and List breaking the state
+
 ## [0.2.9]
 
 ### Fixed

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import get from 'lodash/get';
 import {memoize, bind} from 'lodash-decorators';
 
-import {FieldDescriptor, FieldDescriptors} from '../types';
+import {FieldDescriptor, FieldDescriptors, ValueMapper} from '../types';
 import {mapObject, replace} from '../utilities';
 
 interface Props<Fields> {
@@ -55,7 +55,7 @@ export default class List<Fields> extends React.PureComponent<
     index: number;
     key: any;
   }) {
-    return (newValue: Fields[Key]) => {
+    return (newValue: Fields[Key] | ValueMapper<Fields[]>) => {
       const {
         field: {onChange},
       } = this.props;
@@ -64,7 +64,10 @@ export default class List<Fields> extends React.PureComponent<
         const existingItem = value[index];
         const newItem = {
           ...(existingItem as any),
-          [key]: newValue,
+          [key]:
+            typeof newValue === 'function'
+              ? newValue(value[index][key])
+              : newValue,
         };
         return replace(value, index, newItem);
       });

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import get from 'lodash/get';
 import {memoize, bind} from 'lodash-decorators';
 
-import {FieldDescriptor, FieldDescriptors} from '../types';
+import {FieldDescriptor, FieldDescriptors, ValueMapper} from '../types';
 import {mapObject} from '../utilities';
 
 interface Props<Fields> {
@@ -42,7 +42,7 @@ export default class Nested<Fields> extends React.PureComponent<
   @memoize()
   @bind()
   private handleChange<Key extends keyof Fields>(key: Key) {
-    return (newValue: Fields[Key]) => {
+    return (newValue: Fields[Key] | ValueMapper<Fields>) => {
       const {
         field: {onChange},
       } = this.props;
@@ -50,7 +50,10 @@ export default class Nested<Fields> extends React.PureComponent<
       onChange(value => {
         return {
           ...(value as any),
-          [key]: newValue,
+          [key]:
+            typeof newValue === 'function'
+              ? newValue(value[key as string])
+              : newValue,
         };
       });
     };

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -219,4 +219,100 @@ describe('<FormState.List />', () => {
     expect(updatedFields.title.value).toBe(newTitle);
     expect(updatedFields.department.value).toBe(newDepartment);
   });
+
+  it('Does not have race condition with nested List components', () => {
+    const variants = [
+      {
+        products: [
+          {
+            title: faker.commerce.productName(),
+            department: faker.commerce.department(),
+          },
+        ],
+      },
+    ];
+
+    const renderSpy = jest.fn(({title, department}) => {
+      return (
+        <>
+          <Input label="title" {...title} />
+          <Input label="department" {...department} />
+        </>
+      );
+    });
+
+    mount(
+      <FormState initialValues={{variants}}>
+        {({fields}) => (
+          <FormState.List field={fields.variants}>
+            {nestedFields => (
+              <FormState.List field={nestedFields.products}>
+                {renderSpy}
+              </FormState.List>
+            )}
+          </FormState.List>
+        )}
+      </FormState>,
+    );
+
+    const {title, department} = lastCallArgs(renderSpy);
+
+    const newTitle = faker.commerce.productName();
+    const newDepartment = faker.commerce.department();
+
+    title.onChange(newTitle);
+    department.onChange(newDepartment);
+
+    const updatedFields = lastCallArgs(renderSpy);
+
+    expect(updatedFields.title.value).toBe(newTitle);
+    expect(updatedFields.department.value).toBe(newDepartment);
+  });
+
+  it('Does not have race condition when using Nested -> List', () => {
+    const variants = {
+      products: [
+        {
+          title: faker.commerce.productName(),
+          department: faker.commerce.department(),
+        },
+      ],
+    };
+
+    const renderSpy = jest.fn(({title, department}) => {
+      return (
+        <>
+          <Input label="title" {...title} />
+          <Input label="department" {...department} />
+        </>
+      );
+    });
+
+    mount(
+      <FormState initialValues={{variants}}>
+        {({fields}) => (
+          <FormState.Nested field={fields.variants}>
+            {nestedFields => (
+              <FormState.List field={nestedFields.products}>
+                {renderSpy}
+              </FormState.List>
+            )}
+          </FormState.Nested>
+        )}
+      </FormState>,
+    );
+
+    const {title, department} = lastCallArgs(renderSpy);
+
+    const newTitle = faker.commerce.productName();
+    const newDepartment = faker.commerce.department();
+
+    title.onChange(newTitle);
+    department.onChange(newDepartment);
+
+    const updatedFields = lastCallArgs(renderSpy);
+
+    expect(updatedFields.title.value).toBe(newTitle);
+    expect(updatedFields.department.value).toBe(newDepartment);
+  });
 });

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -171,4 +171,100 @@ describe('<Nested />', () => {
     expect(updatedFields.title.value).toBe(newTitle);
     expect(updatedFields.department.value).toBe(newDepartment);
   });
+
+  it('Does not have race condition when using Nested -> Nested', () => {
+    const product = {
+      nested: {
+        title: faker.commerce.productName(),
+        department: faker.commerce.department(),
+      },
+    };
+
+    const renderSpy = jest.fn(({title, department}) => {
+      return (
+        <>
+          <Input label="title" {...title} />
+          <Input label="department" {...department} />
+        </>
+      );
+    });
+
+    mount(
+      <FormState initialValues={{product}}>
+        {({fields}) => {
+          return (
+            <FormState.Nested field={fields.product}>
+              {nestedFields => (
+                <FormState.Nested field={nestedFields.nested}>
+                  {renderSpy}
+                </FormState.Nested>
+              )}
+            </FormState.Nested>
+          );
+        }}
+      </FormState>,
+    );
+
+    const {title, department} = lastCallArgs(renderSpy);
+
+    const newTitle = faker.commerce.productName();
+    const newDepartment = faker.commerce.department();
+
+    title.onChange(newTitle);
+    department.onChange(newDepartment);
+
+    const updatedFields = lastCallArgs(renderSpy);
+
+    expect(updatedFields.title.value).toBe(newTitle);
+    expect(updatedFields.department.value).toBe(newDepartment);
+  });
+
+  it('Does not have race condition when using List -> Nested', () => {
+    const product = [
+      {
+        nested: {
+          title: faker.commerce.productName(),
+          department: faker.commerce.department(),
+        },
+      },
+    ];
+
+    const renderSpy = jest.fn(({title, department}) => {
+      return (
+        <>
+          <Input label="title" {...title} />
+          <Input label="department" {...department} />
+        </>
+      );
+    });
+
+    mount(
+      <FormState initialValues={{product}}>
+        {({fields}) => {
+          return (
+            <FormState.List field={fields.product}>
+              {nestedFields => (
+                <FormState.Nested field={nestedFields.nested}>
+                  {renderSpy}
+                </FormState.Nested>
+              )}
+            </FormState.List>
+          );
+        }}
+      </FormState>,
+    );
+
+    const {title, department} = lastCallArgs(renderSpy);
+
+    const newTitle = faker.commerce.productName();
+    const newDepartment = faker.commerce.department();
+
+    title.onChange(newTitle);
+    department.onChange(newDepartment);
+
+    const updatedFields = lastCallArgs(renderSpy);
+
+    expect(updatedFields.title.value).toBe(newTitle);
+    expect(updatedFields.department.value).toBe(newDepartment);
+  });
 });


### PR DESCRIPTION
This PR is built off of #320 with changes to ensure that it still works when using multiple levels / combinations of Nested and List components. (#320 fixed the race condition when using one level deep but broke all functionality of multiple levels)

**New tests cases:**
- Nested -> Nested
- Nested -> List
- List -> List
- List -> Nested

**Tophat testing:**
Tested it on a form that uses:
- Individual field
- Nested
- Nested -> Nested
- Nested -> Nested -> List -> Nested

All behaved normally and as expected.