### PR TITLE
Support consolidated manifest

### DIFF
--- a/config/typescript/modules.d.ts
+++ b/config/typescript/modules.d.ts
@@ -29,3 +29,15 @@ declare module 'browser-unhandled-rejection' {
   const auto: Function;
   export {auto};
 }
+
+declare module 'browserslist-useragent' {
+  interface Options {
+    browsers?: any;
+    env?: string;
+    ignorePatch?: boolean;
+    ignoreMinor?: boolean;
+    allowHigherVersions?: boolean;
+  }
+
+  export function matchesUA(ua: string, options?: Options): boolean;
+}

--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The middleware now only supports the multi-client builds added in [version 0.68.0](https://github.com/Shopify/sewing-kit/pull/1096).
+
 ## 1.0.0
 
 Initial release

--- a/packages/sewing-kit-koa/package.json
+++ b/packages/sewing-kit-koa/package.json
@@ -24,9 +24,11 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/sewing-kit-koa/README.md",
   "dependencies": {
+    "@shopify/network": "^1.0.2",
     "@types/koa-mount": "^3.0.1",
     "@types/koa-static": "^4.0.0",
     "app-root-path": "^2.1.0",
+    "browserslist-useragent": "^2.0.1",
     "fs-extra": "^7.0.1",
     "koa-compose": "^4.1.0",
     "koa-mount": "^4.0.0",

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -1,5 +1,6 @@
 import {join} from 'path';
 import {readJson} from 'fs-extra';
+import {matchesUA} from 'browserslist-useragent';
 import appRoot from 'app-root-path';
 
 export interface Asset {
@@ -7,29 +8,40 @@ export interface Asset {
   integrity?: string;
 }
 
-interface Entrypoint {
+export interface Entrypoint {
   js: Asset[];
   css: Asset[];
 }
 
-interface AssetList {
+export interface Manifest {
   entrypoints: {[key: string]: Entrypoint};
 }
 
+export interface ConsolidatedManifestEntry {
+  name: string;
+  browsers?: string[];
+  manifest: Manifest;
+}
+
+export type ConsolidatedManifest = ConsolidatedManifestEntry[];
+
 interface Options {
   assetHost: string;
+  userAgent?: string;
 }
 
 export default class Assets {
   assetHost: string;
-  private resolvedAssetList?: AssetList;
+  userAgent?: string;
+  private resolvedManifest?: Manifest;
 
-  constructor({assetHost}: Options) {
+  constructor({assetHost, userAgent}: Options) {
     this.assetHost = assetHost;
+    this.userAgent = userAgent;
   }
 
   async scripts({name = 'main'} = {}) {
-    const {js} = getAssetsForEntrypoint(name, await this.getAssetList());
+    const {js} = getAssetsForEntrypoint(name, await this.getResolvedManifest());
 
     const scripts =
       // Sewing Kit does not currently include the vendor DLL in its asset
@@ -43,21 +55,61 @@ export default class Assets {
   }
 
   async styles({name = 'main'} = {}) {
-    const {css} = getAssetsForEntrypoint(name, await this.getAssetList());
+    const {css} = getAssetsForEntrypoint(
+      name,
+      await this.getResolvedManifest(),
+    );
     return css;
   }
 
-  private async getAssetList() {
-    if (this.resolvedAssetList) {
-      return this.resolvedAssetList;
+  private async getResolvedManifest() {
+    if (this.resolvedManifest) {
+      return this.resolvedManifest;
     }
 
-    this.resolvedAssetList = await loadConsolidatedManifest();
-    return this.resolvedAssetList;
+    const consolidatedManifest = await loadConsolidatedManifest();
+
+    if (consolidatedManifest.length === 0) {
+      throw new Error('No builds were found.');
+    }
+
+    const {userAgent} = this;
+
+    // We do the following to determine the correct manifest to use:
+    //
+    // 1. If there is no user agent, use the "last" manifest, which is the
+    // least restrictive set of browsers.
+    // 2. If there is only one manifest, use it, regardless of how well it
+    // matches the user agent.
+    // 3. If there is a user agent, find the first manifest where the
+    // browsers it was compiled for matches the user agent, or where there
+    // is no browser restriction on the bundle.
+    // 4. If no matching manifests are found, fall back to the last manifest.
+    if (userAgent == null) {
+      this.resolvedManifest =
+        consolidatedManifest[consolidatedManifest.length - 1].manifest;
+    } else if (consolidatedManifest.length === 1) {
+      this.resolvedManifest = consolidatedManifest[0].manifest;
+    } else {
+      this.resolvedManifest = (
+        consolidatedManifest.find(
+          ({browsers}) =>
+            browsers == null ||
+            matchesUA(userAgent, {
+              browsers,
+              ignoreMinor: true,
+              ignorePatch: true,
+              allowHigherVersions: true,
+            }),
+        ) || consolidatedManifest[consolidatedManifest.length - 1]
+      ).manifest;
+    }
+
+    return this.resolvedManifest;
   }
 }
 
-let consolidatedManifestPromise: Promise<AssetList> | null = null;
+let consolidatedManifestPromise: Promise<ConsolidatedManifest> | null = null;
 
 function loadConsolidatedManifest() {
   if (consolidatedManifestPromise) {
@@ -75,13 +127,17 @@ export function internalOnlyClearCache() {
   consolidatedManifestPromise = null;
 }
 
-function getAssetsForEntrypoint(name: string, {entrypoints}: AssetList) {
+function getAssetsForEntrypoint(name: string, {entrypoints}: Manifest) {
   if (!entrypoints.hasOwnProperty(name)) {
-    throw new Error(
-      `No entrypoints found with the name '${name}'. Available entrypoints: ${Object.keys(
-        entrypoints,
-      ).join(', ')}`,
-    );
+    const entries = Object.keys(entrypoints);
+    const guidance =
+      entries.length === 0
+        ? 'No entrypoints exist.'
+        : `No entrypoints found with the name '${name}'. Available entrypoints: ${entries.join(
+            ', ',
+          )}`;
+
+    throw new Error(guidance);
   }
 
   return entrypoints[name];

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -74,6 +74,8 @@ export default class Assets {
     }
 
     const {userAgent} = this;
+    const lastManifestEntry =
+      consolidatedManifest[consolidatedManifest.length - 1];
 
     // We do the following to determine the correct manifest to use:
     //
@@ -85,11 +87,8 @@ export default class Assets {
     // browsers it was compiled for matches the user agent, or where there
     // is no browser restriction on the bundle.
     // 4. If no matching manifests are found, fall back to the last manifest.
-    if (userAgent == null) {
-      this.resolvedManifest =
-        consolidatedManifest[consolidatedManifest.length - 1].manifest;
-    } else if (consolidatedManifest.length === 1) {
-      this.resolvedManifest = consolidatedManifest[0].manifest;
+    if (userAgent == null || consolidatedManifest.length === 1) {
+      this.resolvedManifest = lastManifestEntry.manifest;
     } else {
       this.resolvedManifest = (
         consolidatedManifest.find(
@@ -101,7 +100,7 @@ export default class Assets {
               ignorePatch: true,
               allowHigherVersions: true,
             }),
-        ) || consolidatedManifest[consolidatedManifest.length - 1]
+        ) || lastManifestEntry
       ).manifest;
     }
 

--- a/packages/sewing-kit-koa/src/index.ts
+++ b/packages/sewing-kit-koa/src/index.ts
@@ -1,2 +1,2 @@
 export {default as Assets} from './assets';
-export {default as middleware} from './middleware';
+export {default as middleware, State} from './middleware';

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -5,6 +5,8 @@ import compose from 'koa-compose';
 import mount from 'koa-mount';
 import appRoot from 'app-root-path';
 
+import {Header} from '@shopify/network';
+
 import Assets, {Asset} from './assets';
 
 export {Assets, Asset};
@@ -25,6 +27,7 @@ export default function middleware({
   async function sewingKitMiddleware(ctx: Context, next: () => Promise<any>) {
     const assets = new Assets({
       assetHost,
+      userAgent: ctx.get(Header.UserAgent),
     });
     ctx.state.assets = assets;
     await next();

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -1,13 +1,17 @@
 import {join} from 'path';
 import withEnv from '@shopify/with-env';
 import appRoot from 'app-root-path';
-import Assets, {internalOnlyClearCache} from '../assets';
+import Assets, {
+  internalOnlyClearCache,
+  Asset,
+  Entrypoint,
+  ConsolidatedManifestEntry,
+  ConsolidatedManifest,
+} from '../assets';
 
 jest.mock('fs-extra', () => ({
   ...require.requireActual('fs-extra'),
-  readJson: jest.fn(() => ({
-    entrypoints: {},
-  })),
+  readJson: jest.fn(() => []),
 }));
 
 const {readJson} = require.requireMock('fs-extra');
@@ -17,7 +21,7 @@ describe('Assets', () => {
 
   beforeEach(() => {
     readJson.mockReset();
-    readJson.mockImplementation(() => createMockAssetList());
+    readJson.mockImplementation(() => createMockConsolidatedManifest());
   });
 
   afterEach(() => {
@@ -46,7 +50,15 @@ describe('Assets', () => {
       const js = '/style.js';
 
       readJson.mockImplementation(() =>
-        createMockAssetList({name: 'main', scripts: [js]}),
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                scripts: [createMockAsset(js)],
+              }),
+            }),
+          }),
+        ]),
       );
 
       const assets = new Assets(defaultOptions);
@@ -58,7 +70,15 @@ describe('Assets', () => {
       const js = '/style.js';
 
       readJson.mockImplementation(() =>
-        createMockAssetList({name: 'custom', scripts: [js]}),
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            manifest: createMockManifest({
+              custom: createMockEntrypoint({
+                scripts: [createMockAsset(js)],
+              }),
+            }),
+          }),
+        ]),
       );
 
       const assets = new Assets(defaultOptions);
@@ -78,7 +98,15 @@ describe('Assets', () => {
       const assetHost = '/sewing-kit-assets/';
 
       readJson.mockImplementation(() =>
-        createMockAssetList({name: 'custom', scripts: [js]}),
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            manifest: createMockManifest({
+              custom: createMockEntrypoint({
+                scripts: [createMockAsset(js)],
+              }),
+            }),
+          }),
+        ]),
       );
 
       const assets = new Assets({...defaultOptions, assetHost});
@@ -98,7 +126,15 @@ describe('Assets', () => {
       const css = '/style.css';
 
       readJson.mockImplementation(() =>
-        createMockAssetList({name: 'main', styles: [css]}),
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                styles: [createMockAsset(css)],
+              }),
+            }),
+          }),
+        ]),
       );
 
       const assets = new Assets(defaultOptions);
@@ -110,7 +146,15 @@ describe('Assets', () => {
       const css = '/style.css';
 
       readJson.mockImplementation(() =>
-        createMockAssetList({name: 'custom', styles: [css]}),
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            manifest: createMockManifest({
+              custom: createMockEntrypoint({
+                styles: [createMockAsset(css)],
+              }),
+            }),
+          }),
+        ]),
       );
 
       const assets = new Assets(defaultOptions);
@@ -125,27 +169,122 @@ describe('Assets', () => {
       ).rejects.toBeInstanceOf(Error);
     });
   });
+
+  describe('userAgent', () => {
+    const scriptOne = 'script-one.js';
+    const scriptTwo = 'script-two.js';
+    const chrome71 =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36';
+
+    it('uses the last manifest when no useragent exists', async () => {
+      readJson.mockImplementation(() =>
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                scripts: [createMockAsset(scriptOne)],
+              }),
+            }),
+          }),
+          createMockManifestEntry({
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                scripts: [createMockAsset(scriptTwo)],
+              }),
+            }),
+          }),
+        ]),
+      );
+
+      const assets = new Assets(defaultOptions);
+
+      expect(await assets.scripts()).toEqual([{path: scriptTwo}]);
+    });
+
+    it('uses the last manifest when no manifest matches', async () => {
+      readJson.mockImplementation(() =>
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            browsers: ['firefox > 1'],
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                scripts: [createMockAsset(scriptOne)],
+              }),
+            }),
+          }),
+          createMockManifestEntry({
+            browsers: ['safari > 1'],
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                scripts: [createMockAsset(scriptTwo)],
+              }),
+            }),
+          }),
+        ]),
+      );
+
+      const assets = new Assets({...defaultOptions, userAgent: chrome71});
+
+      expect(await assets.scripts()).toEqual([{path: scriptTwo}]);
+    });
+
+    it('uses the first matching manifest', async () => {
+      readJson.mockImplementation(() =>
+        createMockConsolidatedManifest([
+          createMockManifestEntry({
+            browsers: ['chrome > 60'],
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                scripts: [createMockAsset(scriptOne)],
+              }),
+            }),
+          }),
+          createMockManifestEntry({
+            browsers: ['chrome > 1'],
+            manifest: createMockManifest({
+              main: createMockEntrypoint({
+                scripts: [createMockAsset(scriptTwo)],
+              }),
+            }),
+          }),
+        ]),
+      );
+
+      const assets = new Assets({...defaultOptions, userAgent: chrome71});
+
+      expect(await assets.scripts()).toEqual([{path: scriptOne}]);
+    });
+  });
 });
 
-function createMockAssetList({
-  name = 'main',
-  styles = [],
+function createMockAsset(path: string): Asset {
+  return {path};
+}
+
+function createMockEntrypoint({
   scripts = [],
+  styles = [],
 }: {
-  name?: string;
-  styles?: string[];
-  scripts?: string[];
+  scripts?: Asset[];
+  styles?: Asset[];
 } = {}) {
-  return {
-    entrypoints: {
-      [name]: {
-        js: scripts.map(path => ({
-          path,
-        })),
-        css: styles.map(path => ({
-          path,
-        })),
-      },
-    },
-  };
+  return {js: scripts, css: styles};
+}
+
+function createMockManifest(entrypoints: {[key: string]: Entrypoint} = {}) {
+  return {entrypoints};
+}
+
+function createMockManifestEntry({
+  name = 'bundle',
+  browsers,
+  manifest = createMockManifest({main: createMockEntrypoint()}),
+}: Partial<ConsolidatedManifestEntry> = {}) {
+  return {name, browsers, manifest};
+}
+
+function createMockConsolidatedManifest(
+  manifests: ConsolidatedManifestEntry[] = [createMockManifestEntry()],
+): ConsolidatedManifest {
+  return manifests;
 }

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -21,7 +21,7 @@ describe('Assets', () => {
 
   beforeEach(() => {
     readJson.mockReset();
-    readJson.mockImplementation(() => createMockConsolidatedManifest());
+    readJson.mockImplementation(() => mockConsolidatedManifest());
   });
 
   afterEach(() => {
@@ -50,11 +50,11 @@ describe('Assets', () => {
       const js = '/style.js';
 
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                scripts: [createMockAsset(js)],
+        mockConsolidatedManifest([
+          mockManifestEntry({
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                scripts: [mockAsset(js)],
               }),
             }),
           }),
@@ -70,11 +70,11 @@ describe('Assets', () => {
       const js = '/style.js';
 
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
-            manifest: createMockManifest({
-              custom: createMockEntrypoint({
-                scripts: [createMockAsset(js)],
+        mockConsolidatedManifest([
+          mockManifestEntry({
+            manifest: mockManifest({
+              custom: mockEntrypoint({
+                scripts: [mockAsset(js)],
               }),
             }),
           }),
@@ -98,11 +98,11 @@ describe('Assets', () => {
       const assetHost = '/sewing-kit-assets/';
 
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
-            manifest: createMockManifest({
-              custom: createMockEntrypoint({
-                scripts: [createMockAsset(js)],
+        mockConsolidatedManifest([
+          mockManifestEntry({
+            manifest: mockManifest({
+              custom: mockEntrypoint({
+                scripts: [mockAsset(js)],
               }),
             }),
           }),
@@ -126,11 +126,11 @@ describe('Assets', () => {
       const css = '/style.css';
 
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                styles: [createMockAsset(css)],
+        mockConsolidatedManifest([
+          mockManifestEntry({
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                styles: [mockAsset(css)],
               }),
             }),
           }),
@@ -146,11 +146,11 @@ describe('Assets', () => {
       const css = '/style.css';
 
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
-            manifest: createMockManifest({
-              custom: createMockEntrypoint({
-                styles: [createMockAsset(css)],
+        mockConsolidatedManifest([
+          mockManifestEntry({
+            manifest: mockManifest({
+              custom: mockEntrypoint({
+                styles: [mockAsset(css)],
               }),
             }),
           }),
@@ -178,18 +178,18 @@ describe('Assets', () => {
 
     it('uses the last manifest when no useragent exists', async () => {
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                scripts: [createMockAsset(scriptOne)],
+        mockConsolidatedManifest([
+          mockManifestEntry({
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptOne)],
               }),
             }),
           }),
-          createMockManifestEntry({
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                scripts: [createMockAsset(scriptTwo)],
+          mockManifestEntry({
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptTwo)],
               }),
             }),
           }),
@@ -203,20 +203,20 @@ describe('Assets', () => {
 
     it('uses the last manifest when no manifest matches', async () => {
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
+        mockConsolidatedManifest([
+          mockManifestEntry({
             browsers: ['firefox > 1'],
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                scripts: [createMockAsset(scriptOne)],
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptOne)],
               }),
             }),
           }),
-          createMockManifestEntry({
+          mockManifestEntry({
             browsers: ['safari > 1'],
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                scripts: [createMockAsset(scriptTwo)],
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptTwo)],
               }),
             }),
           }),
@@ -230,20 +230,20 @@ describe('Assets', () => {
 
     it('uses the first matching manifest', async () => {
       readJson.mockImplementation(() =>
-        createMockConsolidatedManifest([
-          createMockManifestEntry({
+        mockConsolidatedManifest([
+          mockManifestEntry({
             browsers: ['chrome > 60'],
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                scripts: [createMockAsset(scriptOne)],
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptOne)],
               }),
             }),
           }),
-          createMockManifestEntry({
+          mockManifestEntry({
             browsers: ['chrome > 1'],
-            manifest: createMockManifest({
-              main: createMockEntrypoint({
-                scripts: [createMockAsset(scriptTwo)],
+            manifest: mockManifest({
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptTwo)],
               }),
             }),
           }),
@@ -257,11 +257,11 @@ describe('Assets', () => {
   });
 });
 
-function createMockAsset(path: string): Asset {
+function mockAsset(path: string): Asset {
   return {path};
 }
 
-function createMockEntrypoint({
+function mockEntrypoint({
   scripts = [],
   styles = [],
 }: {
@@ -271,20 +271,20 @@ function createMockEntrypoint({
   return {js: scripts, css: styles};
 }
 
-function createMockManifest(entrypoints: {[key: string]: Entrypoint} = {}) {
+function mockManifest(entrypoints: {[key: string]: Entrypoint} = {}) {
   return {entrypoints};
 }
 
-function createMockManifestEntry({
+function mockManifestEntry({
   name = 'bundle',
   browsers,
-  manifest = createMockManifest({main: createMockEntrypoint()}),
+  manifest = mockManifest({main: mockEntrypoint()}),
 }: Partial<ConsolidatedManifestEntry> = {}) {
   return {name, browsers, manifest};
 }
 
-function createMockConsolidatedManifest(
-  manifests: ConsolidatedManifestEntry[] = [createMockManifestEntry()],
+function mockConsolidatedManifest(
+  manifests: ConsolidatedManifestEntry[] = [mockManifestEntry()],
 ): ConsolidatedManifest {
   return manifests;
 }

--- a/packages/sewing-kit-koa/src/tests/middleware.test.ts
+++ b/packages/sewing-kit-koa/src/tests/middleware.test.ts
@@ -1,4 +1,5 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
+import {Header} from '@shopify/network';
 import middleware from '../middleware';
 import Assets from '../assets';
 
@@ -26,6 +27,17 @@ describe('middleware', () => {
     const context = createMockContext();
     await middleware({serveAssets: true})(context, () => Promise.resolve());
     expect(context.state.assets).toHaveProperty('assetHost', '/assets/');
+  });
+
+  it('passes the userAgent to the asset', async () => {
+    const userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36';
+    const context = createMockContext({
+      headers: {[Header.UserAgent]: userAgent},
+    });
+
+    await middleware({serveAssets: true})(context, () => Promise.resolve());
+    expect(context.state.assets).toHaveProperty('userAgent', userAgent);
   });
 
   it('calls the next middleware', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,15 @@ browser-unhandled-rejection@^1.0.2:
   resolved "https://registry.yarnpkg.com/browser-unhandled-rejection/-/browser-unhandled-rejection-1.0.2.tgz#b0091911a2fd12afa852cc80e2ab0abbae5a92c5"
   integrity sha512-WKtQ9zDqXEffcNbvcfhrL/g5N8EVcvUWNskhXAlpx6mBD/kxYFKSY6wVAw59gXIrgxYCLk571hhXyWltaNEZ0A==
 
+browserslist-useragent@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/browserslist-useragent/-/browserslist-useragent-2.0.1.tgz#ea5f706bc426c5fb2b5adf97cde7c1aed0864d0f"
+  integrity sha1-6l9wa8QmxfsrWt+XzefBrtCGTQ8=
+  dependencies:
+    browserslist "^4.0.1"
+    semver "^5.4.1"
+    useragent "^2.2.1"
+
 browserslist@^4.0.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.4.tgz#4477b737db6a1b07077275b24791e680d4300425"
@@ -1217,6 +1226,15 @@ browserslist@^4.0.0:
     caniuse-lite "^1.0.30000899"
     electron-to-chromium "^1.3.82"
     node-releases "^1.0.1"
+
+browserslist@^4.0.1:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.5.tgz#1a917678acc07b55606748ea1adf9846ea8920f7"
+  integrity sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==
+  dependencies:
+    caniuse-lite "^1.0.30000912"
+    electron-to-chromium "^1.3.86"
+    node-releases "^1.0.5"
 
 bs-logger@0.x:
   version "0.2.5"
@@ -1371,6 +1389,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000899:
   version "1.0.30000912"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000912.tgz#08e650d4090a9c0ab06bfd2b46b7d3ad6dcaea28"
   integrity sha512-M3zAtV36U+xw5mMROlTXpAHClmPAor6GPKAMD5Yi7glCB5sbMPFtnQ3rGpk4XqPdUrrTIaVYSJZxREZWNy8QJg==
+
+caniuse-lite@^1.0.30000912:
+  version "1.0.30000921"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000921.tgz#7a607c1623444b22351d834e093aedda3c42fbe8"
+  integrity sha512-Bu09ciy0lMWLgpYC77I0YGuI8eFRBPPzaSOYJK1jTI64txCphYCqnWbxJYjHABYVt/TYX/p3jNjLBR87u1Bfpw==
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2338,6 +2361,11 @@ electron-to-chromium@^1.3.82:
   version "1.3.85"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.85.tgz#5c46f790aa96445cabc57eb9d17346b1e46476fe"
   integrity sha512-kWSDVVF9t3mft2OHVZy4K85X2beP6c6mFm3teFS/mLSDJpQwuFIWHrULCX+w6H1E55ZYmFRlT+ATAFRwhrYzsw==
+
+electron-to-chromium@^1.3.86:
+  version "1.3.91"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.91.tgz#d74437a753b122aa6eca7c722055004d3627635d"
+  integrity sha512-wOWwM4vQpmb97VNkExnwE5e/sUMUb7NXurlEnhE89JOarUp6FOOMKjtTGgj9bmqskZkeRA7u+p0IztJ/y2OP5Q==
 
 emoji-regex@^6.1.0:
   version "6.5.1"
@@ -5288,6 +5316,14 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
+lru-cache@4.1.x:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
@@ -5718,6 +5754,13 @@ node-releases@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.4.tgz#2d585de8c6c81d00017e063e7810a63889aa6756"
   integrity sha512-GqRV9GcHw8JCRDaP/JoeNMNzEGzHAknMvIHqMb2VeTOmg1Cf9+ej8bkV12tHfzWHQMCkQ5zUFgwFUkfraynNCw==
+  dependencies:
+    semver "^5.3.0"
+
+node-releases@^1.0.5:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.1.tgz#8fff8aea1cfcad1fb4205f805149054fbf73cafd"
+  integrity sha512-2UXrBr6gvaebo5TNF84C66qyJJ6r0kxBObgZIDX3D3/mt1ADKiHux3NJPWisq0wxvJJdkjECH+9IIKYViKj71Q==
   dependencies:
     semver "^5.3.0"
 
@@ -7558,7 +7601,7 @@ title-case@^2.1.0:
     no-case "^2.2.0"
     upper-case "^1.0.3"
 
-tmp@^0.0.33:
+tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
@@ -7833,6 +7876,14 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
   integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
+
+useragent@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
+  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
+  dependencies:
+    lru-cache "4.1.x"
+    tmp "0.0.x"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Thus PR adds support to `sewing-kit-koa` for the new, multi-build client setup that I'm adding in https://github.com/Shopify/sewing-kit/pull/1096. It basically just accepts the user agent, compares it against the new `browsers` field alongside each manifest, and then chooses the right asset from that manifest. 