### PR TITLE
🐛 fix list breaking in name generation

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+## Fixed
+
+- `<List />` no longer breaks on name generation.
+
 ## [0.4.0]
 
 ### Added

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -16,7 +16,7 @@ export default class List<Fields> extends React.PureComponent<
 > {
   render() {
     const {
-      field: {value, initialValue, error, onBlur},
+      field: {value, initialValue, error, name, onBlur},
       children,
     } = this.props;
 
@@ -53,9 +53,9 @@ export default class List<Fields> extends React.PureComponent<
     key,
   }: {
     index: number;
-    key: any;
+    key: Key;
   }) {
-    return (newValue: Fields[Key] | ValueMapper<Fields[]>) => {
+    return (newValue: Fields[Key] | ValueMapper<Fields[Key]>) => {
       const {
         field: {onChange},
       } = this.props;
@@ -66,7 +66,7 @@ export default class List<Fields> extends React.PureComponent<
           ...(existingItem as any),
           [key]:
             typeof newValue === 'function'
-              ? newValue(value[index][key])
+              ? (newValue as ValueMapper<Fields[Key]>)(value[index][key])
               : newValue,
         };
         return replace(value, index, newItem);

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -35,9 +35,12 @@ describe('<FormState.List />', () => {
     calls.forEach(([fields], index) => {
       const expectedTitle = products[index].title;
 
-      expect(fields.title.value).toBe(expectedTitle);
-      expect(fields.title.initialValue).toBe(expectedTitle);
-      expect(fields.title.dirty).toBe(false);
+      expect(fields.title).toMatchObject({
+        value: expectedTitle,
+        initialValue: expectedTitle,
+        dirty: false,
+        name: `products.${index}.title`,
+      });
     });
   });
 
@@ -81,8 +84,6 @@ describe('<FormState.List />', () => {
     const newTitle = faker.commerce.productName();
     const newPrice = faker.commerce.price();
 
-    const renderSpy = jest.fn(() => null);
-
     const renderPropSpy = jest.fn(({fields}: any) => {
       return (
         <FormState.List field={fields.products}>
@@ -119,7 +120,7 @@ describe('<FormState.List />', () => {
 
     const renderSpy = jest.fn(() => null);
 
-    const form = mount(
+    mount(
       <FormState initialValues={{products}}>
         {({fields}) => {
           return (


### PR DESCRIPTION
This PR fixes `<List />` breaking on `name` generation. It looks like this was re-broken from a revert of something else that had incidentally fixed this. I also fixed a couple linting errors.