### PR TITLE
✨ Add new package: `@shopify/csrf-token-fetcher`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each package has its own `README` and documentation describing usage.
 | ------- | --- | --- |
 | address | [README](packages/address/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Faddress.svg)](https://badge.fury.io/js/%40shopify%2Faddress) |
 | admin-graphql-api-utilities | [README](packages/admin-graphql-api-utilities/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities) |
+| csrf-token-fetcher | [README](packages/csrf-token-fetcher/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg)](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher) |
 | dates | [README](packages/dates/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fdates.svg)](https://badge.fury.io/js/%40shopify%2Fdates) |
 | enzyme-utilities | [README](packages/enzyme-utilities/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities) |
 | i18n | [README](packages/i18n/README.md) | [![npm version](https://badge.fury.io/js/%40shopify%2Fi18n.svg)](https://badge.fury.io/js/%40shopify%2Fi18n) |

--- a/packages/csrf-token-fetcher/README.md
+++ b/packages/csrf-token-fetcher/README.md
@@ -1,0 +1,33 @@
+# `@shopify/csrf-token-fetcher`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg)](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/csrf-token-fetcher.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/csrf-token-fetcher.svg)
+
+JavaScript utility function to fetch the CSRF token required to make requests to a Rails server
+
+## Installation
+
+```bash
+$ yarn add @shopify/csrf-token-fetcher
+```
+
+## API Reference
+
+### `function getCSRFToken(scope = document)`
+
+Retrieve the CSRF token from the meta tag rendered by a Rails server. This token is required in the `X-CSRF-Token` header for requests to the Rails server.
+
+In the `html.erb` file:
+
+```
+<%= csrf_meta_tags %>
+```
+
+#### Example Usage
+
+```typescript
+import getCSRFToken from '@shopify/csrf-token-fetcher';
+
+getCSRFToken();
+// → 'token_value'
+```

--- a/packages/csrf-token-fetcher/package.json
+++ b/packages/csrf-token-fetcher/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@shopify/csrf-token-fetcher",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "JavaScript utility function to fetch the CSRF token required to make requests to a Rails server",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/csrf-token-fetcher/README.md",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "~3.0.1"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/csrf-token-fetcher/src/index.ts
+++ b/packages/csrf-token-fetcher/src/index.ts
@@ -1,0 +1,21 @@
+const CSRF_SELECTOR = 'meta[name=csrf-token]';
+let token: string;
+
+export default function getCSRFToken(scope = document) {
+  if (token) {
+    return token;
+  }
+  const tokenNode = scope.querySelector(CSRF_SELECTOR);
+  if (tokenNode) {
+    const content = tokenNode.getAttribute('content');
+    if (content) {
+      token = content;
+      return token;
+    }
+  }
+  return '';
+}
+
+export function clearCSRFToken() {
+  token = '';
+}

--- a/packages/csrf-token-fetcher/src/test/index.test.ts
+++ b/packages/csrf-token-fetcher/src/test/index.test.ts
@@ -1,0 +1,30 @@
+import getCSRFToken, {clearCSRFToken} from '..';
+
+describe('csrf-token-fetcher', () => {
+  const originalDom = document.body.innerHTML;
+
+  afterEach(() => clearCSRFToken());
+
+  it('gets CSRF token', () => {
+    const rootNode = '<meta name="csrf-token" content="ACTUAL_TOKEN">';
+    document.body.innerHTML = rootNode;
+
+    expect(getCSRFToken()).toEqual('ACTUAL_TOKEN');
+    expect(getCSRFToken(document)).toEqual('ACTUAL_TOKEN');
+
+    document.body.innerHTML = originalDom;
+  });
+
+  it('returns empty string if meta element not found', () => {
+    expect(getCSRFToken()).toEqual('');
+  });
+
+  it('returns empty string if meta element has no content attribute', () => {
+    const rootNode = '<meta name="csrf-token">';
+    document.body.innerHTML = rootNode;
+
+    expect(getCSRFToken()).toEqual('');
+
+    document.body.innerHTML = originalDom;
+  });
+});

--- a/packages/csrf-token-fetcher/tsconfig.build.json
+++ b/packages/csrf-token-fetcher/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
Add new package `@shopify/csrf-token-fetcher`, which contains a utility function to retrieve the CSRF token from the meta tag rendered by Rails. This token is required in the `X-CSRF-Token` header for requests to the Rails server.

fixes #66