### PR TITLE
[FormState] Adds externalErrors prop

### DIFF
--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -28,6 +28,7 @@ interface Props<Fields> {
   validators?: Partial<ValidatorDictionary<Fields>>;
   onSubmit?: SubmitHandler<Fields>;
   validateOnSubmit?: boolean;
+  externalErrors?: RemoteError[];
   children(form: FormDetails<Fields>): React.ReactNode;
 }
 ```

--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -398,6 +398,50 @@ function MyComponent() {
 
 To learn more about building validators, and the built in functions exposed by this package, check out the [validators guide](validators.md).
 
+## External errors
+
+You can use the `externalErrors` prop to supply `<FormState />` with external errors. This is useful for displaying errors that occur outside of the normal form submit flow. These errors will be available alongside regular errors via the `errors` array.
+
+```typescript
+class MyComponent extends React.Component {
+  state = {
+    externalErrors: [{message: 'Example error', field: 'foo'}]
+  }
+
+  render() {
+    const {externalErrors} = this.state;
+
+    return (
+      <FormState
+        initialValues={{foo: ''}}
+        externalErrors={externalErrors}
+        onSubmit={async (formDetails) => {
+          const response = await submitFormMutation(formDetails);
+
+           if (response.errors) {
+               // we still need to clear the errors ourselves because formstate
+              // doesn't know what they represent or when to clear them
+               this.setState({externalErrors: null});
+               return response.errors;
+           }
+        }}
+      >
+        {({fields, errors}) => {
+           return (
+             <Banner>
+              {/* the externalErrors get seamlessly added to the errors array */}
+               {errors.map(error => <li>{error.message}</li>)}
+             </Banner>
+               {/* and passed down to matching fields */}
+              <TextField {...fields.foo} />
+           )
+        }}
+      </FormState>
+    )
+  }
+}
+```
+
 ## Compound fields
 
 The default API for generating handlers with `<FormState />` is very simple, but real world apps are often very complex. You will often have to represent editing many resources with one form. This can mean needing support for arrays of fields, fields that are nested objects, or both. `<FormState />` allows passing these complex values into `initialValues` and having your own special sub-components that use the handlers, but for most cases it's recommended to use the sub-components `<FormState.List />` and `<FormState.Nested />`.

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -595,7 +595,7 @@ describe('<FormState />', () => {
       await submit();
 
       const {errors} = lastCallArgs(renderPropSpy);
-      expect(errors).toEqual(errors);
+      expect(errors).toEqual(submitErrors);
     });
 
     it('propagates submit errors down to fields when the field array matches', async () => {
@@ -969,6 +969,79 @@ describe('<FormState />', () => {
 
       expect(renderPropSpy).toHaveBeenCalledTimes(2);
       expect(onRenderSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('externalErrors', () => {
+    it('passes externalErrors to form when externalErrors are provided', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const externalErrors = [{message: faker.lorem.sentences()}];
+      mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName,
+          }}
+          externalErrors={externalErrors}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {errors} = lastCallArgs(renderPropSpy);
+
+      expect(errors).toEqual(externalErrors);
+    });
+
+    it('propagates external errors down to fields when the field array matches', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const externalErrors = [
+        {message: faker.lorem.sentences(), field: ['product']},
+      ];
+      mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName,
+          }}
+          externalErrors={externalErrors}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      expect(fields.product.error).toEqual(externalErrors[0].message);
+    });
+
+    it('returns both submit errors and external errors if submit returns an error', async () => {
+      const renderPropSpy = jest.fn(() => null);
+      const product = faker.commerce.productName();
+
+      const submitErrors = [
+        {message: faker.lorem.sentences()},
+        {message: faker.lorem.sentences()},
+      ];
+
+      const externalErrors = [{message: faker.lorem.sentences()}];
+
+      function onSubmit() {
+        return Promise.resolve(submitErrors);
+      }
+
+      mount(
+        <FormState
+          initialValues={{product}}
+          externalErrors={externalErrors}
+          onSubmit={onSubmit}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+      await submit();
+
+      const {errors} = lastCallArgs(renderPropSpy);
+      expect(errors).toEqual([...submitErrors, ...externalErrors]);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
This PR adds an `externalErrors` prop to `FormState`. This allows you to initialize the form with external errors. This API also enables the possibility of async errors.

### Example
Here's how you would initialize the form with external errors. Notice that external errors are merged with remote errors and are returned by the `errors` array.

External errors will also be passed down to corresponding fields if a field is specified. 

Form state will not manage your external errors, you will need to clear them yourself if necessary. 

```jsx
class MyComponent extends React.Component {
    state = {
        externalErrors: [{message: 'Example error', field: 'foo'}]
    }

  render() {
    const {externalErrors} = this.state;
    
    return (
      <FormState
        initialValues={{foo: ''}}
        externalErrors={externalErrors}
        onSubmit={async (formDetails) => {
          const response = await submitFormMutation(formDetails);
          
           if (response.errors) {
               // we still need to clear the errors ourselves because formstate 
              // doesn't know what they represent or when to clear them
               this.setState({externalErrors: null});
               return response.errors;
           }
        }}
      >
        {({fields, errors}) => {
           return (
             <Banner>
              {/* the externalErrors get seamlessly added to the errors array */}
               {errors.map(error => <li>{error.message}</li>)}
             </Banner>
               {/* and passed down to matching fields */}
              <TextField {...fields.foo} />
           )
        }}
      </FormState>
    )
  }
}
```

Here's how this API can enable async errors.

```jsx
class MyComponent extends React.Component {
    state = {
        externalErrors: []
    }

  render() {
    const {externalErrors} = this.state;
    
    return (
      <FormState
        initialValues={{foo: ''}}
        externalErrors={externalErrors}
        onSubmit={async (formDetails) => {
          const response = await submitFormMutation(formDetails);
          
           if (response.errors) {
               return response.errors;
           }
        }}
      >
        {({fields, errors}) => {
           return (
             <Banner>
               {errors.map(error => <li>{error.message}</li>)}
             </Banner>
              <TextField {...fields.foo} />
              {/* this would return the same type of error objects */}
               <RemoteValidation 
                   fields={fields} 
                   url={someUrl} 
                  onFail={(externalErrors) => this.setState({externalErrors}}
                />
           )
        }}
      </FormState>
    )
  }
}
```

### Cases that I've tried to consider
- Initializing form with external errors
- Mixing remote errors with external errors
- Updating external errors when remote errors are present

### Proof it works 😄
This screenshot shows a server error and an external error coexisting.
<img width="970" alt="screen shot 2019-01-02 at 4 46 18 pm" src="https://user-images.githubusercontent.com/4441303/50614203-00adcf80-0eae-11e9-8bf8-893ab05be829.png">
