### PR TITLE
koa-shopify-auth: Accept mixed-case shop parameters

### DIFF
--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## 3.1.12 - 2019-02-05
+
+### Fixed
+
+- OAuth route no longer rejects uppercase shop domains [#493](https://github.com/Shopify/quilt/pull/493)
+
 ## 3.1.11 - 2019-01-10
 
 ### Fixed

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/koa-shopify-auth",
-  "version": "3.1.13",
+  "version": "3.1.12",
   "license": "MIT",
   "description": "",
   "main": "dist/index.js",

--- a/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
+++ b/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
@@ -16,6 +16,7 @@ export default function createOAuthStart(
 
     const shopRegex = new RegExp(
       `^[a-z0-9][a-z0-9\\-]*[a-z0-9]\\.${myShopifyDomain}$`,
+      'i',
     );
 
     if (shop == null || !shopRegex.test(shop)) {

--- a/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
@@ -17,6 +17,7 @@ const baseUrl = 'myapp.com/auth';
 const callbackPath = '/callback';
 const shop = 'sho-p1.myshopify.io';
 const badShop = 'shop1myshopify.io';
+const uppercaseShop = 'SHO-P1.myshopify.io';
 const redirectionURL = `/admin/oauth/authorize`;
 
 const baseConfig: OAuthStartOptions = {
@@ -78,6 +79,21 @@ describe('OAuthStart', () => {
     expect(oAuthQueryString).toBeCalledWith(ctx, baseConfig, callbackPath);
     expect(ctx.redirect).toBeCalledWith(
       `https://${shop}${redirectionURL}?abc=123`,
+    );
+  });
+
+  it('accepts mixed-case shop parameters', () => {
+    const oAuthStart = createOAuthStart(baseConfig, callbackPath);
+    const ctx = createMockContext({
+      url: `https://${baseUrl}?${query({shop: uppercaseShop})}`,
+    });
+
+    (oAuthQueryString as any).mockReturnValueOnce('');
+
+    oAuthStart(ctx);
+
+    expect(ctx.redirect).toBeCalledWith(
+      `https://${uppercaseShop}${redirectionURL}?`,
     );
   });
 });


### PR DESCRIPTION
We discovered today that koa-shopify-auth throws "invalid shop parameter" errors if given domains with uppercase characters, this fixes that.

@Shopify/platform-dev-tools-education 