### PR TITLE
Fix null length property

### DIFF
--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -56,7 +56,7 @@ export default function injectWithI18nArguments({
       }
 
       const args = callExpression.get('arguments');
-      if (args.length !== 0) {
+      if (args != null && args.length !== 0) {
         continue;
       }
 
@@ -148,7 +148,7 @@ function hasTranslations(filename) {
 
 // based on postcss-modules implementation
 // see https://github.com/css-modules/postcss-modules/blob/60920a97b165885683c41655e4ca594d15ec2aa0/src/generateScopedName.js
-function generateID(filename: string) {
+function generateID(filename: string = '') {
   const hash = stringHash(filename)
     .toString(36)
     .substr(0, 5);

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -6,7 +6,7 @@ jest.mock('string-hash', () => () => {
   return Number.MAX_SAFE_INTEGER;
 });
 
-describe('babel-pluin-react-i18n', () => {
+describe('babel-plugin-react-i18n', () => {
   const defaultHash = Number.MAX_SAFE_INTEGER.toString(36).substr(0, 5);
 
   it('injects arguments when adjacent translations exist', async () => {


### PR DESCRIPTION
The current plugin was causing many errors of the form:
```
./app/components/<name>/<name>.tsx
TypeError: Cannot read property 'length' of undefined
```

I anticipate something is weird with the AST we're getting from babel, and I'm hoping this PR will fix that.