### PR TITLE
🐛 fix submitting status when submit validation fails

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.3.2]
+
+### Fixed
+
+- when validators fail during a submit submitting is reset to false.
+
 ## [0.3.0]
 
 ### Added

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -181,6 +181,7 @@ export default class FormState<
       await this.validateForm();
 
       if (this.hasClientErrors) {
+        this.setState({submitting: false});
         return;
       }
     }

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -755,6 +755,35 @@ describe('<FormState />', () => {
       expect(submitSpy).not.toBeCalled();
     });
 
+    it('resets submitting state when validation on submit fails', async () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      mount(
+        <FormState
+          validateOnSubmit
+          initialValues={{
+            product: faker.commerce.productName,
+          }}
+          validators={{
+            product() {
+              return 'product bad';
+            },
+          }}
+          onSubmit={noop}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+
+      await submit();
+
+      const {submitting} = lastCallArgs(renderPropSpy);
+
+      expect(submitting).toBe(false);
+    });
+
     it('does not call any validators on submit when validateOnSubmit is false', async () => {
       const renderPropSpy = jest.fn(() => null);
       const productValidatorSpy = jest.fn();


### PR DESCRIPTION
This PR fixes [submission status getting stuck](https://codesandbox.io/s/1v2zlzm0lj) when `validateOnSubmit` is true and a validator fails.