### PR TITLE
[FormState] Fixes validation when external errors are not provided

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - lodash is no longer used internally. [#475](https://github.com/Shopify/quilt/pull/475)
 
+### Fixed
+
+- Fixes validators for cases where `externalErrors` are not provided. [#504](https://github.com/Shopify/quilt/pull/504)
+
 ## [0.7.0]
 
 ### Added

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -75,9 +75,10 @@ export default class FormState<
       externalErrors = [],
     } = newProps;
 
-    const externalErrorsChanged =
-      externalErrors !== oldState.externalErrors ||
-      externalErrors.length !== oldState.externalErrors.length;
+    const externalErrorsChanged = !isEqual(
+      externalErrors,
+      oldState.externalErrors,
+    );
 
     const updatedExternalErrors = externalErrorsChanged
       ? {
@@ -409,6 +410,10 @@ function fieldsWithErrors<Fields>(
   );
 
   return mapObject(fields, (field, path) => {
+    if (!errorDictionary[path]) {
+      return field;
+    }
+
     return {
       ...field,
       error: errorDictionary[path],

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -450,6 +450,32 @@ describe('<FormState />', () => {
       const {errors} = lastCallArgs(renderPropSpy);
       expect(errors).toEqual([...submitErrors, ...externalErrors]);
     });
+
+    it('does not reset fields if externalErrors are not provided', () => {
+      const renderPropSpy = jest.fn(() => null);
+      const errorMessage = faker.lorem.sentence();
+
+      mount(
+        <FormState
+          initialValues={{
+            product: faker.commerce.productName,
+          }}
+          validators={{
+            product: () => errorMessage,
+          }}
+        >
+          {renderPropSpy}
+        </FormState>,
+      );
+
+      const {fields} = lastCallArgs(renderPropSpy);
+      fields.product.onChange(faker.commerce.productName);
+      fields.product.onBlur();
+
+      const {fields: updatedFields} = lastCallArgs(renderPropSpy);
+
+      expect(updatedFields.product.error).toEqual(errorMessage);
+    });
   });
 
   describe('reset()', () => {


### PR DESCRIPTION
Fixes: https://github.com/Shopify/quilt/issues/500

## What does this PR do
This PR fixes a bug where inline validation was not working if `externalErrors` are not provided.

## How does it fix it
Updates the equality check that is used to determine if the value of `externalErrors` has changed. If a value was not provided, we use an empty array as a fallback value. Since this is a new array, the equality check was failing when we checked if the new value was the same as the old value.

When this failed, we would return updated fields with no validation errors.

## Proof it works
Here's validation working when external errors are not provided
![validation without external error](https://user-images.githubusercontent.com/4441303/52357581-67219280-2a04-11e9-9102-b3d8ca95b868.gif)

Here's validation working when external errors _are_ provided
![validation with external error](https://user-images.githubusercontent.com/4441303/52357654-815b7080-2a04-11e9-9695-bafd75ec3e76.gif)