### PR TITLE
🐛[FormState] Check that preventDefault exists on an event before calling it

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- `submit` now checks for the existence of `preventDefault` on the event passed in before calling it.
+
 ## [0.6]
 
 ### Added

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -181,7 +181,7 @@ export default class FormState<
       return;
     }
 
-    if (event && !event.defaultPrevented) {
+    if (event && event.preventDefault && !event.defaultPrevented) {
       event.preventDefault();
     }
 

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -1032,6 +1032,65 @@ describe('<FormState />', () => {
     });
   });
 
+  describe('submit event', () => {
+    it('calls preventDefault on event if it exists', async () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      mount(
+        <FormState initialValues={{}} onSubmit={noop}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+
+      const mockEvent = {
+        preventDefault: jest.fn(),
+      };
+      await submit(mockEvent);
+
+      expect(mockEvent.preventDefault).toBeCalled();
+    });
+
+    it('does not call preventDefault on event if was prevented', async () => {
+      const renderPropSpy = jest.fn(() => null);
+
+      mount(
+        <FormState initialValues={{}} onSubmit={noop}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+
+      const mockEvent = {
+        preventDefault: jest.fn(),
+        defaultPrevented: true,
+      };
+      await submit(mockEvent);
+
+      expect(mockEvent.preventDefault).not.toBeCalled();
+    });
+
+    it('calls onSubmit if event with no preventDefault function is provided', async () => {
+      const renderPropSpy = jest.fn(() => null);
+      const onSubmitSpy = jest.fn();
+
+      mount(
+        <FormState initialValues={{}} onSubmit={onSubmitSpy}>
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {submit} = lastCallArgs(renderPropSpy);
+
+      const mockEvent = {};
+      await submit(mockEvent);
+
+      expect(onSubmitSpy).toBeCalled();
+    });
+  });
+
   describe('validateForm', () => {
     it('calls all validators', () => {
       const productValidatorSpy = jest.fn();


### PR DESCRIPTION
In `FormState` `submit`: check that `preventDefault` exists on an event before calling it.

Context:
In some common use cases, the submit function is passed directly into `onAction` handlers. When using this with AppBridge & Polaris V3 in an embedded Shopify app, this can cause an error because the object passed the `onAction` handler does not have the function `preventDefault`.

This can be fixed by not passing anything to `submit`. However, it doesn't seem like a bad idea to check for the existence of `preventDefault` before calling it.