### PR TITLE
Allow keyboard shortcuts for alternate modifier combinations

### DIFF
--- a/packages/react-shortcuts/README.md
+++ b/packages/react-shortcuts/README.md
@@ -45,9 +45,9 @@ export interface Props {
   */
   ordered: Key[];
   /*
-    keys that need to be kept pressed along with `keys` to trigger `onMatch`
+    modifier keys that need to be kept pressed along with `keys` to trigger `onMatch`
   */
-  held?: ModifierKey[];
+  held?: HeldKey;
   /*
     a callback that will trigger when the key combination is pressed
   */
@@ -101,6 +101,30 @@ export default function MyComponent() {
         held={['Control', 'Shift']}
         ordered={['B']}
         onMatch={() => console.log('bar!')}
+      />
+    </div>
+  );
+}
+```
+
+You may also want to provide alternate groupings of `held` modifier keys. For example, “undo/redo” key combos are slightly different on Windows vs Mac OS. The below example will register `onMatch` if either `Control + z` or `Meta + z` is pressed simultaneously.
+
+> **Note**: `Meta` refers to the “Command” key on Mac keyboards.
+
+```ts
+// MyComponent.tsx
+
+import * as React from 'react';
+import {Shortcut} from '@shopify/react-shortcuts';
+
+export default function MyComponent() {
+  return (
+    <div>
+      {/* some app markup here */}
+      <Shortcut
+        held={[['Control'], ['Meta']]}
+        ordered={['z']}
+        onMatch={() => console.log('undo!')}
       />
     </div>
   );

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {Consumer, Context} from '../ShortcutProvider';
-import Key, {ModifierKey} from '../keys';
+import Key, {HeldKey} from '../keys';
 
 export interface Props {
   ordered: Key[];
-  held?: ModifierKey[];
+  held?: HeldKey;
   node?: HTMLElement | null;
   ignoreInput?: boolean;
-  onMatch(matched: {ordered: Key[]; held?: ModifierKey[]}): void;
+  onMatch(matched: {ordered: Key[]; held?: HeldKey}): void;
   allowDefault?: boolean;
 }
 
@@ -32,6 +32,7 @@ class ShortcutConsumer extends React.Component<Props & Context, never> {
     onMatch: this.props.onMatch,
     allowDefault: this.props.allowDefault || false,
   };
+
   public subscription!: Subscription;
 
   componentDidMount() {
@@ -42,9 +43,11 @@ class ShortcutConsumer extends React.Component<Props & Context, never> {
     }
 
     const {shortcutManager} = this.props;
+
     if (shortcutManager == null) {
       return;
     }
+
     this.subscription = shortcutManager.subscribe(this.data);
   }
 

--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -1,13 +1,13 @@
-import Key, {ModifierKey} from '../keys';
+import Key, {HeldKey, ModifierKey} from '../keys';
 
 const ON_MATCH_DELAY = 500;
 
 export interface Data {
   node: HTMLElement | null | undefined;
   ordered: Key[];
-  held?: ModifierKey[];
+  held?: HeldKey;
   ignoreInput: boolean;
-  onMatch(matched: {ordered: Key[]; held?: ModifierKey[]}): void;
+  onMatch(matched: {ordered: Key[]; held?: HeldKey}): void;
   allowDefault: boolean;
 }
 
@@ -61,6 +61,20 @@ export default class ShortcutManager {
     }
   };
 
+  private allModifiersAreHeld(heldKeys: HeldKey, event: KeyboardEvent) {
+    function hasKeyGroups(groups: HeldKey): groups is HeldKey {
+      return groups.every(key => Array.isArray(key));
+    }
+
+    function keyGroupIsHeld(keyGroup: ModifierKey[]) {
+      return keyGroup.every((key: ModifierKey) => event.getModifierState(key));
+    }
+
+    return hasKeyGroups(heldKeys)
+      ? heldKeys.some(keyGroupIsHeld)
+      : keyGroupIsHeld(heldKeys);
+  }
+
   private updateMatchingShortcuts(event: KeyboardEvent) {
     const shortcuts =
       this.shortcutsMatched.length > 0 ? this.shortcutsMatched : this.shortcuts;
@@ -71,7 +85,7 @@ export default class ShortcutManager {
           return false;
         }
 
-        if (held && !held.every(key => event.getModifierState(key))) {
+        if (held && !this.allModifiersAreHeld(held, event)) {
           return false;
         }
 
@@ -116,7 +130,8 @@ export default class ShortcutManager {
 
 function isFocusedInput() {
   const target = document.activeElement;
-  if (target.tagName == null) {
+
+  if (target == null || target.tagName == null) {
     return false;
   }
 

--- a/packages/react-shortcuts/src/index.ts
+++ b/packages/react-shortcuts/src/index.ts
@@ -13,6 +13,7 @@ export {
   AlphabetKey,
   NumericKey,
   ModifierKey,
+  HeldKey,
   WhiteSpaceKey,
   NavigationKey,
   EditingKey,

--- a/packages/react-shortcuts/src/keys.ts
+++ b/packages/react-shortcuts/src/keys.ts
@@ -103,6 +103,8 @@ export type ModifierKey =
   | 'Symbol'
   | 'SymbolLock';
 
+export type HeldKey = Array<ModifierKey | ModifierKey[]>;
+
 export type SymbolKey =
   | '~'
   | '`'


### PR DESCRIPTION
In the app I am building, I have a number of keyboard shortcuts I need to map to actions.

**To give a quick example:**
1. `undo` most recent change
2. `redo` most recent change

I need keyboard modifiers to accommodate both Mac and Windows users.

> **Note:** For those curious, `Meta` maps to the "Command" key.

**Undo**
Windows: `Control + z`
Mac: `Meta + z`

**This allows us to do:**

```
interface KeyboardShortcuts {
  held: HeldKey;
  ordered: Key[];
}

const UNDO_KEY_PROPS: KeyboardShortcuts = {
  held: [['Meta'], ['Control']],
  ordered: ['z'],
};

<Shortcut {...UNDO_KEY_PROPS} onMatch={this.handleUndo} />
```

The above code means I can execute the `Shortcut` by pressing either `Control + z` or `Meta + z`.

This proposed change would not break anything, as a single "modifier group" is still supported _(a single array vs a nested array)_.

The code I have committed so far does in fact work! But... I am encountering some TypeScript pains... so, I have not moved forward with writing any tests yet. Would love it if I could get some help figuring out the right way to author this code.