### PR TITLE
🐛 Fix hashes in babel plugin relying on filenameRelative

### DIFF
--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -43,7 +43,6 @@ export default function injectWithI18nArguments({
     binding,
     bindingName,
     filename,
-    filenameRelative,
     fallbackID,
     insertImport,
   }) {
@@ -76,7 +75,7 @@ export default function injectWithI18nArguments({
 
       callExpression.replaceWith(
         i18nCallExpression({
-          id: generateID(filenameRelative),
+          id: generateID(filename),
           fallbackID,
           decoratorName: bindingName,
         }),
@@ -116,13 +115,12 @@ export default function injectWithI18nArguments({
             const {lastImport} = state;
             const fallbackID = nodePath.scope.generateUidIdentifier('en').name;
 
-            const {filename, filenameRelative} = this.file.opts;
+            const {filename} = this.file.opts;
 
             addI18nArguments({
               binding,
               bindingName,
               filename,
-              filenameRelative,
               fallbackID,
               insertImport() {
                 lastImport.insertAfter(

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -209,8 +209,6 @@ function optionsForFile(filename, withTranslations = false) {
     ? path.join(__dirname, 'fixtures', 'adjacentTranslations', filename)
     : path.join(__dirname, 'fixtures', filename);
   return {
-    sourceRoot: __dirname,
     filename: dummyPath,
-    filenameRelative: path.relative(__dirname, dummyPath),
   };
 }


### PR DESCRIPTION
`filenameRelative` doesn't seem to be consistently passed through to the plugin. For example, when using `babel-loader`, we get the `filename`, but not `filenameRelative`.