### PR TITLE
✨ create new graphql testing package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each package has its own `README` and documentation describing usage.
 | csrf-token-fetcher | [directory](packages/csrf-token-fetcher) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg)](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher) |
 | dates | [directory](packages/dates) | [![npm version](https://badge.fury.io/js/%40shopify%2Fdates.svg)](https://badge.fury.io/js/%40shopify%2Fdates) |
 | enzyme-utilities | [directory](packages/enzyme-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities) |
+| graphql-testing | [directory](packages/graphql-testing) | [![npm version](https://badge.fury.io/js/%40shopify%2Fgraphql-testing.svg)](https://badge.fury.io/js/%40shopify%2Fgraphql-testing) |
 | i18n | [directory](packages/i18n) | [![npm version](https://badge.fury.io/js/%40shopify%2Fi18n.svg)](https://badge.fury.io/js/%40shopify%2Fi18n) |
 | jest-dom-mocks | [directory](packages/jest-dom-mocks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks) |
 | jest-koa-mocks | [directory](packages/jest-koa-mocks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks) |

--- a/packages/graphql-testing/CHANGELOG.md
+++ b/packages/graphql-testing/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/graphql-testing` package - next generation of `jest-mock-apollo` with rename of the package

--- a/packages/graphql-testing/README.md
+++ b/packages/graphql-testing/README.md
@@ -1,0 +1,122 @@
+# `@shopify/graphql-testing`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fgraphql-testing.svg)](https://badge.fury.io/js/%40shopify%2Fgraphql-testing.svg)
+
+This package provides utilities to help in the following testing scenarios:
+
+1. Testing a graphQL operation with mock data.
+2. Testing the state of your application before/after all the graphQL operations resolve.
+
+## Installation
+
+```bash
+$ yarn add @shopify/graphql-testing
+```
+
+## Usage
+
+The default utility exported by this library is `createGraphQLFactory`.
+
+```js
+const createGraphQL = createGraphQLFactory();
+```
+
+This factory function can then be use to creating a mock `ApolloClient` that you will pass into your test setup with the desire mock data.
+
+```js
+const graphQL = createGraphQL(mockData);
+const apolloClient = graphQL.client;
+```
+
+By default, this mock client will hold all the graphQL operations triggered by your application in a pending state.
+
+To resolve all pending graphQL operations:
+
+```js
+await graphQL.resolveAll();
+```
+
+You can also access all the graphQL operations triggered by your application (pending and non-pending) using:
+
+```js
+graphQL.operations.all();
+```
+
+and only those graphQL operations with specific name using:
+
+```js
+graphQL.operations.all({operationName: 'Pet'});
+```
+
+### Examples
+
+Below is an example of how to use `createGraphQLFactory` in a React component test.
+
+Note: In a typical application you will want to generalized some of this implementation (ie. mouting of `ApolloProvider`) for repeated use.
+
+```ts
+import {mount} from 'enzyme';
+import {ApolloProvider} from 'react-apollo';
+import createGraphQLFactory from '@shopify/graphql-testing';
+
+export const createGraphQL = createGraphQLFactory();
+
+it('loads mock data from GraphQL', async () => {
+  const mockCustomerData = {firstName: 'Jane', lastName: 'Doe'};
+  const graphQL = createGraphQL({
+    CustomerDetails: {
+      customer: mockCustomerData,
+    },
+  });
+
+  const customerDetails = mount(
+    <ApolloProvider client={graphQL.client}>
+      <CustomerDetails id="123" />
+    </ApolloProvider>,
+  );
+
+  expect(customerDetails.find(TextField)).toHaveProp('value', '');
+
+  await graphQL.resolveAll();
+  customerDetails.update();
+
+  expect(customerDetails.find(TextField)).toHaveProp(
+    'value',
+    mockCustomerData.firstName,
+  );
+});
+```
+
+Below is an example of how to assert that a graphQL request was triggered.
+
+```ts
+import {mount} from 'enzyme';
+import {ApolloProvider} from 'react-apollo';
+import {trigger} from '@shopify/enzyme-utilities';
+import createGraphQLFactory from '@shopify/graphql-testing';
+
+export const createGraphQL = createGraphQLFactory();
+
+it('triggers a graphQL request when the load data button is clicked', async () => {
+  const mockCustomerData = {firstName: 'Jane', lastName: 'Doe'};
+  const graphQL = createGraphQL({
+    CustomerDetails: {
+      customer: mockCustomerData,
+    },
+  });
+
+  const customerDetails = mount(
+    <ApolloProvider client={graphQL.client}>
+      <CustomerDetails id="123" />
+    </ApolloProvider>,
+  );
+
+  expect(graphQL.operations.all()).toHaveLength(0);
+
+  trigger(customerDetails.find(LoadDataButton), 'onClick');
+
+  expect(graphQL.operations.all()).toHaveLength(1);
+  expect(graphQL.operations.last().operationName).toEqual('CustomerDetails');
+});
+```

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@shopify/graphql-testing",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Utilities to create mock graphql factory.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/graphql-testing/README.md",
+  "dependencies": {
+    "apollo-link": "^1.2.3",
+    "apollo-client": "^2.3.4",
+    "apollo-cache-inmemory": "^1.2.4",
+    "graphql": "0.13.2"
+  },
+  "devDependencies": {
+    "typescript": "~3.0.1",
+    "graphql-typed": "^0.2.0",
+    "@shopify/useful-types": "^1.1.0"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/graphql-testing/src/MemoryApolloClient.ts
+++ b/packages/graphql-testing/src/MemoryApolloClient.ts
@@ -1,0 +1,45 @@
+import ApolloClient, {ApolloClientOptions} from 'apollo-client';
+import {ApolloLink} from 'apollo-link';
+import {Omit} from '@shopify/useful-types';
+
+import MemoryApolloLink from './MemoryApolloLink';
+import Operations from './Operations';
+import {MockRequest} from './types';
+
+type MemoryApolloClientOptions = Omit<ApolloClientOptions<unknown>, 'link'> & {
+  link?: ApolloLink;
+};
+
+export default class MemoryApolloClient extends ApolloClient<unknown> {
+  readonly operations: Operations;
+  readonly pendingRequests: Set<MockRequest>;
+
+  constructor(options: MemoryApolloClientOptions) {
+    const memoryLink = new MemoryApolloLink();
+    super({
+      ...options,
+      link: options.link ? memoryLink.concat(options.link) : memoryLink,
+    });
+
+    this.operations = new Operations();
+    this.pendingRequests = new Set<MockRequest>();
+
+    memoryLink.onRequestCreated(this.onRequestCreated.bind(this));
+    memoryLink.onRequestResolved(this.onRequestResolved.bind(this));
+  }
+
+  async resolveAll() {
+    await Promise.all(
+      Array.from(this.pendingRequests).map(({resolve}) => resolve()),
+    );
+  }
+
+  private onRequestCreated(request: MockRequest) {
+    this.operations.push(request.operation);
+    this.pendingRequests.add(request);
+  }
+
+  private onRequestResolved(request: MockRequest) {
+    this.pendingRequests.delete(request);
+  }
+}

--- a/packages/graphql-testing/src/MemoryApolloLink.ts
+++ b/packages/graphql-testing/src/MemoryApolloLink.ts
@@ -1,0 +1,66 @@
+import {ApolloLink, Observable, Operation, NextLink} from 'apollo-link';
+
+import {MockRequest} from './types';
+
+export default class MemoryApolloLink extends ApolloLink {
+  private onRequestCreatedCallback:
+    | ((request: MockRequest) => void)
+    | undefined;
+  private onRequestResolvedCallback:
+    | ((request: MockRequest) => void)
+    | undefined;
+
+  constructor() {
+    super();
+  }
+
+  request(operation: Operation, nextLink?: NextLink) {
+    if (nextLink == null || !nextLink) {
+      throw new Error('The memory link must not be a terminating link');
+    }
+
+    let resolver: Function;
+
+    const promise = new Promise<void>(resolve => {
+      resolver = resolve;
+    });
+
+    const request = {
+      operation,
+      resolve: () => {
+        resolver();
+        this.onRequestResolvedCallback &&
+          this.onRequestResolvedCallback(request);
+
+        return promise;
+      },
+    };
+
+    this.onRequestCreatedCallback && this.onRequestCreatedCallback(request);
+
+    return new Observable(observer => {
+      return nextLink(operation).subscribe({
+        complete() {
+          const complete = observer.complete.bind(observer);
+          promise.then(complete).catch(complete);
+        },
+        next(result) {
+          const next = observer.next.bind(observer, result);
+          promise.then(next).catch(next);
+        },
+        error(error) {
+          const fail = observer.error.bind(observer, error);
+          promise.then(fail).catch(fail);
+        },
+      });
+    });
+  }
+
+  onRequestCreated(onRequestCreated: (request: MockRequest) => void) {
+    this.onRequestCreatedCallback = onRequestCreated;
+  }
+
+  onRequestResolved(onRequestResolved: (request: MockRequest) => void) {
+    this.onRequestResolvedCallback = onRequestResolved;
+  }
+}

--- a/packages/graphql-testing/src/MockApolloLink.ts
+++ b/packages/graphql-testing/src/MockApolloLink.ts
@@ -1,0 +1,65 @@
+import {ApolloLink, Observable, Operation} from 'apollo-link';
+import {ExecutionResult, GraphQLError} from 'graphql';
+import {GraphQLMock, MockGraphQLFunction} from './types';
+
+export default class MockApolloLink extends ApolloLink {
+  constructor(private mock: GraphQLMock) {
+    super();
+  }
+
+  request(operation: Operation) {
+    return new Observable(obs => {
+      const {mock} = this;
+      const {operationName = ''} = operation;
+
+      let response: object | null = null;
+
+      if (typeof mock === 'function') {
+        response = mock(operation);
+      } else {
+        const mockForOperation = mock[operationName || ''];
+
+        response =
+          typeof mockForOperation === 'function'
+            ? (mockForOperation as MockGraphQLFunction)(operation)
+            : mockForOperation;
+      }
+
+      let result: ExecutionResult | Error;
+
+      if (response == null) {
+        let message = `Can’t perform GraphQL operation '${operationName}' because no valid mocks were found`;
+
+        if (typeof mock === 'object') {
+          const operationNames = Object.keys(mock);
+          // We will provide a more helpful message when it looks like they just provided data,
+          // not an object mapping names to fixtures.
+          const looksLikeDataNotFixtures = operationNames.every(
+            name => name === name.toLowerCase(),
+          );
+
+          message += looksLikeDataNotFixtures
+            ? ` (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({${operationName}: yourFixture}).'`
+            : ` (you provided an object that had mocks only for the following operations: ${Object.keys(
+                mock,
+              ).join(', ')}).`;
+        } else {
+          message +=
+            ' (you provided a function that did not return a valid mock result)';
+        }
+
+        const error = new Error(message);
+        result = error;
+      } else if (response instanceof Error) {
+        result = {errors: [new GraphQLError(response.message)]};
+      } else {
+        result = {
+          data: response,
+        };
+      }
+
+      obs.next(result);
+      obs.complete();
+    });
+  }
+}

--- a/packages/graphql-testing/src/Operations.ts
+++ b/packages/graphql-testing/src/Operations.ts
@@ -1,0 +1,55 @@
+import {Operation} from 'apollo-link';
+
+export default class Operations {
+  private operations: Operation[] = [];
+
+  constructor(operations?: Operation[]) {
+    this.operations = operations ? [...operations] : [];
+  }
+
+  [Symbol.iterator]() {
+    return this.operations[Symbol.iterator]();
+  }
+
+  nth(index: number) {
+    return index < 0
+      ? this.operations[this.operations.length - 1 + index]
+      : this.operations[index];
+  }
+
+  push(operation: Operation) {
+    this.operations.push(operation);
+  }
+
+  all(options?: {operationName?: string}): Operation[] {
+    const operationName = options && options.operationName;
+    if (!options || !operationName) {
+      return this.operations;
+    }
+
+    const allMatchedOperations = this.operations.filter(
+      req => req.operationName === operationName,
+    );
+
+    return allMatchedOperations;
+  }
+
+  last(options?: {operationName?: string}): Operation {
+    const operationName = options && options.operationName;
+    const lastOperation = operationName
+      ? this.operations
+          .reverse()
+          .find(req => req.operationName === operationName)
+      : this.operations[this.operations.length - 1];
+
+    if (lastOperation == null && operationName) {
+      throw new Error(
+        `no operation with operationName '${operationName}' were found.`,
+      );
+    } else if (lastOperation == null) {
+      throw new Error(`no operation were found.`);
+    }
+
+    return lastOperation;
+  }
+}

--- a/packages/graphql-testing/src/createGraphQLFactory.ts
+++ b/packages/graphql-testing/src/createGraphQLFactory.ts
@@ -1,0 +1,74 @@
+import {GraphQLRequest} from 'apollo-link';
+import {
+  ApolloReducerConfig,
+  InMemoryCache,
+  IntrospectionFragmentMatcher,
+} from 'apollo-cache-inmemory';
+import {ApolloClientOptions} from 'apollo-client';
+
+import MemoryApolloClient from './MemoryApolloClient';
+import MockApolloLink from './MockApolloLink';
+import Operations from './Operations';
+import {GraphQLMock} from './types';
+
+export interface Options {
+  unionOrIntersectionTypes?: any[];
+  cacheOptions?: ApolloReducerConfig;
+}
+
+function defaultGraphQLMock({operationName}: GraphQLRequest) {
+  return new Error(
+    `Can’t perform GraphQL operation '${operationName ||
+      ''}' because no mocks were set.`,
+  );
+}
+
+class GraphQL {
+  client: MemoryApolloClient;
+  readonly operations: Operations;
+  private afterResolver: (() => void) | undefined;
+
+  constructor(
+    mock: GraphQLMock,
+    {unionOrIntersectionTypes = [], cacheOptions = {}}: Options = {},
+  ) {
+    const cache = new InMemoryCache({
+      fragmentMatcher: new IntrospectionFragmentMatcher({
+        introspectionQueryResultData: {
+          __schema: {
+            types: unionOrIntersectionTypes,
+          },
+        },
+      }),
+      ...cacheOptions,
+    });
+
+    const mockApolloClientOptions: ApolloClientOptions<unknown> = {
+      link: new MockApolloLink(mock),
+      cache,
+    };
+
+    const memoryApolloClient = new MemoryApolloClient(mockApolloClientOptions);
+
+    this.client = memoryApolloClient;
+    this.operations = memoryApolloClient.operations;
+  }
+
+  afterResolve(resolver: () => void) {
+    this.afterResolver = resolver;
+  }
+
+  async resolveAll() {
+    await this.client.resolveAll();
+
+    if (this.afterResolver) {
+      this.afterResolver();
+    }
+  }
+}
+
+export default function createGraphQLFactory(options?: Options) {
+  return function createGraphQLClient(mock: GraphQLMock = defaultGraphQLMock) {
+    return new GraphQL(mock, options);
+  };
+}

--- a/packages/graphql-testing/src/index.ts
+++ b/packages/graphql-testing/src/index.ts
@@ -1,0 +1,3 @@
+export {default} from './createGraphQLFactory';
+
+export * from './types';

--- a/packages/graphql-testing/src/test/MemoryApolloClient.test.ts
+++ b/packages/graphql-testing/src/test/MemoryApolloClient.test.ts
@@ -1,0 +1,36 @@
+import {InMemoryCache} from 'apollo-cache-inmemory';
+import {SimpleLink} from './utilities/apollo-link';
+
+import MemoryApolloClient from '../MemoryApolloClient';
+import petQuery from './fixtures/PetQuery.graphql';
+
+describe('MemoryApolloClient', () => {
+  it('adds query to request when executed', () => {
+    const mockOptions = {link: new SimpleLink(), cache: new InMemoryCache()};
+    const memoryApolloClient = new MemoryApolloClient(mockOptions);
+
+    expect(memoryApolloClient.operations.all()).toHaveLength(0);
+    memoryApolloClient.query({query: petQuery});
+    expect(memoryApolloClient.operations.all()).toHaveLength(1);
+  });
+
+  it('resolve all pendingRequests when resolveAll was called', () => {
+    const mockOptions = {link: new SimpleLink(), cache: new InMemoryCache()};
+    const memoryApolloClient = new MemoryApolloClient(mockOptions);
+
+    memoryApolloClient.query({query: petQuery});
+    expect(Array.from(memoryApolloClient.pendingRequests)).toHaveLength(1);
+    memoryApolloClient.resolveAll();
+    expect(Array.from(memoryApolloClient.pendingRequests)[0]).resolves;
+  });
+
+  it('delete request from pendingRequests when resolved', () => {
+    const mockOptions = {link: new SimpleLink(), cache: new InMemoryCache()};
+    const memoryApolloClient = new MemoryApolloClient(mockOptions);
+
+    memoryApolloClient.query({query: petQuery});
+    expect(Array.from(memoryApolloClient.pendingRequests)).toHaveLength(1);
+    memoryApolloClient.resolveAll();
+    expect(Array.from(memoryApolloClient.pendingRequests)).toHaveLength(0);
+  });
+});

--- a/packages/graphql-testing/src/test/MemoryApolloLink.test.ts
+++ b/packages/graphql-testing/src/test/MemoryApolloLink.test.ts
@@ -1,0 +1,60 @@
+import {ApolloLink} from 'apollo-link';
+import {executeOnce, SimpleLink} from './utilities/apollo-link';
+
+import MemoryApolloLink from '../MemoryApolloLink';
+import petQuery from './fixtures/PetQuery.graphql';
+import {MockRequest} from '../types';
+
+describe('MemoryApolloLink', () => {
+  it('throw error when MemoryApolloLink are being executed as a terminating link', () => {
+    const mockApolloLink = new MemoryApolloLink();
+
+    expect(executeOnce(mockApolloLink, petQuery)).rejects.toEqual(
+      'The memory link must not be a terminating link',
+    );
+  });
+
+  it('calls requestCreated once when query executed', () => {
+    const requestCreated = jest.fn();
+    const memoryApolloLink = new MemoryApolloLink();
+    memoryApolloLink.onRequestCreated(requestCreated);
+
+    executeOnce(
+      ApolloLink.from([memoryApolloLink, new SimpleLink()]),
+      petQuery,
+    );
+
+    expect(requestCreated).toHaveBeenCalledTimes(1);
+    expect(requestCreated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: expect.objectContaining({operationName: 'Pet'}),
+        resolve: expect.any(Function),
+      }),
+    );
+  });
+
+  it('calls requestResolved when the request resolved', async () => {
+    const requests: MockRequest[] = [];
+    const requestResolved = jest.fn();
+    const memoryApolloLink = new MemoryApolloLink();
+    memoryApolloLink.onRequestCreated(request => {
+      requests.push(request);
+    });
+    memoryApolloLink.onRequestResolved(requestResolved);
+
+    executeOnce(
+      ApolloLink.from([memoryApolloLink, new SimpleLink()]),
+      petQuery,
+    );
+
+    await Promise.all(requests.map(({resolve}) => resolve()));
+
+    expect(requestResolved).toHaveBeenCalledTimes(1);
+    expect(requestResolved).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: expect.objectContaining({operationName: 'Pet'}),
+        resolve: expect.any(Function),
+      }),
+    );
+  });
+});

--- a/packages/graphql-testing/src/test/MockApolloLink.test.ts
+++ b/packages/graphql-testing/src/test/MockApolloLink.test.ts
@@ -1,0 +1,43 @@
+import {MockGraphQLResponse} from '../types';
+import {executeOnce} from './utilities/apollo-link';
+
+import MockApolloLink from '../MockApolloLink';
+import petQuery from './fixtures/PetQuery.graphql';
+
+describe('MockApolloLink', () => {
+  it('returns error message with empty mock object', async () => {
+    const mockApolloLink = new MockApolloLink({});
+    const {result} = await executeOnce(mockApolloLink, petQuery);
+
+    expect(result).toMatchObject(
+      new Error(
+        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({Pet: yourFixture}).'",
+      ),
+    );
+  });
+
+  it('returns error message when there are no matching mocks', async () => {
+    const mockApolloLink = new MockApolloLink({LostPets: {}, PetsForSale: {}});
+    const {result} = await executeOnce(mockApolloLink, petQuery);
+
+    expect(result).toMatchObject(
+      new Error(
+        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
+      ),
+    );
+  });
+
+  it('returns error message with empty mock function', async () => {
+    const mockApolloLink = new MockApolloLink(
+      () => (null as unknown) as MockGraphQLResponse,
+    );
+
+    const {result} = await executeOnce(mockApolloLink, petQuery);
+
+    expect(result).toMatchObject(
+      new Error(
+        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided a function that did not return a valid mock result)",
+      ),
+    );
+  });
+});

--- a/packages/graphql-testing/src/test/Operations.test.ts
+++ b/packages/graphql-testing/src/test/Operations.test.ts
@@ -1,0 +1,91 @@
+import {Operation} from 'apollo-link';
+import gql from 'graphql-tag';
+
+import Operations from '../Operations';
+
+function pushOperations(opertaions: Operations, opertaionList: Operation[]) {
+  opertaionList.forEach(operation => opertaions.push(operation));
+}
+
+const Q1 = gql`
+  {
+    q1
+  }
+`;
+
+const Q2 = gql`
+  {
+    q2
+  }
+`;
+
+const Q3 = gql`
+  {
+    q3
+  }
+`;
+
+const mockOperations: Operation[] = [
+  {
+    query: Q1,
+    operationName: 'operation 1',
+    variables: {},
+    extensions: {},
+    setContext: () => ({}),
+    getContext: () => ({}),
+    toKey: () => 'operation 1',
+  },
+  {
+    query: Q2,
+    operationName: 'operation 2',
+    variables: {},
+    extensions: {},
+    setContext: () => ({}),
+    getContext: () => ({}),
+    toKey: () => 'operation 2',
+  },
+  {
+    query: Q3,
+    operationName: 'operation 2',
+    variables: {},
+    extensions: {},
+    setContext: () => ({}),
+    getContext: () => ({}),
+    toKey: () => 'operation 2',
+  },
+];
+
+const opertaions = new Operations();
+pushOperations(opertaions, mockOperations);
+
+describe('graphql-testing Operations', () => {
+  it('gets last operation', () => {
+    expect(opertaions.last().query).toBe(Q3);
+  });
+
+  it('gets nth operation', () => {
+    expect(opertaions.nth(2).query).toBe(Q3);
+    expect(opertaions.nth(-1).query).toBe(Q2);
+  });
+
+  it('gets all operations', () => {
+    expect(opertaions.all().length).toBe(3);
+  });
+
+  it('gets all operations with operationName', () => {
+    expect(
+      opertaions.all({operationName: mockOperations[0].operationName}).length,
+    ).toBe(1);
+    expect(
+      opertaions.all({operationName: mockOperations[1].operationName}).length,
+    ).toBe(2);
+  });
+
+  it('throws an error when last operation of type does not exist', () => {
+    const opertaions = new Operations();
+
+    expect(() => opertaions.last({operationName: 'LostPet'})).toThrow(
+      "no operation with operationName 'LostPet' were found.",
+    );
+  });
+});

--- a/packages/graphql-testing/src/test/createGraphQLFactory.test.tsx
+++ b/packages/graphql-testing/src/test/createGraphQLFactory.test.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import {graphql} from 'react-apollo';
+
+import {mount} from 'enzyme';
+
+import createGraphQLFactory from '../createGraphQLFactory';
+import unionOrIntersectionTypes from './fixtures/schema-unions-and-interfaces.json';
+import petQuery from './fixtures/PetQuery.graphql';
+
+// setup
+const createGraphQL = createGraphQLFactory({
+  unionOrIntersectionTypes,
+});
+
+interface Props {
+  data?: {
+    loading?: boolean;
+    pets?: any[];
+    error?: any;
+  };
+}
+
+// mock Component
+function SomePageBase(props: Props) {
+  if (!props.data) {
+    return null;
+  }
+  const {
+    data: {loading = true, pets, error},
+  } = props;
+  const errorMessage = error ? <p>{error.message}</p> : null;
+
+  return (
+    <>
+      <p>{loading ? 'Loading' : 'Loaded!'}</p>
+      <p>{pets && pets.length ? pets[0].name : 'No pets'}</p>
+      {errorMessage}
+    </>
+  );
+}
+const SomePage = graphql(petQuery)(SomePageBase);
+
+const graphQL = createGraphQL({
+  Pet: {
+    pets: [
+      {
+        __typename: 'Cat',
+        name: 'Garfield',
+      },
+    ],
+  },
+});
+
+describe('graphql-testing', () => {
+  it('throws error when no mock provided', async () => {
+    const graphQL = createGraphQL();
+    const somePage = mount(<SomePage />, {
+      context: {
+        client: graphQL.client,
+      },
+      childContextTypes: {
+        client: PropTypes.object,
+      },
+    });
+
+    await graphQL.resolveAll();
+    somePage.update();
+
+    expect(
+      somePage.containsMatchingElement(
+        <p>
+          GraphQL error: Can’t perform GraphQL operation {"'Pet'"} because no
+          mocks were set.
+        </p>,
+      ),
+    ).toBe(true);
+  });
+
+  it('resolves mock query and renders data', async () => {
+    const somePage = mount(<SomePage />, {
+      context: {
+        client: graphQL.client,
+      },
+      childContextTypes: {
+        client: PropTypes.object,
+      },
+    });
+
+    await graphQL.resolveAll();
+    somePage.update();
+
+    const query = graphQL.operations.last({operationName: 'Pet'});
+    expect(query).toMatchObject({operationName: 'Pet'});
+
+    expect(somePage.containsMatchingElement(<p>Garfield</p>)).toBe(true);
+  });
+});

--- a/packages/graphql-testing/src/test/fixtures/PetQuery.graphql
+++ b/packages/graphql-testing/src/test/fixtures/PetQuery.graphql
@@ -1,0 +1,9 @@
+query Pet {
+  pets {
+    ...CatInfo
+  }
+}
+
+fragment CatInfo on Cat {
+  name
+}

--- a/packages/graphql-testing/src/test/fixtures/schema-unions-and-interfaces.json
+++ b/packages/graphql-testing/src/test/fixtures/schema-unions-and-interfaces.json
@@ -1,0 +1,16 @@
+[
+  {
+    "kind": "UNION",
+    "name": "Pet",
+    "possibleTypes": [
+      {
+        "kind": "OBJECT",
+        "name": "Dog"
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Cat"
+      }
+    ]
+  }
+]

--- a/packages/graphql-testing/src/test/utilities/apollo-link.ts
+++ b/packages/graphql-testing/src/test/utilities/apollo-link.ts
@@ -1,0 +1,78 @@
+import {
+  ApolloLink,
+  execute,
+  Operation,
+  Observable,
+  FetchResult,
+  NextLink,
+} from 'apollo-link';
+import {DocumentNode} from 'graphql-typed';
+
+interface ExecuteOnceOutcome {
+  operation: Operation;
+  result?: FetchResult;
+  error?: Error;
+}
+
+function noop() {}
+
+export function executeOnce(link: ApolloLink, query: DocumentNode) {
+  let op: Operation;
+  const storeLink = new ApolloLink((operation, nextLink) => {
+    op = operation;
+
+    if (nextLink == null) {
+      return null;
+    }
+
+    return nextLink(operation);
+  });
+
+  return new Promise<ExecuteOnceOutcome>(resolve => {
+    execute(storeLink.concat(link), {query}).subscribe({
+      next(result) {
+        resolve({operation: op, result});
+      },
+      error(error) {
+        resolve({operation: op, error});
+      },
+    });
+  });
+}
+
+type BeforeResult = ((operation: Operation) => void);
+
+export class SimpleLink extends ApolloLink {
+  constructor(
+    private result: object | Error | Promise<object | Error> = {data: {}},
+    private beforeResult: BeforeResult = noop,
+  ) {
+    super();
+  }
+
+  request(operation: Operation, nextLink?: NextLink) {
+    this.beforeResult(operation);
+
+    if (nextLink != null) {
+      return nextLink(operation);
+    }
+
+    return new Observable(obs => {
+      function handleResult(result: object | Error) {
+        if (result instanceof Error) {
+          obs.error(result);
+        } else {
+          obs.next(result);
+        }
+
+        obs.complete();
+      }
+
+      if (this.result instanceof Promise) {
+        this.result.then(handleResult).catch(handleResult);
+      } else {
+        handleResult(this.result);
+      }
+    });
+  }
+}

--- a/packages/graphql-testing/src/types.ts
+++ b/packages/graphql-testing/src/types.ts
@@ -1,0 +1,14 @@
+import {GraphQLRequest, Operation} from 'apollo-link';
+
+export type MockGraphQLResponse = Error | object;
+export type MockGraphQLFunction = (
+  request: GraphQLRequest,
+) => MockGraphQLResponse;
+export type GraphQLMock =
+  | {[key: string]: MockGraphQLResponse | MockGraphQLFunction}
+  | MockGraphQLFunction;
+
+export interface MockRequest {
+  operation: Operation;
+  resolve(): Promise<void>;
+}

--- a/packages/graphql-testing/tsconfig.build.json
+++ b/packages/graphql-testing/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/jest-mock-apollo/README.md
+++ b/packages/jest-mock-apollo/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo)
 
+:warning: This is being replace with [`@shopify/graphql-testing`](../../packages/graphql-testing)
+
 Jest + Enzyme mocks for Apollo 2.x.
 
 ## Installation


### PR DESCRIPTION
This PR create a new package `graphql-testing` which is and updated version of `jest-mock-apollo` with rename. The biggest change being you no longer need to build with schema when creating the factory.