### PR TITLE
Adding CHANGELOG template to package generator

### DIFF
--- a/plopfile.js
+++ b/plopfile.js
@@ -1,9 +1,9 @@
-const {readdirSync, existsSync} = require('fs');
+const { readdirSync, existsSync } = require('fs');
 const path = require('path');
 
 const packageNames = getPackageNames();
 
-module.exports = function(plop) {
+module.exports = function (plop) {
   plop.setGenerator('package', {
     description: 'create a new package from scratch',
     prompts: [
@@ -41,6 +41,11 @@ module.exports = function(plop) {
       },
       {
         type: 'add',
+        path: 'packages/{{kebabCase name}}/CHANGELOG.md',
+        templateFile: 'templates/CHANGELOG.hbs.md',
+      },
+      {
+        type: 'add',
         path: 'packages/{{kebabCase name}}/src/index.ts',
         templateFile: 'templates/index.hbs',
       },
@@ -74,7 +79,7 @@ const sharedActions = {
     path: 'README.md',
     templateFile: 'templates/ROOT_README.hbs.md',
     force: true,
-    data: {packageNames},
+    data: { packageNames },
   },
 };
 

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,9 +1,9 @@
-const { readdirSync, existsSync } = require('fs');
+const {readdirSync, existsSync} = require('fs');
 const path = require('path');
 
 const packageNames = getPackageNames();
 
-module.exports = function (plop) {
+module.exports = function(plop) {
   plop.setGenerator('package', {
     description: 'create a new package from scratch',
     prompts: [
@@ -79,7 +79,7 @@ const sharedActions = {
     path: 'README.md',
     templateFile: 'templates/ROOT_README.hbs.md',
     force: true,
-    data: { packageNames },
+    data: {packageNames},
   },
 };
 

--- a/templates/CHANGELOG.hbs.md
+++ b/templates/CHANGELOG.hbs.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/{{name}}` package


### PR DESCRIPTION
This pr introduces a CHANGELOG template for the package generator, addressing this issue: https://github.com/Shopify/quilt/issues/296

🎩 snapshots:
![image](https://user-images.githubusercontent.com/9055413/46762130-55252280-cca4-11e8-8ddc-bb85f757ccb6.png)

![image](https://user-images.githubusercontent.com/9055413/46762157-62421180-cca4-11e8-932b-e48badedf63d.png)
