### PR TITLE
Update koa-metrics to use distribution

### DIFF
--- a/packages/koa-metrics/README.md
+++ b/packages/koa-metrics/README.md
@@ -45,9 +45,9 @@ An instance of the `Metrics` object will be available on `ctx.metrics` further d
 
 ### `Metrics`
 
-#### `.timing(name: string, value: number, sampleRate?: number, tags?: Tags)`
+#### `.distribution(name: string, value: number, sampleRate?: number, tags?: Tags)`
 
-Sends a timing command with the specified `value` in milliseconds.
+Sends a distribution command with the specified `value` in milliseconds.
 
 #### `.measure(name: string, value: number, sampleRate?: number, tags?: Tags)`
 

--- a/packages/koa-metrics/src/Metrics.ts
+++ b/packages/koa-metrics/src/Metrics.ts
@@ -1,7 +1,7 @@
 import {StatsD} from 'hot-shots';
 
 enum MetricType {
-  Timing = 'timing',
+  Distribution = 'distribution',
   Measure = 'measure',
 }
 
@@ -41,10 +41,10 @@ export default class Metrics {
     this.client = this.rootClient;
   }
 
-  public timing(name: string, value: number, tags?: TagsMap) {
-    this.log(MetricType.Timing, name, value, tags);
+  public distribution(name: string, value: number, tags?: TagsMap) {
+    this.log(MetricType.Distribution, name, value, tags);
     // the any type below is to fix the improper typing on the histogram method
-    this.client.timing(name, value, tags as any);
+    this.client.distribution(name, value, tags as any);
   }
 
   public measure(name: string, value: number, tags?: TagsMap) {

--- a/packages/koa-metrics/src/index.ts
+++ b/packages/koa-metrics/src/index.ts
@@ -47,7 +47,7 @@ export default function metrics({
       timer = metrics.initTimer();
       const queuingTime = getQueuingTime(ctx);
       if (queuingTime) {
-        metrics.timing(CustomMetrics.QueuingTime, queuingTime);
+        metrics.distribution(CustomMetrics.QueuingTime, queuingTime);
       }
     }
 
@@ -62,7 +62,7 @@ export default function metrics({
       if (!skipInstrumentation) {
         if (timer) {
           const duration = timer.stop();
-          metrics.timing(CustomMetrics.RequestDuration, duration);
+          metrics.distribution(CustomMetrics.RequestDuration, duration);
         }
 
         const contentLength = getContentLength(ctx);

--- a/packages/koa-metrics/src/test/Metrics.test.ts
+++ b/packages/koa-metrics/src/test/Metrics.test.ts
@@ -32,46 +32,46 @@ describe('Metrics', () => {
     expect(StatsDMock).toHaveBeenCalledWith(defaultOptions);
   });
 
-  describe('timing', () => {
-    it('passes timing metrics to the statsd client', () => {
+  describe('distribution', () => {
+    it('passes distribution metrics to the statsd client', () => {
       const metrics = new Metrics(defaultOptions);
-      metrics.timing(name, value, tags);
+      metrics.distribution(name, value, tags);
 
       const stats = StatsDMock.mock.instances[0];
-      const timingFn = stats.timing;
-      expect(timingFn).toHaveBeenCalledTimes(1);
-      expect(timingFn).toHaveBeenCalledWith(name, value, tags);
+      const distributionFn = stats.distribution;
+      expect(distributionFn).toHaveBeenCalledTimes(1);
+      expect(distributionFn).toHaveBeenCalledWith(name, value, tags);
     });
 
-    it('logs timing metrics to the logger in development', () => {
+    it('logs distribution metrics to the logger in development', () => {
       withEnv('development', () => {
         const logger = jest.fn();
         const metrics = new Metrics(defaultOptions, logger);
-        metrics.timing(name, value);
+        metrics.distribution(name, value);
 
         expect(logger).toHaveBeenCalledTimes(1);
-        expect(logger).toHaveBeenCalledWith(`timing ${name}:${value}`);
+        expect(logger).toHaveBeenCalledWith(`distribution ${name}:${value}`);
       });
     });
 
-    it('logs tags with timing metrics to the logger in development', () => {
+    it('logs tags with distribution metrics to the logger in development', () => {
       withEnv('development', () => {
         const logger = jest.fn();
         const metrics = new Metrics(defaultOptions, logger);
-        metrics.timing(name, value, tags);
+        metrics.distribution(name, value, tags);
 
         expect(logger).toHaveBeenCalledTimes(1);
         expect(logger).toHaveBeenCalledWith(
-          `timing ${name}:${value} #${tagName}:${tags[tagName]}`,
+          `distribution ${name}:${value} #${tagName}:${tags[tagName]}`,
         );
       });
     });
 
-    it('does not log timing metrics to the logger in production', () => {
+    it('does not log distribution metrics to the logger in production', () => {
       withEnv('production', () => {
         const logger = jest.fn();
         const metrics = new Metrics(defaultOptions, logger);
-        metrics.timing(name, value, tags);
+        metrics.distribution(name, value, tags);
 
         expect(logger).not.toHaveBeenCalled();
       });
@@ -139,10 +139,10 @@ describe('Metrics', () => {
         globalTags: supplementaryTags,
       });
 
-      metrics.timing(name, value);
+      metrics.distribution(name, value);
 
-      expect(StatsDMock.mock.instances[0].timing).not.toHaveBeenCalled();
-      expect(StatsDMock.mock.instances[1].timing).toHaveBeenCalled();
+      expect(StatsDMock.mock.instances[0].distribution).not.toHaveBeenCalled();
+      expect(StatsDMock.mock.instances[1].distribution).toHaveBeenCalled();
     });
   });
 

--- a/packages/koa-metrics/src/test/index.test.ts
+++ b/packages/koa-metrics/src/test/index.test.ts
@@ -176,7 +176,7 @@ describe('koa-metrics', () => {
       });
 
       await metricsMiddleware(ctx, () => {
-        expect(MetricsMock.mock.instances[0].timing).toHaveBeenCalledWith(
+        expect(MetricsMock.mock.instances[0].distribution).toHaveBeenCalledWith(
           CustomMetrics.QueuingTime,
           queuingTime,
         );
@@ -189,11 +189,10 @@ describe('koa-metrics', () => {
       const ctx = createMockContext();
 
       await metricsMiddleware(ctx, () => {
-        const timingFn = MetricsMock.mock.instances[0].timing as jest.Mock<
-          Metrics['timing']
-        >;
+        const distributionFn = MetricsMock.mock.instances[0]
+          .distribution as jest.Mock<Metrics['distribution']>;
         expect(
-          timingFn.mock.calls.map(([metricName]) => metricName),
+          distributionFn.mock.calls.map(([metricName]) => metricName),
         ).not.toContain(CustomMetrics.QueuingTime);
       });
     });
@@ -218,7 +217,7 @@ describe('koa-metrics', () => {
         timingFn.mockReturnValueOnce({stop: () => requestTime});
       });
 
-      expect(MetricsMock.mock.instances[0].timing).toHaveBeenCalledWith(
+      expect(MetricsMock.mock.instances[0].distribution).toHaveBeenCalledWith(
         CustomMetrics.RequestDuration,
         requestTime,
       );
@@ -297,7 +296,7 @@ describe('koa-metrics', () => {
         };
       });
 
-      expect(MetricsMock.mock.instances[0].timing).not.toHaveBeenCalled();
+      expect(MetricsMock.mock.instances[0].distribution).not.toHaveBeenCalled();
       expect(MetricsMock.mock.instances[0].measure).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
### Purpose

Update `timing` -> `distribution` since datadog removed support for `timing`.
