### PR TITLE
Adds User Timing Mock

### DIFF
--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- User timing mocks [#468](https://github.com/Shopify/quilt/pull/468).
+
 ## 2.1.3 - 2019-01-09
 
 - Start of Changelog

--- a/packages/jest-dom-mocks/src/index.ts
+++ b/packages/jest-dom-mocks/src/index.ts
@@ -5,6 +5,7 @@ import Location from './location';
 import MatchMedia from './match-media';
 import Storage from './storage';
 import Timer from './timer';
+import UserTiming from './user-timing';
 
 export const animationFrame = new AnimationFrame();
 
@@ -21,6 +22,7 @@ export const localStorage = new Storage();
 export const sessionStorage = new Storage();
 
 export const timer = new Timer();
+export const userTiming = new UserTiming();
 
 export function installMockStorage() {
   if (typeof window !== 'undefined') {
@@ -42,6 +44,7 @@ const mocksToEnsureReset = {
   animationFrame,
   fetch,
   matchMedia,
+  userTiming,
 };
 
 export function ensureMocksReset() {

--- a/packages/jest-dom-mocks/src/test/user-timing.test.ts
+++ b/packages/jest-dom-mocks/src/test/user-timing.test.ts
@@ -1,0 +1,53 @@
+import UserTiming from '../user-timing';
+
+describe('UserTiming', () => {
+  describe('mock', () => {
+    it('sets isMocked()', () => {
+      const userTiming = new UserTiming();
+      userTiming.mock();
+
+      expect(userTiming.isMocked()).toBe(true);
+    });
+
+    it('throws if it is already mocked', () => {
+      const userTiming = new UserTiming();
+      userTiming.mock();
+
+      expect(() => {
+        userTiming.mock();
+      }).toThrow();
+    });
+
+    it('delegates stubbed options to window.performance.timing', () => {
+      const userTiming = new UserTiming();
+      const mockRequestStart = 123;
+      const mockResponseEnd = 456;
+
+      userTiming.mock({
+        requestStart: mockRequestStart,
+        responseEnd: mockResponseEnd,
+      });
+
+      expect(window.performance.timing.requestStart).toBe(mockRequestStart);
+      expect(window.performance.timing.responseEnd).toBe(mockResponseEnd);
+    });
+  });
+
+  describe('restore', () => {
+    it('sets isMocked', () => {
+      const userTiming = new UserTiming();
+      userTiming.mock();
+      userTiming.restore();
+
+      expect(userTiming.isMocked()).toBe(false);
+    });
+
+    it('throws if it has not yet been mocked', () => {
+      const userTiming = new UserTiming();
+
+      expect(() => {
+        userTiming.restore();
+      }).toThrow();
+    });
+  });
+});

--- a/packages/jest-dom-mocks/src/user-timing.ts
+++ b/packages/jest-dom-mocks/src/user-timing.ts
@@ -1,0 +1,59 @@
+import set from 'lodash/set';
+
+type UserTimingMock = typeof window.performance.timing;
+
+export default class Performance {
+  private isUsingMockUserTiming = false;
+  private originalUserTiming?: UserTimingMock = window.performance.timing;
+
+  mock(timing: Partial<UserTimingMock> = {}) {
+    if (this.isUsingMockUserTiming) {
+      throw new Error(
+        'You tried to mock window.performance.timing when it was already mocked.',
+      );
+    }
+
+    const mockTiming: Partial<UserTimingMock> = {
+      navigationStart: 0,
+      unloadEventStart: 0,
+      unloadEventEnd: 0,
+      redirectStart: 0,
+      redirectEnd: 0,
+      fetchStart: 0,
+      domainLookupStart: 0,
+      domainLookupEnd: 0,
+      connectStart: 0,
+      connectEnd: 0,
+      secureConnectionStart: 0,
+      requestStart: 0,
+      responseStart: 0,
+      responseEnd: 0,
+      domLoading: 0,
+      domInteractive: 0,
+      domContentLoadedEventStart: 0,
+      domContentLoadedEventEnd: 0,
+      domComplete: 0,
+      loadEventStart: 0,
+      loadEventEnd: 0,
+      ...timing,
+    };
+
+    set(window.performance, 'timing', mockTiming);
+    this.isUsingMockUserTiming = true;
+  }
+
+  restore() {
+    if (!this.isUsingMockUserTiming) {
+      throw new Error(
+        'You tried to restore window.performance.timing when it was already restored.',
+      );
+    }
+
+    set(window.performance, 'timing', this.originalUserTiming);
+    this.isUsingMockUserTiming = false;
+  }
+
+  isMocked() {
+    return this.isUsingMockUserTiming;
+  }
+}


### PR DESCRIPTION
This PR adds a `user-timing` mock to `jest-dom-mocks`.

I started this PR thinking I would mock the entire `window.performance` API, but after realizing that the global exists in the most recent versions of `jest`, opted for just providing a way to mock user timing metrics instead.