### PR TITLE
Add react-effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Each package has its own `README` and documentation describing usage.
 | koa-shopify-graphql-proxy | [directory](packages/koa-shopify-graphql-proxy) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy) |
 | logger | [directory](packages/logger) | [![npm version](https://badge.fury.io/js/%40shopify%2Flogger.svg)](https://badge.fury.io/js/%40shopify%2Flogger) |
 | react-compose | [directory](packages/react-compose) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-compose.svg)](https://badge.fury.io/js/%40shopify%2Freact-compose) |
+| react-effect | [directory](packages/react-effect) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
 | react-form-state | [directory](packages/react-form-state) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
 | react-google-analytics | [directory](packages/react-google-analytics) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg)](https://badge.fury.io/js/%40shopify%2Freact-google-analytics) |
 | react-html | [directory](packages/react-html) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-html.svg)](https://badge.fury.io/js/%40shopify%2Freact-html) |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Each package has its own `README` and documentation describing usage.
 | koa-shopify-graphql-proxy | [directory](packages/koa-shopify-graphql-proxy) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy) |
 | logger | [directory](packages/logger) | [![npm version](https://badge.fury.io/js/%40shopify%2Flogger.svg)](https://badge.fury.io/js/%40shopify%2Flogger) |
 | react-compose | [directory](packages/react-compose) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-compose.svg)](https://badge.fury.io/js/%40shopify%2Freact-compose) |
-| react-effect | [directory](packages/react-effect) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
+| react-effect | [directory](packages/react-effect) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect) |
 | react-form-state | [directory](packages/react-form-state) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
 | react-google-analytics | [directory](packages/react-google-analytics) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg)](https://badge.fury.io/js/%40shopify%2Freact-google-analytics) |
 | react-html | [directory](packages/react-html) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-html.svg)](https://badge.fury.io/js/%40shopify%2Freact-html) |

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "jest --maxWorkers=3",
     "check": "lerna run check",
     "release": "lerna publish && git push --follow-tags",
-    "clean": "rimraf './packages/**/*.{js,d.ts}'",
+    "clean": "rimraf './packages/*/dist/**/*.{js,d.ts}'",
     "generate": "yarn plop"
   },
   "repository": {

--- a/packages/react-effect/CHANGELOG.md
+++ b/packages/react-effect/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/react-effect` package

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -1,0 +1,121 @@
+# `@shopify/react-effect`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-effect.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-effect.svg)
+
+A component and set of utilities for performing effects within a universal React app. This package gives you the tools you need to extract details from an application during server rendering using only a single pass.
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-effect
+```
+
+## Usage
+
+### `<Effect />`
+
+This package is largely built around a component, `Effect`. To set up an action to be performed, use the `perform` prop:
+
+```ts
+import {Effect} from '@shopify/react-effect';
+
+export default function MyComponent() {
+  return <Effect perform={() => console.log('Doing something!')} />;
+}
+```
+
+By default, this callback will run in two ways:
+
+- On the client, during `componentDidMount`
+- On the server, when called using the [`extract`](#extract) function documented below
+
+This callback can return anything, but returning a promise has a special effect: it will be waited for on the server when calling `extract()`.
+
+This component accepts three additional optional properties:
+
+- `kind`: a symbol detailing the "category" of the effect. This will be used to optionally skip some categories when calling `extract()`
+- `clientOnly`: will only call the effect in `componentDidMount`, not when extracting on the server
+- `serverOnly`: will only call the effect during extraction, not in `componentDidMount`
+
+This component also accepts children which are rendered as-is.
+
+### `extract()`
+
+You can call `extract()` on a React tree in order to perform all of the effects within that tree. This function uses the [`react-tree-walker`](https://github.com/ctrlplusb/react-tree-walker) package to perform the tree walk, which creates some implications for the return value of your `perform` actions:
+
+- Returning a promise will wait on the promise before processing the rest of the tree
+- Returning `false` will prevent the rest of the tree from being processed
+
+This function returns a promise that resolves when the tree has been fully processed.
+
+```ts
+import {renderToString} from 'react-dom/server';
+import {extract} from '@shopify/react-effect/server';
+
+async function app(ctx) {
+  const app = <App />;
+  await extract(app);
+  ctx.body = renderToString(app);
+}
+```
+
+You may optionally pass a second argument to this function: an array of symbols representing the categories to include in your processing of the tree (matching the `kind` prop on `Extract` components).
+
+### Custom extractable components
+
+Usually, the `Extract` component will do what you need, but you may occasionally need your own component to directly implement the "extractable" part. This can be the case when your component must do something in `extract` that ends up calling `setState`. In these cases, you can use two additional exports from this module, `METHOD_NAME` and the `Extractable` interface, to manually implement a method that will be called during extraction:
+
+```ts
+import {METHOD_NAME, Extractable} from '@shopify/react-effect';
+
+class MyComponent extends React.Component implements Extractable {
+  [METHOD_NAME]() {
+    this.setState({extracting: true});
+  }
+}
+```
+
+## Gotchas
+
+A common mistake is initializing a provider entirely within your application component, and setting some details on this provider during the extraction. There is nothing implicitly wrong with this, but it will usually not have the effect you are after. When you call `renderToString()` to actually generate your HTML, the app will be reinitialized, and all of the work you did in the extraction call will be lost. To avoid this, pass any "stateful" managers/ providers into your application:
+
+```ts
+class StatefulManager {}
+const {Provider, Consumer} = React.createContext();
+
+// bad
+export default function App() {
+  return (
+    <Provider value={new StatefulManager()}>
+      <Consumer>
+        {manager => <Effect perform={() => (manager.value = true)} />}
+      </Consumer>
+    </Provider>
+  );
+}
+
+const app = <App />;
+await extract(app);
+
+// All your work is lost now, because the components are reinitialized
+renderToString(app);
+
+// good
+export default function App({manager}) {
+  return (
+    <Provider value={manager}>
+      <Consumer>
+        {manager => <Effect perform={() => (manager.value = true)} />}
+      </Consumer>
+    </Provider>
+  );
+}
+
+const manager = new StatefulManager();
+const app = <App manager={manager} />;
+await extract(app);
+
+// All your work is preserved, because you passed in the same manager
+renderToString(app);
+```

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@shopify/react-effect",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A component and set of utilities for performing effects within a universal React app",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-effect/README.md",
+  "dependencies": {
+    "react-tree-walker": "^4.3.0"
+  },
+  "devDependencies": {
+    "typescript": "~3.0.1"
+  },
+  "files": [
+    "dist/*"
+  ],
+  "peerDependencies": {
+    "react": ">=16.0.0"
+  }
+}

--- a/packages/react-effect/server.d.ts
+++ b/packages/react-effect/server.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/server';

--- a/packages/react-effect/server.js
+++ b/packages/react-effect/server.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/server');

--- a/packages/react-effect/src/Effect.tsx
+++ b/packages/react-effect/src/Effect.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {METHOD_NAME, Extractable} from './extractable';
+
+interface Props {
+  kind?: symbol;
+  serverOnly?: boolean;
+  clientOnly?: boolean;
+  perform(): void;
+}
+
+export default class Effect extends React.PureComponent<Props>
+  implements Extractable {
+  componentDidMount() {
+    const {serverOnly} = this.props;
+    return this.perform(!serverOnly);
+  }
+
+  [METHOD_NAME](include: boolean | symbol[]) {
+    const {clientOnly} = this.props;
+    return this.perform(clientOnly ? false : include);
+  }
+
+  render() {
+    return this.props.children || null;
+  }
+
+  private perform(include: boolean | symbol[]) {
+    const {kind, perform} = this.props;
+
+    if (!include) {
+      return undefined;
+    }
+
+    if (include === true || (kind != null && include.includes(kind))) {
+      return perform();
+    }
+
+    return undefined;
+  }
+}

--- a/packages/react-effect/src/extractable.ts
+++ b/packages/react-effect/src/extractable.ts
@@ -1,0 +1,9 @@
+export const METHOD_NAME = Symbol('extract');
+
+export interface Extractable {
+  [METHOD_NAME](include: boolean | symbol[]): any;
+}
+
+export function isExtractable(instance: any): instance is Extractable {
+  return instance != null && typeof instance[METHOD_NAME] === 'function';
+}

--- a/packages/react-effect/src/index.ts
+++ b/packages/react-effect/src/index.ts
@@ -1,0 +1,2 @@
+export {default as Effect} from './Effect';
+export {Extractable, METHOD_NAME} from './extractable';

--- a/packages/react-effect/src/server.ts
+++ b/packages/react-effect/src/server.ts
@@ -1,0 +1,22 @@
+import {ReactElement} from 'react';
+import reactTreeWalker from 'react-tree-walker';
+import {isExtractable, METHOD_NAME} from './extractable';
+
+const defaultContext = {
+  reactExtractRunning: true,
+};
+
+export function extract(
+  app: ReactElement<any>,
+  include: symbol[] | boolean = true,
+) {
+  return reactTreeWalker(
+    app,
+    (_, instance) => {
+      return isExtractable(instance)
+        ? instance[METHOD_NAME](include)
+        : undefined;
+    },
+    {...defaultContext},
+  );
+}

--- a/packages/react-effect/src/test/Effect.test.tsx
+++ b/packages/react-effect/src/test/Effect.test.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+
+import Effect from '../Effect';
+import {METHOD_NAME} from '../extractable';
+
+describe('<Effect />', () => {
+  it('calls perform() on componentDidMount', () => {
+    const spy = jest.fn();
+    mount(<Effect clientOnly perform={spy} />);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('does not call perform() on componentDidMount for serverOnly', () => {
+    const spy = jest.fn();
+    mount(<Effect serverOnly perform={spy} />);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('calls perform() during extraction', () => {
+    const spy = jest.fn();
+    const effect = mount(<Effect serverOnly perform={spy} />);
+    simulateExtractCall(effect, true);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('does not call perform() during extraction for clientOnly', () => {
+    const spy = jest.fn();
+    const effect = mount(<Effect clientOnly perform={spy} />);
+    simulateExtractCall(effect);
+    // We still have the one for didMount
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call perform() when extraction passes false', () => {
+    const spy = jest.fn();
+    const effect = mount(<Effect serverOnly perform={spy} />);
+    simulateExtractCall(effect, false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not call perform() when extraction passes a an array of symbols to include and there is no kind on the effect', () => {
+    const kind = Symbol('kind');
+    const spy = jest.fn();
+    const effect = mount(<Effect serverOnly perform={spy} />);
+    simulateExtractCall(effect, [kind]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not call perform() when extraction passes a non-matching array of symbols to include', () => {
+    const kind = Symbol('kind');
+    const include = Symbol('include');
+    const spy = jest.fn();
+    const effect = mount(<Effect serverOnly kind={kind} perform={spy} />);
+    simulateExtractCall(effect, [include]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('calls perform() when extraction passes a matching array of symbols to include', () => {
+    const kind = Symbol('kind');
+    const spy = jest.fn();
+    const effect = mount(<Effect serverOnly kind={kind} perform={spy} />);
+    simulateExtractCall(effect, [kind]);
+    expect(spy).toHaveBeenCalled();
+  });
+});
+
+function simulateExtractCall(
+  tree: ReturnType<typeof mount>,
+  argument: boolean | symbol[] = true,
+) {
+  (tree.instance() as Effect)[METHOD_NAME](argument);
+}

--- a/packages/react-effect/src/test/Effect.test.tsx
+++ b/packages/react-effect/src/test/Effect.test.tsx
@@ -39,7 +39,7 @@ describe('<Effect />', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('does not call perform() when extraction passes a an array of symbols to include and there is no kind on the effect', () => {
+  it('does not call perform() when extraction passes an array of symbols to include and there is no kind on the effect', () => {
     const kind = Symbol('kind');
     const spy = jest.fn();
     const effect = mount(<Effect serverOnly perform={spy} />);

--- a/packages/react-effect/src/test/server.test.tsx
+++ b/packages/react-effect/src/test/server.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import {extract} from '../server';
+import {METHOD_NAME, Extractable} from '../extractable';
+
+describe('extract()', () => {
+  it('calls the extraction method with true by default', async () => {
+    const spy = jest.fn();
+    const Component = createComponent(spy);
+    await extract(<Component />);
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('calls the extraction method with an array of symbols', async () => {
+    const spy = jest.fn();
+    const include = [];
+    const Component = createComponent(spy);
+    await extract(<Component />, include);
+    expect(spy).toHaveBeenCalledWith(include);
+  });
+
+  it('waits on promises higher in the tree before calling the lower values', async () => {
+    const globalContext = {value: 0};
+    const spy = jest.fn();
+    const Component = createComponent(() => {
+      return Promise.resolve().then(() => {
+        spy(globalContext.value);
+        globalContext.value += 1;
+      });
+    });
+
+    await extract(
+      <Component>
+        <Component />
+      </Component>,
+    );
+
+    expect(spy).toHaveBeenLastCalledWith(1);
+    expect(globalContext).toHaveProperty('value', 2);
+  });
+});
+
+function createComponent(extract: Extractable[typeof METHOD_NAME]) {
+  return class ExtractableComponent
+    extends React.Component<{children?: React.ReactNode}>
+    implements Extractable {
+    [METHOD_NAME](include) {
+      extract(include);
+    }
+
+    render() {
+      return this.props.children || <div />;
+    }
+  };
+}

--- a/packages/react-effect/tsconfig.build.json
+++ b/packages/react-effect/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6322,6 +6322,16 @@ react-tree-walker@^4.3.0:
   resolved "https://registry.yarnpkg.com/react-tree-walker/-/react-tree-walker-4.3.0.tgz#b7cae498cebb490281e9e99a01bdb9c6b4926cd3"
   integrity sha512-sO/pk+JQ2mbtPGdlKbeeo2aT4qXl5nPkGVO96yYQOdX9jYvRNXSnMWIydniLVEoiPvUbpfoc057blGbAQgMBRg==
 
+react@>=16.0.0:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
+  integrity sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.11.2"
+
 react@^16.2.0:
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.3.0.tgz#fc5a01c68f91e9b38e92cf83f7b795ebdca8ddff"
@@ -6753,6 +6763,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+  integrity sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 "semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
This PR adds a new library, `@shopify/react-effect`. This library will be our way of having a single pass for all things that involve extracting some details from the server. I have a few libraries that can depend on this to make serialization and CSP stuff nicer, and we can also update our react-i18n library to use this same thing in order to reduce additional tree passes.