### PR TITLE
🚨 fix inconsistent component state update

### DIFF
--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -199,7 +199,7 @@ export default class FormState<
 
   @bind()
   private reset() {
-    this.setState((state, props) => createFormState(props.initialValues));
+    this.setState((_state, props) => createFormState(props.initialValues));
   }
 
   @memoize()

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -199,7 +199,7 @@ export default class FormState<
 
   @bind()
   private reset() {
-    this.setState(createFormState(this.props.initialValues));
+    this.setState((state, props) => createFormState(props.initialValues));
   }
 
   @memoize()


### PR DESCRIPTION
Not sure if you accept these kinds of contributions, but thought i'd try in any case. This addresses a potential inconsistent state update.

React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

These were all found on LGTM.com, and there are [a few other alerts](https://lgtm.com/projects/g/Shopify/quilt/alerts) for this project too.

*(Full disclosure: I'm part of the team behind LGTM.com)*