### PR TITLE
react-shortcuts: export Provider for enabling external ShortcutProvider implementors

### DIFF
--- a/packages/react-shortcuts/src/ShortcutProvider/index.ts
+++ b/packages/react-shortcuts/src/ShortcutProvider/index.ts
@@ -1,4 +1,4 @@
 import ShortcutProvider from './ShortcutProvider';
 
-export {Props, Context, Consumer} from './ShortcutProvider';
+export {Props, Context, Provider, Consumer} from './ShortcutProvider';
 export default ShortcutProvider;

--- a/packages/react-shortcuts/src/index.ts
+++ b/packages/react-shortcuts/src/index.ts
@@ -4,6 +4,7 @@ export {
   default as ShortcutProvider,
   Props as ProviderProps,
   Context,
+  Provider as ContextProvider,
 } from './ShortcutProvider';
 
 export {default as ShortcutManager} from './ShortcutManager';


### PR DESCRIPTION
The default `ShortcutProvider` is great for most React applications, but when
React is being rendered into multiple locations on a page (for example, in [a
browser extension that extends multiple different locations on a page with
React](https://github.com/sourcegraph/browser-extensions/pull/263)), the default `ShortcutProvider` does not work as it is intended to be a singleton.

In order to implement one's own `ShortcutProvider` for this use case, the `ContextProvider`
must be exported.