### PR TITLE
[react-shortcuts] 🔥 Remove `Fn` and `FnLock`

### DIFF
--- a/packages/react-shortcuts/README.md
+++ b/packages/react-shortcuts/README.md
@@ -109,8 +109,6 @@ export default function MyComponent() {
 
 You may also want to provide alternate groupings of `held` modifier keys. For example, “undo/redo” key combos are slightly different on Windows vs Mac OS. The below example will register `onMatch` if either `Control + z` or `Meta + z` is pressed simultaneously.
 
-> **Note**: `Meta` refers to the “Command” key on Mac keyboards.
-
 ```ts
 // MyComponent.tsx
 
@@ -130,6 +128,11 @@ export default function MyComponent() {
   );
 }
 ```
+
+**Some Gotchas**
+
+1. `Meta` refers to the “Command” key on Mac keyboards.
+2. `Fn` and `FnLock` keys are not supported because they don't produce events, as mentioned in the [spec](https://w3c.github.io/uievents-key/#key-Fn)
 
 #### On a focused node
 

--- a/packages/react-shortcuts/src/keys.ts
+++ b/packages/react-shortcuts/src/keys.ts
@@ -92,8 +92,6 @@ export type ModifierKey =
   | 'AltGraph'
   | 'CapsLock'
   | 'Control'
-  | 'Fn'
-  | 'FnLock'
   | 'Hyper'
   | 'Meta'
   | 'NumLock'


### PR DESCRIPTION
#433 mentions that the `Fn` key does not generate events. This is expected, according to the spec [here](https://w3c.github.io/uievents-key/#key-Fn). This PR removes those keys from types, so no one uses them.

cc: @TheMallen @beefchimi 