### PR TITLE
Remove context destructuring

### DIFF
--- a/packages/react-network/src/context.tsx
+++ b/packages/react-network/src/context.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import {Manager, NoopManager} from './manager';
 
-const {Consumer, Provider} = React.createContext<Manager>(new NoopManager());
+const Context = React.createContext<Manager>(new NoopManager());
+
+const Consumer = Context.Consumer;
+const Provider = Context.Provider;
 
 interface Props {
   manager?: Manager;

--- a/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
+++ b/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
@@ -9,7 +9,10 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-export const {Provider, Consumer} = React.createContext<Context>({});
+const Context = React.createContext<Context>({});
+
+export const Provider = Context.Provider;
+export const Consumer = Context.Consumer;
 
 export default class ShortcutProvider extends React.Component<Props, never> {
   private shortcutManager = new ShortcutManager();


### PR DESCRIPTION
This PR removes a few cases where we immediately destructure the `Consumer` and `Provider` from `React.CreateContext`. These to lead to weird bugs in React ^16.6.0.