### PR TITLE
Make the enable_cookies route redirect to ${prefix}/auth/inline

### DIFF
--- a/packages/koa-shopify-auth/src/auth/create-enable-cookies.ts
+++ b/packages/koa-shopify-auth/src/auth/create-enable-cookies.ts
@@ -1,3 +1,4 @@
+import querystring from 'querystring';
 import {Context} from 'koa';
 
 import Error from './errors';
@@ -10,10 +11,13 @@ const FOOTER = `Cookies let the app authenticate you by temporarily storing your
 information. They expire after 30 days.`;
 const ACTION = 'Enable cookies';
 
-export default function createEnableCookies({apiKey}: OAuthStartOptions) {
+export default function createEnableCookies({apiKey, prefix}: OAuthStartOptions) {
   return function enableCookies(ctx: Context) {
-    const {query} = ctx;
+    const {host, query} = ctx;
     const {shop} = query;
+    const path = `${prefix}/auth/inline`;
+    const params = {shop};
+    const queryString = querystring.stringify(params);
 
     if (shop == null) {
       ctx.throw(400, Error.ShopParamMissing);
@@ -370,7 +374,7 @@ export default function createEnableCookies({apiKey}: OAuthStartOptions) {
     (function() {
       function setCookieAndRedirect() {
         document.cookie = "shopify.cookies_persist=true";
-        window.location.href = window.shopOrigin + "/admin/apps/" + window.apiKey;
+        window.location.href = "https://${host}${path}?${queryString}"
       }
 
       function shouldDisplayPrompt() {


### PR DESCRIPTION
Previously, the **/auth/enable_cookies** route redirected to:

```
https://${window.shopOrigin}/admin/apps/${window.apiKey} 
```

which seems useless, because all it ever does is 404.  This results in the first installation attempt failing.

```
GET /shopify/auth?hmac=b7d85bd1976f2f4e3d2badab0473ed47d456855f199cc15917470f1da04ed213&shop=dbap-dev.myshopify.com&timestamp=1547106686 200 2.777 ms - 802
GET /shopify/auth/enable_cookies?shop=dbap-dev.myshopify.com 200 1.664 ms - 10350
```

However, the **/auth/enable_cookies** route does set the `shopifyTestCookie` so the second time around and ever subsequent time afterward, the installation works.  Also, notice that subsequent installation attempts go to **/auth/inline** instead. 

```
GET /shopify/auth?hmac=cc729de08ca82c5bb06e28872e4fc23b0a396678c2af9ec9e95b90e5b0619e37&shop=dbap-dev.myshopify.com&timestamp=1547106888 200 1.463 ms - 786
GET /shopify/auth/inline?shop=dbap-dev.myshopify.com 302 1.916 ms - 619
```

## Solution

What this pull request implements is a change to the **/auth/enable_cookies** route that redirects to **/auth/inline**.  This makes installation ALWAYS work on the first try and every subsequent try.  Let me know if this seems like a reasonable change, @ragalie ?