### PR TITLE
Adds `DeepPartial` mapped type

### DIFF
--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -7,7 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [Unreleased]
+### Added
+
+- Added new `DeepPartial` type. ([#456](https://github.com/Shopify/quilt/pull/456))
 
 ## [1.0.0]
 

--- a/packages/useful-types/README.md
+++ b/packages/useful-types/README.md
@@ -60,3 +60,16 @@ The following type aliases are provided by this library:
   type MyComponentProps = Props<typeof MyComponent>; // {name: string}
   type MyOtherComponentProps = Props<typeof MyOtherComponent>; // {seconds: number}
   ```
+
+- `DeepPartial<T>`: Recusively maps over all properties in a type and transforms them to be optional. Useful when you need to make optional all of the properties (and nested properties) of an existing type.
+
+  ```ts
+  interface Obj {
+    foo: string;
+    bar: {
+      baz: boolean;
+    };
+  }
+
+  type DeepPartialObj = DeepPartial<Obj>; // {foo?: string; bar?: { baz?: boolean }}
+  ```

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -4,3 +4,10 @@ export type ThenType<T> = T extends Promise<infer U> ? U : T;
 export type FirstArgument<T> = T extends ((arg: infer U) => any) ? U : never;
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type Props<T> = T extends ComponentType<infer P> ? P : never;
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T[P] extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : DeepPartial<T[P]>
+};


### PR DESCRIPTION
The `Partial<T>` mapped type only applies to the first level of properties. 

This PR adds a `DeepPartial<T>` mapped type that recursively makes optional all properties in a given type.