### PR TITLE
adds `importHelpers` and `tslib`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@types/enzyme": "^3.1.10",
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/jest": "^23.3.5",
-    "@types/react-helmet": "^5.0.6",
     "@types/react": "16.3.18",
+    "@types/react-helmet": "^5.0.6",
     "codecov": "^3.0.2",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
@@ -55,6 +55,7 @@
     "react-helmet": "^5.2.0",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.10.4",
+    "tslib": "^1.9.3",
     "typescript": "~3.0.1"
   },
   "resolutions": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "experimentalDecorators": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
+    "importHelpers": true,
     "lib": [
       "dom",
       "dom.iterable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7445,12 +7445,7 @@ ts-jest@^23.10.4:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@^1.7.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
-  integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
-
-tslib@^1.9.2:
+tslib@^1.7.1, tslib@^1.9.2, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
Closes https://github.com/Shopify/quilt/issues/385

Adding `importHelpers` and compiling with `tsLib` reduced the size of most bundles, and a few just stayed the same. See difference breakdown below.