### PR TITLE
✨ [react-form-state] support custom keys for list

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.5]
+
+## Added
+
+- `<List />` supports `getChildKey` to provide custom `key`s for it's children. [#387](https://github.com/Shopify/quilt/pull/387)
+
 ## [0.4.1]
 
 ## Fixed

--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -542,6 +542,17 @@ export function ProductPage() {
 }
 ```
 
+By default `<List />` will use the `index` of your objects in the array as React `key`s. This is problematic if your array items could be re-ordered, so it is highly recommended you provide a `getChildKey` function. Your `getChildKey` will be passed each item in your array, and expects you to return a unique value that can be used to identify that item. This could be an `id` if that exists, or something else that makes sense in your usecase.
+
+For our example above, it makes sense to assume that each combination of `option` and `value` is unique.
+
+```typescript
+<FormState.List
+  field={fields.variants}
+  getChildKey={(variant) => `${variant.option}-${variant.value}`}
+>
+```
+
 ## Putting it all together
 
 The following example shows how you can use everything this documentation covered to build a full [Polaris](https://polaris.shopify.com) styled page.

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -8,6 +8,7 @@ import {mapObject, replace} from '../utilities';
 interface Props<Fields> {
   field: FieldDescriptor<Fields[]>;
   children(fields: FieldDescriptors<Fields>, index: number): React.ReactNode;
+  getChildKey?(item: Fields): string;
 }
 
 export default class List<Fields> extends React.PureComponent<
@@ -17,6 +18,7 @@ export default class List<Fields> extends React.PureComponent<
   render() {
     const {
       field: {value, initialValue, error, name, onBlur},
+      getChildKey,
       children,
     } = this.props;
 
@@ -37,9 +39,11 @@ export default class List<Fields> extends React.PureComponent<
         },
       );
 
+      const key = getChildKey ? getChildKey(fieldValues) : index;
+
       return (
         // eslint-disable-next-line
-        <React.Fragment key={index}>
+        <React.Fragment key={key}>
           {children(innerFields, index)}
         </React.Fragment>
       );

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -44,6 +44,28 @@ describe('<FormState.List />', () => {
     });
   });
 
+  it('uses getChildKey to determine keys for each item', () => {
+    const products = [{title: faker.commerce.productName()}];
+
+    const childKeySpy = jest.fn(item => item.title);
+
+    mount(
+      <FormState initialValues={{products}}>
+        {({fields}) => {
+          return (
+            <FormState.List field={fields.products} getChildKey={childKeySpy}>
+              {_ => <div />}
+            </FormState.List>
+          );
+        }}
+      </FormState>,
+    );
+
+    expect(childKeySpy).toBeCalledWith(products[0]);
+    // Enzyme still has incomplete support for fragments so we can't actually test that the key is rendered
+    // expect(wrapper.find('Fragment').key()).toBe(products[0].title);
+  });
+
   it('updates the top level FormState‘s array when an inner field is updated', () => {
     const products = [{title: faker.commerce.productName()}];
     const newTitle = faker.commerce.productName();


### PR DESCRIPTION
closes #334 

This Pr adds the ability customize `<FormState.List />`'s logic for assigning `key`s to it's iterations. This makes the component usable for drag-and-drop lists and other contexts where the contents might be re-ordered.
