### PR TITLE
✨ better behaviour for <FormState /> initialValue changes

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,15 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- You can control how `<FormState />` reacts to changes in the initialValue prop using onInitialValueChanged.
+
 ## [0.5]
 
-## Added
+### Added
 
 - `<List />` supports `getChildKey` to provide custom `key`s for it's children. [#387](https://github.com/Shopify/quilt/pull/387)
 
 ## [0.4.1]
 
-## Fixed
+### Fixed
 
 - `<List />` no longer breaks on name generation.
 

--- a/packages/react-form-state/docs/FAQ.md
+++ b/packages/react-form-state/docs/FAQ.md
@@ -82,7 +82,7 @@ function MyForm() {
 You can control how `<FormState />` reacts to changes in the `initialValue` prop using `onInitialValueChanged`. This prop has three options:
 
 - (default) `reset-all`: Reset the entire form when `initialValues` changes.
-- `reset-changed`: Reset only the changed field objects when `initialValues` changes.
+- `reset-where-changed`: Reset only the changed field objects when `initialValues` changes.
 - `ignore`: Ignore changes to the `initialValues` prop. This option makes `<FormState />` behave like a [fully controlled component](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-controlled-component). You will generally want to accompany this option with a [`key`](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) or [`ref`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs).
 
 ## More questions

--- a/packages/react-form-state/docs/FAQ.md
+++ b/packages/react-form-state/docs/FAQ.md
@@ -17,7 +17,7 @@ As such the main difference in our solution is the explicit, declarative api. Fo
 
 ## I want to invoke all my validators whenever I want, how can I do this?
 
-You can do this by setting a `ref` on your `<FormState />`, and calling `validateForm` on the instance passed in.
+You can do this by setting a [`ref`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs) on your `<FormState />`, and calling `validateForm` on the instance passed in.
 
 ```typescript
 // use `createRef` and validate imperatively later
@@ -37,6 +37,53 @@ class MyComponent extends React.Component {
 ```
 
 If you need to do something immediately on mount you could also use old fashioned [callback refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs).
+
+## My form keeps resetting for no reason! / My form is resetting whenever I change an input!
+
+By default `<FormState />` resets whenever any value in your `initialValues` changes. If you are basing your initial values on existing state, this lets it update when your state changes (usually this would be the result of submitting).
+
+If this is happening on each rerender, it is likely that you are generating your `initialValues` in some way that is different each time. This can happen when you construct `Date` objects, `UUID`s, or other dynamic values inline. You can solve this by `memoize`ing your initial value creation or creating dates and other dynamic data only once outside of your component's `render` method.
+
+```typescript
+// Bad!
+function MyForm() {
+  return (
+    <FormState
+      initialValues={
+        publicationDate: new Date(),
+        text: '',
+      }
+    >
+    {({fields}) => /* markup*/ }
+    </FormState>
+  );
+}
+
+
+// Good!
+const today = new Date();
+
+function MyForm() {
+  return (
+    <FormState
+      initialValues={
+        publicationDate: today,
+        text: '',
+      }
+    >
+    {({fields}) => /* markup*/ }
+    </FormState>
+  );
+}
+```
+
+## Can I have more control over what happens when initialValues change?
+
+You can control how `<FormState />` reacts to changes in the `initialValue` prop using `onInitialValueChanged`. This prop has three options:
+
+- (default) `reset-all`: Reset the entire form when `initialValues` changes.
+- `reset-changed`: Reset only the changed field objects when `initialValues` changes.
+- `ignore`: Ignore changes to the `initialValues` prop. This option makes `<FormState />` behave like a [fully controlled component](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-controlled-component). You will generally want to accompany this option with a [`key`](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) or [`ref`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs).
 
 ## More questions
 


### PR DESCRIPTION
fixes #323 (hopefully, please let me know if this doesn't work for you)

## What this?
As seen in the issue above, `<FormState />`'s behaviour around resetting could be problematic for some usecases. To address this I've added a new prop.

You can now control how `<FormState />` reacts to changes in the `initialValue` prop using `onInitialValueChanged`. This prop has three options:

- (default) `reset-all`: Reset the entire form when `initialValues` changes.
- `reset-where-changed`: Reset only the changed field objects when `initialValues` changes.
- `ignore`: Ignore changes to the `initialValues` prop. This option makes `<FormState />` behave like a [fully controlled component](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-controlled-component). You will generally want to accompany this option with a [`key`](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) or [`ref`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs).

In adding this I had to make some calls around whether to reset errors / dirty state, and I tried to do the right thing. Let me know if it's bad.

I also ended up moving `formState#reset` into the public namespace like `validateForm` so that it can be used with `onInitialValueChanged: ignore` if preferred to using a `key`.

## Yeah but I want even more control
If there's a way we can make a simple api like this work for you I'd really rather do that. If it's really not doable, we can change this api to be 

```
onInitialValueChanged: 
| 'reset-all'
| 'reset-changed'
| 'ignore'
| typeof FormState.getDerivedStateFromProps
```

In which case the user would be able to do literally anything they wanted. I had suggested something similar (but scoped to controlling how a given key of fields is reconciled) in the issue, but I'd rather avoid the 'cooking with flamethrowers' approach if we can.

## Can I try?
Since the tophat script is still not merged and we don't have a playground yet, I made this sandbox: 

https://codesandbox.io/s/z77yjjvwp

It might be a little out of date around prop names because I've changed them a thousand times, but it should give you an idea how this looks.

## I think `reset-where-changed` should be the default
Same, but I want to do a relatively large 1.0+ bump sometime soon, so since that would be a pretty large breaking change lets see if that bears out and do it then :)
