### PR TITLE
Prevent GA calls in disableTracking and debug mode

### DIFF
--- a/packages/react-google-analytics/src/GaJS.tsx
+++ b/packages/react-google-analytics/src/GaJS.tsx
@@ -21,7 +21,7 @@ export const SETUP_SCRIPT = `
 
 export function setupWithDebugScript(account: String) {
   // https://developers.google.com/analytics/devguides/collection/gajs/#disable
-  return `window['ga-disable-GA_${account}'] = true;${SETUP_SCRIPT}`;
+  return `window['ga-disable-${account}'] = true;${SETUP_SCRIPT}`;
 }
 
 export const GA_JS_SCRIPT = 'https://stats.g.doubleclick.net/dc.js';

--- a/packages/react-google-analytics/src/Universal.tsx
+++ b/packages/react-google-analytics/src/Universal.tsx
@@ -68,13 +68,13 @@ export default class UniversalGoogleAnalytics extends React.PureComponent<
       allowLinker: true,
     };
 
+    googleAnalytics('create', account, 'auto', options);
+
     if (debug || disableTracking) {
       // Prevent data being sent to Google
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging#testing_your_implementation_without_sending_hits
       googleAnalytics('set', 'sendHitTask', null);
     }
-
-    googleAnalytics('create', account, 'auto', options);
 
     for (const [key, value] of Object.entries(setVariables)) {
       googleAnalytics('set', key, value);

--- a/packages/react-google-analytics/src/tests/Universal.test.tsx
+++ b/packages/react-google-analytics/src/tests/Universal.test.tsx
@@ -156,7 +156,18 @@ describe('<Universal />', () => {
         UNIVERSAL_GA_DEBUG_SCRIPT,
       );
       trigger(universal.find(ImportRemote), 'onImported', analytics);
-      expect(analytics).toHaveBeenCalledWith('set', 'sendHitTask', null);
+      expect(analytics).toHaveBeenNthCalledWith(
+        1,
+        'create',
+        mockProps.account,
+        'auto',
+        {
+          allowLinker: true,
+          cookieDomain: 'myshopify.com',
+          legacyCookieDomain: 'myshopify.com',
+        },
+      );
+      expect(analytics).toHaveBeenNthCalledWith(2, 'set', 'sendHitTask', null);
     });
 
     it('loads the GA script and does not prevent sending data to GA when debug is set to false', () => {
@@ -178,7 +189,18 @@ describe('<Universal />', () => {
         UNIVERSAL_GA_SCRIPT,
       );
       trigger(universal.find(ImportRemote), 'onImported', analytics);
-      expect(analytics).toHaveBeenCalledWith('set', 'sendHitTask', null);
+      expect(analytics).toHaveBeenNthCalledWith(
+        1,
+        'create',
+        mockProps.account,
+        'auto',
+        {
+          allowLinker: true,
+          cookieDomain: 'myshopify.com',
+          legacyCookieDomain: 'myshopify.com',
+        },
+      );
+      expect(analytics).toHaveBeenNthCalledWith(2, 'set', 'sendHitTask', null);
     });
 
     it('loads the GA script and does not prevent sending data to GA when disableTracking is set to false', () => {


### PR DESCRIPTION
Call `ga('create', 'UA-XXXXX-Y', 'auto');` before `ga('set', 'sendHitTask', null);` in order to disable correctly calls to GA.

GA documentation: https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging#testing_your_implementation_without_sending_hits