### PR TITLE
[i18n] Fix default timezone test

### DIFF
--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -607,22 +607,15 @@ describe('I18n', () => {
     });
 
     it('uses UTC when defaultTimezone is Etc/GMT+12', () => {
-      const date = new Date();
+      const date = new Date('2018-01-01T12:34:56-12:00');
       const defaultTimezone = 'Etc/GMT+12';
 
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
         timezone: defaultTimezone,
       });
-      const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
-        timeZone: 'UTC',
-      }).format(date);
 
-      expect(
-        i18n.formatDate(date, {
-          timeZone: defaultTimezone,
-        }),
-      ).toBe(expected);
+      expect(i18n.formatDate(date)).toBe('1/1/2018');
     });
 
     it('formats a date using DateStyle.Long', () => {


### PR DESCRIPTION
Fixes https://github.com/Shopify/quilt/issues/513

The issue is only reproducible at a certain time of day, the test passes as of right now, but to be absolutely certain we should try testing it at a X hours close to midnight.