### PR TITLE
[address] Improve cache by memoizing async functions

### DIFF
--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -13,21 +13,13 @@ const ORDERED_COUNTRIES_CACHE: {
   [locale: string]: Country[];
 } = {};
 
-const COUNTRIES_CACHE: {
-  [locale: string]: {
-    [countryCode: string]: Country;
-  };
-} = {};
-
 export default class AddressFormatter {
   constructor(private locale: string) {
     this.locale = locale;
-    COUNTRIES_CACHE[this.locale] = {};
   }
 
   updateLocale(locale: string) {
     this.locale = locale;
-    COUNTRIES_CACHE[this.locale] = {};
   }
 
   async getCountry(countryCode: string): Promise<Country> {
@@ -37,15 +29,11 @@ export default class AddressFormatter {
     }
 
     country = await loadCountry(this.locale, countryCode);
-    COUNTRIES_CACHE[this.locale][country.code] = country;
 
     return country;
   }
 
   async getCountries(): Promise<Country[]> {
-    if (ORDERED_COUNTRIES_CACHE[this.locale]) {
-      return ORDERED_COUNTRIES_CACHE[this.locale];
-    }
     const countries = await loadCountries(this.locale);
     ORDERED_COUNTRIES_CACHE[this.locale] = countries;
 
@@ -121,12 +109,6 @@ export default class AddressFormatter {
   private loadCountryFromCache(
     countryCode: string,
   ): Country | undefined | null {
-    const cachedCountry = COUNTRIES_CACHE[this.locale][countryCode];
-
-    if (cachedCountry) {
-      return cachedCountry;
-    }
-
     if (ORDERED_COUNTRIES_CACHE[this.locale]) {
       return ORDERED_COUNTRIES_CACHE[this.locale].find(country => {
         return country.code === countryCode;

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -18,7 +18,9 @@ const HEADERS = {
   'Access-Control-Allow-Origin': '*',
 };
 
-export async function loadCountries(locale: string): Promise<Country[]> {
+export const loadCountries: (
+  locale: string,
+) => Promise<Country[]> = memoizeAsync(async (locale: string) => {
   const response = await fetch(GRAPHQL_ENDPOINT, {
     method: 'POST',
     headers: HEADERS,
@@ -30,39 +32,45 @@ export async function loadCountries(locale: string): Promise<Country[]> {
       },
     }),
   });
+
   const countries:
     | LoadCountriesResponse
     | ResponseError = await response.json();
+
   if ('errors' in countries) {
     throw new CountryLoaderError(countries);
-  } else {
-    return countries.data.countries;
   }
-}
 
-export async function loadCountry(
+  return countries.data.countries;
+});
+
+export const loadCountry: (
   locale: string,
   countryCode: string,
-): Promise<Country> {
-  const response = await fetch(GRAPHQL_ENDPOINT, {
-    method: 'POST',
-    headers: HEADERS,
-    body: JSON.stringify({
-      query,
-      operationName: GRAPHQL_OPERATION_NAMES.country,
-      variables: {
-        countryCode,
-        locale: toSupportedLocale(locale),
-      },
-    }),
-  });
-  const country: LoadCountryResponse = await response.json();
-  if ('errors' in country) {
-    throw new CountryLoaderError(country);
-  } else {
+) => Promise<Country> = memoizeAsync(
+  async (locale: string, countryCode: string): Promise<Country> => {
+    const response = await fetch(GRAPHQL_ENDPOINT, {
+      method: 'POST',
+      headers: HEADERS,
+      body: JSON.stringify({
+        query,
+        operationName: GRAPHQL_OPERATION_NAMES.country,
+        variables: {
+          countryCode,
+          locale: toSupportedLocale(locale),
+        },
+      }),
+    });
+
+    const country: LoadCountryResponse = await response.json();
+
+    if ('errors' in country) {
+      throw new CountryLoaderError(country);
+    }
+
     return country.data.country;
-  }
-}
+  },
+);
 
 class CountryLoaderError extends Error {
   constructor(errors: ResponseError) {
@@ -93,4 +101,21 @@ export function toSupportedLocale(locale: string) {
   } else {
     return DEFAULT_LOCALE;
   }
+}
+
+type AsyncFunc = (...args: any[]) => Promise<any>;
+interface Cache {
+  [key: string]: Promise<any>;
+}
+
+function memoizeAsync(asyncFunction: AsyncFunc) {
+  const cache: Cache = {};
+
+  return (...args: any[]) => {
+    const stringifiedArgs = JSON.stringify(args);
+    if (!cache[stringifiedArgs]) {
+      cache[stringifiedArgs] = asyncFunction.apply(this, args);
+    }
+    return cache[stringifiedArgs] as Promise<any>;
+  };
 }

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -52,7 +52,8 @@ describe('getCountry()', () => {
   });
 
   it('should not call the API again for the same country if the locale is the same', async () => {
-    const addressFormatter = new AddressFormatter('ja');
+    const addressFormatter = new AddressFormatter('pt-br');
+
     await addressFormatter.getCountry('CA');
     await addressFormatter.getCountry('CA');
 
@@ -60,12 +61,12 @@ describe('getCountry()', () => {
   });
 
   it('should call the API again for the same country if the locale changes', async () => {
-    const addressFormatter = new AddressFormatter('ja');
+    const addressFormatter = new AddressFormatter('fr');
     await addressFormatter.getCountry('CA');
 
     expect(fetch.calls()).toHaveLength(1);
 
-    addressFormatter.updateLocale('en');
+    addressFormatter.updateLocale('es');
     await addressFormatter.getCountry('CA');
 
     expect(fetch.calls()).toHaveLength(2);


### PR DESCRIPTION
### Problem

Right now, if `.getCountries` is called one after the other before the request has finished, the cache is useless. This is something that will happen often when used with components. We already have the problem in [`CustomerNew`](https://github.com/Shopify/web/blob/master/app/sections/Customers/CustomerNew/CustomerNew.tsx#L205) where we have both `PhoneField` and `AddressForm` that fetch all countries.

### Solution

- Memoize async functions
- Remove cache for `.getCountry` since now the fetch call is memoized
- Don't remove it when calling `.getCountries` because it will still be used if we do something like:

```tsx
addressFormatter.getCountries()
addressFormatter.getCountry("CA") // Will retrieve from `ORDERED_COUNTRIES_CACHE`
```