### PR TITLE
React-i18n / Add support for `getCurrencySymbol`

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -66,6 +66,7 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 - `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `Provider` component will be used where no custom currency code is passed.
 - `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `Provider` component will be used when no custom `timezone` is provided.
 - `weekStartDay()`: returns start day of the week according to the country.
+- `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.
 
 Most notably, you will frequently use `i18n`’s `translate()` method. This method looks up a key in translation files that you supply based on the provided locale. This method is discussed in detail in the next section.
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -1,4 +1,5 @@
 import {languageFromLocale, regionFromLocale} from '@shopify/i18n';
+import {memoize, autobind} from '@shopify/javascript-utilities/decorators';
 import {
   I18nDetails,
   PrimitiveReplacementDictionary,
@@ -17,7 +18,11 @@ import {
   MissingTimezoneError,
   MissingCountryError,
 } from './errors';
-import {translate, TranslateOptions as RootTranslateOptions} from './utilities';
+import {
+  getCurrencySymbol,
+  translate,
+  TranslateOptions as RootTranslateOptions,
+} from './utilities';
 
 export interface NumberFormatOptions extends Intl.NumberFormatOptions {
   as?: 'number' | 'currency' | 'percent';
@@ -168,6 +173,22 @@ export default class I18n {
     }
 
     return WEEK_START_DAYS.get(country) || DEFAULT_WEEK_START_DAY;
+  }
+
+  @autobind
+  getCurrencySymbol(currencyCode?: string) {
+    const currency = currencyCode || this.defaultCurrency;
+    if (currency == null) {
+      throw new MissingCurrencyCodeError(
+        `No currency code provided. formatCurrency cannot be called without a currency code.`,
+      );
+    }
+    return this.getCurrencySymbolLocalized(this.locale, currency);
+  }
+
+  @memoize((currency: string, locale: string) => `${locale}${currency}`)
+  getCurrencySymbolLocalized(locale: string, currency: string) {
+    return getCurrencySymbol(locale, {currency});
   }
 }
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -6,9 +6,11 @@ import {Weekdays} from '../constants';
 
 jest.mock('../utilities', () => ({
   translate: jest.fn(),
+  getCurrencySymbol: jest.fn(),
 }));
 
 const translate: jest.Mock = require('../utilities').translate;
+const getCurrencySymbol: jest.Mock = require('../utilities').getCurrencySymbol;
 
 describe('I18n', () => {
   const defaultDetails = {locale: 'en-ca'};
@@ -16,6 +18,7 @@ describe('I18n', () => {
 
   beforeEach(() => {
     translate.mockReset();
+    getCurrencySymbol.mockReset();
   });
 
   describe('#locale', () => {
@@ -411,6 +414,20 @@ describe('I18n', () => {
       expect(() => i18n.weekStartDay()).toThrowError(
         'No country code provided. weekStartDay() cannot be called without a country code.',
       );
+    });
+  });
+
+  describe('#getCurrencySymbol()', () => {
+    it('correctly returns the locale-specific currency symbol and its position', () => {
+      const mockResult = {
+        symbol: '€',
+        prefixed: true,
+      };
+      getCurrencySymbol.mockReturnValue(mockResult);
+
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.getCurrencySymbol('eur')).toEqual(mockResult);
     });
   });
 });

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import {translate, PSEUDOTRANSLATE_OPTIONS} from '../utilities';
+import {
+  translate,
+  PSEUDOTRANSLATE_OPTIONS,
+  getCurrencySymbol,
+} from '../utilities';
 
 const {pseudotranslate} = require.requireMock('@shopify/i18n') as {
   pseudotranslate: jest.Mock;
@@ -157,6 +161,15 @@ describe('translate()', () => {
       expect(pseudotranslate).toHaveBeenCalledWith('bar', {
         ...PSEUDOTRANSLATE_OPTIONS,
         toLocale: 'de',
+      });
+    });
+  });
+
+  describe('getCurrencySymbol', () => {
+    it('correctly returns the locale-specific currency symbol and its position', () => {
+      expect(getCurrencySymbol('en', {currency: 'eur'})).toEqual({
+        symbol: '€',
+        prefixed: true,
       });
     });
   });

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -1,0 +1,15 @@
+import {getCurrencySymbol} from './money';
+import {noop} from './noop';
+import {
+  PSEUDOTRANSLATE_OPTIONS,
+  TranslateOptions,
+  translate,
+} from './translate';
+
+export {
+  getCurrencySymbol,
+  noop,
+  PSEUDOTRANSLATE_OPTIONS,
+  translate,
+  TranslateOptions,
+};

--- a/packages/react-i18n/src/utilities/money.ts
+++ b/packages/react-i18n/src/utilities/money.ts
@@ -1,0 +1,41 @@
+export function getCurrencySymbol(
+  locale: string,
+  options: Intl.NumberFormatOptions,
+) {
+  const delimiters = ',.';
+  const directionControlCharacters = new RegExp(`[\u{200E}\u{200F}]`, 'u');
+  const numReg = new RegExp(`0[${delimiters}]*0*`);
+
+  const currencyStringRaw = formatCurrency(0, locale, options);
+  const currencyString = currencyStringRaw.replace(
+    directionControlCharacters,
+    '',
+  );
+  const matchResult = currencyString.match(numReg);
+  if (!matchResult) {
+    throw new Error(
+      `Number input in locale ${locale} is currently not supported.`,
+    );
+  }
+  const formattedAmount = matchResult[0];
+  const [currencyPrefix, currencySuffix] = currencyString.split(
+    formattedAmount,
+  );
+  const elements = {
+    symbol: currencyPrefix || currencySuffix,
+    prefixed: currencyPrefix !== '',
+  };
+
+  return elements;
+}
+
+function formatCurrency(
+  amount: number,
+  locale: string,
+  options: Intl.NumberFormatOptions,
+) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    ...options,
+  }).format(amount);
+}

--- a/packages/react-i18n/src/utilities/noop.ts
+++ b/packages/react-i18n/src/utilities/noop.ts
@@ -1,0 +1,1 @@
+export function noop() {}

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -7,8 +7,8 @@ import {
   TranslationDictionary,
   ComplexReplacementDictionary,
   PrimitiveReplacementDictionary,
-} from './types';
-import {MissingTranslationError, MissingReplacementError} from './errors';
+} from '../types';
+import {MissingTranslationError, MissingReplacementError} from '../errors';
 
 const REPLACE_REGEX = /{([^}]*)}/g;
 const MISSING_TRANSLATION = Symbol('Missing translation');
@@ -230,5 +230,3 @@ function normalizeIdentifier(id: string, scope?: string | string[]) {
     typeof scope === 'string' ? scope : scope.join(SEPARATOR)
   }${SEPARATOR}${id}`;
 }
-
-export function noop() {}


### PR DESCRIPTION
This PR adds support for `getCurrencySymbol`.

This method will return the currency symbol according to the currency code and locale.

The implementation has been duplicated from `withIntl` in `web`.

Also 🔥 the `utilities.tsx` to organize all utilities under a folder.

🎩 instructions to come... 

No luck with `yarn link`. You'll have to copy the generated `dist` folder in `web` under `node_modules/@shopify/react-i18n`

You can then checkout `discounts/localize-currency` in `web` and run `dev run dev` 