### PR TITLE
Only ask for an async translation once

### DIFF
--- a/packages/react-i18n/src/manager.ts
+++ b/packages/react-i18n/src/manager.ts
@@ -65,6 +65,12 @@ export default class Manager {
         continue;
       }
 
+      if (this.translationPromises.has(id)) {
+        // eslint-disable-next-line typescript/no-non-null-assertion
+        promises.push(this.translationPromises.get(id)!);
+        continue;
+      }
+
       if (
         locale === this.details.fallbackLocale &&
         connection.fallbackTranslations
@@ -159,7 +165,7 @@ export default class Manager {
       for (const locale of possibleLocales) {
         const id = localeId(connection, locale);
 
-        if (this.translations.has(id)) {
+        if (this.translations.has(id) || this.translationPromises.has(id)) {
           continue;
         }
 

--- a/packages/react-i18n/src/test/manager.test.ts
+++ b/packages/react-i18n/src/test/manager.test.ts
@@ -81,6 +81,23 @@ describe('Manager', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
+    it('requests translations only once for async translations while resolving', () => {
+      const spy = jest.fn(() => new Promise(() => {}));
+      const id = createID();
+      const manager = new Manager(basicDetails);
+
+      manager.connect(
+        new Connection({id, translations: spy}),
+        noop,
+      );
+      manager.connect(
+        new Connection({id, translations: spy}),
+        noop,
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
     it('requests translations for the full locale and language when the country code is provided', () => {
       const spy = jest.fn();
       const connection = new Connection({id: createID(), translations: spy});


### PR DESCRIPTION
This PR fixes an issue where, when many components would mount with async translations, the translations would be individually requested and resolved for each one. It does so by checking for an in-progress async translation with a given ID, and bails out early if it finds one (just like we do for sync translations).

I didn't think this would make much of a difference but wow, it does. I tested this by creating a component with async translations, and mounted 100 of them on a page. Before this change, the performance tab showed this:

![screen shot 2019-02-04 at 5 15 19 pm](https://user-images.githubusercontent.com/3012583/52242430-a933c280-28a4-11e9-9175-218538ce16d0.png)

This doesn't look so bad, but that is not one bar of yellow at the top; it's actually a hundred small tasks that each happen individually. For whatever reason, the `setState`s that result from this are not combined together, so each component individually updates, then React starts the whole process over for the next component. In all, it took my Mac mini 15 seconds to transition to the page that had only these components. With this change, the dev tools looks a bit more sane:

![screen shot 2019-02-04 at 5 16 43 pm](https://user-images.githubusercontent.com/3012583/52242514-e5672300-28a4-11e9-8fee-37967f0bdd75.png)

I still couldn't get all the updates to coalesce into a single React reconciliation; if anyone knows how it would be awesome. But, even as-is, this went from a 15 second page transition to about 300ms. I still think it's better for people not to attach translations at this level, but if they do, it at least doesn't fall over.

cc/ @qq99 and @rexmac who helpfully brought this up.