### PR TITLE
Export CurrencyCode and LanguageDirection from types

### DIFF
--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -3,5 +3,5 @@ export {default as Manager, ExtractedTranslations} from './manager';
 export {default as I18n} from './i18n';
 export {withI18n, WithI18nProps} from './decorator';
 export {translate} from './utilities';
-export {I18nDetails} from './types';
+export {I18nDetails, LanguageDirection, CurrencyCode} from './types';
 export {DateStyle, Weekdays} from './constants';


### PR DESCRIPTION
I noticed that some consuming libraries were relying on imports like:

```
import {CurrencyCode} from '@shopify/react-i18n/src/types';
```

We're being more strict on what we upload to npm now, and we no longer export our src directory. As such, I feel that these types should be exposed from the main entrypoint.