### PR TITLE
Warn about building dependencies before using yarn tophat

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,6 +46,8 @@ To try out your changes in another locally cloned project, you can use `yarn top
 
 Example: To test my changes to `@shopify/react-form-state` in my local project named `cool-proj`, I would run `yarn tophat react-form-state ../path/to/cool-proj`.
 
+Note: If the package you are testing has dependencies inside Quilt itself, you will need to run `dev build` first.
+
 ### Emoji commits
 
 We have found that prefacing a commit message or PR title with an emoji can be a great way to improve the developer experience when browsing the repo code. Additionally, it is a terse way to convey information. Many of our contributors have found the guide at https://gitmoji.carloscuesta.me/ to be helpful in preserving this dynamic.


### PR DESCRIPTION
Took me a few hours to figure out, when using yarn tophat on a package that has `@shopify/*` dependencies, you need those dependencies to have been built first (`@shopify/react-i18n` depends on `@shopify/i18n` and `@shopify/react-effect` in my case.

Hopefully this will save someone some time in the future!