### PR TITLE
Have ExtractedLocation contain null for locales that are not available (instead of undefined)

### DIFF
--- a/packages/react-i18n/src/test/manager.test.ts
+++ b/packages/react-i18n/src/test/manager.test.ts
@@ -90,7 +90,7 @@ describe('Manager', () => {
         noop,
       );
       expect(spy).toHaveBeenCalledWith('en-US');
-      expect(spy).toHaveBeenCalledWith('en-US');
+      expect(spy).toHaveBeenCalledWith('en-us');
       expect(spy).toHaveBeenCalledWith('en');
     });
 
@@ -627,6 +627,29 @@ describe('Manager', () => {
 
       // Prevents leaving a hanging promise
       await connectionResult.resolve();
+    });
+
+    it('provides null for non-existent translations', async () => {
+      const connection = new Connection({
+        id: createID(),
+        translations: getTranslationAsync,
+      });
+
+      const manager = new Manager({...basicDetails, locale: 'en-XX'});
+
+      await manager
+        .connect(
+          connection,
+          noop,
+        )
+        .resolve();
+
+      const translationsByID = manager.extract();
+      expect(Object.keys(translationsByID)).toBeArrayOfUniqueItems();
+
+      const translations = Object.values(translationsByID);
+      expect(translations).toContain(null);
+      expect(translations).toContain(en);
     });
 
     it('does not provide synchronous translations', async () => {


### PR DESCRIPTION
This will allow use to serialize and keep the information as our serializer removed undefined properties.

It will remove the necessity of a hack around it on [web#10270](https://github.com/Shopify/web/pull/10270)

I decided to change only the `ExtractedTranslations` interface as it will minimise the impact on other systems, makes for a much simpler implementation (as `undefined` is the return value in case of failure of a lot of methods like `Map.get`), and its the only place we need `null`.