### PR TITLE
✨ Disable all fields when form is submitting, add `disableOnSubmit`

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.8]
+
+## Added
+
+- The `disableOnSubmit` prop can be used to disable all fields while `onSubmit` is being called. [#435](https://github.com/Shopify/quilt/pull/435)
+
 ## [0.7.0] - 2019-01-11
 
 ### Added

--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -28,6 +28,7 @@ interface Props<Fields> {
   validators?: Partial<ValidatorDictionary<Fields>>;
   onSubmit?: SubmitHandler<Fields>;
   validateOnSubmit?: boolean;
+  disableOnSubmit?: boolean;
   children(form: FormDetails<Fields>): React.ReactNode;
 }
 ```

--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -398,6 +398,40 @@ function MyComponent() {
 
 To learn more about building validators, and the built in functions exposed by this package, check out the [validators guide](validators.md).
 
+### disableOnSubmit
+
+You can configure `<FormState />` to disable all fields in the form while executing `onSubmit` by passing it the `disableOnSubmit` prop.
+
+```typescript
+import {TextField, Form, Button} from '@shopify/polaris';
+import FormState, {validators} from '@shopify/react-form-state';
+
+function MyComponent() {
+  return (
+    <FormState
+      initialValues={{
+        title: 'Cool title',
+      }}
+      disableOnSubmit
+      onSubmit={() => {
+        console.log('I take a long time to run');
+      }}
+    >
+      {formDetails => {
+        const {fields, submit} = formDetails;
+
+        return (
+          <Form onSubmit={submit}>
+            <TextField label="Title" {...fields.title} />
+            <Button type="submit">Submit</Button>
+          </Form>
+        );
+      }}
+    </FormState>
+  );
+}
+```
+
 ## External errors
 
 You can use the `externalErrors` prop to supply `<FormState />` with external errors. This is useful for displaying errors that occur outside of the normal form submit flow. These errors will be available alongside regular errors via the `errors` array.
@@ -436,7 +470,6 @@ class MyComponent extends React.Component {
      </FormState>
    )
  }
-}
 ```
 
 ## Compound fields

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -20,23 +20,25 @@ export default class List<Fields> extends React.Component<
       field: {
         value: nextValue,
         error: nextError,
+        disabled: nextDisabled,
         initialValue: nextInitialValue,
       },
     } = nextProps;
     const {
-      field: {value, error, initialValue},
+      field: {value, error, disabled, initialValue},
     } = this.props;
 
     return (
       nextValue !== value ||
       nextError !== error ||
+      nextDisabled !== disabled ||
       nextInitialValue !== initialValue
     );
   }
 
   render() {
     const {
-      field: {value, initialValue, error, name, onBlur},
+      field: {value, initialValue, error, disabled, name, onBlur},
       getChildKey,
       children,
     } = this.props;
@@ -53,6 +55,7 @@ export default class List<Fields> extends React.Component<
             initialValue: initialFieldValue,
             dirty: value !== initialFieldValue,
             error: error && error[index] && error[index][fieldPath],
+            disabled,
             onChange: this.handleChange({index, key: fieldPath}),
           };
         },

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -19,23 +19,25 @@ export default class Nested<Fields> extends React.Component<
       field: {
         value: nextValue,
         error: nextError,
+        disabled: nextDisabled,
         initialValue: nextInitialValue,
       },
     } = nextProps;
     const {
-      field: {value, error, initialValue},
+      field: {value, error, disabled, initialValue},
     } = this.props;
 
     return (
       nextValue !== value ||
       nextError !== error ||
+      nextDisabled !== disabled ||
       nextInitialValue !== initialValue
     );
   }
 
   render() {
     const {
-      field: {name, value, onBlur, initialValue, error},
+      field: {name, value, onBlur, initialValue, error, disabled},
       children,
     } = this.props;
 
@@ -50,6 +52,7 @@ export default class Nested<Fields> extends React.Component<
           initialValue: initialFieldValue,
           dirty: value !== initialFieldValue,
           error: error && error[fieldPath],
+          disabled,
           onChange: this.handleChange(fieldPath),
         };
       },

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -204,6 +204,40 @@ describe('<FormState.List />', () => {
     });
   });
 
+  it('passes disabled down to inner fields', () => {
+    const products = [
+      {
+        title: faker.commerce.productName(),
+        department: faker.commerce.department(),
+      },
+      {
+        title: faker.commerce.productName(),
+        department: faker.commerce.department(),
+      },
+    ];
+
+    const field = {
+      name: 'products',
+      value: products,
+      initialValue: products,
+      onChange: jest.fn(),
+      onBlur: jest.fn(),
+      dirty: false,
+      changed: false,
+      disabled: true,
+    };
+
+    const renderSpy = jest.fn(() => null);
+    mount(<FormState.List field={field}>{renderSpy}</FormState.List>);
+
+    renderSpy.mock.calls.forEach(([fields]) => {
+      const {title, department} = fields;
+
+      expect(title.disabled).toBe(field.disabled);
+      expect(department.disabled).toBe(field.disabled);
+    });
+  });
+
   it('Does not have race condition with multiple onChange calls', () => {
     const products = [
       {

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -131,6 +131,32 @@ describe('<Nested />', () => {
     expect(renderPropArgs.department.error).toBe(field.error.department);
   });
 
+  it('passes disabled down to inner fields', () => {
+    const product = {
+      title: faker.commerce.productName(),
+      department: faker.commerce.department(),
+    };
+
+    const field = {
+      name: 'product',
+      value: product,
+      initialValue: product,
+      onChange: jest.fn(),
+      onBlur: jest.fn(),
+      dirty: false,
+      changed: false,
+      disabled: true,
+    };
+
+    const renderSpy = jest.fn(() => null);
+    mount(<FormState.Nested field={field}>{renderSpy}</FormState.Nested>);
+
+    const renderPropArgs = lastCallArgs(renderSpy);
+
+    expect(renderPropArgs.title.disabled).toBe(field.disabled);
+    expect(renderPropArgs.department.disabled).toBe(field.disabled);
+  });
+
   it('Does not have race condition with multiple onChange calls', () => {
     const product = {
       title: faker.commerce.productName(),

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -1273,6 +1273,133 @@ describe('<FormState />', () => {
     });
   });
 
+  describe('disableOnSubmit', () => {
+    it('propagates disabled to fields when form is submitting and disableOnSubmit is true', () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          onSubmit={onSubmit}
+          disableOnSubmit
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      submit();
+
+      const {fields: beforeSubmitFields} = lastCallArgs(renderPropSpy);
+      expect(beforeSubmitFields.product.disabled).toBeTruthy();
+    });
+
+    it('clears disabled from fields when form submit is complete and disableOnSubmit is true', async () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          onSubmit={onSubmit}
+          disableOnSubmit
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      await submit();
+
+      const {fields: afterSubmitFields} = lastCallArgs(renderPropSpy);
+      expect(afterSubmitFields.product.disabled).toBeUndefined();
+    });
+
+    it('clears disabled from fields when form submit is complete with errors and disableOnSubmit is true', async () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          onSubmit={onSubmit}
+          disableOnSubmit
+          validateOnSubmit
+          validators={{
+            product() {
+              return 'product bad';
+            },
+          }}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      await submit();
+
+      const {fields: afterSubmitFields} = lastCallArgs(renderPropSpy);
+      expect(afterSubmitFields.product.disabled).toBeUndefined();
+    });
+
+    it('does not call propogate disabled to fields when form is submitting and disableOnSubmit is false', () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          onSubmit={onSubmit}
+          disableOnSubmit={false}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      submit();
+
+      const {fields: beforeSubmitFields} = lastCallArgs(renderPropSpy);
+      expect(beforeSubmitFields.product.disabled).toBeUndefined();
+    });
+
+    it('does not call propogate disabled to fields when form is submitting and disableOnSubmit is undefined', () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      function onSubmit() {
+        return Promise.resolve();
+      }
+
+      mount(
+        <FormState
+          initialValues={{product: faker.commerce.productName()}}
+          onSubmit={onSubmit}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      submit();
+
+      const {fields: beforeSubmitFields} = lastCallArgs(renderPropSpy);
+      expect(beforeSubmitFields.product.disabled).toBeUndefined();
+    });
+  });
+
   describe('validateForm', () => {
     it('calls all validators', () => {
       const productValidatorSpy = jest.fn();

--- a/packages/react-form-state/src/types.ts
+++ b/packages/react-form-state/src/types.ts
@@ -4,6 +4,7 @@ export interface FieldState<Value> {
   value: Value;
   dirty: boolean;
   changed: boolean;
+  disabled?: boolean;
   error?: any;
 }
 


### PR DESCRIPTION
Part of this Hack Days project: https://hackdays.shopify.io/projects/11630

This PR adds the `disableOnSubmit` prop to `<FormState>`. This prop allows you disable all your fields while submission is happening and prevent users from accidentally editing fields further.

Rational around this... when the form submission is taking time, users can make changes to fields. This leads to two different problems: 

1. there's ambiguity around which value was actually persisted
2. the dirty flag will not get reset after submission

As a best practice, we're proposing form fields should be disabled. As a breaking change this could be default behaviour in the future but for now we're introducing it as an opt-in prop.

Lastly, this maps 1-to-1 with Polaris form components props so developers don't have to keep track of disabling fields themselves.

![kapture 2018-12-07 at 15 20 35](https://user-images.githubusercontent.com/5184848/49670771-bf9fd800-fa33-11e8-977d-0303163bc80b.gif)

🎩 instructions
clone branch
yarn install && yarn build
cd packages/react-form-state
yarn link
go to your own project
yarn link @shopify/react-form-state
try it out :)

cc @atesgoral 