### PR TITLE
Add linting for full lodash package

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": [
     "plugin:shopify/typescript-react",
     "plugin:shopify/typescript-prettier"
-  ]
+  ],
+  "rules": {
+    "shopify/restrict-full-import": ["error", "lodash"]
+  }
 }

--- a/packages/dates/src/parse-date-string.ts
+++ b/packages/dates/src/parse-date-string.ts
@@ -18,7 +18,7 @@ export function parseDateString(dateString: string, timeZone?: string) {
   }
 
   const [
-    ,
+    _,
     rawYear,
     rawMonth,
     rawDay,

--- a/packages/dates/src/parse-date-string.ts
+++ b/packages/dates/src/parse-date-string.ts
@@ -18,6 +18,7 @@ export function parseDateString(dateString: string, timeZone?: string) {
   }
 
   const [
+    // @ts-ignore
     _,
     rawYear,
     rawMonth,


### PR DESCRIPTION
Closes https://github.com/Shopify/quilt/issues/337

We want to restrict importing the entire lodash package.

Errors:
<img width="462" alt="screen shot 2018-10-24 at 5 04 00 pm" src="https://user-images.githubusercontent.com/9055413/47461629-38621200-d7af-11e8-96e9-8d2f53544105.png">

No Errors:
<img width="219" alt="screen shot 2018-10-24 at 5 07 52 pm" src="https://user-images.githubusercontent.com/9055413/47461680-5c255800-d7af-11e8-88d5-2e56f946e48d.png">
