### PR TITLE
[react-i18n] Removed MissingTimezoneError

### DIFF
--- a/packages/react-i18n/src/errors.ts
+++ b/packages/react-i18n/src/errors.ts
@@ -1,6 +1,5 @@
 export class MissingTranslationError extends Error {}
 export class MissingReplacementError extends Error {}
 export class MissingCurrencyCodeError extends Error {}
-export class MissingTimezoneError extends Error {}
 export class MissingCountryError extends Error {}
 export class InvalidI18nConnectionError extends Error {}

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -17,7 +17,6 @@ import {
 } from './constants';
 import {
   MissingCurrencyCodeError,
-  MissingTimezoneError,
   MissingCountryError,
 } from './errors';
 import {
@@ -163,12 +162,6 @@ export default class I18n {
     options?: Intl.DateTimeFormatOptions & {style?: DateStyle},
   ): string {
     const {locale, defaultTimezone: timezone} = this;
-
-    if (timezone == null && (options == null || options.timeZone == null)) {
-      throw new MissingTimezoneError(
-        `No timezone code provided. formatDate() cannot be called without a timezone.`,
-      );
-    }
 
     const {style = undefined, ...formatOptions} = options || {};
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -15,10 +15,7 @@ import {
   RTL_LANGUAGES,
   Weekdays,
 } from './constants';
-import {
-  MissingCurrencyCodeError,
-  MissingCountryError,
-} from './errors';
+import {MissingCurrencyCodeError, MissingCountryError} from './errors';
 import {
   getCurrencySymbol,
   translate,

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -389,11 +389,11 @@ describe('I18n', () => {
       expect(i18n.formatDate(date, options)).toBe(expected);
     });
 
-    it('throws an error when no timezone is given as the default or as an option', () => {
+    it('formats a date using Intl when no timezone is given as the default or as an option', () => {
+      const date = new Date();
       const i18n = new I18n(defaultTranslations, defaultDetails);
-      expect(() => i18n.formatDate(new Date())).toThrowError(
-        'No timezone code provided.',
-      );
+      const expected = new Intl.DateTimeFormat(defaultDetails.locale, {}).format(date);
+      expect(i18n.formatDate(date)).toBe(expected);
     });
 
     it('uses the Intl number formatter with the default timezone', () => {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -392,7 +392,10 @@ describe('I18n', () => {
     it('formats a date using Intl when no timezone is given as the default or as an option', () => {
       const date = new Date();
       const i18n = new I18n(defaultTranslations, defaultDetails);
-      const expected = new Intl.DateTimeFormat(defaultDetails.locale, {}).format(date);
+      const expected = new Intl.DateTimeFormat(
+        defaultDetails.locale,
+        {},
+      ).format(date);
       expect(i18n.formatDate(date)).toBe(expected);
     });
 


### PR DESCRIPTION
react-i18n formatDate required a timezone to be passed. 
Since `Intl` doesn't require a timezone to work the error was removed.