### PR TITLE
jest-dom-mocks: Improve typing of mediaQueryList

### DIFF
--- a/packages/jest-dom-mocks/src/match-media.ts
+++ b/packages/jest-dom-mocks/src/match-media.ts
@@ -54,7 +54,16 @@ function defaultMatcher(): MediaQueryList {
   return {media: '', addListener: noop, removeListener: noop, matches: false};
 }
 
-export function mediaQueryList(values: Partial<MediaQueryList>) {
+export function mediaQueryList(
+  values: Partial<MediaQueryList>,
+): MediaQueryList {
+  // Explictly state a return type as TypeScript does not attempt to shrink the
+  // type when using Object spread. Without the explicit return type TypeScript
+  // exports a type that exposes the internals of `MediaQueryList` (which
+  // changed in TS 3.1.0).
+  // This ensures that this function can be used in projects that use any
+  // version of Typescript instead of only <3.1.0 or >= 3.1.0 depending on the
+  // version that this library was compiled using.
   return {
     ...defaultMatcher(),
     ...values,


### PR DESCRIPTION
Typescript isn't smart enough to infer the typing of mediaQueryList when
using the spread operator.

Previously the typing was:

```
export declare function mediaQueryList(values: Partial<MediaQueryList>): {
    matches: boolean;
    media: string;
    addListener: (listener: MediaQueryListListener) => void;
    removeListener: (listener: MediaQueryListListener) => void;
};
```

~Using Object.assign gives mediaQueryList the better return typing of: `MediaQueryList & Partial<MediaQueryList>`~

EDIT! Forcing a return type gives a better return typing of `MediaQueryList`

This means that jest-dom-mocks can now be used in projects using
TypeScript >=3.1 as they no longer complain that
MediaQueryListListener does not exist (as [that type that was removed in 3.1](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#some-vendor-specific-types-are-removed-from-libdts)). This means I can remove [this daft workaround](https://github.com/Shopify/polaris-react/pull/700/files#diff-9ec8e71dffcfd96f8154dca63a9c0ac8) I encountered when updating polaris-react to use TypeScript 3.1