### PR TITLE
🎨 Use reduceRight for react-compose

### DIFF
--- a/packages/react-compose/src/index.ts
+++ b/packages/react-compose/src/index.ts
@@ -14,18 +14,11 @@ export default function compose<Props>(
   return function wrapComponent<ComposedProps, C>(
     OriginalComponent: ReactComponent<ComposedProps> & C,
   ): ReactComponent<Props> & C {
-    let result: ReactComponent<ComposedProps>;
-
-    if (wrappingFunctions.length === 0) {
-      result = OriginalComponent;
-    } else {
-      result = wrappingFunctions.reduce(
-        (wrappingFunctionA, wrappingFunctionB) => {
-          return (WrappingComponent: ReactComponent<any>) =>
-            wrappingFunctionA(wrappingFunctionB(WrappingComponent));
-        },
-      )(OriginalComponent);
-    }
+    const result: ReactComponent<ComposedProps> = wrappingFunctions.reduceRight(
+      (component: ReactComponent<any>, wrappingFunction: WrappingFunction) =>
+        wrappingFunction(component),
+      OriginalComponent,
+    );
 
     return hoistStatics(
       result as ComponentClass,


### PR DESCRIPTION
This updates `react-compose` to use `reduceRight` to successively call the enhancers, rather than build a chain of functions that all call each other.

This also removes the need to check the length of `wrappingFunctions`, as we can just pass `OriginalComponent` in as the initial value.

I was reading through the code to understand how `react-compose` works, and I was a little confused off my the implementation. 😅 **I'm not sure if there is a reason for the original implementation**, but as far as I can tell they behave identically.

It should be noted here that [`reduceRight`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/ReduceRight) is used, not [`reduce`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce), as otherwise the order of enhancement would be reversed.