### PR TITLE
🐛 fix Etc/GMT+12 timezone for formatDate

### DIFF
--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -160,6 +160,17 @@ export default class I18n {
   ): string {
     const {locale, defaultTimezone: timezone} = this;
 
+    // Etc/GMT+12 is not supported in most browsers and there is no equivalent fallback
+    if (
+      options &&
+      options.timeZone != null &&
+      options.timeZone === 'Etc/GMT+12'
+    ) {
+      const adjustedDate = new Date(date.valueOf() - 12 * 60 * 60 * 1000);
+
+      return this.formatDate(adjustedDate, {...options, timeZone: 'UTC'});
+    }
+
     const {style = undefined, ...formatOptions} = options || {};
 
     if (style) {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -423,6 +423,18 @@ describe('I18n', () => {
       expect(i18n.formatDate(date, {timeZone: timezone})).toBe(expected);
     });
 
+    it('uses UTC when given a date in the Etc/GMT+12 timezone', () => {
+      const date = new Date('2018-01-01T12:34:56-12:00');
+      const timeZone = 'Etc/GMT+12';
+
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
+        timeZone: 'UTC',
+      }).format(new Date('2018-01-01'));
+
+      expect(i18n.formatDate(date, {timeZone})).toBe(expected);
+    });
+
     it('formats a date using DateStyle.Long', () => {
       const date = new Date('2012-12-20T00:00:00-00:00');
       const i18n = new I18n(defaultTranslations, {


### PR DESCRIPTION
This PR pulls in a workaround we had in our legacy intl library to `react-i18n`'s `formatDate` function. 