### PR TITLE
Changing display none to visibility hidden of on body to allow measuring on render

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Added metadata components: `AppleHomeScreen` and `Responsive`. [#481](https://github.com/Shopify/quilt/pull/481)
+- Changing body styles from `display: none` to `visisbility: hidden` while page loads in development. [#515](https://github.com/Shopify/quilt/pull/515)
 
 ## 6.0.2 - 2019-01-09
 

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -111,9 +111,9 @@ export default function Html({
     );
   });
 
-  const bodyStyles =
+  const bodyStyles: {visibility: 'hidden'} | undefined =
     // eslint-disable-next-line no-process-env
-    process.env.NODE_ENV === 'development' ? {display: 'none'} : undefined;
+    process.env.NODE_ENV === 'development' ? {visibility: 'hidden'} : undefined;
 
   const faviconMarkup = favicon ? <Favicon source={favicon} /> : null;
 

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -42,14 +42,14 @@ describe('<Html />', () => {
   it('hides the body contents in development', () => {
     const html = withEnv('development', () => mount(<Html {...mockProps} />));
     expect(html.find('body').prop('style')).toMatchObject({
-      display: 'none',
+      visibility: 'hidden',
     });
   });
 
   it('does not hide the body contents in other environments', () => {
     const html = mount(<Html {...mockProps} />);
     const styles = html.find('#app').prop('style') || {};
-    expect(styles).not.toHaveProperty('display');
+    expect(styles).not.toHaveProperty('visibility');
   });
 
   describe('locale', () => {

--- a/packages/react-html/src/utilities.ts
+++ b/packages/react-html/src/utilities.ts
@@ -48,7 +48,7 @@ export function showPage(): Promise<void> {
     process.env.NODE_ENV === 'development' && typeof document !== 'undefined'
       ? new Promise(resolve => {
           setTimeout(() => {
-            document.body.style.display = '';
+            document.body.style.visibility = '';
             resolve();
           }, 0);
         })


### PR DESCRIPTION
Currently the `Sticky` component of `Polaris` needs to measure the height of the topbar in order to know where to start making `Sticky` elements position: fixed. Since the body element is set to `display: none` until styles are loaded, this prevents the measuring to occur. Changing to visibility: hidden fixes this issue.