### PR TITLE
Add @shopify/performance

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,1 +1,2 @@
 **/*/node_modules/@types/graphql/
+**/*/node_modules/@types/react/

--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/performance` package

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -1,0 +1,88 @@
+# `@shopify/performance`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fperformance.svg)](https://badge.fury.io/js/%40shopify%2Fperformance.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/performance.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/performance.svg)
+
+Primitives for collecting browser performance metrics.
+
+## Installation
+
+```bash
+$ yarn add @shopify/performance
+```
+
+## Usage
+
+This library wraps around the native `Performance` and `PerformanceObserver` browser globals, providing a normalized interface for tracking performance across browsers. It also adds the notion of "navigations": sections of time spent navigating to a "complete" page, during which events (time to first byte, script downloads, GraphQL queries, etc) occur. Finally, it provides a few event listeners to be informed of new navigation and key events.
+
+### `Performance`
+
+To start using this library, construct an instance of the `Performance` class. Only one instance of this class should exist during the lifecycle of your app, as this class assumes it is constructed near the page’s initial load.
+
+```ts
+import {Performance} from '@shopify/performance';
+
+const performance = new Performance();
+```
+
+If you want to listen for events, you can use the `on` method. There are three events you can listen for:
+
+```ts
+// Listen for completed navigations. If you call this after the initial load
+// "navigation", your handler will immediately be invoked with that object.
+performance.on('navigation', navigation => {});
+
+// Listen for the start of new navigations.
+performance.on('navigationStart', () => {});
+
+// Listen for "lifecycle" events; that is, those that are part of the initial
+// page load and come directly from the browser. These are events like time
+// to first byte and time to first paint. See the `LifecycleEvent` type for
+// the full set of possible events. If you add your listener after some of these
+// events have been triggered, it will immediately be invoked once for each
+// previously-triggered event.
+performance.on('lifecycleEvent', event => {});
+```
+
+You can also manage navigations using this object. Calling `performance.start()` will begin a new navigation, cancelling any that are currently inflight. `performance.event()` allows you to register custom events on the navigation. Finally, `performance.finish()` marks the navigation is complete.
+
+```ts
+import {now} from '@shopify/performance';
+
+// You usually don't need this, as we automatically start a visit when the
+// browser first loads, and when the history API is used to navigate the app.
+performance.start({
+  target: '/my-page',
+});
+
+// A duration of 0 indicates a mark of some kind, while a non-0 duration would
+// be used for things like network requests. Make sure to use the `now()` function
+// because it will use high-resolution time when available.
+performance.event({
+  type: 'customevent',
+  start: now(),
+  duration: 0,
+});
+
+performance.finish();
+```
+
+### `Navigation`
+
+The `Navigation` object represents a full navigation, either from a full-page refresh, or between two pages. It has the following key details about the navigation:
+
+- `start`: the full timestamp when the navigation started, using high-resolution time when available.
+- `duration`: how long the navigation took, using high-resolution time when available.
+- `target`: a string representing the "end" of the navigation, defaulting to the target page’s pathname.
+- `result`: a `NavigationResult` marking the navigation as either finished, cancelled (another navigation began before this one completed), or timed out (`performance.finish()` was not called in a reasonable amount of time, which defaults to 60 seconds from when `performance.start()` is called)
+- `metadata`: an object giving additional context to the navigation. This object has the following properties:
+  - `index` (the number of navigations before this one since the last full page navigation)
+  - `supportsDetailedEvents` (whether events like time to first paint are supported by the browser)
+  - `supportsDetailedTime` (whether high-resolution time is supported by the browser)
+- `events`: an array of objects representing the events that occurred during the navigation. These events include the following properties:
+  - `type`: the type of event
+  - `start`: when the event started, _relative to the start of the navigation_
+  - `duration`: how long the event took (0 indicates a mark, rather than an event occurring over time)
+  - `metadata`: an object with arbitrary key-value pairs providing additional context
+
+`Navigation` also provides a number of utility methods for gathering more actionable information, such as `eventsByType` for filtering events to a particular type, or `totalDownloadSize` for the cumulative size of all requested resources. Please consult the TypeScript definitions for a full listing of these methods.

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@shopify/performance",
-  "version": "0.0.0",
+  "name": "lemon-performance",
+  "version": "0.0.1",
   "license": "MIT",
   "description": "Primitives for collecting browser performance metrics.",
   "main": "dist/index.js",
@@ -27,5 +27,7 @@
   "devDependencies": {
     "typescript": "~3.0.1"
   },
-  "files": ["dist/*"]
+  "files": [
+    "dist/*"
+  ]
 }

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shopify/performance",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Primitives for collecting browser performance metrics.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/performance/README.md",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "~3.0.1"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lemon-performance",
+  "name": "@shopify/performance",
   "version": "0.0.1",
   "license": "MIT",
   "description": "Primitives for collecting browser performance metrics.",

--- a/packages/performance/src/index.ts
+++ b/packages/performance/src/index.ts
@@ -1,0 +1,4 @@
+export {Performance} from './performance';
+export {Navigation} from './navigation';
+export * from './types';
+export {now} from './utilities';

--- a/packages/performance/src/inflight.ts
+++ b/packages/performance/src/inflight.ts
@@ -1,0 +1,105 @@
+import {now} from './utilities';
+import {Event, NavigationResult, NavigationMetadata, EventType} from './types';
+import {Navigation} from './navigation';
+
+interface NavigationStartOptions {
+  timeOrigin: number;
+  target?: string;
+  start?: number;
+}
+
+const MATCHES_CHECK_MAP = new Map<
+  Event['type'],
+  (newEvent: Event, oldEvent: Event) => boolean
+>([
+  [
+    EventType.ScriptDownload,
+    (newEvent: Event, oldEvent: Event) =>
+      oldEvent.type === EventType.ScriptDownload &&
+      // eslint-disable-next-line typescript/no-non-null-assertion
+      oldEvent.metadata!.name === newEvent.metadata!.name,
+  ],
+]);
+
+function defaultEqualityCheck({type}: Event, {type: otherType}: Event) {
+  return type === otherType;
+}
+
+export class InflightNavigation {
+  private timeOrigin: number;
+  private start: number;
+  private target: string;
+  private events: Event[] = [];
+
+  constructor(
+    {
+      timeOrigin,
+      start = now(),
+      target = window.location.pathname,
+    }: NavigationStartOptions,
+    private metadata: NavigationMetadata,
+  ) {
+    this.timeOrigin = timeOrigin;
+    this.start = this.normalize(start);
+    this.target = target;
+  }
+
+  event(
+    event: Event,
+    replaceExisting:
+      | boolean
+      | ((newEvent: Event, oldEvent: Event) => boolean) = false,
+  ) {
+    const normalizedEvent = {...event, start: this.normalize(event.start)};
+
+    if (replaceExisting) {
+      const check =
+        typeof replaceExisting === 'function'
+          ? replaceExisting
+          : MATCHES_CHECK_MAP.get(event.type) || defaultEqualityCheck;
+
+      const existingIndex = this.events.findIndex(oldEvent =>
+        check(event, oldEvent),
+      );
+
+      if (existingIndex >= 0) {
+        this.events.splice(existingIndex, 1, normalizedEvent);
+      } else {
+        this.events.push(normalizedEvent);
+      }
+    } else {
+      this.events.push(normalizedEvent);
+    }
+  }
+
+  cancel(timeStamp = now()) {
+    return this.end(timeStamp, NavigationResult.Cancelled);
+  }
+
+  timeout(timeStamp = now()) {
+    return this.end(timeStamp, NavigationResult.TimedOut);
+  }
+
+  finish(timeStamp = now()) {
+    return this.end(timeStamp, NavigationResult.Finished);
+  }
+
+  private end(timeStamp: number, result: NavigationResult) {
+    return new Navigation(
+      {
+        target: this.target,
+        start: this.start,
+        duration: this.normalize(timeStamp) - this.start,
+        events: this.events.sort(
+          (eventOne, eventTwo) => eventOne.start - eventTwo.start,
+        ),
+        result,
+      },
+      this.metadata,
+    );
+  }
+
+  private normalize(timeStamp: number) {
+    return this.timeOrigin + timeStamp;
+  }
+}

--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -1,0 +1,112 @@
+import {
+  Event,
+  EventType,
+  NavigationDefinition,
+  NavigationResult,
+  NavigationMetadata,
+  LifecycleEvent,
+  EventMap,
+} from './types';
+import {getUniqueRanges} from './utilities';
+
+const LIFECYCLE_EVENTS: LifecycleEvent['type'][] = [
+  EventType.TimeToFirstByte,
+  EventType.TimeToFirstPaint,
+  EventType.TimeToFirstContentfulPaint,
+  EventType.DomContentLoaded,
+  EventType.Load,
+];
+
+export class Navigation implements NavigationDefinition {
+  start: number;
+  duration: number;
+  target: string;
+  events: Event[];
+  result: NavigationResult;
+
+  get isFullPageNavigation() {
+    return this.metadata.index === 0;
+  }
+
+  constructor(
+    {start, duration, target, events, result}: NavigationDefinition,
+    public metadata: NavigationMetadata,
+  ) {
+    this.start = start;
+    this.duration = duration;
+    this.target = target;
+    this.events = events;
+    this.result = result;
+  }
+
+  eventsByType<T extends Event['type'], EventType = EventMap[T]>(
+    targetType: T,
+  ): EventType[] {
+    return this.events.filter(({type}) => type === targetType) as any[];
+  }
+
+  totalDurationByEventType(type: Event['type'], {countOverlaps = false} = {}) {
+    const events = this.eventsByType(type);
+
+    if (events.length === 0) {
+      return 0;
+    }
+
+    const ranges = countOverlaps ? events : getUniqueRanges(events);
+    return ranges.reduce((total, {duration}) => total + duration, 0);
+  }
+
+  get resourceEvents() {
+    return [
+      ...this.eventsByType(EventType.ScriptDownload),
+      ...this.eventsByType(EventType.StyleDownload),
+    ];
+  }
+
+  get totalDownloadSize() {
+    return this.resourceEvents.reduce<number | undefined>(
+      (total, {metadata: {size}}) =>
+        size == null || typeof total !== 'number' ? undefined : total + size,
+      0,
+    );
+  }
+
+  get cacheEffectiveness() {
+    const events = this.resourceEvents;
+
+    if (
+      events.length === 0 ||
+      events.some(({metadata: {size}}) => size == null)
+    ) {
+      return undefined;
+    }
+
+    return (
+      events.filter(({metadata: {size}}) => size === 0).length / events.length
+    );
+  }
+
+  toJSON({
+    stripEventMetadata = true,
+    stripLifecycleEvents = true,
+  } = {}): NavigationDefinition {
+    const events = stripLifecycleEvents
+      ? this.events.filter(
+          ({type}) =>
+            !LIFECYCLE_EVENTS.includes(type as LifecycleEvent['type']),
+        )
+      : this.events;
+
+    const processedEvents = stripEventMetadata
+      ? events.map(({metadata, ...rest}) => rest)
+      : events;
+
+    return {
+      start: this.start,
+      duration: this.duration,
+      target: this.target,
+      events: processedEvents,
+      result: this.result,
+    };
+  }
+}

--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -56,6 +56,15 @@ export class Navigation implements NavigationDefinition {
     return ranges.reduce((total, {duration}) => total + duration, 0);
   }
 
+  get timeToComplete() {
+    return this.duration;
+  }
+
+  get timeToUsable() {
+    const usableEvent = this.eventsByType(EventType.Usable)[0];
+    return usableEvent ? usableEvent.start : this.timeToComplete;
+  }
+
   get resourceEvents() {
     return [
       ...this.eventsByType(EventType.ScriptDownload),

--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -64,7 +64,13 @@ export class Navigation implements NavigationDefinition {
   }
 
   get totalDownloadSize() {
-    return this.resourceEvents.reduce<number | undefined>(
+    const events = this.resourceEvents;
+
+    if (events.length === 0) {
+      return undefined;
+    }
+
+    return events.reduce<number | undefined>(
       (total, {metadata: {size}}) =>
         size == null || typeof total !== 'number' ? undefined : total + size,
       0,
@@ -87,17 +93,17 @@ export class Navigation implements NavigationDefinition {
   }
 
   toJSON({
-    stripEventMetadata = true,
-    stripLifecycleEvents = true,
+    removeEventMetadata = true,
+    removeLifecycleEvents = true,
   } = {}): NavigationDefinition {
-    const events = stripLifecycleEvents
+    const events = removeLifecycleEvents
       ? this.events.filter(
           ({type}) =>
             !LIFECYCLE_EVENTS.includes(type as LifecycleEvent['type']),
         )
       : this.events;
 
-    const processedEvents = stripEventMetadata
+    const processedEvents = removeEventMetadata
       ? events.map(({metadata, ...rest}) => rest)
       : events;
 

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -1,0 +1,274 @@
+import {InflightNavigation} from './inflight';
+import {Navigation} from './navigation';
+import {
+  now,
+  withEntriesOfType,
+  withNavigation,
+  withTiming,
+  supportsPerformanceObserver,
+  referenceTime,
+  hasGlobal,
+} from './utilities';
+import {
+  Event,
+  EventType,
+  LifecycleEvent,
+  TimeToFirstPaintEvent,
+  TimeToFirstContentfulPaintEvent,
+} from './types';
+
+const WATCH_RESOURCE_TYPES = ['script', 'css'];
+
+interface EventMap {
+  navigation: (navigation: Navigation) => void;
+  navigationStart: () => void;
+  lifecycleEvent: (event: LifecycleEvent) => void;
+}
+
+const DEFAULT_TIMEOUT = 60_000;
+
+export class Performance {
+  readonly supportsMarks = hasGlobal('PerformanceMark');
+  readonly supportsNavigationEntries = hasGlobal('PerformanceNavigationTiming');
+  readonly supportsLongtaskEntries = hasGlobal('PerformanceLongTaskTiming');
+  readonly supportsResourceEntries = hasGlobal('PerformanceResourceTiming');
+  readonly supportsPaintEntries = hasGlobal('PerformancePaintTiming');
+
+  readonly timeOrigin = referenceTime();
+  readonly supportsDetailedTime = supportsPerformanceObserver;
+  readonly supportsDetailedEvents =
+    this.supportsNavigationEntries &&
+    this.supportsLongtaskEntries &&
+    this.supportsResourceEntries &&
+    this.supportsPaintEntries;
+
+  private inflightNavigation?: InflightNavigation;
+  private navigationTimeout?: ReturnType<typeof setTimeout>;
+  private firstNavigation?: Navigation;
+  private lifecycleEvents: LifecycleEvent[] = [];
+  private navigationCount = 0;
+  private eventHandlers = {
+    navigation: new Set<EventMap['navigation']>(),
+    navigationStart: new Set<EventMap['navigationStart']>(),
+    lifecycleEvent: new Set<EventMap['lifecycleEvent']>(),
+  };
+
+  constructor() {
+    this.start({timeStamp: 0});
+
+    withNavigation(this.start.bind(this));
+
+    if (!this.supportsDetailedTime || !this.supportsNavigationEntries) {
+      withTiming(
+        ({responseStart, domContentLoadedEventStart, loadEventStart}) => {
+          this.lifecycleEvent({
+            type: EventType.TimeToFirstByte,
+            start: responseStart - this.timeOrigin,
+            duration: 0,
+          });
+
+          this.lifecycleEvent({
+            type: EventType.DomContentLoaded,
+            start: domContentLoadedEventStart - this.timeOrigin,
+            duration: 0,
+          });
+
+          this.lifecycleEvent({
+            type: EventType.Load,
+            start: loadEventStart - this.timeOrigin,
+            duration: 0,
+          });
+        },
+      );
+    } else {
+      withEntriesOfType('navigation', entry => {
+        this.lifecycleEvent({
+          type: EventType.TimeToFirstByte,
+          start: entry.responseStart,
+          duration: 0,
+        });
+
+        if (entry.domContentLoadedEventStart > 0) {
+          this.lifecycleEvent({
+            type: EventType.DomContentLoaded,
+            start: entry.domContentLoadedEventStart,
+            duration: 0,
+          });
+        }
+
+        if (entry.loadEventStart > 0) {
+          this.lifecycleEvent({
+            type: EventType.Load,
+            start: entry.loadEventStart,
+            duration: 0,
+          });
+        }
+      });
+    }
+
+    if (this.supportsResourceEntries) {
+      withEntriesOfType('resource', entry => {
+        if (!WATCH_RESOURCE_TYPES.includes(entry.initiatorType)) {
+          return;
+        }
+
+        this.event(
+          {
+            type:
+              entry.initiatorType === 'script'
+                ? EventType.ScriptDownload
+                : EventType.StyleDownload,
+            start: entry.startTime,
+            duration: entry.duration,
+            metadata: {
+              name: entry.name,
+              size: entry.encodedBodySize,
+            },
+          },
+          {replace: true},
+        );
+      });
+    }
+
+    if (this.supportsLongtaskEntries) {
+      withEntriesOfType('longtask', entry => {
+        this.event({
+          type: EventType.LongTask,
+          start: entry.startTime,
+          duration: entry.duration,
+        });
+      });
+    }
+
+    if (this.supportsPaintEntries) {
+      withEntriesOfType('paint', entry => {
+        const type =
+          entry.name === 'first-paint'
+            ? EventType.TimeToFirstPaint
+            : EventType.TimeToFirstContentfulPaint;
+
+        this.lifecycleEvent({type, start: entry.startTime, duration: 0} as
+          | TimeToFirstPaintEvent
+          | TimeToFirstContentfulPaintEvent);
+      });
+    }
+  }
+
+  on<T extends keyof EventMap>(event: T, handler: EventMap[T]) {
+    const handlers = this.eventHandlers[event] as Set<any>;
+    handlers.add(handler);
+
+    // If they are registering to hear about completed navigations, and we have already
+    // completed the first load, tell them about it. This allows them to bind to the
+    // listener later and still feel as if they had registered as early as possible.
+    if (
+      event === 'navigation' &&
+      this.firstNavigation != null &&
+      this.navigationCount === 1
+    ) {
+      (handler as EventMap['navigation'])(this.firstNavigation);
+    }
+
+    // If they are registered to here about new navigations, and one is in flight,
+    // tell them right away.
+    if (event === 'navigationStart' && this.inflightNavigation != null) {
+      (handler as EventMap['navigationStart'])();
+    }
+
+    if (event === 'lifecycleEvent') {
+      for (const event of this.lifecycleEvents) {
+        (handler as EventMap['lifecycleEvent'])(event);
+      }
+    }
+
+    return () => handlers.delete(handler);
+  }
+
+  event(event: Event, {replace = false} = {}) {
+    if (this.inflightNavigation == null) {
+      return;
+    }
+
+    this.inflightNavigation.event(event, replace);
+  }
+
+  start({
+    timeStamp = now(),
+    target = window.location.pathname,
+    timeout = DEFAULT_TIMEOUT,
+  } = {}) {
+    this.clearTimeout();
+
+    if (this.inflightNavigation) {
+      this.record(this.inflightNavigation.cancel(timeStamp));
+    }
+
+    this.inflightNavigation = new InflightNavigation(
+      {
+        timeOrigin: this.timeOrigin,
+        start: timeStamp,
+        target,
+      },
+      {
+        index: this.navigationCount,
+        supportsDetailedTime: this.supportsDetailedTime,
+        supportsDetailedEvents: this.supportsDetailedEvents,
+      },
+    );
+
+    this.navigationTimeout = setTimeout(() => this.timeout.bind(this), timeout);
+
+    for (const subscriber of this.eventHandlers.navigationStart) {
+      subscriber();
+    }
+  }
+
+  finish(timeStamp = now()) {
+    this.clearTimeout();
+
+    if (this.inflightNavigation == null) {
+      return;
+    }
+
+    this.record(this.inflightNavigation.finish(timeStamp));
+    this.inflightNavigation = undefined;
+  }
+
+  private lifecycleEvent(event: LifecycleEvent) {
+    if (this.lifecycleEvents.find(({type}) => type === event.type) != null) {
+      return;
+    }
+
+    this.event(event);
+    this.lifecycleEvents.push(event);
+
+    for (const handler of this.eventHandlers.lifecycleEvent) {
+      handler(event);
+    }
+  }
+
+  private timeout() {
+    this.clearTimeout();
+
+    if (this.inflightNavigation == null) {
+      return;
+    }
+
+    this.record(this.inflightNavigation.timeout());
+  }
+
+  private clearTimeout() {
+    if (this.navigationTimeout) {
+      clearTimeout(this.navigationTimeout);
+      this.navigationTimeout = undefined;
+    }
+  }
+
+  private record(navigation: Navigation) {
+    this.navigationCount += 1;
+
+    for (const subscriber of this.eventHandlers.navigation) {
+      subscriber(navigation);
+    }
+  }
+}

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -230,7 +230,10 @@ export class Performance {
       return;
     }
 
-    this.record(this.inflightNavigation.finish(timeStamp));
+    const navigation = this.inflightNavigation.finish(timeStamp);
+
+    this.firstNavigation = this.firstNavigation || navigation;
+    this.record(navigation);
     this.inflightNavigation = undefined;
   }
 

--- a/packages/performance/src/test/navigation.test.ts
+++ b/packages/performance/src/test/navigation.test.ts
@@ -3,6 +3,12 @@ import {
   NavigationDefinition,
   NavigationMetadata,
   NavigationResult,
+  CustomEvent,
+  ScriptDownloadEvent,
+  EventType,
+  StyleDownloadEvent,
+  LifecycleEvent,
+  EventMap,
 } from '../types';
 
 describe('Navigation', () => {
@@ -43,18 +49,256 @@ describe('Navigation', () => {
     );
   });
 
-  describe('#isFirstLoad', () => {
+  describe('#isFullPageNavigation', () => {
     it('is true when the navigation is index 0', () => {
       const navigation = createNavigation(undefined, {index: 0});
-      expect(navigation).toHaveProperty('isFirstLoad', true);
+      expect(navigation).toHaveProperty('isFullPageNavigation', true);
     });
 
     it('is false when the navigation is not index 0', () => {
       const navigation = createNavigation(undefined, {index: 2});
-      expect(navigation).toHaveProperty('isFirstLoad', false);
+      expect(navigation).toHaveProperty('isFullPageNavigation', false);
+    });
+  });
+
+  describe('#resourceEvents', () => {
+    it('does not return non-resource events', () => {
+      const navigation = createNavigation({events: [createGenericEvent()]});
+      expect(navigation.resourceEvents).toHaveLength(0);
+    });
+
+    it('returns script download events', () => {
+      const event = createScriptDownloadEvent();
+      const navigation = createNavigation({
+        events: [event],
+      });
+      expect(navigation.resourceEvents).toEqual([event]);
+    });
+
+    it('returns style download events', () => {
+      const event = createStyleDownloadEvent();
+      const navigation = createNavigation({
+        events: [event],
+      });
+      expect(navigation.resourceEvents).toEqual([event]);
+    });
+  });
+
+  describe('#totalDownloadSize', () => {
+    it('is undefined when there are no resource downloads', () => {
+      const navigation = createNavigation();
+      expect(navigation).toHaveProperty('totalDownloadSize', undefined);
+    });
+
+    it('is undefined when any resource downloads have an undefined size', () => {
+      const navigation = createNavigation({
+        events: [
+          createScriptDownloadEvent({metadata: {size: 100}}),
+          createStyleDownloadEvent({metadata: {size: undefined}}),
+        ],
+      });
+      expect(navigation).toHaveProperty('totalDownloadSize', undefined);
+    });
+
+    it('sums the size of all resource downloads', () => {
+      const navigation = createNavigation({
+        events: [
+          createScriptDownloadEvent({metadata: {size: 100}}),
+          createStyleDownloadEvent({metadata: {size: 250}}),
+        ],
+      });
+      expect(navigation).toHaveProperty('totalDownloadSize', 350);
+    });
+  });
+
+  describe('#cacheEffectiveness', () => {
+    it('is undefined when there are no resource downloads', () => {
+      const navigation = createNavigation();
+      expect(navigation).toHaveProperty('cacheEffectiveness', undefined);
+    });
+
+    it('is undefined when any resource downloads have an undefined size', () => {
+      const navigation = createNavigation({
+        events: [
+          createScriptDownloadEvent({metadata: {size: 100}}),
+          createStyleDownloadEvent({metadata: {size: undefined}}),
+        ],
+      });
+      expect(navigation).toHaveProperty('cacheEffectiveness', undefined);
+    });
+
+    it('returns a ratio of cached (size = 0) resources to uncached ones', () => {
+      const navigation = createNavigation({
+        events: [
+          createScriptDownloadEvent({metadata: {size: 0}}),
+          createScriptDownloadEvent({metadata: {size: 0}}),
+          createStyleDownloadEvent({metadata: {size: 250}}),
+        ],
+      });
+      expect(navigation).toHaveProperty('cacheEffectiveness', 2 / 3);
+    });
+  });
+
+  describe('#eventsByType()', () => {
+    it('filters to only the matching events', () => {
+      const type = 'my-type';
+      const events = [
+        createGenericEvent({type}),
+        createGenericEvent({type: 'another-type'}),
+        createGenericEvent({type}),
+      ];
+      const navigation = createNavigation({events});
+      expect(navigation.eventsByType(type)).toEqual([events[0], events[2]]);
+    });
+  });
+
+  describe('#totalDurationByEventType()', () => {
+    it('sums up the duration of non-overlapping events', () => {
+      const type = 'my-type';
+      const events = [
+        createGenericEvent({type, start: 0, duration: 100}),
+        createGenericEvent({type, start: 200, duration: 150}),
+      ];
+      const navigation = createNavigation({events});
+      expect(navigation.totalDurationByEventType(type)).toBe(250);
+    });
+
+    it('sums up the duration of partially-overlapping events', () => {
+      const type = 'my-type';
+      const events = [
+        createGenericEvent({type, start: 0, duration: 100}),
+        createGenericEvent({type, start: 50, duration: 150}),
+      ];
+      const navigation = createNavigation({events});
+      expect(navigation.totalDurationByEventType(type)).toBe(200);
+    });
+
+    it('sums up the duration of fully-overlapping events', () => {
+      const type = 'my-type';
+      const events = [
+        createGenericEvent({type, start: 0, duration: 300}),
+        createGenericEvent({type, start: 50, duration: 150}),
+      ];
+      const navigation = createNavigation({events});
+      expect(navigation.totalDurationByEventType(type)).toBe(300);
+    });
+  });
+
+  describe('#toJSON()', () => {
+    it('always returns the basic fields', () => {
+      const basicDetails = {
+        start: 0,
+        duration: 1000,
+        target: '/admin',
+        result: NavigationResult.TimedOut,
+      };
+      expect(createNavigation(basicDetails).toJSON()).toMatchObject(
+        basicDetails,
+      );
+    });
+
+    it('removes all lifecycle events by default', () => {
+      const nonLifecycleEvent = createGenericEvent();
+      const events = [
+        createLifecycleEventEvent(EventType.TimeToFirstByte),
+        createLifecycleEventEvent(EventType.TimeToFirstPaint),
+        createLifecycleEventEvent(EventType.TimeToFirstContentfulPaint),
+        createLifecycleEventEvent(EventType.DomContentLoaded),
+        createLifecycleEventEvent(EventType.Load),
+        nonLifecycleEvent,
+      ];
+
+      expect(createNavigation({events}).toJSON()).toHaveProperty('events', [
+        nonLifecycleEvent,
+      ]);
+    });
+
+    it('includes lifecycle events when removeLifecycleEvents is false', () => {
+      const nonLifecycleEvent = createGenericEvent();
+      const events = [
+        createLifecycleEventEvent(EventType.TimeToFirstByte),
+        createLifecycleEventEvent(EventType.TimeToFirstPaint),
+        createLifecycleEventEvent(EventType.TimeToFirstContentfulPaint),
+        createLifecycleEventEvent(EventType.DomContentLoaded),
+        createLifecycleEventEvent(EventType.Load),
+        nonLifecycleEvent,
+      ];
+
+      expect(
+        createNavigation({events}).toJSON({removeLifecycleEvents: false}),
+      ).toHaveProperty('events', events);
+    });
+
+    it('removes event metadata by default', () => {
+      const event = createGenericEvent({
+        metadata: {foo: 'bar'},
+      });
+
+      expect(createNavigation({events: [event]}).toJSON()).not.toHaveProperty(
+        'events.0.metadata',
+      );
+    });
+
+    it('preserves event metadata when removeEventMetadata is false', () => {
+      const event = createGenericEvent({
+        metadata: {foo: 'bar'},
+      });
+
+      expect(
+        createNavigation({events: [event]}).toJSON({
+          removeEventMetadata: false,
+        }),
+      ).toHaveProperty('events.0.metadata', event.metadata);
     });
   });
 });
+
+function createGenericEvent(event: Partial<CustomEvent> = {}): CustomEvent {
+  return {
+    type: 'event',
+    duration: 0,
+    start: 0,
+    ...event,
+  };
+}
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K]
+};
+
+function createScriptDownloadEvent(
+  event: DeepPartial<ScriptDownloadEvent> = {},
+): ScriptDownloadEvent {
+  return {
+    type: EventType.ScriptDownload,
+    duration: 0,
+    start: 0,
+    ...event,
+    metadata: {name: 'script.js', ...event.metadata},
+  };
+}
+
+function createStyleDownloadEvent(
+  event: DeepPartial<StyleDownloadEvent> = {},
+): StyleDownloadEvent {
+  return {
+    type: EventType.StyleDownload,
+    duration: 0,
+    start: 0,
+    ...event,
+    metadata: {name: 'style.css', ...event.metadata},
+  };
+}
+
+function createLifecycleEventEvent<T extends LifecycleEvent['type']>(
+  type: T,
+): EventMap[T] {
+  return {
+    type,
+    duration: 0,
+    start: 0,
+  } as LifecycleEvent;
+}
 
 function createNavigation(
   details: Partial<NavigationDefinition> = {},

--- a/packages/performance/src/test/navigation.test.ts
+++ b/packages/performance/src/test/navigation.test.ts
@@ -1,0 +1,79 @@
+import {Navigation} from '../navigation';
+import {
+  NavigationDefinition,
+  NavigationMetadata,
+  NavigationResult,
+} from '../types';
+
+describe('Navigation', () => {
+  it('has a start time', () => {
+    const start = Date.now();
+    const navigation = createNavigation({start});
+    expect(navigation).toHaveProperty('start', start);
+  });
+
+  it('has a duration', () => {
+    const duration = 123;
+    const navigation = createNavigation({duration});
+    expect(navigation).toHaveProperty('duration', duration);
+  });
+
+  it('has a result', () => {
+    const result = NavigationResult.Cancelled;
+    const navigation = createNavigation({result});
+    expect(navigation).toHaveProperty('result', result);
+  });
+
+  it('has a target', () => {
+    const target = '/foobar';
+    const navigation = createNavigation({target});
+    expect(navigation).toHaveProperty('target', target);
+  });
+
+  it('has metadata', () => {
+    const metadata = {
+      index: 1,
+      supportsDetailedEvents: false,
+      supportsDetailedTime: true,
+    };
+    const navigation = createNavigation(undefined, metadata);
+    expect(navigation).toHaveProperty(
+      'metadata',
+      expect.objectContaining(metadata),
+    );
+  });
+
+  describe('#isFirstLoad', () => {
+    it('is true when the navigation is index 0', () => {
+      const navigation = createNavigation(undefined, {index: 0});
+      expect(navigation).toHaveProperty('isFirstLoad', true);
+    });
+
+    it('is false when the navigation is not index 0', () => {
+      const navigation = createNavigation(undefined, {index: 2});
+      expect(navigation).toHaveProperty('isFirstLoad', false);
+    });
+  });
+});
+
+function createNavigation(
+  details: Partial<NavigationDefinition> = {},
+  metadata: Partial<NavigationMetadata> = {},
+) {
+  return new Navigation(
+    {
+      start: Date.now(),
+      duration: 100,
+      events: [],
+      result: NavigationResult.Finished,
+      target: '/admin',
+      ...details,
+    },
+    {
+      index: 0,
+      supportsDetailedEvents: true,
+      supportsDetailedTime: true,
+      ...metadata,
+    },
+  );
+}

--- a/packages/performance/src/test/navigation.test.ts
+++ b/packages/performance/src/test/navigation.test.ts
@@ -61,6 +61,32 @@ describe('Navigation', () => {
     });
   });
 
+  describe('#timeToComplete', () => {
+    it('is the duration of the navigation', () => {
+      const duration = 123;
+      expect(createNavigation({duration})).toHaveProperty(
+        'timeToComplete',
+        duration,
+      );
+    });
+  });
+
+  describe('#timeToUsable', () => {
+    it('is the time to complete when no "usable" events were triggered', () => {
+      const navigation = createNavigation();
+      expect(navigation).toHaveProperty(
+        'timeToUsable',
+        navigation.timeToComplete,
+      );
+    });
+
+    it('is the start time of the "usable" event when available', () => {
+      const event = {type: EventType.Usable, duration: 0, start: 123};
+      const navigation = createNavigation({events: [event]});
+      expect(navigation).toHaveProperty('timeToUsable', event.start);
+    });
+  });
+
   describe('#resourceEvents', () => {
     it('does not return non-resource events', () => {
       const navigation = createNavigation({events: [createGenericEvent()]});

--- a/packages/performance/src/test/performance.test.ts
+++ b/packages/performance/src/test/performance.test.ts
@@ -1,0 +1,15 @@
+import {Performance} from '../performance';
+import {Navigation} from '../navigation';
+
+describe('Performance', () => {
+  // We are not adding all the required tests here until we have time
+  // to write a useful mock for Performance/ PerformanceObserver
+  it.skip('records a navigation on finish', () => {
+    const performance = new Performance();
+    const spy = jest.fn();
+    performance.on('navigation', spy);
+
+    performance.finish();
+    expect(spy).toHaveBeenCalledWith(expect.any(Navigation));
+  });
+});

--- a/packages/performance/src/types.ts
+++ b/packages/performance/src/types.ts
@@ -1,0 +1,115 @@
+export enum EventType {
+  TimeToFirstByte = 'ttfb',
+  TimeToFirstPaint = 'ttfp',
+  TimeToFirstContentfulPaint = 'ttfcp',
+  DomContentLoaded = 'dcl',
+  Load = 'load',
+  LongTask = 'longtask',
+  // eslint-disable-next-line shopify/typescript/prefer-pascal-case-enums
+  GraphQL = 'graphql',
+  ScriptDownload = 'script',
+  StyleDownload = 'style',
+}
+
+interface BasicEvent {
+  start: number;
+  duration: number;
+  metadata?: {[key: string]: any};
+}
+
+export interface TimeToFirstByteEvent extends BasicEvent {
+  type: EventType.TimeToFirstByte;
+  metadata?: undefined;
+}
+
+export interface TimeToFirstPaintEvent extends BasicEvent {
+  type: EventType.TimeToFirstPaint;
+  metadata?: undefined;
+}
+
+export interface TimeToFirstContentfulPaintEvent extends BasicEvent {
+  type: EventType.TimeToFirstContentfulPaint;
+  metadata?: undefined;
+}
+
+export interface DomContentLoadedEvent extends BasicEvent {
+  type: EventType.DomContentLoaded;
+  metadata?: undefined;
+}
+
+export interface LoadEvent extends BasicEvent {
+  type: EventType.Load;
+  metadata?: undefined;
+}
+
+export interface LongTaskEvent extends BasicEvent {
+  type: EventType.LongTask;
+  metadata?: undefined;
+}
+
+export interface ScriptDownloadEvent extends BasicEvent {
+  type: EventType.ScriptDownload;
+  metadata: {name: string; size?: number};
+}
+
+export interface StyleDownloadEvent extends BasicEvent {
+  type: EventType.StyleDownload;
+  metadata: {name: string; size?: number};
+}
+
+export interface GraphQLEvent extends BasicEvent {
+  type: EventType.GraphQL;
+  metadata: {name: string; size?: number};
+}
+
+export interface CustomEvent extends BasicEvent {
+  type: string;
+}
+
+export type LifecycleEvent =
+  | TimeToFirstByteEvent
+  | TimeToFirstPaintEvent
+  | TimeToFirstContentfulPaintEvent
+  | DomContentLoadedEvent
+  | LoadEvent;
+
+export type Event =
+  | LifecycleEvent
+  | LongTaskEvent
+  | ScriptDownloadEvent
+  | StyleDownloadEvent
+  | GraphQLEvent
+  | CustomEvent;
+
+export interface EventMap {
+  [EventType.TimeToFirstByte]: TimeToFirstByteEvent;
+  [EventType.TimeToFirstPaint]: TimeToFirstPaintEvent;
+  [EventType.TimeToFirstContentfulPaint]: TimeToFirstContentfulPaintEvent;
+  [EventType.DomContentLoaded]: DomContentLoadedEvent;
+  [EventType.Load]: LoadEvent;
+  [EventType.ScriptDownload]: ScriptDownloadEvent;
+  [EventType.StyleDownload]: StyleDownloadEvent;
+  [EventType.GraphQL]: GraphQLEvent;
+  [EventType.LongTask]: LongTaskEvent;
+  [key: string]: CustomEvent;
+}
+
+export interface NavigationMetadata {
+  index: number;
+  supportsDetailedTime: boolean;
+  supportsDetailedEvents: boolean;
+}
+
+export interface NavigationDefinition {
+  start: number;
+  duration: number;
+  target: string;
+  events: Event[];
+  result: NavigationResult;
+}
+
+export enum NavigationResult {
+  Finished,
+  TimedOut,
+  Cancelled,
+}

--- a/packages/performance/src/types.ts
+++ b/packages/performance/src/types.ts
@@ -5,6 +5,7 @@ export enum EventType {
   DomContentLoaded = 'dcl',
   Load = 'load',
   LongTask = 'longtask',
+  Usable = 'usable',
   // eslint-disable-next-line shopify/typescript/prefer-pascal-case-enums
   GraphQL = 'graphql',
   ScriptDownload = 'script',
@@ -62,6 +63,11 @@ export interface GraphQLEvent extends BasicEvent {
   metadata: {name: string; size?: number};
 }
 
+export interface UsableEvent extends BasicEvent {
+  type: EventType.Usable;
+  metadata?: undefined;
+}
+
 export interface CustomEvent extends BasicEvent {
   type: string;
 }
@@ -79,6 +85,7 @@ export type Event =
   | ScriptDownloadEvent
   | StyleDownloadEvent
   | GraphQLEvent
+  | UsableEvent
   | CustomEvent;
 
 export interface EventMap {
@@ -91,6 +98,7 @@ export interface EventMap {
   [EventType.StyleDownload]: StyleDownloadEvent;
   [EventType.GraphQL]: GraphQLEvent;
   [EventType.LongTask]: LongTaskEvent;
+  [EventType.Usable]: UsableEvent;
   [key: string]: CustomEvent;
 }
 

--- a/packages/performance/src/utilities.ts
+++ b/packages/performance/src/utilities.ts
@@ -1,0 +1,133 @@
+export function referenceTime() {
+  // If no performance, then we always used Date.now(), which is a full
+  // (if inaccurate) timestamp
+  if (typeof performance === 'undefined') {
+    return 0;
+  }
+
+  // Safari does not support performance.timeOrigin. We simulate it by using the
+  // (less precise) Date.now(), and subtracting the time since the timeOrigin
+  // (performance.now())
+  return performance.timeOrigin || Date.now() - performance.now();
+}
+
+export function now() {
+  return typeof performance === 'undefined' ? Date.now() : performance.now();
+}
+
+interface EntryMap {
+  resource: PerformanceResourceTiming;
+  longtask: PerformanceEntry;
+  paint: PerformanceEntry;
+  mark: PerformanceMark;
+  navigation: PerformanceNavigationTiming;
+}
+
+export function withEntriesOfType<T extends keyof EntryMap>(
+  type: T,
+  handler: (entry: EntryMap[T]) => void,
+) {
+  const initialEntries = performance.getEntriesByType(type);
+
+  initialEntries.forEach(entry => handler(entry));
+
+  const observer = new PerformanceObserver(entries => {
+    entries.getEntriesByType(type).forEach(entry => handler(entry));
+  });
+
+  observer.observe({
+    entryTypes: [type],
+    buffered: true,
+  });
+}
+
+export function withNavigation(
+  handler: (details?: {target?: string; timeStamp?: number}) => void,
+) {
+  const {pushState} = window.history;
+
+  window.addEventListener('popstate', () => {
+    handler();
+  });
+
+  history.pushState = (...args) => {
+    handler({target: args[2] || undefined});
+    pushState.call(history, ...args);
+  };
+}
+
+export function withTiming(
+  handler: (timing: typeof performance.timing) => void,
+) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  if (document.readyState === 'complete') {
+    handler(performance.timing);
+  } else {
+    window.addEventListener('load', () => handler(performance.timing), {
+      once: true,
+    });
+  }
+}
+
+export const supportsPerformanceObserver =
+  typeof PerformanceObserver !== 'undefined';
+
+export function hasGlobal(global: string) {
+  return typeof window !== 'undefined' && global in window;
+}
+
+interface Range {
+  start: number;
+  duration: number;
+}
+
+export function getUniqueRanges(ranges: Range[]) {
+  const uniqueRanges = new Set<Range>();
+
+  ranges.forEach(range => {
+    const overlappingRanges = [...uniqueRanges].filter(
+      // eslint-disable-next-line no-loop-func
+      otherRange => rangesOverlap(range, otherRange),
+    );
+
+    for (const overlappingRange of overlappingRanges) {
+      uniqueRanges.delete(overlappingRange);
+    }
+
+    uniqueRanges.add(squashRanges([range, ...overlappingRanges]));
+  });
+
+  return [...uniqueRanges];
+}
+
+function rangesOverlap(rangeOne: Range, rangeTwo: Range) {
+  const rangeOneEnd = rangeOne.start + rangeOne.duration;
+  const rangeTwoEnd = rangeTwo.start + rangeTwo.duration;
+
+  return (
+    // rangeOne starts in rangeTwo
+    (rangeOne.start >= rangeTwo.start && rangeOne.start <= rangeTwoEnd) ||
+    // rangeOne ends in rangeTwo
+    (rangeOneEnd >= rangeTwo.start && rangeOneEnd <= rangeTwoEnd) ||
+    // rangeTwo entirely within rangeOne
+    (rangeTwo.start >= rangeOne.start && rangeTwo.start <= rangeOneEnd)
+  );
+}
+
+function squashRanges(ranges: Range[]) {
+  const [first, ...rest] = ranges;
+  return rest.reduce<Range>((fullRange, range) => {
+    const start = Math.min(range.start, fullRange.start);
+    return {
+      start,
+      duration:
+        Math.max(
+          range.start + range.duration,
+          fullRange.start + fullRange.duration,
+        ) - start,
+    };
+  }, first);
+}

--- a/packages/performance/tsconfig.build.json
+++ b/packages/performance/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,11 +415,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.1.tgz#e2d374ef15b315b48e7efc308fa1a7cd51faa06c"
   integrity sha512-xwlHq5DXQFRpe+u6hmmNkzYk/3oxxqDp71a/AJMupOQYmxyaBetqrVMqdNlSQfbg7XTJYD8vARjf3Op06OzdtQ==
 
-"@types/prop-types@*":
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
-  integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
-
 "@types/react-helmet@^5.0.6":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.6.tgz#49607cbb72e1bb7dcefa9174cb591434d3b6f0af"
@@ -435,19 +430,11 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.3.18", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.3.18", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.3.18"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.18.tgz#bf195aed4d77dc86f06e4c9bb760214a3b822b8d"
   integrity sha512-aWTvLHzKqbVWCiee8huwf5x7Ob4n4gxDwgJT/X31HqjGVZpeUeFeSFYH5Gvi5Dmm5HKF+s+dQkwa/nnEVVzzzg==
   dependencies:
-    csstype "^2.2.0"
-
-"@types/react@>=16.4.0":
-  version "16.7.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
-  integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==
-  dependencies:
-    "@types/prop-types" "*"
     csstype "^2.2.0"
 
 "@types/safe-compare@^1.1.0":


### PR DESCRIPTION
This PR adds a new package. `@shopify/performance`. It sits on top of `Performance` and `PerformanceObserver` in the browser, and provides a nice API around tracking "navigations" — either full page loads, or incremental loads within the app. I'll add tests if we can commit to this approach, and I will follow this up with some React-/koa-specific bindings that are kind of just evolved versions of what currently exists in Web.

API is fairly well described in the README, start there if you want to have a general sense of what this is doing.