### PR TITLE
✨ Support use of onInitialValueChanged prop with fields having nested properties

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- You can now use the onInitialValueChanged prop with fields having nested properties.
+
 ### Fixed
 
 - `submit` now checks for the existence of `preventDefault` on the event passed in before calling it.

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -395,7 +395,7 @@ function reconcileFormState<Fields>(
   const fields: FieldStates<Fields> = mapObject(values, (value, key) => {
     const oldField = oldFields[key];
 
-    if (value === oldField.initialValue) {
+    if (isEqual(value, oldField.initialValue)) {
       return oldField;
     }
 

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -182,6 +182,64 @@ describe('<FormState />', () => {
         });
       });
 
+      it('does not reset a field when initial value has not changed and deep comparison is required', () => {
+        const renderPropSpy = jest.fn(() => null);
+        const originalOption = 'color';
+        const originalVariant1 = faker.commerce.color();
+        const originalVariant2 = faker.commerce.color();
+        const originalValues = {
+          variants: [
+            {
+              option: originalOption,
+              values: [originalVariant1, originalVariant2],
+            },
+          ],
+        };
+
+        const form = mount(
+          <FormState
+            initialValues={originalValues}
+            onInitialValuesChange="reset-where-changed"
+          >
+            {renderPropSpy}
+          </FormState>,
+        );
+
+        const formDetails = lastCallArgs(renderPropSpy);
+        const changedVariants = [
+          {
+            option: 'material',
+            values: [
+              faker.commerce.productMaterial(),
+              faker.commerce.productMaterial(),
+            ],
+          },
+        ];
+        formDetails.fields.variants.onChange(changedVariants);
+
+        const unchangedInitialVariants = [
+          {
+            option: originalOption,
+            values: [originalVariant1, originalVariant2],
+          },
+        ];
+
+        form.setProps({
+          initialValues: {
+            variants: unchangedInitialVariants,
+          },
+        });
+
+        const {fields} = lastCallArgs(renderPropSpy);
+        expect(fields).toMatchObject({
+          variants: {
+            value: changedVariants,
+            initialValue: originalValues.variants,
+            dirty: true,
+          },
+        });
+      });
+
       it('does not reset errors when the initialValues prop is updated', async () => {
         const renderPropSpy = jest.fn(() => null);
         const originalValues = {


### PR DESCRIPTION
https://github.com/Shopify/quilt/pull/446 introduced the `onInitialValueChanged` prop to `<FormState />`, allowing control over the form's reset behaviour when the value of the `initialValues` prop changed.

## The problem

When `onInitialValueChanged` is set to `reset-where-changed`, only fields whose initial values had been changed are reset. However, `!==` was being used to check for changes rather than a deep equality check. This meant that for fields that had nested properties, if the field's initial value pointed to a new object but with unchanged values from the previous, `<FormState />` would interpret that the field's initial value had changed, and would reset it.

## The suggested fix

This PR introduces a deep equality check to support having complex fields for which we cannot rely on shallow equality. It also makes the reconciliation more consistent with the deep equality check performed by default when no value is specified for `onInitialValueChanged`.

## Some concerns
- Is there a legitimate use case for wanting to clear a field when an initial value is reassigned, even if the actual values don't change?
- Would support for the intended use case here be better achieved through using a custom function for `onInitialValueChanged`?