### PR TITLE
Deprecate react-preconnect in favour of react-html

### DIFF
--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -228,7 +228,7 @@ Renders a `<link />` tag with the necessary props to specify a favicon. Accepts 
 
 ### `<Preconnect />`
 
-Renders a `<link />` tag with the necessary props to fully preconnect to the host specified by the `source` prop.
+Renders a `<link />` tag that preconnects the browser to the host specified by the `source` prop. You can read more about preconnecting on [Google’s guide to resource prioritization](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect).
 
 ### `<Serialize />`
 

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -226,6 +226,10 @@ This component accepts a string child, which will be used to set the title of th
 
 Renders a `<link />` tag with the necessary props to specify a favicon. Accepts a `source` property that should be the image source for the favicon.
 
+### `<Preconnect />`
+
+Renders a `<link />` tag with the necessary props to fully preconnect to the host specified by the `source` prop.
+
 ### `<Serialize />`
 
 The Serialize component takes care of rendering a `script` tag with a serialized version of the `data` prop. It is provided for incremental adoption of the `createSerializer()` method of generating serializations [documented above](#in-your-app-code).

--- a/packages/react-html/src/components/Preconnect.tsx
+++ b/packages/react-html/src/components/Preconnect.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import Link from './Link';
+
+interface Props {
+  source: string;
+}
+
+export default function Preconnect({source}: Props) {
+  return <Link rel="dns-prefetch preconnect" href={source} />;
+}

--- a/packages/react-html/src/components/index.ts
+++ b/packages/react-html/src/components/index.ts
@@ -1,6 +1,7 @@
 export {default as Favicon} from './Favicon';
 export {default as Link} from './Link';
 export {default as Meta} from './Meta';
+export {default as Preconnect} from './Preconnect';
 export {default as Script} from './Script';
 export {default as Style} from './Style';
 export {default as Title} from './Title';

--- a/packages/react-html/src/components/tests/Preconnect.test.tsx
+++ b/packages/react-html/src/components/tests/Preconnect.test.tsx
@@ -5,7 +5,7 @@ import Link from '../Link';
 import Preconnect from '../Preconnect';
 
 describe('<Preconnect />', () => {
-  it('renders a <Link /> with DNS prefetch and preconnect props', () => {
+  it('renders a <Link /> with with rel set to dns-prefetch and preconnect', () => {
     const preconnect = mount(<Preconnect source="" />);
     expect(preconnect.find(Link).props()).toMatchObject({
       rel: 'dns-prefetch preconnect',

--- a/packages/react-html/src/components/tests/Preconnect.test.tsx
+++ b/packages/react-html/src/components/tests/Preconnect.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+
+import Link from '../Link';
+import Preconnect from '../Preconnect';
+
+describe('<Preconnect />', () => {
+  it('renders a <Link /> with DNS prefetch and preconnect props', () => {
+    const preconnect = mount(<Preconnect source="" />);
+    expect(preconnect.find(Link).props()).toMatchObject({
+      rel: 'dns-prefetch preconnect',
+    });
+  });
+
+  it('renders a <Link /> with the href set to the passed source', () => {
+    const source = '//my.domain.com';
+    const preconnect = mount(<Preconnect source={source} />);
+    expect(preconnect.find(Link).prop('href')).toBe(source);
+  });
+});

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-import-remote/README.md",
   "dependencies": {
-    "@shopify/react-preconnect": "^0.1.6",
+    "@shopify/react-html": "^6.0.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Preconnect from '@shopify/react-preconnect';
+import {Preconnect} from '@shopify/react-html';
 import load from './load';
 
 export interface Props<Imported = any> {
@@ -29,7 +29,7 @@ export default class ImportRemote extends React.PureComponent<Props, never> {
 
     if (preconnect) {
       const url = new URL(source);
-      return <Preconnect hosts={[url.hostname]} />;
+      return <Preconnect source={url.origin} />;
     }
 
     return null;

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
-import Preconnect from '@shopify/react-preconnect';
+import {Preconnect} from '@shopify/react-html';
 import {noop} from '@shopify/javascript-utilities/other';
 
 import ImportRemote, {Props} from '../ImportRemote';
 
-jest.mock('react-helmet', () => ({
-  Helmet: function Helmet({children}: any) {
-    return children || null;
+jest.mock('@shopify/react-html', () => ({
+  Preconnect() {
+    return null;
   },
 }));
 
@@ -124,12 +124,12 @@ describe('<ImportRemote />', () => {
       expect(importRemote.find(Preconnect)).toHaveLength(0);
     });
 
-    it('creates a preconnect link with the source’s hostname when preconnecting is requested', () => {
+    it('creates a preconnect link with the source’s origin when preconnecting is requested', () => {
       const importRemote = mount(<ImportRemote {...mockProps} preconnect />);
 
-      expect(importRemote.find(Preconnect).prop('hosts')).toEqual([
-        new URL(mockProps.source).hostname,
-      ]);
+      expect(importRemote.find(Preconnect).prop('source')).toBe(
+        new URL(mockProps.source).origin,
+      );
     });
   });
 });

--- a/packages/react-preconnect/README.md
+++ b/packages/react-preconnect/README.md
@@ -1,5 +1,7 @@
 # `@shopify/react-preconnect`
 
+**Note**: This module is now deprecated. You should move to using the `<Preconnect />` component from [`@shopify/react-html`](../react-html) instead.
+
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-preconnect.svg)](https://badge.fury.io/js/%40shopify%2Freact-preconnect.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-preconnect.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-preconnect.svg)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,6 +415,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.1.tgz#e2d374ef15b315b48e7efc308fa1a7cd51faa06c"
   integrity sha512-xwlHq5DXQFRpe+u6hmmNkzYk/3oxxqDp71a/AJMupOQYmxyaBetqrVMqdNlSQfbg7XTJYD8vARjf3Op06OzdtQ==
 
+"@types/prop-types@*":
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
+  integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
+
 "@types/react-helmet@^5.0.6":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.6.tgz#49607cbb72e1bb7dcefa9174cb591434d3b6f0af"
@@ -430,11 +435,19 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.3.18", "@types/react@>=16.4.0", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.3.18", "@types/react@^16.0.2":
   version "16.3.18"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.18.tgz#bf195aed4d77dc86f06e4c9bb760214a3b822b8d"
   integrity sha512-aWTvLHzKqbVWCiee8huwf5x7Ob4n4gxDwgJT/X31HqjGVZpeUeFeSFYH5Gvi5Dmm5HKF+s+dQkwa/nnEVVzzzg==
   dependencies:
+    csstype "^2.2.0"
+
+"@types/react@>=16.4.0":
+  version "16.7.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
+  integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==
+  dependencies:
+    "@types/prop-types" "*"
     csstype "^2.2.0"
 
 "@types/safe-compare@^1.1.0":


### PR DESCRIPTION
This PR adds a `<Preconnect />` component to `react-html`, which obviates the need for `react-preconnect`. This package was still referencing Helmet which we know to be a dangerous, non-thread-safe package, so I think it's fine to remove it, and one less import is always nice.