### PR TITLE
Add default country option and weekStartDay()

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -65,6 +65,7 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 
 - `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `Provider` component will be used where no custom currency code is passed.
 - `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `Provider` component will be used when no custom `timezone` is provided.
+- `weekStartDay()`: returns start day of the week according to the country.
 
 Most notably, you will frequently use `i18n`’s `translate()` method. This method looks up a key in translation files that you supply based on the provided locale. This method is discussed in detail in the next section.
 

--- a/packages/react-i18n/src/constants.ts
+++ b/packages/react-i18n/src/constants.ts
@@ -1,0 +1,147 @@
+export enum Weekdays {
+  Sunday = 'sunday',
+  Monday = 'monday',
+  Tuesday = 'tuesday',
+  Wednesday = 'wednesday',
+  Thursday = 'thursday',
+  Friday = 'friday',
+  Saturday = 'saturday',
+}
+
+export const DEFAULT_WEEK_START_DAY = Weekdays.Sunday;
+export const WEEK_START_DAYS = new Map([
+  // Saturday
+  ['AF', Weekdays.Saturday],
+  ['DZ', Weekdays.Saturday],
+  ['BH', Weekdays.Saturday],
+  ['EG', Weekdays.Saturday],
+  ['IR', Weekdays.Saturday],
+  ['IQ', Weekdays.Saturday],
+  ['JO', Weekdays.Saturday],
+  ['KW', Weekdays.Saturday],
+  ['LY', Weekdays.Saturday],
+  ['OM', Weekdays.Saturday],
+  ['QA', Weekdays.Saturday],
+  ['SA', Weekdays.Saturday],
+  ['SY', Weekdays.Saturday],
+  ['AE', Weekdays.Saturday],
+  ['YE', Weekdays.Saturday],
+  // Sunday
+  ['AR', Weekdays.Sunday],
+  ['BZ', Weekdays.Sunday],
+  ['BO', Weekdays.Sunday],
+  ['BR', Weekdays.Sunday],
+  ['CA', Weekdays.Sunday],
+  ['CL', Weekdays.Sunday],
+  ['CN', Weekdays.Sunday],
+  ['CO', Weekdays.Sunday],
+  ['CR', Weekdays.Sunday],
+  ['DO', Weekdays.Sunday],
+  ['EC', Weekdays.Sunday],
+  ['SV', Weekdays.Sunday],
+  ['GT', Weekdays.Sunday],
+  ['HN', Weekdays.Sunday],
+  ['HK', Weekdays.Sunday],
+  ['IL', Weekdays.Sunday],
+  ['JM', Weekdays.Sunday],
+  ['JP', Weekdays.Sunday],
+  ['KE', Weekdays.Sunday],
+  ['MO', Weekdays.Sunday],
+  ['MX', Weekdays.Sunday],
+  ['NI', Weekdays.Sunday],
+  ['PA', Weekdays.Sunday],
+  ['PE', Weekdays.Sunday],
+  ['PH', Weekdays.Sunday],
+  ['SG', Weekdays.Sunday],
+  ['ZA', Weekdays.Sunday],
+  ['KR', Weekdays.Sunday],
+  ['TW', Weekdays.Sunday],
+  ['US', Weekdays.Sunday],
+  ['VE', Weekdays.Sunday],
+  ['ZW', Weekdays.Sunday],
+  // Monday
+  ['AL', Weekdays.Monday],
+  ['AD', Weekdays.Monday],
+  ['AM', Weekdays.Monday],
+  ['AU', Weekdays.Monday],
+  ['AZ', Weekdays.Monday],
+  ['BY', Weekdays.Monday],
+  ['BE', Weekdays.Monday],
+  ['BN', Weekdays.Monday],
+  ['BG', Weekdays.Monday],
+  ['HR', Weekdays.Monday],
+  ['CZ', Weekdays.Monday],
+  ['DK', Weekdays.Monday],
+  ['EE', Weekdays.Monday],
+  ['FI', Weekdays.Monday],
+  ['FR', Weekdays.Monday],
+  ['GF', Weekdays.Monday],
+  ['GE', Weekdays.Monday],
+  ['DE', Weekdays.Monday],
+  ['GR', Weekdays.Monday],
+  ['HU', Weekdays.Monday],
+  ['IS', Weekdays.Monday],
+  ['IN', Weekdays.Monday],
+  ['ID', Weekdays.Monday],
+  ['IE', Weekdays.Monday],
+  ['IT', Weekdays.Monday],
+  ['KZ', Weekdays.Monday],
+  ['XK', Weekdays.Monday],
+  ['KG', Weekdays.Monday],
+  ['LV', Weekdays.Monday],
+  ['LB', Weekdays.Monday],
+  ['LT', Weekdays.Monday],
+  ['LU', Weekdays.Monday],
+  ['MK', Weekdays.Monday],
+  ['MY', Weekdays.Monday],
+  ['MC', Weekdays.Monday],
+  ['MN', Weekdays.Monday],
+  ['MA', Weekdays.Monday],
+  ['NL', Weekdays.Monday],
+  ['NZ', Weekdays.Monday],
+  ['NO', Weekdays.Monday],
+  ['PK', Weekdays.Monday],
+  ['PY', Weekdays.Monday],
+  ['PL', Weekdays.Monday],
+  ['PT', Weekdays.Monday],
+  ['RO', Weekdays.Monday],
+  ['RU', Weekdays.Monday],
+  ['RS', Weekdays.Monday],
+  ['SK', Weekdays.Monday],
+  ['ES', Weekdays.Monday],
+  ['SE', Weekdays.Monday],
+  ['CH', Weekdays.Monday],
+  ['TH', Weekdays.Monday],
+  ['TN', Weekdays.Monday],
+  ['TR', Weekdays.Monday],
+  ['UA', Weekdays.Monday],
+  ['GB', Weekdays.Monday],
+  ['UY', Weekdays.Monday],
+  ['UZ', Weekdays.Monday],
+  ['VN', Weekdays.Monday],
+]);
+
+/* eslint-disable line-comment-position */
+// See https://en.wikipedia.org/wiki/Right-to-left
+export const RTL_LANGUAGES = [
+  'ae', // Avestan
+  'ar', // 'العربية', Arabic
+  'arc', // Aramaic
+  'bcc', // 'بلوچی مکرانی', Southern Balochi
+  'bqi', // 'بختياري', Bakthiari
+  'ckb', // 'Soranî / کوردی', Sorani
+  'dv', // Dhivehi
+  'fa', // 'فارسی', Persian
+  'glk', // 'گیلکی', Gilaki
+  'he', // 'עברית', Hebrew
+  'ku', // 'Kurdî / كوردی', Kurdish
+  'mzn', // 'مازِرونی', Mazanderani
+  'nqo', // N'Ko
+  'pnb', // 'پنجابی', Western Punjabi
+  'ps', // 'پښتو', Pashto,
+  'sd', // 'سنڌي', Sindhi
+  'ug', // 'Uyghurche / ئۇيغۇرچە', Uyghur
+  'ur', // 'اردو', Urdu
+  'yi', // 'ייִדיש', Yiddish
+];
+/* eslint-enable */

--- a/packages/react-i18n/src/errors.ts
+++ b/packages/react-i18n/src/errors.ts
@@ -2,4 +2,5 @@ export class MissingTranslationError extends Error {}
 export class MissingReplacementError extends Error {}
 export class MissingCurrencyCodeError extends Error {}
 export class MissingTimezoneError extends Error {}
+export class MissingCountryError extends Error {}
 export class InvalidI18nConnectionError extends Error {}

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -6,7 +6,16 @@ import {
   TranslationDictionary,
   LanguageDirection,
 } from './types';
-import {MissingCurrencyCodeError, MissingTimezoneError} from './errors';
+import {
+  DEFAULT_WEEK_START_DAY,
+  WEEK_START_DAYS,
+  RTL_LANGUAGES,
+} from './constants';
+import {
+  MissingCurrencyCodeError,
+  MissingTimezoneError,
+  MissingCountryError,
+} from './errors';
 import {translate, TranslateOptions as RootTranslateOptions} from './utilities';
 
 export interface NumberFormatOptions extends Intl.NumberFormatOptions {
@@ -18,34 +27,10 @@ export interface TranslateOptions {
   scope: RootTranslateOptions<any>['scope'];
 }
 
-/* eslint-disable line-comment-position */
-// See https://en.wikipedia.org/wiki/Right-to-left
-const RTL_LANGUAGES = [
-  'ae', // Avestan
-  'ar', // 'العربية', Arabic
-  'arc', // Aramaic
-  'bcc', // 'بلوچی مکرانی', Southern Balochi
-  'bqi', // 'بختياري', Bakthiari
-  'ckb', // 'Soranî / کوردی', Sorani
-  'dv', // Dhivehi
-  'fa', // 'فارسی', Persian
-  'glk', // 'گیلکی', Gilaki
-  'he', // 'עברית', Hebrew
-  'ku', // 'Kurdî / كوردی', Kurdish
-  'mzn', // 'مازِرونی', Mazanderani
-  'nqo', // N'Ko
-  'pnb', // 'پنجابی', Western Punjabi
-  'ps', // 'پښتو', Pashto,
-  'sd', // 'سنڌي', Sindhi
-  'ug', // 'Uyghurche / ئۇيغۇرچە', Uyghur
-  'ur', // 'اردو', Urdu
-  'yi', // 'ייִדיש', Yiddish
-];
-/* eslint-enable */
-
 export default class I18n {
   readonly locale: string;
   readonly pseudolocalize: boolean | string;
+  readonly defaultCountry?: string;
   readonly defaultCurrency?: string;
   readonly defaultTimezone?: string;
 
@@ -80,9 +65,10 @@ export default class I18n {
 
   constructor(
     public translations: TranslationDictionary[],
-    {locale, currency, timezone, pseudolocalize = false}: I18nDetails,
+    {locale, currency, timezone, country, pseudolocalize = false}: I18nDetails,
   ) {
     this.locale = locale;
+    this.defaultCountry = country;
     this.defaultCurrency = currency;
     this.defaultTimezone = timezone;
     this.pseudolocalize = pseudolocalize;
@@ -169,6 +155,18 @@ export default class I18n {
       timeZone: timezone,
       ...options,
     }).format(date);
+  }
+
+  weekStartDay(argCountry?: I18n['defaultCountry']) {
+    const country = argCountry || this.defaultCountry;
+
+    if (!country) {
+      throw new MissingCountryError(
+        `No country code provided. weekStartDay() cannot be called without a country code.`,
+      );
+    }
+
+    return WEEK_START_DAYS.get(country) || DEFAULT_WEEK_START_DAY;
   }
 }
 

--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -5,3 +5,4 @@ export {default as getTranslationsFromTree} from './server';
 export {withI18n, WithI18nProps} from './decorator';
 export {translate} from './utilities';
 export {I18nDetails} from './types';
+export {Weekdays} from './constants';

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -2,6 +2,7 @@ import './matchers';
 
 import I18n from '../i18n';
 import {LanguageDirection} from '../types';
+import {Weekdays} from '../constants';
 
 jest.mock('../utilities', () => ({
   translate: jest.fn(),
@@ -382,6 +383,34 @@ describe('I18n', () => {
       }).format(date);
 
       expect(i18n.formatDate(date, {timeZone: timezone})).toBe(expected);
+    });
+  });
+
+  describe('#weekStartDay()', () => {
+    it('uses the defaultCountry to get the week start day', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en', country: 'FR'});
+
+      expect(i18n.weekStartDay()).toBe(Weekdays.Monday);
+    });
+
+    it('uses the country passed in the params instead of the defaultCountry', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en', country: 'FR'});
+
+      expect(i18n.weekStartDay('CA')).toBe(Weekdays.Sunday);
+    });
+
+    it('fallsback to Sunday if country is not in the list', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en', country: 'XX'});
+
+      expect(i18n.weekStartDay()).toBe(Weekdays.Sunday);
+    });
+
+    it('throws an error if no country code is passed', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(() => i18n.weekStartDay()).toThrowError(
+        'No country code provided. weekStartDay() cannot be called without a country code.',
+      );
     });
   });
 });

--- a/packages/react-i18n/src/types.ts
+++ b/packages/react-i18n/src/types.ts
@@ -5,6 +5,7 @@ export enum LanguageDirection {
 
 export interface I18nDetails {
   locale: string;
+  country?: string;
   currency?: string;
   timezone?: string;
   pseudolocalize?: boolean;


### PR DESCRIPTION
Addresses https://github.com/Shopify/web/issues/7245

- Add an option to pass `country` to `i18n` which will allow to return `weekStartDay`.
- `weekStartDay` returns a `Weekday` enum value
- It defaults to Sunday

Data is inlined and comes from https://github.com/Shopify/country_db/pull/217 (Source: http://chartsbin.com/view/41671 + Shopifolks)

This addresses an immediate problem we have. We will have to investigate to find a proper solution to keep data in sync with https://github.com/Shopify/country_db/