### PR TITLE
Transform GMT+12 as default timezone to UTC

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] - -->
 
+## [0.9.1] - 2019-02-06
+
+### Fixed
+
+- Invalid `defaultTimezone: 'Etc/GMT+12'` is transformed to UTC [#496](https://github.com/Shopify/quilt/pull/496)
+
 ## [0.8.0] - 2019-01-30
 
 ### Added

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -195,16 +195,13 @@ export default class I18n {
 
   formatDate(
     date: Date,
-    options?: Intl.DateTimeFormatOptions & {style?: DateStyle},
+    options: Intl.DateTimeFormatOptions & {style?: DateStyle} = {},
   ): string {
-    const {locale, defaultTimezone: timezone} = this;
+    const {locale, defaultTimezone} = this;
+    const {timeZone = defaultTimezone} = options;
 
     // Etc/GMT+12 is not supported in most browsers and there is no equivalent fallback
-    if (
-      options &&
-      options.timeZone != null &&
-      options.timeZone === 'Etc/GMT+12'
-    ) {
+    if (timeZone === 'Etc/GMT+12') {
       const adjustedDate = new Date(date.valueOf() - 12 * 60 * 60 * 1000);
 
       return this.formatDate(adjustedDate, {...options, timeZone: 'UTC'});
@@ -219,7 +216,7 @@ export default class I18n {
     }
 
     return new Intl.DateTimeFormat(locale, {
-      timeZone: timezone,
+      timeZone,
       ...formatOptions,
     }).format(date);
   }

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -522,7 +522,7 @@ describe('I18n', () => {
   });
 
   describe('#formatDate()', () => {
-    const timezone = 'Australia/Sydney';
+    const defaultTimezone = 'Australia/Sydney';
 
     afterEach(() => {
       if (clock.isMocked()) {
@@ -532,22 +532,28 @@ describe('I18n', () => {
 
     it('formats a date using Intl', () => {
       const date = new Date();
-      const i18n = new I18n(defaultTranslations, {...defaultDetails, timezone});
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone: defaultTimezone,
+      });
       const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
-        timeZone: timezone,
+        timeZone: defaultTimezone,
       }).format(date);
       expect(i18n.formatDate(date)).toBe(expected);
     });
 
     it('passes additional options to the date formatter', () => {
       const date = new Date();
-      const i18n = new I18n(defaultTranslations, {...defaultDetails, timezone});
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone: defaultTimezone,
+      });
       const options: Partial<Intl.DateTimeFormatOptions> = {
         era: 'narrow',
       };
 
       const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
-        timeZone: timezone,
+        timeZone: defaultTimezone,
         ...options,
       }).format(date);
 
@@ -568,11 +574,11 @@ describe('I18n', () => {
       const date = new Date();
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
-        timezone,
+        timezone: defaultTimezone,
       });
 
       const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
-        timeZone: timezone,
+        timeZone: defaultTimezone,
       }).format(date);
 
       expect(i18n.formatDate(date)).toBe(expected);
@@ -582,10 +588,10 @@ describe('I18n', () => {
       const date = new Date();
       const i18n = new I18n(defaultTranslations, defaultDetails);
       const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
-        timeZone: timezone,
+        timeZone: defaultTimezone,
       }).format(date);
 
-      expect(i18n.formatDate(date, {timeZone: timezone})).toBe(expected);
+      expect(i18n.formatDate(date, {timeZone: defaultTimezone})).toBe(expected);
     });
 
     it('uses UTC when given a date in the Etc/GMT+12 timezone', () => {
@@ -600,11 +606,30 @@ describe('I18n', () => {
       expect(i18n.formatDate(date, {timeZone})).toBe(expected);
     });
 
+    it('uses UTC when defaultTimezone is Etc/GMT+12', () => {
+      const date = new Date();
+      const defaultTimezone = 'Etc/GMT+12';
+
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone: defaultTimezone,
+      });
+      const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
+        timeZone: 'UTC',
+      }).format(date);
+
+      expect(
+        i18n.formatDate(date, {
+          timeZone: defaultTimezone,
+        }),
+      ).toBe(expected);
+    });
+
     it('formats a date using DateStyle.Long', () => {
       const date = new Date('2012-12-20T00:00:00-00:00');
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
-        timezone,
+        timezone: defaultTimezone,
       });
 
       expect(i18n.formatDate(date, {style: DateStyle.Long})).toBe(
@@ -616,7 +641,7 @@ describe('I18n', () => {
       const date = new Date('2012-12-20T00:00:00-00:00');
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
-        timezone,
+        timezone: defaultTimezone,
       });
 
       expect(i18n.formatDate(date, {style: DateStyle.Short})).toBe(
@@ -628,7 +653,7 @@ describe('I18n', () => {
       const date = new Date('2012-12-20T00:00:00-00:00');
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
-        timezone,
+        timezone: defaultTimezone,
       });
 
       expect(i18n.formatDate(date, {style: DateStyle.Humanize})).toBe(
@@ -641,7 +666,10 @@ describe('I18n', () => {
       const i18n = new I18n(defaultTranslations, defaultDetails);
 
       expect(
-        i18n.formatDate(date, {style: DateStyle.Humanize, timeZone: timezone}),
+        i18n.formatDate(date, {
+          style: DateStyle.Humanize,
+          timeZone: defaultTimezone,
+        }),
       ).toBe('December 20, 2012');
     });
 
@@ -650,7 +678,7 @@ describe('I18n', () => {
       clock.mock(today);
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
-        timezone,
+        timezone: defaultTimezone,
       });
 
       expect(i18n.formatDate(today, {style: DateStyle.Humanize})).toBe(
@@ -664,7 +692,7 @@ describe('I18n', () => {
       clock.mock(today);
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
-        timezone,
+        timezone: defaultTimezone,
       });
 
       expect(i18n.formatDate(yesterday, {style: DateStyle.Humanize})).toBe(
@@ -676,7 +704,7 @@ describe('I18n', () => {
       const date = new Date('2012-12-20T00:00:00-00:00');
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
-        timezone,
+        timezone: defaultTimezone,
       });
 
       expect(i18n.formatDate(date, {style: DateStyle.Time})).toBe('11:00 AM');


### PR DESCRIPTION
`i18n.formatDate` doesn't transform `defaultTimezone = Etc/GMT+12` to `UTC` like it does for an IANA timezone passed as an `Intl.DateTimeFormat` option. This resulted in [`RangeError`](https://app.bugsnag.com/shopify/shopify-web-server/timeline?filters[event.since][0]=all&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[search][0][type]=eq&filters[search][0][value]=RangeError) spikes on the server when the default timezone from web's request details query was `GMT+12`.

The fix is to give the `Intl` timezone option a fallback value of the `defaultTimezone` so the check to determine if the timezone is `Etc/GMT+12` will always run, unlike before where if you passed no `Intl` timezone option, the `defaultTimezone` value would miss the check.

Also bumps the version patch.