### PR TITLE
adding formatCurrency utility function to simplify legacy i18n migration

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -64,6 +64,7 @@ export default withI18n()(NotFound);
 The provided `i18n` object exposes many useful methods for internationalizing your apps. You can see the full details in the [`i18n` source file](https://github.com/Shopify/quilt/blob/master/packages/react-i18n/src/i18n.ts), but you will commonly need the following:
 
 - `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `Provider` component will be used where no custom currency code is passed.
+- `formatCurrency()`: formats a number as a currency according ot the locale. Convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`.
 - `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `Provider` component will be used when no custom `timezone` is provided.
 - `weekStartDay()`: returns start day of the week according to the country.
 - `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -148,6 +148,10 @@ export default class I18n {
     }).format(amount);
   }
 
+  formatCurrency(amount: number, options: Intl.NumberFormatOptions = {}) {
+    return this.formatNumber(amount, {as: 'currency', ...options});
+  }
+
   formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
     const {locale, defaultTimezone: timezone} = this;
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -330,6 +330,20 @@ describe('I18n', () => {
     });
   });
 
+  describe('#formatCurrency()', () => {
+    const currency = 'USD';
+
+    it('formats the number as a currency', () => {
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      const expected = Intl.NumberFormat(defaultDetails.locale, {
+        style: 'currency',
+        currency,
+      }).format(1);
+
+      expect(i18n.formatCurrency(1, {currency})).toBe(expected);
+    });
+  });
+
   describe('#formatDate()', () => {
     const timezone = 'Australia/Sydney';
 


### PR DESCRIPTION
this is a utility _passthru_ function to simplify migration from legacy `i18n` solutions that simply calls back into `formatNumber` with `{as: 'currency'}` automatically added to the format options.

relates to #396 