### PR TITLE
[polyfills] use full paths in imports

### DIFF
--- a/packages/polyfills/src/baseline.node.ts
+++ b/packages/polyfills/src/baseline.node.ts
@@ -1,4 +1,4 @@
 import '@babel/polyfill';
 
 // eslint-disable-next-line import/extensions
-import './fetch.node';
+import '@shopify/polyfills/fetch.node';

--- a/packages/polyfills/src/baseline.ts
+++ b/packages/polyfills/src/baseline.ts
@@ -1,6 +1,6 @@
 import '@babel/polyfill';
 import {auto as unhandledRejectionPolyfill} from 'browser-unhandled-rejection';
 
-import './fetch';
+import '@shopify/polyfills/fetch';
 
 unhandledRejectionPolyfill();


### PR DESCRIPTION
Resolution aliases still need to respect imports performed within the polyfills package itself. Here we use module paths inside the module to make sure that the aliasing is performed.