### PR TITLE
Fix Navigation#timeToUsable value

### DIFF
--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -64,7 +64,7 @@ export class Navigation implements NavigationDefinition {
 
   get timeToUsable() {
     const usableEvent = this.eventsByType(EventType.Usable)[0];
-    return usableEvent ? usableEvent.start : this.timeToComplete;
+    return usableEvent ? usableEvent.start - this.start : this.timeToComplete;
   }
 
   get resourceEvents(): (ScriptDownloadEvent | StyleDownloadEvent)[] {

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -62,6 +62,12 @@ export class Performance {
     if (!this.supportsDetailedTime || !this.supportsNavigationEntries) {
       withTiming(
         ({responseStart, domContentLoadedEventStart, loadEventStart}) => {
+          // window.performance.timing uses full timestamps, while
+          // the ones coming from observing navigation entries are
+          // time from performance.timeOrigin. We just normalize these
+          // ones to be relative to "start" since things listening for
+          // events expect them to be relative to when the navigation
+          // began.
           this.lifecycleEvent({
             type: EventType.TimeToFirstByte,
             start: responseStart - this.timeOrigin,

--- a/packages/performance/src/test/navigation.test.ts
+++ b/packages/performance/src/test/navigation.test.ts
@@ -80,10 +80,17 @@ describe('Navigation', () => {
       );
     });
 
-    it('is the start time of the "usable" event when available', () => {
+    it('is the start time of the "usable" event when available, relative to when the navigation started', () => {
+      const navigationStart = 12;
       const event = {type: EventType.Usable, duration: 0, start: 123};
-      const navigation = createNavigation({events: [event]});
-      expect(navigation).toHaveProperty('timeToUsable', event.start);
+      const navigation = createNavigation({
+        events: [event],
+        start: navigationStart,
+      });
+      expect(navigation).toHaveProperty(
+        'timeToUsable',
+        event.start - navigationStart,
+      );
     });
   });
 


### PR DESCRIPTION
It's tough to choose whether we should use absolute timestamps for events, or timestamps relative to navigation start. The current flow of events generally starts by having start-relative timestamps (unless we need to use `performance.timing`, which we normalize to start-relative, and for which I have added additional comments in this PR), but we then adjust them to be absolute as we turn them in to a `Navigation` object. This confusion made me accidentally use the start of the `usable` event for `Navigation#timeToUsable`, which always gives a value in the trillions (since it is absolute).

This PR just updates `timeToUsable` to be relative to start, which is what you would expect given that `timeToComplete` is also start-relative. I will noodle on whether we have the right representation of these events out of band.