### PR TITLE
add DateStyle date formatting helpers to react-i18n

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -66,7 +66,11 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 - `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `Provider` component will be used where no custom currency code is passed.
 - `formatCurrency()`: formats a number as a currency according ot the locale. Convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`.
 - `formatPercentage()`: formats a number as a percentage according ot the locale. Convenience function that simply _auto-assigns_ the `as` option to `percent` and calls `formatNumber()`.
-- `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `Provider` component will be used when no custom `timezone` is provided.
+- `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `Provider` component will be used when no custom `timezone` is provided. Assign the `style` option to a `DateStyle` value to use common formatting options.
+  - `DateStyle.Long`: e.g., `Thursday, December 20, 2012`
+  - `DateStyle.Short`: e.g., `Dec 20, 2012`
+  - `DateStyle.Humanize`: e.g., `December 20, 2012`, `Today`, or `Yesterday`
+  - `DateStyle.Time`: e.g., `11:00 AM`
 - `weekStartDay()`: returns start day of the week according to the country.
 - `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.
 

--- a/packages/react-i18n/src/constants.ts
+++ b/packages/react-i18n/src/constants.ts
@@ -1,3 +1,33 @@
+export enum DateStyle {
+  Long = 'Long',
+  Short = 'Short',
+  Humanize = 'Humanize',
+  Time = 'Time',
+}
+
+export const dateStyle = {
+  [DateStyle.Long]: {
+    weekday: 'long',
+    month: 'long',
+    day: '2-digit',
+    year: 'numeric',
+  },
+  [DateStyle.Short]: {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  },
+  [DateStyle.Humanize]: {
+    month: 'long',
+    day: '2-digit',
+    year: 'numeric',
+  },
+  [DateStyle.Time]: {
+    hour: '2-digit',
+    minute: '2-digit',
+  },
+};
+
 export enum Weekdays {
   Sunday = 'sunday',
   Monday = 'monday',

--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -5,4 +5,4 @@ export {default as getTranslationsFromTree} from './server';
 export {withI18n, WithI18nProps} from './decorator';
 export {translate} from './utilities';
 export {I18nDetails} from './types';
-export {Weekdays} from './constants';
+export {DateStyle, Weekdays} from './constants';

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1,8 +1,10 @@
+import {clock} from '@shopify/jest-dom-mocks';
+
 import './matchers';
 
 import I18n from '../i18n';
 import {LanguageDirection} from '../types';
-import {Weekdays} from '../constants';
+import {DateStyle, Weekdays} from '../constants';
 
 jest.mock('../utilities', () => ({
   translate: jest.fn(),
@@ -357,6 +359,12 @@ describe('I18n', () => {
   describe('#formatDate()', () => {
     const timezone = 'Australia/Sydney';
 
+    afterEach(() => {
+      if (clock.isMocked()) {
+        clock.restore();
+      }
+    });
+
     it('formats a date using Intl', () => {
       const date = new Date();
       const i18n = new I18n(defaultTranslations, {...defaultDetails, timezone});
@@ -410,6 +418,88 @@ describe('I18n', () => {
       }).format(date);
 
       expect(i18n.formatDate(date, {timeZone: timezone})).toBe(expected);
+    });
+
+    it('formats a date using DateStyle.Long', () => {
+      const date = new Date('2012-12-20T00:00:00-00:00');
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone,
+      });
+
+      expect(i18n.formatDate(date, {style: DateStyle.Long})).toBe(
+        'Thursday, December 20, 2012',
+      );
+    });
+
+    it('formats a date using DateStyle.Short', () => {
+      const date = new Date('2012-12-20T00:00:00-00:00');
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone,
+      });
+
+      expect(i18n.formatDate(date, {style: DateStyle.Short})).toBe(
+        'Dec 20, 2012',
+      );
+    });
+
+    it('formats a date using DateStyle.Humanize', () => {
+      const date = new Date('2012-12-20T00:00:00-00:00');
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone,
+      });
+
+      expect(i18n.formatDate(date, {style: DateStyle.Humanize})).toBe(
+        'December 20, 2012',
+      );
+    });
+
+    it('formats a date using DateStyle.Humanize in a custom timezone', () => {
+      const date = new Date('2012-12-20T00:00:00-00:00');
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+
+      expect(
+        i18n.formatDate(date, {style: DateStyle.Humanize, timeZone: timezone}),
+      ).toBe('December 20, 2012');
+    });
+
+    it('formats today using DateStyle.Humanize', () => {
+      const today = new Date('2012-12-20T00:00:00-00:00');
+      clock.mock(today);
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone,
+      });
+
+      expect(i18n.formatDate(today, {style: DateStyle.Humanize})).toBe(
+        i18n.translate('today'),
+      );
+    });
+
+    it('formats yesterday using DateStyle.Humanize', () => {
+      const today = new Date('2012-12-20T00:00:00-00:00');
+      const yesterday = new Date('2012-12-19T00:00:00-00:00');
+      clock.mock(today);
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone,
+      });
+
+      expect(i18n.formatDate(yesterday, {style: DateStyle.Humanize})).toBe(
+        i18n.translate('yesterday'),
+      );
+    });
+
+    it('formats a date using DateStyle.Time', () => {
+      const date = new Date('2012-12-20T00:00:00-00:00');
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone,
+      });
+
+      expect(i18n.formatDate(date, {style: DateStyle.Time})).toBe('11:00 AM');
     });
   });
 


### PR DESCRIPTION
Provides `DateStyle` helpers to `formatDate` (`Long`, `Short`, `Humanize`, `Time`) to simplify migration from legacy `i18n` solutions.

`Humanize` adds additional formatting for `Today` and `Yesterday`.

This change is the first pass of adding date formats, with #398 covering the remaining formats.