### PR TITLE
adding formatPercentage utility function to simplify legacy i18n migration

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -65,6 +65,7 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 
 - `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `Provider` component will be used where no custom currency code is passed.
 - `formatCurrency()`: formats a number as a currency according ot the locale. Convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`.
+- `formatPercentage()`: formats a number as a percentage according ot the locale. Convenience function that simply _auto-assigns_ the `as` option to `percent` and calls `formatNumber()`.
 - `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `Provider` component will be used when no custom `timezone` is provided.
 - `weekStartDay()`: returns start day of the week according to the country.
 - `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -152,6 +152,10 @@ export default class I18n {
     return this.formatNumber(amount, {as: 'currency', ...options});
   }
 
+  formatPercentage(amount: number, options: Intl.NumberFormatOptions = {}) {
+    return this.formatNumber(amount, {as: 'percent', ...options});
+  }
+
   formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
     const {locale, defaultTimezone: timezone} = this;
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -344,6 +344,16 @@ describe('I18n', () => {
     });
   });
 
+  describe('#formatPercentage()', () => {
+    it('formats the number as a percentage', () => {
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      const expected = Intl.NumberFormat(defaultDetails.locale, {
+        style: 'percent',
+      }).format(50);
+      expect(i18n.formatPercentage(50)).toBe(expected);
+    });
+  });
+
   describe('#formatDate()', () => {
     const timezone = 'Australia/Sydney';
 


### PR DESCRIPTION
this is a utility _passthru_ function to simplify migration from legacy `i18n` solutions that simply calls back into `formatNumber` with `{as: 'currency'}` automatically added to the format options.

relates to #395 