### PR TITLE
Add explicity Weekdays return type

### DIFF
--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_WEEK_START_DAY,
   WEEK_START_DAYS,
   RTL_LANGUAGES,
+  Weekdays,
 } from './constants';
 import {
   MissingCurrencyCodeError,
@@ -157,7 +158,7 @@ export default class I18n {
     }).format(date);
   }
 
-  weekStartDay(argCountry?: I18n['defaultCountry']) {
+  weekStartDay(argCountry?: I18n['defaultCountry']): Weekdays {
     const country = argCountry || this.defaultCountry;
 
     if (!country) {


### PR DESCRIPTION
When building the packages, `packages/react-i18n/dist/i18n.d.ts` does not import `Weekdays` from constants. Which results in linting errors.

To test:
Run `yarn run build`.
Then `cat packages/react-i18n/dist/i18n.d.ts`

Current output after changes:
```
/// <reference types="react" />
import { I18nDetails, PrimitiveReplacementDictionary, ComplexReplacementDictionary, TranslationDictionary, LanguageDirection } from './types';
import { Weekdays } from './constants';
import { TranslateOptions as RootTranslateOptions } from './utilities';
export interface NumberFormatOptions extends Intl.NumberFormatOptions {
    as?: 'number' | 'currency' | 'percent';
    precision?: number;
}
export interface TranslateOptions {
    scope: RootTranslateOptions<any>['scope'];
}
export default class I18n {
    translations: TranslationDictionary[];
    readonly locale: string;
    readonly pseudolocalize: boolean | string;
    readonly defaultCountry?: string;
    readonly defaultCurrency?: string;
    readonly defaultTimezone?: string;
    readonly language: string;
    readonly region: string | undefined;
    /**
     * @deprecated Use I18n#region instead.
     */
    readonly countryCode: string | undefined;
    readonly languageDirection: LanguageDirection;
    readonly isRtlLanguage: boolean;
    readonly isLtrLanguage: boolean;
    constructor(translations: TranslationDictionary[], { locale, currency, timezone, country, pseudolocalize }: I18nDetails);
    translate(id: string, options: TranslateOptions, replacements?: PrimitiveReplacementDictionary): string;
    translate(id: string, options: TranslateOptions, replacements?: ComplexReplacementDictionary): React.ReactElement<any>;
    translate(id: string, replacements?: PrimitiveReplacementDictionary): string;
    translate(id: string, replacements?: ComplexReplacementDictionary): React.ReactElement<any>;
    formatNumber(amount: number, { as, precision, ...options }?: NumberFormatOptions): string;
    formatDate(date: Date, options?: Intl.DateTimeFormatOptions): string;
    weekStartDay(argCountry?: I18n['defaultCountry']): Weekdays;
}
```