### PR TITLE
Content length zero 400 error fix

### DIFF
--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -33,7 +33,7 @@ export default function shopifyGraphQLProxy(proxyOptions?: ProxyOptions) {
 
     await proxy(shop, {
       https: true,
-      parseReqBody: false,
+      parseReqBody: true,
       // Setting request header here, not response. That's why we don't use ctx.set()
       // proxy middleware will grab this request header
       headers: {

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -138,7 +138,7 @@ describe('koa-shopify-graphql-proxy', () => {
         'X-Shopify-Access-Token': accessToken,
       },
       https: true,
-      parseReqBody: false,
+      parseReqBody: true,
     });
   });
 
@@ -167,7 +167,7 @@ describe('koa-shopify-graphql-proxy', () => {
         'X-Shopify-Access-Token': password,
       },
       https: true,
-      parseReqBody: false,
+      parseReqBody: true,
     });
   });
 


### PR DESCRIPTION
I found issue when testing the /graphql proxy as part of project for shopify-app

Starting 3-4 days Shopify backend always responds with 400 error and response
`
{"errors":{"query":"Required parameter missing or invalid"}}
`
when sending requests to proxy. Hunting for error I found that proxy code sends the headers with:
`
Content-Length: 0
`
as it informed to not parse the body.

GraphQL bodies are quite small so I suppose the parsing couldn't be a problem, as https://github.com/nsimmons/koa-better-http-proxy#parsereqbody advising use it for large payloads.

After change in generated JS code it started to work again.
