### PR TITLE
Allow to specify multiple env vars in withEnv

### DIFF
--- a/packages/with-env/CHANGELOG.md
+++ b/packages/with-env/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+## 1.1.0 - 2019-05-03
+
+### Added
+
+- allows to specify multiple env vars in withEnv
+
 ## 1.0.10 - 2019-01-09
 
 - Start of Changelog

--- a/packages/with-env/README.md
+++ b/packages/with-env/README.md
@@ -36,3 +36,15 @@ it('does another thing in production', () => {
   });
 });
 ```
+
+It also allows to change (and reset) multiple environment variables at once.
+
+```ts
+import withEnv from '@shopify/with-env';
+
+it('does one thing', () => {
+  withEnv({MY_ENV_ONE: 'test', ANOTHER_ENV: 'test-2'}, () => {
+    // your code here
+  });
+});
+```

--- a/packages/with-env/src/test/index.test.ts
+++ b/packages/with-env/src/test/index.test.ts
@@ -1,16 +1,16 @@
 import withEnv from '../index';
 
-function getEnv() {
-  return process.env.NODE_ENV;
-}
-
 function wait(duration: number) {
   return new Promise(resolve => {
     setTimeout(resolve, duration);
   });
 }
 
-describe('withEnv', () => {
+describe('withEnv NODE_ENV', () => {
+  function getEnv() {
+    return process.env.NODE_ENV;
+  }
+
   it('changes the NODE_ENV for a standard Function', () => {
     withEnv('development', () => {
       expect(getEnv()).toBe('development');
@@ -30,5 +30,48 @@ describe('withEnv', () => {
       await wait(50);
       expect(getEnv()).toBe('production');
     });
+  });
+});
+
+describe('withEnv env object', () => {
+  afterEach(() => {
+    delete process.env.TEST_ONE;
+    delete process.env.TEST_TWO;
+    delete process.env.TEST_EXISTING;
+  });
+
+  it('changes multiple env vars', () => {
+    withEnv({TEST_ONE: 'foo', TEST_TWO: 'bar'}, () => {
+      expect(process.env.TEST_ONE).toBe('foo');
+      expect(process.env.TEST_TWO).toBe('bar');
+    });
+  });
+
+  it('does not override other env vars', () => {
+    process.env.TEST_EXISTING = 'existing';
+
+    withEnv({TEST_ONE: 'foo'}, () => {
+      expect(process.env.TEST_ONE).toBe('foo');
+      expect(process.env.TEST_EXISTING).toBe('existing');
+    });
+    expect(process.env.TEST_EXISTING).toBe('existing');
+  });
+
+  it('resets multiple env vars for a standard Function', () => {
+    process.env.TEST_ONE = 'pre-test';
+
+    withEnv({TEST_ONE: 'foo', TEST_TWO: 'bar'}, () => {
+      expect(process.env.TEST_ONE).toBe('foo');
+    });
+
+    expect(process.env.TEST_ONE).toBe('pre-test');
+  });
+
+  it('clears env vars that were previously undefined', () => {
+    withEnv({NON_EXISTING: 'foo'}, () => {
+      expect(process.env.NON_EXISTING).toBe('foo');
+    });
+
+    expect(process.env.NON_EXISTING).toBeUndefined();
   });
 });

--- a/packages/with-env/src/types.ts
+++ b/packages/with-env/src/types.ts
@@ -1,0 +1,1 @@
+export type Env = string | {[key: string]: string};


### PR DESCRIPTION
Hey 👋,

this is just an idea that crossed my mind when I had a look at the repository. Feel free to close this PR if you don't deem it useful.

## What does it do?
This PR allows to use `withEnv` not only with `NODE_ENV`, but also lets consumers pass in an object to set multiple environment variables. Those variables will also be reset to their previous values after the callback has run.

Before:
```ts
import withEnv from '@shopify/with-env';

it('does one thing in development', () => {
  withEnv('development', () => {
    // your code here
  });
});
```

Now also supports:

```ts
import withEnv from '@shopify/with-env';

it('does one thing', () => {
  withEnv({MY_ENV_ONE: 'test', ANOTHER_ENV: 'test-2'}, () => {
    // your code here
  });
});
```
