### PR TITLE
fix koa-shopify-graphql-proxy for requests outisde of graphql endpoint

### DIFF
--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -21,13 +21,13 @@ export default function shopifyGraphQLProxy(proxyOptions?: ProxyOptions) {
       ? proxyOptions.password
       : session.accessToken;
 
-    if (accessToken == null || shop == null) {
-      ctx.throw(403, 'Unauthorized');
+    if (ctx.path !== PROXY_BASE_PATH || ctx.method !== 'POST') {
+      await next();
       return;
     }
 
-    if (ctx.path !== PROXY_BASE_PATH || ctx.method !== 'POST') {
-      await next();
+    if (accessToken == null || shop == null) {
+      ctx.throw(403, 'Unauthorized');
       return;
     }
 

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -85,6 +85,20 @@ describe('koa-shopify-graphql-proxy', () => {
     expect(proxyFactory).not.toBeCalled();
   });
 
+  it('bails and calls next if path does not start with the base url and no session', async () => {
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const ctx = createMockContext({
+      url: '/not/graphql',
+      throw: jest.fn(),
+    });
+    const nextSpy = jest.fn();
+
+    await koaShopifyGraphQLProxyMiddleware(ctx, nextSpy);
+
+    expect(nextSpy).toBeCalled();
+    expect(proxyFactory).not.toBeCalled();
+  });
+
   it('does not bail or throw when request is for the graphql api', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
     const ctx = createMockContext({


### PR DESCRIPTION
Currently this middleware throws a error on any request that doesn't have a session, which is making it incompatible with webhooks. This PR makes sure the check for the graphql endpoint is first.

cc: @katiedavis 