### PR TITLE
[Address] Rename province to zone

### DIFF
--- a/packages/address-mocks/src/fixtures/countries_en.ts
+++ b/packages/address-mocks/src/fixtures/countries_en.ts
@@ -14,7 +14,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Åland Islands',
@@ -29,7 +29,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Albania',
@@ -44,7 +44,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Algeria',
@@ -59,7 +59,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Andorra',
@@ -74,7 +74,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Angola',
@@ -89,7 +89,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Anguilla',
@@ -104,7 +104,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Antigua & Barbuda',
@@ -119,7 +119,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Argentina',
@@ -134,7 +134,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Buenos Aires',
             code: 'B',
@@ -246,7 +246,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Aruba',
@@ -261,7 +261,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Australia',
@@ -276,7 +276,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Australian Capital Territory',
             code: 'ACT',
@@ -324,7 +324,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Azerbaijan',
@@ -339,7 +339,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bahamas',
@@ -354,7 +354,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bahrain',
@@ -369,7 +369,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bangladesh',
@@ -384,7 +384,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address2}_{address1}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Barbados',
@@ -399,7 +399,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Belarus',
@@ -414,7 +414,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Belgium',
@@ -429,7 +429,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Belize',
@@ -444,7 +444,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Benin',
@@ -459,7 +459,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bermuda',
@@ -474,7 +474,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bhutan',
@@ -489,7 +489,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bolivia',
@@ -504,7 +504,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bosnia & Herzegovina',
@@ -519,7 +519,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Botswana',
@@ -534,7 +534,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bouvet Island',
@@ -549,7 +549,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Brazil',
@@ -564,7 +564,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Acre',
             code: 'AC',
@@ -688,7 +688,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'British Virgin Islands',
@@ -703,7 +703,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Brunei',
@@ -718,7 +718,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Bulgaria',
@@ -733,7 +733,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Burkina Faso',
@@ -748,7 +748,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Burundi',
@@ -763,7 +763,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Cambodia',
@@ -778,7 +778,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Cameroon',
@@ -793,7 +793,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Canada',
@@ -808,7 +808,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alberta',
             code: 'AB',
@@ -876,7 +876,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Caribbean Netherlands',
@@ -891,7 +891,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Cayman Islands',
@@ -906,7 +906,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Central African Republic',
@@ -921,7 +921,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Chad',
@@ -936,7 +936,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Chile',
@@ -951,7 +951,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'China',
@@ -966,7 +966,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Anhui',
             code: 'AH',
@@ -1106,7 +1106,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Cocos (Keeling) Islands',
@@ -1121,7 +1121,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Colombia',
@@ -1136,7 +1136,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Bogotá, D.C.',
             code: 'DC',
@@ -1284,7 +1284,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Congo - Brazzaville',
@@ -1299,7 +1299,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Congo - Kinshasa',
@@ -1314,7 +1314,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Cook Islands',
@@ -1329,7 +1329,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Costa Rica',
@@ -1344,7 +1344,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Croatia',
@@ -1359,7 +1359,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Cuba',
@@ -1374,7 +1374,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Curaçao',
@@ -1389,7 +1389,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Cyprus',
@@ -1404,7 +1404,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Czech Republic',
@@ -1419,7 +1419,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Côte d’Ivoire',
@@ -1434,7 +1434,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Denmark',
@@ -1449,7 +1449,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Djibouti',
@@ -1464,7 +1464,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Dominica',
@@ -1479,7 +1479,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Dominican Republic',
@@ -1494,7 +1494,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Ecuador',
@@ -1509,7 +1509,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Egypt',
@@ -1524,7 +1524,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: '6th of October',
             code: 'SU',
@@ -1656,7 +1656,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Equatorial Guinea',
@@ -1671,7 +1671,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Eritrea',
@@ -1686,7 +1686,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Estonia',
@@ -1701,7 +1701,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Ethiopia',
@@ -1716,7 +1716,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Falkland Islands',
@@ -1731,7 +1731,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Faroe Islands',
@@ -1746,7 +1746,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Fiji',
@@ -1761,7 +1761,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Finland',
@@ -1776,7 +1776,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'France',
@@ -1791,7 +1791,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'French Guiana',
@@ -1806,7 +1806,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'French Polynesia',
@@ -1821,7 +1821,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'French Southern Territories',
@@ -1836,7 +1836,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Gabon',
@@ -1851,7 +1851,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Gambia',
@@ -1866,7 +1866,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Georgia',
@@ -1881,7 +1881,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Germany',
@@ -1896,7 +1896,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Ghana',
@@ -1911,7 +1911,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Gibraltar',
@@ -1926,7 +1926,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Greece',
@@ -1941,7 +1941,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Greenland',
@@ -1956,7 +1956,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Grenada',
@@ -1971,7 +1971,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Guadeloupe',
@@ -1986,7 +1986,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Guatemala',
@@ -2001,7 +2001,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alta Verapaz',
             code: 'AVE',
@@ -2105,7 +2105,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Guinea',
@@ -2120,7 +2120,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Guinea-Bissau',
@@ -2135,7 +2135,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Guyana',
@@ -2150,7 +2150,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Haiti',
@@ -2165,7 +2165,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Heard & McDonald Islands',
@@ -2180,7 +2180,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Honduras',
@@ -2195,7 +2195,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Hong Kong SAR China',
@@ -2210,7 +2210,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address2}_{address1}_{city}_{country}{province}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Hong Kong Island',
             code: 'HK',
@@ -2238,7 +2238,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Iceland',
@@ -2253,7 +2253,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'India',
@@ -2268,7 +2268,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Andaman and Nicobar',
             code: 'AN',
@@ -2428,7 +2428,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Aceh',
             code: 'AC',
@@ -2580,7 +2580,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Iraq',
@@ -2595,7 +2595,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Ireland',
@@ -2610,7 +2610,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Carlow',
             code: 'CW',
@@ -2730,7 +2730,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Israel',
@@ -2745,7 +2745,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Italy',
@@ -2760,7 +2760,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Agrigento',
             code: 'AG',
@@ -3216,7 +3216,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Japan',
@@ -3231,7 +3231,7 @@ const data = {
           show:
             '{country}_〒{zip}{province}{city}{address1}{address2}_{company}_{lastName} {firstName}様_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Hokkaidō',
             code: 'JP-01',
@@ -3435,7 +3435,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Jordan',
@@ -3450,7 +3450,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Kazakhstan',
@@ -3465,7 +3465,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Kenya',
@@ -3480,7 +3480,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Kiribati',
@@ -3495,7 +3495,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Kosovo',
@@ -3510,7 +3510,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Kuwait',
@@ -3525,7 +3525,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Kyrgyzstan',
@@ -3540,7 +3540,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Laos',
@@ -3555,7 +3555,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Latvia',
@@ -3570,7 +3570,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Lebanon',
@@ -3585,7 +3585,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Lesotho',
@@ -3600,7 +3600,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Liberia',
@@ -3615,7 +3615,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Libya',
@@ -3630,7 +3630,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Liechtenstein',
@@ -3645,7 +3645,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Lithuania',
@@ -3660,7 +3660,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Luxembourg',
@@ -3675,7 +3675,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Macau SAR China',
@@ -3690,7 +3690,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Macedonia',
@@ -3705,7 +3705,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Madagascar',
@@ -3720,7 +3720,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Malawi',
@@ -3735,7 +3735,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Malaysia',
@@ -3750,7 +3750,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Johor',
             code: 'JHR',
@@ -3830,7 +3830,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Mali',
@@ -3845,7 +3845,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Malta',
@@ -3860,7 +3860,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Martinique',
@@ -3875,7 +3875,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Mauritania',
@@ -3890,7 +3890,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Mauritius',
@@ -3905,7 +3905,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Mayotte',
@@ -3920,7 +3920,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Mexico',
@@ -3935,7 +3935,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Aguascalientes',
             code: 'AGS',
@@ -4079,7 +4079,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Monaco',
@@ -4094,7 +4094,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Mongolia',
@@ -4109,7 +4109,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Montenegro',
@@ -4124,7 +4124,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Montserrat',
@@ -4139,7 +4139,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Morocco',
@@ -4154,7 +4154,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Mozambique',
@@ -4169,7 +4169,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Myanmar (Burma)',
@@ -4184,7 +4184,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Namibia',
@@ -4199,7 +4199,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Nauru',
@@ -4214,7 +4214,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Nepal',
@@ -4229,7 +4229,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Netherlands',
@@ -4244,7 +4244,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Netherlands Antilles',
@@ -4259,7 +4259,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'New Caledonia',
@@ -4274,7 +4274,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'New Zealand',
@@ -4289,7 +4289,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Auckland',
             code: 'AUK',
@@ -4369,7 +4369,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Niger',
@@ -4384,7 +4384,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Nigeria',
@@ -4399,7 +4399,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Abia',
             code: 'AB',
@@ -4563,7 +4563,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Norfolk Island',
@@ -4578,7 +4578,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'North Korea',
@@ -4593,7 +4593,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Norway',
@@ -4608,7 +4608,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Oman',
@@ -4623,7 +4623,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Pakistan',
@@ -4638,7 +4638,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Palestinian Territories',
@@ -4653,7 +4653,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Panama',
@@ -4668,7 +4668,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Bocas del Toro',
             code: 'PA-1',
@@ -4736,7 +4736,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Paraguay',
@@ -4751,7 +4751,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Peru',
@@ -4766,7 +4766,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {zip}_{province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Amazonas',
             code: 'PE-AMA',
@@ -4886,7 +4886,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Pitcairn Islands',
@@ -4901,7 +4901,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Poland',
@@ -4916,7 +4916,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Portugal',
@@ -4931,7 +4931,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city} {province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Açores',
             code: 'PT-20',
@@ -5027,7 +5027,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Réunion',
@@ -5042,7 +5042,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Romania',
@@ -5057,7 +5057,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alba',
             code: 'AB',
@@ -5241,7 +5241,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Altai Krai',
             code: 'ALT',
@@ -5585,7 +5585,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Saint Martin',
@@ -5600,7 +5600,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Samoa',
@@ -5615,7 +5615,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'San Marino',
@@ -5630,7 +5630,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'São Tomé & Príncipe',
@@ -5645,7 +5645,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Saudi Arabia',
@@ -5660,7 +5660,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Senegal',
@@ -5675,7 +5675,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Serbia',
@@ -5690,7 +5690,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Seychelles',
@@ -5705,7 +5705,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Sierra Leone',
@@ -5720,7 +5720,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Singapore',
@@ -5735,7 +5735,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Slovakia',
@@ -5750,7 +5750,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Slovenia',
@@ -5765,7 +5765,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Solomon Islands',
@@ -5780,7 +5780,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Somalia',
@@ -5795,7 +5795,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'South Africa',
@@ -5810,7 +5810,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Eastern Cape',
             code: 'EC',
@@ -5862,7 +5862,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'South Korea',
@@ -5877,7 +5877,7 @@ const data = {
           show:
             '{country}_{address1} {address2}_{zip}{province}{city}_{company}_{lastName}{firstName}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Busan',
             code: 'KR-26',
@@ -5961,7 +5961,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Spain',
@@ -5976,7 +5976,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'A Coruña',
             code: 'C',
@@ -6200,7 +6200,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'St. Barthélemy',
@@ -6215,7 +6215,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'St. Helena',
@@ -6230,7 +6230,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'St. Kitts & Nevis',
@@ -6245,7 +6245,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'St. Lucia',
@@ -6260,7 +6260,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'St. Martin',
@@ -6275,7 +6275,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'St. Pierre & Miquelon',
@@ -6290,7 +6290,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'St. Vincent & Grenadines',
@@ -6305,7 +6305,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Sudan',
@@ -6320,7 +6320,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Suriname',
@@ -6335,7 +6335,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Svalbard & Jan Mayen',
@@ -6350,7 +6350,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Swaziland',
@@ -6365,7 +6365,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Sweden',
@@ -6380,7 +6380,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Switzerland',
@@ -6395,7 +6395,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Syria',
@@ -6410,7 +6410,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Taiwan',
@@ -6425,7 +6425,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Tajikistan',
@@ -6440,7 +6440,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Tanzania',
@@ -6455,7 +6455,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Thailand',
@@ -6470,7 +6470,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Amnat Charoen',
             code: 'TH-37',
@@ -6798,7 +6798,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Togo',
@@ -6813,7 +6813,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Tokelau',
@@ -6828,7 +6828,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Tonga',
@@ -6843,7 +6843,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Trinidad & Tobago',
@@ -6858,7 +6858,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Tunisia',
@@ -6873,7 +6873,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Turkey',
@@ -6888,7 +6888,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Turkmenistan',
@@ -6903,7 +6903,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Turks & Caicos Islands',
@@ -6918,7 +6918,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Tuvalu',
@@ -6933,7 +6933,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'U.S. Outlying Islands',
@@ -6948,7 +6948,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Uganda',
@@ -6963,7 +6963,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Ukraine',
@@ -6978,7 +6978,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'United Arab Emirates',
@@ -6993,7 +6993,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Abu Dhabi',
             code: 'AZ',
@@ -7037,7 +7037,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'United States',
@@ -7052,7 +7052,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alabama',
             code: 'AL',
@@ -7316,7 +7316,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Uzbekistan',
@@ -7331,7 +7331,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Vanuatu',
@@ -7346,7 +7346,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Vatican City',
@@ -7361,7 +7361,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Venezuela',
@@ -7376,7 +7376,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Vietnam',
@@ -7391,7 +7391,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Wallis & Futuna',
@@ -7406,7 +7406,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Western Sahara',
@@ -7421,7 +7421,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Yemen',
@@ -7436,7 +7436,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Zambia',
@@ -7451,7 +7451,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'Zimbabwe',
@@ -7466,7 +7466,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
     ],
   },

--- a/packages/address-mocks/src/fixtures/countries_ja.ts
+++ b/packages/address-mocks/src/fixtures/countries_ja.ts
@@ -14,7 +14,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アイルランド',
@@ -29,7 +29,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Carlow',
             code: 'CW',
@@ -149,7 +149,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アフガニスタン',
@@ -164,7 +164,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アメリカ合衆国',
@@ -179,7 +179,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alabama',
             code: 'AL',
@@ -443,7 +443,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Abu Dhabi',
             code: 'AZ',
@@ -487,7 +487,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アルゼンチン',
@@ -502,7 +502,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Buenos Aires',
             code: 'B',
@@ -614,7 +614,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アルバニア',
@@ -629,7 +629,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アルメニア',
@@ -644,7 +644,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アンギラ',
@@ -659,7 +659,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アンゴラ',
@@ -674,7 +674,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アンティグア・バーブーダ',
@@ -689,7 +689,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'アンドラ',
@@ -704,7 +704,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'イエメン',
@@ -719,7 +719,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'イギリス',
@@ -734,7 +734,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'イスラエル',
@@ -749,7 +749,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'イタリア',
@@ -764,7 +764,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Agrigento',
             code: 'AG',
@@ -1220,7 +1220,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'イラン',
@@ -1235,7 +1235,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'インド',
@@ -1250,7 +1250,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Andaman and Nicobar',
             code: 'AN',
@@ -1410,7 +1410,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Aceh',
             code: 'AC',
@@ -1562,7 +1562,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ウガンダ',
@@ -1577,7 +1577,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ウクライナ',
@@ -1592,7 +1592,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ウズベキスタン',
@@ -1607,7 +1607,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ウルグアイ',
@@ -1622,7 +1622,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'エクアドル',
@@ -1637,7 +1637,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'エジプト',
@@ -1652,7 +1652,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: '6th of October',
             code: 'SU',
@@ -1784,7 +1784,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'エチオピア',
@@ -1799,7 +1799,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'エリトリア',
@@ -1814,7 +1814,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'エルサルバドル',
@@ -1829,7 +1829,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'オマーン',
@@ -1844,7 +1844,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'オランダ',
@@ -1859,7 +1859,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'オランダ領アンティル',
@@ -1874,7 +1874,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'オランダ領カリブ',
@@ -1889,7 +1889,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'オーストラリア',
@@ -1904,7 +1904,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Australian Capital Territory',
             code: 'ACT',
@@ -1952,7 +1952,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'オーランド諸島',
@@ -1967,7 +1967,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'カザフスタン',
@@ -1982,7 +1982,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'カタール',
@@ -1997,7 +1997,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'カナダ',
@@ -2012,7 +2012,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alberta',
             code: 'AB',
@@ -2080,7 +2080,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'カンボジア',
@@ -2095,7 +2095,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'カーボベルデ',
@@ -2110,7 +2110,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ガイアナ',
@@ -2125,7 +2125,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ガボン',
@@ -2140,7 +2140,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ガンビア',
@@ -2155,7 +2155,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ガーナ',
@@ -2170,7 +2170,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ガーンジー',
@@ -2185,7 +2185,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'キプロス',
@@ -2200,7 +2200,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'キュラソー',
@@ -2215,7 +2215,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'キューバ',
@@ -2230,7 +2230,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'キリバス',
@@ -2245,7 +2245,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'キルギス',
@@ -2260,7 +2260,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ギニア',
@@ -2275,7 +2275,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ギニアビサウ',
@@ -2290,7 +2290,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ギリシャ',
@@ -2305,7 +2305,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'クウェート',
@@ -2320,7 +2320,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'クック諸島',
@@ -2335,7 +2335,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'クリスマス島',
@@ -2350,7 +2350,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'クロアチア',
@@ -2365,7 +2365,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'グアテマラ',
@@ -2380,7 +2380,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alta Verapaz',
             code: 'AVE',
@@ -2484,7 +2484,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'グリーンランド',
@@ -2499,7 +2499,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'グルジア',
@@ -2514,7 +2514,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'グレナダ',
@@ -2529,7 +2529,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ケイマン諸島',
@@ -2544,7 +2544,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ケニア',
@@ -2559,7 +2559,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ココス(キーリング)諸島',
@@ -2574,7 +2574,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'コスタリカ',
@@ -2589,7 +2589,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'コソボ',
@@ -2604,7 +2604,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'コモロ',
@@ -2619,7 +2619,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'コロンビア',
@@ -2634,7 +2634,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Bogotá, D.C.',
             code: 'DC',
@@ -2782,7 +2782,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'コンゴ民主共和国(キンシャサ)',
@@ -2797,7 +2797,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'コートジボワール',
@@ -2812,7 +2812,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'サウジアラビア',
@@ -2827,7 +2827,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'サモア',
@@ -2842,7 +2842,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'サントメ・プリンシペ',
@@ -2857,7 +2857,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'サンピエール島・ミクロン島',
@@ -2872,7 +2872,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'サンマリノ',
@@ -2887,7 +2887,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'サン・バルテルミー島',
@@ -2902,7 +2902,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'サン・マルタン',
@@ -2917,7 +2917,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ザンビア',
@@ -2932,7 +2932,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'シエラレオネ',
@@ -2947,7 +2947,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'シリア',
@@ -2962,7 +2962,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'シンガポール',
@@ -2977,7 +2977,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'シント・マールテン',
@@ -2992,7 +2992,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ジブチ',
@@ -3007,7 +3007,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ジブラルタル',
@@ -3022,7 +3022,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ジャマイカ',
@@ -3037,7 +3037,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ジャージー',
@@ -3052,7 +3052,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ジンバブエ',
@@ -3067,7 +3067,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スイス',
@@ -3082,7 +3082,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スウェーデン',
@@ -3097,7 +3097,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スバールバル諸島・ヤンマイエン島',
@@ -3112,7 +3112,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スペイン',
@@ -3127,7 +3127,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'A Coruña',
             code: 'C',
@@ -3351,7 +3351,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スリランカ',
@@ -3366,7 +3366,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スロバキア',
@@ -3381,7 +3381,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スロベニア',
@@ -3396,7 +3396,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スワジランド',
@@ -3411,7 +3411,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'スーダン',
@@ -3426,7 +3426,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'セネガル',
@@ -3441,7 +3441,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'セルビア',
@@ -3456,7 +3456,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'セントクリストファー・ネイビス',
@@ -3471,7 +3471,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'セントビンセント・グレナディーン諸島',
@@ -3486,7 +3486,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'セントヘレナ',
@@ -3501,7 +3501,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'セントルシア',
@@ -3516,7 +3516,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'セーシェル',
@@ -3531,7 +3531,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ソマリア',
@@ -3546,7 +3546,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ソロモン諸島',
@@ -3561,7 +3561,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'タイ',
@@ -3576,7 +3576,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Amnat Charoen',
             code: 'TH-37',
@@ -3904,7 +3904,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'タンザニア',
@@ -3919,7 +3919,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'タークス・カイコス諸島',
@@ -3934,7 +3934,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'チェコ共和国',
@@ -3949,7 +3949,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'チャド',
@@ -3964,7 +3964,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'チュニジア',
@@ -3979,7 +3979,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'チリ',
@@ -3994,7 +3994,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ツバル',
@@ -4009,7 +4009,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'デンマーク',
@@ -4024,7 +4024,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'トケラウ',
@@ -4039,7 +4039,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'トリニダード・トバゴ',
@@ -4054,7 +4054,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'トルクメニスタン',
@@ -4069,7 +4069,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'トルコ',
@@ -4084,7 +4084,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'トンガ',
@@ -4099,7 +4099,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'トーゴ',
@@ -4114,7 +4114,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ドイツ',
@@ -4129,7 +4129,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ドミニカ共和国',
@@ -4144,7 +4144,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ドミニカ国',
@@ -4159,7 +4159,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ナイジェリア',
@@ -4174,7 +4174,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Abia',
             code: 'AB',
@@ -4338,7 +4338,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ナミビア',
@@ -4353,7 +4353,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ニウエ島',
@@ -4368,7 +4368,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ニカラグア',
@@ -4383,7 +4383,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ニジェール',
@@ -4398,7 +4398,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ニューカレドニア',
@@ -4413,7 +4413,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ニュージーランド',
@@ -4428,7 +4428,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Auckland',
             code: 'AUK',
@@ -4508,7 +4508,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ノルウェー',
@@ -4523,7 +4523,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ノーフォーク島',
@@ -4538,7 +4538,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ハイチ',
@@ -4553,7 +4553,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ハンガリー',
@@ -4568,7 +4568,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ハード島・マクドナルド諸島',
@@ -4583,7 +4583,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'バチカン市国',
@@ -4598,7 +4598,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'バヌアツ',
@@ -4613,7 +4613,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'バハマ',
@@ -4628,7 +4628,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'バミューダ',
@@ -4643,7 +4643,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'バルバドス',
@@ -4658,7 +4658,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'バングラデシュ',
@@ -4673,7 +4673,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address2}_{address1}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'バーレーン',
@@ -4688,7 +4688,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'パキスタン',
@@ -4703,7 +4703,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'パナマ',
@@ -4718,7 +4718,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Bocas del Toro',
             code: 'PA-1',
@@ -4786,7 +4786,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'パラグアイ',
@@ -4801,7 +4801,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'パレスチナ',
@@ -4816,7 +4816,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ピトケアン諸島',
@@ -4831,7 +4831,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'フィジー',
@@ -4846,7 +4846,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'フィリピン',
@@ -4861,7 +4861,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'フィンランド',
@@ -4876,7 +4876,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'フェロー諸島',
@@ -4891,7 +4891,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'フォークランド諸島',
@@ -4906,7 +4906,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'フランス',
@@ -4921,7 +4921,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ブラジル',
@@ -4936,7 +4936,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Acre',
             code: 'AC',
@@ -5060,7 +5060,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ブルキナファソ',
@@ -5075,7 +5075,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ブルネイ',
@@ -5090,7 +5090,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ブルンジ',
@@ -5105,7 +5105,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ブータン',
@@ -5120,7 +5120,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ブーベ島',
@@ -5135,7 +5135,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ベトナム',
@@ -5150,7 +5150,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ベナン',
@@ -5165,7 +5165,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ベネズエラ',
@@ -5180,7 +5180,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ベラルーシ',
@@ -5195,7 +5195,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ベリーズ',
@@ -5210,7 +5210,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ベルギー',
@@ -5225,7 +5225,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ペルー',
@@ -5240,7 +5240,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {zip}_{province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Amazonas',
             code: 'PE-AMA',
@@ -5360,7 +5360,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ボスニア・ヘルツェゴビナ',
@@ -5375,7 +5375,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ボツワナ',
@@ -5390,7 +5390,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ボリビア',
@@ -5405,7 +5405,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ポルトガル',
@@ -5420,7 +5420,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city} {province}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Açores',
             code: 'PT-20',
@@ -5516,7 +5516,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{zip} {city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マケドニア',
@@ -5531,7 +5531,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マダガスカル',
@@ -5546,7 +5546,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マヨット島',
@@ -5561,7 +5561,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マラウイ',
@@ -5576,7 +5576,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マリ',
@@ -5591,7 +5591,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マルタ',
@@ -5606,7 +5606,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マルティニーク',
@@ -5621,7 +5621,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'マレーシア',
@@ -5636,7 +5636,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Johor',
             code: 'JHR',
@@ -5716,7 +5716,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ミャンマー',
@@ -5731,7 +5731,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'メキシコ',
@@ -5746,7 +5746,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Aguascalientes',
             code: 'AGS',
@@ -5890,7 +5890,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モナコ',
@@ -5905,7 +5905,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モルディブ',
@@ -5920,7 +5920,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モルドバ',
@@ -5935,7 +5935,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モロッコ',
@@ -5950,7 +5950,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モンゴル',
@@ -5965,7 +5965,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モンテネグロ',
@@ -5980,7 +5980,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モントセラト',
@@ -5995,7 +5995,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モーリシャス',
@@ -6010,7 +6010,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{zip}_{city}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'モーリタニア',
@@ -6025,7 +6025,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ヨルダン',
@@ -6040,7 +6040,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ラオス',
@@ -6055,7 +6055,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ラトビア',
@@ -6070,7 +6070,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'リトアニア',
@@ -6085,7 +6085,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'リヒテンシュタイン',
@@ -6100,7 +6100,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'リビア',
@@ -6115,7 +6115,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'リベリア',
@@ -6130,7 +6130,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ルクセンブルグ',
@@ -6145,7 +6145,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ルワンダ',
@@ -6160,7 +6160,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ルーマニア',
@@ -6175,7 +6175,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Alba',
             code: 'AB',
@@ -6359,7 +6359,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'レバノン',
@@ -6374,7 +6374,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'レユニオン島',
@@ -6389,7 +6389,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: 'ロシア',
@@ -6404,7 +6404,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Altai Krai',
             code: 'ALT',
@@ -6748,7 +6748,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Anhui',
             code: 'AH',
@@ -6888,7 +6888,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '中華人民共和国マカオ特別行政区',
@@ -6903,7 +6903,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '中華人民共和国香港特別行政区',
@@ -6918,7 +6918,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address2}_{address1}_{city}_{country}{province}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Hong Kong Island',
             code: 'HK',
@@ -6946,7 +6946,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '仏領ポリネシア',
@@ -6961,7 +6961,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '仏領極南諸島',
@@ -6976,7 +6976,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '南アフリカ',
@@ -6991,7 +6991,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Eastern Cape',
             code: 'EC',
@@ -7043,7 +7043,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '南スーダン',
@@ -7058,7 +7058,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '台湾',
@@ -7073,7 +7073,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '大韓民国',
@@ -7088,7 +7088,7 @@ const data = {
           show:
             '{country}_{address1} {address2}_{zip}{province}{city}_{company}_{lastName}{firstName}_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: 'Busan',
             code: 'KR-26',
@@ -7172,7 +7172,7 @@ const data = {
           show:
             '{country}_〒{zip}{province}{city}{address1}{address2}_{company}_{lastName} {firstName}様_{phone}',
         },
-        provinces: [
+        zones: [
           {
             name: '北海道',
             code: 'JP-01',
@@ -7376,7 +7376,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '東ティモール',
@@ -7391,7 +7391,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '米領太平洋諸島',
@@ -7406,7 +7406,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '英領インド洋地域',
@@ -7421,7 +7421,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '英領ヴァージン諸島',
@@ -7436,7 +7436,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '西サハラ',
@@ -7451,7 +7451,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
       {
         name: '赤道ギニア',
@@ -7466,7 +7466,7 @@ const data = {
           show:
             '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
         },
-        provinces: [],
+        zones: [],
       },
     ],
   },

--- a/packages/address-mocks/src/fixtures/country_ca_en.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_en.ts
@@ -13,7 +13,7 @@ const data = {
         show:
           '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
       },
-      provinces: [
+      zones: [
         {
           name: 'Alberta',
           code: 'AB',

--- a/packages/address-mocks/src/fixtures/country_ca_fr.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_fr.ts
@@ -13,7 +13,7 @@ const data = {
         show:
           '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
       },
-      provinces: [
+      zones: [
         {
           name: 'Alberta',
           code: 'AB',

--- a/packages/address-mocks/src/fixtures/country_ca_ja.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_ja.ts
@@ -13,7 +13,7 @@ const data = {
         show:
           '{firstName} {lastName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}',
       },
-      provinces: [
+      zones: [
         {
           name: 'Alberta',
           code: 'AB',

--- a/packages/address/README.md
+++ b/packages/address/README.md
@@ -30,7 +30,7 @@ Loads and return data about a given country in the locale used for instanciation
 
 #### `async .getCountries(): Promise<Country[]>`
 
-Loads and return data about a all countries in the given locale. Countries are ordered alphabetically based on the locale. Provinces are also ordered based on the locale.
+Loads and return data about a all countries in the given locale. Countries are ordered alphabetically based on the locale. Zones are also ordered based on the locale.
 
 #### `async .getOrderedFields(countryCode): FieldName[][]`
 

--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -95,7 +95,7 @@ export default class AddressFormatter {
     const country = await this.getCountry(countryCode);
 
     switch (key) {
-      case FieldName.Province:
+      case FieldName.Zone:
         return country.provinceKey;
       case FieldName.Zip:
         return country.zipKey;

--- a/packages/address/src/graphqlQuery.ts
+++ b/packages/address/src/graphqlQuery.ts
@@ -11,7 +11,7 @@ query countries($locale: SupportedLocale!) {
       edit
       show
     }
-    provinces {
+    zones {
       name
       code
     }
@@ -30,7 +30,7 @@ query country($countryCode: SupportedCountry!, $locale: SupportedLocale!) {
       edit
       show
     }
-    provinces {
+    zones {
       name
       code
     }

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -47,7 +47,7 @@ describe('getCountry()', () => {
       'provinceKey',
       'zipKey',
       'formatting',
-      'provinces',
+      'zones',
     ]);
   });
 
@@ -171,7 +171,7 @@ describe('getTranslationKey()', () => {
     const addressFormatter = new AddressFormatter('ja');
     const result = await addressFormatter.getTranslationKey(
       'JP',
-      FieldName.Province,
+      FieldName.Zone,
     );
 
     expect(result).toBe('PREFECTURE');

--- a/packages/address/src/tests/utilities.test.ts
+++ b/packages/address/src/tests/utilities.test.ts
@@ -51,7 +51,7 @@ describe('renderLineTemplate()', () => {
     expect(renderLineTemplate(Canada, template, address)).toEqual('');
   });
 
-  it('returns empty string for province if country does not have provinces', () => {
+  it('returns empty string for province if country does not have zones', () => {
     const template = '{province}';
     expect(
       renderLineTemplate(Canada, template, {

--- a/packages/address/src/types.ts
+++ b/packages/address/src/types.ts
@@ -4,14 +4,14 @@ export enum FieldName {
   Country = 'country',
   City = 'city',
   Zip = 'zip',
-  Province = 'province',
+  Zone = 'province',
   Address1 = 'address1',
   Address2 = 'address2',
   Phone = 'phone',
   Company = 'company',
 }
 
-export type ProvinceKey =
+export type ZoneKey =
   | 'COUNTY'
   | 'EMIRATE'
   | 'GOVERNORATE'
@@ -55,13 +55,13 @@ export interface Country {
   code: string;
   phoneNumberPrefix: number;
   address2Key: Address2Key;
-  provinceKey: ProvinceKey;
+  provinceKey: ZoneKey;
   zipKey: ZipKey;
   formatting: {
     edit: string;
     show: string;
   };
-  provinces: Province[];
+  zones: Province[];
 }
 
 export interface ResponseError {

--- a/packages/address/src/utilities.ts
+++ b/packages/address/src/utilities.ts
@@ -9,7 +9,7 @@ export const FIELDS_MAPPING: {
   '{country}': FieldName.Country, // eslint-disable-line id-length
   '{city}': FieldName.City, // eslint-disable-line id-length
   '{zip}': FieldName.Zip, // eslint-disable-line id-length
-  '{province}': FieldName.Province, // eslint-disable-line id-length
+  '{province}': FieldName.Zone, // eslint-disable-line id-length
   '{address1}': FieldName.Address1, // eslint-disable-line id-length
   '{address2}': FieldName.Address2, // eslint-disable-line id-length
   '{phone}': FieldName.Phone, // eslint-disable-line id-length
@@ -43,12 +43,10 @@ export function renderLineTemplate(
       case FieldName.Country:
         line = line.replace(`{${FieldName.Country}}`, country.name);
         break;
-      case FieldName.Province:
+      case FieldName.Zone:
         line = line.replace(
-          `{${FieldName.Province}}`,
-          address.province
-            ? getProvince(country.provinces, address.province).name
-            : '',
+          `{${FieldName.Zone}}`,
+          address.province ? getZone(country.zones, address.province).name : '',
         );
         break;
       default:
@@ -63,9 +61,9 @@ export function renderLineTemplate(
   }
 }
 
-function getProvince(provinces: Province[], provinceCode: string): Province {
+function getZone(zones: Province[], provinceCode: string): Province {
   return (
-    provinces.find(province => province.code === provinceCode) || {
+    zones.find(zone => zone.code === provinceCode) || {
       name: '',
       code: '',
     }


### PR DESCRIPTION
## What

`country-service` now exposes `zones` as well as `provinces` (see: https://github.com/Shopify/country-service). They both return the same data, the goal is to move away from `provinces` to use the proper naming. 

This PR refactor some variable names and changes the graphQL query.