### PR TITLE
🐛 [ react-form-state] fix buggy types in validators

### DIFF
--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -5,17 +5,19 @@ import set from 'lodash/set';
 import {memoize, bind} from 'lodash-decorators';
 
 import {mapObject} from './utilities';
-import {FieldDescriptors, FieldState, ValueMapper} from './types';
+import {
+  FieldDescriptors,
+  FieldState,
+  ValueMapper,
+  FieldStates,
+  ValidationFunction,
+} from './types';
 import {List, Nested} from './components';
 
 export interface RemoteError {
   field?: string[] | null;
   message: string;
 }
-
-export type FieldStates<Fields> = {
-  [FieldPath in keyof Fields]: FieldState<Fields[FieldPath]>
-};
 
 type MaybeArray<T> = T | T[];
 type MaybePromise<T> = T | Promise<T>;
@@ -31,10 +33,6 @@ export type Validator<T, F> = MaybeArray<ValidationFunction<T, F>>;
 export type ValidatorDictionary<FieldMap> = {
   [FieldPath in keyof FieldMap]: Validator<FieldMap[FieldPath], FieldMap>
 };
-
-interface ValidationFunction<Value, Fields> {
-  (value: Value, fields: FieldStates<Fields>): any;
-}
 
 export interface FormData<Fields> {
   fields: FieldDescriptors<Fields>;
@@ -225,7 +223,10 @@ export default class FormState<
     this.setState<any>(({fields, dirtyFields}: State<Fields>) => {
       const field = fields[fieldPath];
 
-      const newValue = typeof value === 'function' ? value(field.value) : value;
+      const newValue =
+        typeof value === 'function'
+          ? (value as ValueMapper<Fields[Key]>)(field.value)
+          : value;
 
       const dirty = !isEqual(newValue, field.initialValue);
 

--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -48,8 +48,14 @@ describe('validation helpers', () => {
         return `${input} error`;
       }
 
-      const alwaysPassValidator = validate(trueMatcher, error);
-      const alwaysFailValidator = validate(falseMatcher, error);
+      const alwaysPassValidator = validate<'' | null | undefined>(
+        trueMatcher,
+        error,
+      );
+      const alwaysFailValidator = validate<'' | null | undefined>(
+        falseMatcher,
+        error,
+      );
 
       expect(alwaysPassValidator('')).toBeUndefined();
       expect(alwaysFailValidator('')).toBeUndefined();
@@ -144,7 +150,8 @@ describe('validation helpers', () => {
 
       const results = compoundValidator(data, {});
 
-      results.forEach((result, index) => {
+      // eslint-disable-next-line typescript/no-non-null-assertion
+      results!.forEach((result, index) => {
         expect(result).toMatchObject({
           title: alwaysPassValidator(data[index].title),
           product: alwaysFailValidator(data[index].product),

--- a/packages/react-form-state/src/types.ts
+++ b/packages/react-form-state/src/types.ts
@@ -7,6 +7,10 @@ export interface FieldState<Value> {
   error?: any;
 }
 
+export interface ValidationFunction<Value, Fields> {
+  (value: Value, fields: FieldStates<Fields>): any;
+}
+
 export interface FieldDescriptor<Value> extends FieldState<Value> {
   onChange(newValue: Value | ValueMapper<Value>): void;
   onBlur(): void;
@@ -19,3 +23,7 @@ export type FieldDescriptors<Fields> = {
 export interface ValueMapper<Value> {
   (value: Value): Value;
 }
+
+export type FieldStates<Fields> = {
+  [FieldPath in keyof Fields]: FieldState<Fields[FieldPath]>
+};

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -1,12 +1,9 @@
 import toString from 'lodash/toString';
 import isArray from 'lodash/isArray';
 import {mapObject} from './utilities';
+import {ValidationFunction} from './types';
 
-interface Matcher<Input> {
-  (input: Input): boolean;
-}
-
-interface Matcher<Input, Fields = never> {
+interface Matcher<Input, Fields> {
   (input: Input, fields: Fields): boolean;
 }
 
@@ -37,10 +34,8 @@ export function isEmptyString(input: string) {
   return input.trim().length < 1;
 }
 
-export function not<Input>(matcher: Matcher<Input>): Matcher<Input>;
-
-export function not<Input, Fields>(matcher: Matcher<Input, Fields>) {
-  return (input: Input, fields: Fields) => !matcher(input, fields);
+export function not<A extends Array<any>, R>(fn: (...a: A) => R) {
+  return (...args: A) => !fn(...args);
 }
 
 export function validateNested<Input extends Object, Fields>(
@@ -100,14 +95,14 @@ export function validateList<Input extends Object, Fields>(
 }
 
 export function validate<Input>(
-  matcher: Matcher<Input>,
+  matcher: Matcher<Input, any>,
   errorContent: ErrorContent,
-): (input: Input) => ErrorContent | void;
+): (input: Input) => ValidationFunction<Input, never>;
 
-export function validate<Input, Fields = never>(
+export function validate<Input, Fields>(
   matcher: Matcher<Input, Fields>,
   errorContent: ErrorContent,
-) {
+): (input: Input, fields: Fields) => ValidationFunction<Input, Fields> {
   return (input: Input, fields: Fields) => {
     const matches = matcher(input, fields);
 


### PR DESCRIPTION
closes #307 

This PR fixes the typing for validation matchers that use `Fields`.