### PR TITLE
Improve defer handling for async components

### DIFF
--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -6,8 +6,11 @@ import {Effect} from '@shopify/react-effect';
 import {DeferTiming} from './shared';
 import {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 
-interface Props<Value> extends LoadProps<Value> {
+export interface AsyncPropsRuntime {
   defer?: DeferTiming;
+}
+
+interface Props<Value> extends LoadProps<Value>, AsyncPropsRuntime {
   manager?: AsyncAssetManager;
   render?(value: Value | null): React.ReactNode;
   renderLoading?(): React.ReactNode;

--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -3,10 +3,11 @@ import {LoadProps} from '@shopify/async';
 import {Omit} from '@shopify/useful-types';
 import {Effect} from '@shopify/react-effect';
 
+import {DeferTiming} from './shared';
 import {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 
 interface Props<Value> extends LoadProps<Value> {
-  defer?: boolean;
+  defer?: DeferTiming;
   manager?: AsyncAssetManager;
   render?(value: Value | null): React.ReactNode;
   renderLoading?(): React.ReactNode;
@@ -22,6 +23,25 @@ declare const __webpack_require__: (id: string) => any;
 declare const __webpack_modules__: {[key: string]: any};
 /* eslint-enable camelcase */
 
+type RequestIdleCallbackHandle = any;
+
+interface RequestIdleCallbackOptions {
+  timeout: number;
+}
+
+interface RequestIdleCallbackDeadline {
+  readonly didTimeout: boolean;
+  timeRemaining: (() => number);
+}
+
+interface WindowWithRequestIdleCallback {
+  requestIdleCallback: ((
+    callback: ((deadline: RequestIdleCallbackDeadline) => void),
+    opts?: RequestIdleCallbackOptions,
+  ) => RequestIdleCallbackHandle);
+  cancelIdleCallback: ((handle: RequestIdleCallbackHandle) => void);
+}
+
 class ConnectedAsync<Value> extends React.Component<
   Props<Value>,
   State<Value>
@@ -29,24 +49,44 @@ class ConnectedAsync<Value> extends React.Component<
   state: State<Value> = initialState(this.props);
 
   private mounted = true;
+  private idleCallbackHandle?: RequestIdleCallbackHandle;
 
   componentWillUnmount() {
     this.mounted = false;
+
+    if (this.idleCallbackHandle != null && 'cancelIdleCallback' in window) {
+      (window as WindowWithRequestIdleCallback).cancelIdleCallback(
+        this.idleCallbackHandle,
+      );
+    }
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     if (this.state.resolved != null) {
       return;
     }
 
-    try {
-      const resolved = await this.props.load();
+    const load = async () => {
+      try {
+        const resolved = await this.props.load();
 
-      if (this.mounted) {
-        this.setState({resolved: normalize(resolved), loading: false});
+        if (this.mounted) {
+          this.setState({resolved: normalize(resolved), loading: false});
+        }
+      } catch (error) {
+        // Silently swallowing errors for now
       }
-    } catch (error) {
-      // Silently swallowing errors for now
+    };
+
+    if (
+      this.props.defer === DeferTiming.Idle &&
+      'requestIdleCallback' in window
+    ) {
+      this.idleCallbackHandle = (window as WindowWithRequestIdleCallback).requestIdleCallback(
+        load,
+      );
+    } else {
+      load();
     }
   }
 
@@ -87,7 +127,7 @@ export function Async<Value>(props: Omit<Props<Value>, 'manager'>) {
 }
 
 function initialState<Value>(props: Props<Value>): State<Value> {
-  const canResolve = !props.defer && props.id;
+  const canResolve = props.defer == null && props.id;
   const resolved = canResolve && props.id ? tryRequire(props.id()) : null;
 
   return {

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -3,6 +3,7 @@ import {LoadProps} from '@shopify/async';
 import {Props as ComponentProps} from '@shopify/useful-types';
 
 import {Async} from './Async';
+import {DeferTiming} from './shared';
 
 interface Options<
   Props,
@@ -61,7 +62,7 @@ export function createAsyncComponent<
     return (
       <>
         {renderPreload(props)}
-        <Async defer load={load} />
+        <Async defer={DeferTiming.Idle} load={load} />
       </>
     );
   }
@@ -70,7 +71,7 @@ export function createAsyncComponent<
     return (
       <>
         {renderPrefetch(props)}
-        <Async defer load={load} />
+        <Async defer={DeferTiming.Mount} load={load} />
       </>
     );
   }
@@ -79,7 +80,7 @@ export function createAsyncComponent<
     return (
       <>
         {renderKeepFresh(props)}
-        <Async defer load={load} />
+        <Async defer={DeferTiming.Mount} load={load} />
       </>
     );
   }

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -11,6 +11,7 @@ interface Options<
   PrefetchProps = {},
   KeepFreshProps = {}
 > extends LoadProps<React.ComponentType<Props>> {
+  defer?: DeferTiming;
   renderLoading?(): React.ReactNode;
   renderPreload?(props?: PreloadProps): React.ReactNode;
   renderPrefetch?(props?: PrefetchProps): React.ReactNode;
@@ -35,8 +36,9 @@ export function createAsyncComponent<
   PrefetchProps = {},
   KeepFreshProps = {}
 >({
-  load,
   id,
+  load,
+  defer,
   renderLoading,
   renderPreload = noopRender,
   renderPrefetch = noopRender,
@@ -52,6 +54,7 @@ export function createAsyncComponent<
       <Async
         load={load}
         id={id}
+        defer={defer}
         renderLoading={renderLoading}
         render={Component => (Component ? <Component {...props} /> : null)}
       />

--- a/packages/react-async/src/index.ts
+++ b/packages/react-async/src/index.ts
@@ -3,6 +3,7 @@ export {Prefetcher} from './Prefetcher';
 export {PrefetchRoute} from './PrefetchRoute';
 export {createAsyncComponent, AsyncComponentType} from './component';
 export {createAsyncContext, AsyncContextType} from './provider';
+export {DeferTiming} from './shared';
 
 export {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 export {PrefetchContext, PrefetchManager} from './context/prefetch';

--- a/packages/react-async/src/index.ts
+++ b/packages/react-async/src/index.ts
@@ -1,4 +1,4 @@
-export {Async} from './Async';
+export {Async, AsyncPropsRuntime} from './Async';
 export {Prefetcher} from './Prefetcher';
 export {PrefetchRoute} from './PrefetchRoute';
 export {createAsyncComponent, AsyncComponentType} from './component';

--- a/packages/react-async/src/provider.tsx
+++ b/packages/react-async/src/provider.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {LoadProps} from '@shopify/async';
 
 import {Async} from './Async';
+import {DeferTiming} from './shared';
 
 interface Options<Value> extends LoadProps<Value> {}
 
@@ -41,7 +42,7 @@ export function createAsyncContext<Value>({
   }
 
   function Preload() {
-    return <Async defer load={load} />;
+    return <Async defer={DeferTiming.Idle} load={load} />;
   }
 
   return {Context, Provider, Consumer, Preload};

--- a/packages/react-async/src/shared.ts
+++ b/packages/react-async/src/shared.ts
@@ -3,3 +3,8 @@ export type Prefetchable<Props> =
       Prefetch: React.ComponentType<Props>;
     }
   | React.ComponentType<Props>;
+
+export enum DeferTiming {
+  Mount,
+  Idle,
+}

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -4,6 +4,7 @@ import {trigger} from '@shopify/enzyme-utilities';
 
 import {Async} from '../Async';
 import {createAsyncComponent} from '../component';
+import {DeferTiming} from '../shared';
 
 jest.mock('../Async', () => ({
   Async() {
@@ -42,12 +43,32 @@ describe('createAsyncComponent()', () => {
     ).toEqual(<MockComponent {...props} />);
   });
 
+  it('creates a deferred <Async /> when specified', () => {
+    const load = () => Promise.resolve(MockComponent);
+    const defer = DeferTiming.Idle;
+
+    const AsyncComponent = createAsyncComponent({load, defer});
+    const asyncComponent = mount(<AsyncComponent />);
+    expect(asyncComponent.find(Async)).toHaveProp('defer', defer);
+  });
+
+  it('allows passing custom async props', () => {
+    const load = () => Promise.resolve(MockComponent);
+    const async = {defer: DeferTiming.Idle};
+
+    const AsyncComponent = createAsyncComponent({load});
+    const asyncComponent = mount(<AsyncComponent async={async} />);
+    expect(asyncComponent.find(Async).props()).toMatchObject(async);
+  });
+
   describe('<Preload />', () => {
     it('renders a deferred loader', () => {
       const load = () => Promise.resolve(MockComponent);
       const AsyncComponent = createAsyncComponent({load});
       const preload = mount(<AsyncComponent.Preload />);
-      expect(preload).toContainReact(<Async defer load={load} />);
+      expect(preload).toContainReact(
+        <Async defer={DeferTiming.Idle} load={load} />,
+      );
     });
 
     it('renders the result of calling renderPreload()', () => {
@@ -67,6 +88,15 @@ describe('createAsyncComponent()', () => {
       );
       expect(preload).toContainReact(<Preload />);
     });
+
+    it('allows passing custom async props', () => {
+      const load = () => Promise.resolve(MockComponent);
+      const async = {defer: undefined};
+
+      const AsyncComponent = createAsyncComponent({load});
+      const preload = mount(<AsyncComponent.Preload async={async} />);
+      expect(preload.find(Async).props()).toMatchObject(async);
+    });
   });
 
   describe('<Prefetch />', () => {
@@ -74,7 +104,9 @@ describe('createAsyncComponent()', () => {
       const load = () => Promise.resolve(MockComponent);
       const AsyncComponent = createAsyncComponent({load});
       const prefetch = mount(<AsyncComponent.Prefetch />);
-      expect(prefetch).toContainReact(<Async defer load={load} />);
+      expect(prefetch).toContainReact(
+        <Async defer={DeferTiming.Mount} load={load} />,
+      );
     });
 
     it('renders the result of calling renderPrefetch()', () => {
@@ -94,6 +126,15 @@ describe('createAsyncComponent()', () => {
       );
       expect(prefetch).toContainReact(<Prefetch />);
     });
+
+    it('allows passing custom async props', () => {
+      const load = () => Promise.resolve(MockComponent);
+      const async = {defer: undefined};
+
+      const AsyncComponent = createAsyncComponent({load});
+      const prefetch = mount(<AsyncComponent.Prefetch async={async} />);
+      expect(prefetch.find(Async).props()).toMatchObject(async);
+    });
   });
 
   describe('<KeepFresh />', () => {
@@ -101,7 +142,9 @@ describe('createAsyncComponent()', () => {
       const load = () => Promise.resolve(MockComponent);
       const AsyncComponent = createAsyncComponent({load});
       const keepFresh = mount(<AsyncComponent.KeepFresh />);
-      expect(keepFresh).toContainReact(<Async defer load={load} />);
+      expect(keepFresh).toContainReact(
+        <Async defer={DeferTiming.Idle} load={load} />,
+      );
     });
 
     it('renders the result of calling renderKeepFresh()', () => {
@@ -120,6 +163,15 @@ describe('createAsyncComponent()', () => {
         </div>,
       );
       expect(keepFresh).toContainReact(<KeepFresh />);
+    });
+
+    it('allows passing custom async props', () => {
+      const load = () => Promise.resolve(MockComponent);
+      const async = {defer: undefined};
+
+      const AsyncComponent = createAsyncComponent({load});
+      const keepFresh = mount(<AsyncComponent.KeepFresh async={async} />);
+      expect(keepFresh.find(Async).props()).toMatchObject(async);
     });
   });
 });

--- a/packages/react-async/src/tests/provider.test.tsx
+++ b/packages/react-async/src/tests/provider.test.tsx
@@ -4,6 +4,7 @@ import {trigger} from '@shopify/enzyme-utilities';
 
 import {Async} from '../Async';
 import {createAsyncContext} from '../provider';
+import {DeferTiming} from '../shared';
 
 jest.mock('../Async', () => ({
   Async() {
@@ -49,7 +50,9 @@ describe('createAsyncContext()', () => {
       const load = () => Promise.resolve(mockValue);
       const AsyncContext = createAsyncContext({load});
       const preload = mount(<AsyncContext.Preload />);
-      expect(preload).toContainReact(<Async defer load={load} />);
+      expect(preload).toContainReact(
+        <Async defer={DeferTiming.Idle} load={load} />,
+      );
     });
   });
 });

--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -67,6 +67,17 @@ const ProductDetailsQuery = createAsyncQueryComponent({
 });
 ```
 
+As with `@shopify/react-async`, you can also pass a `defer` prop that is a member of the `DeferTiming` enum to force the GraphQL query to resolve later on in its lifecycle:
+
+```tsx
+import {createAsyncQueryComponent, DeferTiming} from '@shopify/react-graphql';
+
+const ProductDetailsQuery = createAsyncQueryComponent({
+  load: () => import('./graphql/ProductDetailsQuery.graphql'),
+  defer: DeferTiming.Idle,
+});
+```
+
 This component can now be used just like a regular `Query` component. It accepts all the same props, except that the query (and associated types) are already embedded in it, so those do not need to be provided.
 
 ```tsx
@@ -113,4 +124,21 @@ const MyQuery = createAsyncQueryComponent({
 <MyQuery.Preload />
 <MyQuery.Prefetch />
 <MyQuery.KeepFresh pollInterval={20_000} />
+```
+
+All components created by this library also reserve an `async` prop (that is, you can’t have any props on these components also named `async`). This prop can be used to pass custom instructions to the underlying async loading component.
+
+Currently, this prop is an object with a `defer?: DeferTiming` property, which changes the default `defer` behaviour of the component (by default, the `Query`/ "root" component is not deferred, `Preload` and `KeepFresh` are deferred until idle, and `Prefetch` is deferred until mount).
+
+```tsx
+const MyQuery = createAsyncQueryComponent({
+  load: () => import('./graphql/MyQuery.graphql'),
+});
+
+<MyQuery async={{defer: DeferTiming.Mount}} />
+
+// This will force all of these components not to be deferred at all
+<MyQuery.Preload async={{defer: undefined}} />
+<MyQuery.Prefetch async={{defer: undefined}} />
+<MyQuery.KeepFresh pollInterval={20_000} async={{defer: undefined}} />
 ```

--- a/packages/react-graphql/src/async.tsx
+++ b/packages/react-graphql/src/async.tsx
@@ -64,7 +64,7 @@ export function createAsyncQueryComponent<Data, Variables>({
   }
 
   function Preload(props: ConstantProps) {
-    const [, asyncProps] = splitProps(props);
+    const asyncProps = splitProps(props)[1];
     return (
       <Async defer={DeferTiming.Idle} load={load} id={id} {...asyncProps} />
     );

--- a/packages/react-graphql/src/async.tsx
+++ b/packages/react-graphql/src/async.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {LoadProps} from '@shopify/async';
-import {Async} from '@shopify/react-async';
+import {Async, DeferTiming} from '@shopify/react-async';
 import {Omit} from '@shopify/useful-types';
 import {DocumentNode} from 'graphql-typed';
 
@@ -10,11 +10,14 @@ import {Query} from './Query';
 import {AsyncQueryComponentType, QueryProps, VariableOptions} from './types';
 
 interface QueryComponentOptions<Data, Variables>
-  extends LoadProps<DocumentNode<Data, Variables>> {}
+  extends LoadProps<DocumentNode<Data, Variables>> {
+  deferTiming: DeferTiming;
+}
 
 export function createAsyncQueryComponent<Data, Variables>({
   id,
   load,
+  defer,
 }: QueryComponentOptions<Data, Variables>): AsyncQueryComponentType<
   Data,
   Variables
@@ -24,6 +27,7 @@ export function createAsyncQueryComponent<Data, Variables>({
       <Async
         load={load}
         id={id}
+        defer={defer}
         render={query =>
           query ? <Query query={query} {...props as any} /> : null
         }
@@ -34,7 +38,7 @@ export function createAsyncQueryComponent<Data, Variables>({
   function Prefetch({variables}: VariableOptions<Variables>) {
     return (
       <Async
-        defer
+        defer={DeferTiming.Mount}
         load={load}
         render={query =>
           query ? (
@@ -46,7 +50,7 @@ export function createAsyncQueryComponent<Data, Variables>({
   }
 
   function Preload() {
-    return <Async defer load={load} id={id} />;
+    return <Async defer={DeferTiming.Idle} load={load} id={id} />;
   }
 
   type KeepFreshProps = VariableOptions<Variables> & {
@@ -56,7 +60,7 @@ export function createAsyncQueryComponent<Data, Variables>({
   function KeepFresh({variables, pollInterval = 10_000}: KeepFreshProps) {
     return (
       <Async
-        defer
+        defer={DeferTiming.Mount}
         load={load}
         render={query =>
           query ? (

--- a/packages/react-graphql/src/index.ts
+++ b/packages/react-graphql/src/index.ts
@@ -1,3 +1,4 @@
+export {DeferTiming} from '@shopify/react-async';
 export {Query} from './Query';
 export {Prefetch, Props as PrefetchProps} from './Prefetch';
 export {createAsyncQueryComponent} from './async';

--- a/packages/react-graphql/src/tests/async.test.tsx
+++ b/packages/react-graphql/src/tests/async.test.tsx
@@ -38,9 +38,11 @@ describe('createAsyncQueryComponent()', () => {
     const load = () => Promise.resolve(query);
     const id = () => 'foo';
 
-    const AsyncComponent = createAsyncQueryComponent({load, id});
-    const asyncComponent = mount(<AsyncComponent {...defaultProps} />);
-    expect(asyncComponent.find(Async).props()).toMatchObject({load, id});
+    const AsyncQueryComponent = createAsyncQueryComponent({load, id});
+    const asyncQueryComponent = mount(
+      <AsyncQueryComponent {...defaultProps} />,
+    );
+    expect(asyncQueryComponent.find(Async).props()).toMatchObject({load, id});
   });
 
   it('renders a Query component when the query is available, and null otherwise', () => {
@@ -49,41 +51,63 @@ describe('createAsyncQueryComponent()', () => {
       ...defaultProps,
       fetchPolicy: 'cache-first' as 'cache-first',
     };
-    const AsyncComponent = createAsyncQueryComponent({load});
-    const asyncComponent = mount(<AsyncComponent {...props} />);
+    const AsyncQueryComponent = createAsyncQueryComponent({load});
+    const asyncQueryComponent = mount(<AsyncQueryComponent {...props} />);
 
-    expect(trigger(asyncComponent.find(Async), 'render', null)).toBeNull();
-    expect(trigger(asyncComponent.find(Async), 'render', query)).toEqual(
+    expect(trigger(asyncQueryComponent.find(Async), 'render', null)).toBeNull();
+    expect(trigger(asyncQueryComponent.find(Async), 'render', query)).toEqual(
       <Query query={query} {...props} />,
     );
   });
 
   it('creates a deferred <Async /> when specified', () => {
     const defer = DeferTiming.Idle;
-    const AsyncComponent = createAsyncQueryComponent({
+    const AsyncQueryComponent = createAsyncQueryComponent({
       load: () => Promise.resolve(query),
       defer,
     });
-    const asyncComponent = mount(<AsyncComponent {...defaultProps} />);
-    expect(asyncComponent.find(Async)).toHaveProp('defer', defer);
+    const asyncQueryComponent = mount(
+      <AsyncQueryComponent {...defaultProps} />,
+    );
+    expect(asyncQueryComponent.find(Async)).toHaveProp('defer', defer);
+  });
+
+  it('allows passing custom async props', () => {
+    const load = () => Promise.resolve(query);
+    const async = {defer: undefined};
+
+    const AsyncQueryComponent = createAsyncQueryComponent({load});
+    const asyncQueryComponent = mount(
+      <AsyncQueryComponent {...defaultProps} async={async} />,
+    );
+    expect(asyncQueryComponent.find(Async).props()).toMatchObject(async);
   });
 
   describe('<Preload />', () => {
     it('renders a deferred (to idle) loader', () => {
       const load = () => Promise.resolve(query);
-      const AsyncComponent = createAsyncQueryComponent({load});
-      const preload = mount(<AsyncComponent.Preload />);
+      const AsyncQueryComponent = createAsyncQueryComponent({load});
+      const preload = mount(<AsyncQueryComponent.Preload />);
       expect(preload).toContainReact(
         <Async defer={DeferTiming.Idle} load={load} />,
       );
+    });
+
+    it('allows passing custom async props', () => {
+      const load = () => Promise.resolve(query);
+      const async = {defer: undefined};
+
+      const AsyncQueryComponent = createAsyncQueryComponent({load});
+      const preload = mount(<AsyncQueryComponent.Preload async={async} />);
+      expect(preload.find(Async).props()).toMatchObject(async);
     });
   });
 
   describe('<Prefetch />', () => {
     it('renders a deferred (to mount) <Async /> that then renders a prefetch query', () => {
       const load = () => Promise.resolve(query);
-      const AsyncComponent = createAsyncQueryComponent({load});
-      const prefetch = mount(<AsyncComponent.Prefetch />);
+      const AsyncQueryComponent = createAsyncQueryComponent({load});
+      const prefetch = mount(<AsyncQueryComponent.Prefetch />);
 
       expect(prefetch.find(Async).props()).toMatchObject({
         load,
@@ -94,15 +118,27 @@ describe('createAsyncQueryComponent()', () => {
         <Prefetch ignoreCache query={query} />,
       );
     });
+
+    it('allows passing custom async props', () => {
+      const load = () => Promise.resolve(query);
+      const async = {defer: undefined};
+
+      const AsyncQueryComponent = createAsyncQueryComponent({load});
+      const prefetch = mount(<AsyncQueryComponent.Prefetch async={async} />);
+      expect(prefetch.find(Async).props()).toMatchObject(async);
+    });
   });
 
   describe('<KeepFresh />', () => {
     it('renders an <Async /> that then renders a prefetch query with a poll interval', () => {
       const load = () => Promise.resolve(query);
-      const AsyncComponent = createAsyncQueryComponent({load});
-      const keepFresh = mount(<AsyncComponent.KeepFresh />);
+      const AsyncQueryComponent = createAsyncQueryComponent({load});
+      const keepFresh = mount(<AsyncQueryComponent.KeepFresh />);
 
-      expect(keepFresh.find(Async).props()).toMatchObject({load, defer: true});
+      expect(keepFresh.find(Async).props()).toMatchObject({
+        load,
+        defer: DeferTiming.Idle,
+      });
       expect(trigger(keepFresh.find(Async), 'render', null)).toBeNull();
       expect(trigger(keepFresh.find(Async), 'render', query)).toEqual(
         <Prefetch query={query} pollInterval={expect.any(Number)} />,
@@ -112,14 +148,23 @@ describe('createAsyncQueryComponent()', () => {
     it('uses a custom poll interval', () => {
       const load = () => Promise.resolve(query);
       const pollInterval = 12_345;
-      const AsyncComponent = createAsyncQueryComponent({load});
+      const AsyncQueryComponent = createAsyncQueryComponent({load});
       const keepFresh = mount(
-        <AsyncComponent.KeepFresh pollInterval={pollInterval} />,
+        <AsyncQueryComponent.KeepFresh pollInterval={pollInterval} />,
       );
 
       expect(trigger(keepFresh.find(Async), 'render', query)).toEqual(
         <Prefetch query={query} pollInterval={pollInterval} />,
       );
+    });
+
+    it('allows passing custom async props', () => {
+      const load = () => Promise.resolve(query);
+      const async = {defer: undefined};
+
+      const AsyncQueryComponent = createAsyncQueryComponent({load});
+      const keepFresh = mount(<AsyncQueryComponent.KeepFresh async={async} />);
+      expect(keepFresh.find(Async).props()).toMatchObject(async);
     });
   });
 });

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -9,6 +9,7 @@ import {
   ApolloClient,
 } from 'apollo-client';
 import {Omit, IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
+import {AsyncPropsRuntime} from '@shopify/react-async';
 
 export type VariableOptions<Variables> = IfEmptyObject<
   Variables,
@@ -33,12 +34,20 @@ export type QueryProps<Data = any, Variables = OperationVariables> = {
   onError?: (error: ApolloError) => void;
 } & VariableOptions<Variables>;
 
+export interface ConstantProps {
+  async?: AsyncPropsRuntime;
+}
+
 export interface AsyncQueryComponentType<Data, Variables> {
-  (props: Omit<QueryProps<Data, Variables>, 'query'>): React.ReactElement<{}>;
-  Prefetch(props: VariableOptions<Variables>): React.ReactElement<{}>;
-  Preload(): React.ReactElement<{}>;
+  (
+    props: Omit<QueryProps<Data, Variables>, 'query'> & ConstantProps,
+  ): React.ReactElement<{}>;
+  Prefetch(
+    props: VariableOptions<Variables> & ConstantProps,
+  ): React.ReactElement<{}>;
+  Preload(props: ConstantProps): React.ReactElement<{}>;
   KeepFresh(
-    props: VariableOptions<Variables> & {pollInterval?: number},
+    props: VariableOptions<Variables> & {pollInterval?: number} & ConstantProps,
   ): React.ReactElement<{}>;
 }
 


### PR DESCRIPTION
In the initial version of the async libraries, I made it so that "low priority" components (`Preload`, `Prefetch`, `KeepFresh`) only start loading their components on mount. This is fine and dandy but we often want to do more than that. In some cases, we want the component itself to not actually be server rendered, even if it could be. Or, we want to defer things past just mount, and into a spot where the browser actually has time to deal with it.

This PR enables this by enhancing the `defer` prop, and by letting you pass it in more places:

* You can pass it to `createAsyncComponent`/ `createAsyncQueryComponent` to force a component to always be deferred in that way
* You can pass it as a custom `async={{defer: DeferTiming.Whatever}}` prop to either the root component returned by one of the above, or the static `Preload`/ `Prefetch`/ `KeepFresh` components to force only that instance to be deferred in that way.

`DeferTiming` is a new enum that lets you specify whether it should be deferred until mount (`DeferTiming.Mount`) or until idle (`DeferTiming.Idle`). I updated the `Preload` and `KeepFresh` components to use the new idle behaviour, because that feels more relevant for them as "low priority" prefetches.

With this PR, I think we can cover all the custom async component stuff we have in Web.