### PR TITLE
Expose async GraphQL component as an GraphQLOperation

### DIFF
--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -27,7 +27,7 @@
     "@shopify/async": "^1.0.1",
     "@shopify/react-async": "^1.1.0",
     "@shopify/useful-types": "^1.1.1",
-    "graphql-typed": "^0.2.0",
+    "graphql-typed": "^0.3.0",
     "react-apollo": ">=2.1.0 <3.0.0"
   },
   "devDependencies": {

--- a/packages/react-graphql/src/async.tsx
+++ b/packages/react-graphql/src/async.tsx
@@ -14,19 +14,20 @@ import {
   VariableOptions,
 } from './types';
 
-interface QueryComponentOptions<Data, Variables>
-  extends LoadProps<DocumentNode<Data, Variables>> {
+interface QueryComponentOptions<Data, Variables, DeepPartial>
+  extends LoadProps<DocumentNode<Data, Variables, DeepPartial>> {
   defer?: DeferTiming;
 }
 
-export function createAsyncQueryComponent<Data, Variables>({
+export function createAsyncQueryComponent<Data, Variables, DeepPartial>({
   id,
   load,
   defer,
-}: QueryComponentOptions<Data, Variables>): AsyncQueryComponentType<
+}: QueryComponentOptions<
   Data,
-  Variables
-> {
+  Variables,
+  DeepPartial
+>): AsyncQueryComponentType<Data, Variables, DeepPartial> {
   function AsyncQuery(
     props: Omit<QueryProps<Data, Variables>, 'query'> & ConstantProps,
   ) {
@@ -101,7 +102,8 @@ export function createAsyncQueryComponent<Data, Variables>({
   // will know to augment its type
   const FinalComponent: AsyncQueryComponentType<
     Data,
-    Variables
+    Variables,
+    DeepPartial
   > = AsyncQuery as any;
 
   FinalComponent.Preload = Preload;

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import {DocumentNode} from 'graphql-typed';
+import {
+  DocumentNode,
+  GraphQLOperation,
+  GraphQLData,
+  GraphQLVariables,
+  GraphQLDeepPartial,
+} from 'graphql-typed';
 import {QueryResult} from 'react-apollo';
 import {
   FetchPolicy,
@@ -10,6 +16,8 @@ import {
 } from 'apollo-client';
 import {Omit, IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
 import {AsyncPropsRuntime} from '@shopify/react-async';
+
+export {GraphQLData, GraphQLVariables, GraphQLDeepPartial, GraphQLOperation};
 
 export type VariableOptions<Variables> = IfEmptyObject<
   Variables,
@@ -38,7 +46,8 @@ export interface ConstantProps {
   async?: AsyncPropsRuntime;
 }
 
-export interface AsyncQueryComponentType<Data, Variables> {
+export interface AsyncQueryComponentType<Data, Variables, DeepPartial>
+  extends GraphQLOperation<Data, Variables, DeepPartial> {
   (
     props: Omit<QueryProps<Data, Variables>, 'query'> & ConstantProps,
   ): React.ReactElement<{}>;
@@ -50,11 +59,3 @@ export interface AsyncQueryComponentType<Data, Variables> {
     props: VariableOptions<Variables> & {pollInterval?: number} & ConstantProps,
   ): React.ReactElement<{}>;
 }
-
-export type GraphQLData<T> = T extends DocumentNode<infer Data, any>
-  ? Data
-  : T extends AsyncQueryComponentType<infer Data, any> ? Data : never;
-
-export type GraphQLVariables<T> = T extends DocumentNode<any, infer Variables>
-  ? Variables
-  : T extends AsyncQueryComponentType<any, infer Variables> ? Variables : never;

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,10 +597,18 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.2", "@types/react@^16.0.2", "@types/react@^16.8.1":
+"@types/react@*", "@types/react@16.8.2", "@types/react@^16.0.2":
   version "16.8.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
   integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@>=16.4.0":
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"
+  integrity sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -3852,6 +3860,11 @@ graphql-typed@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/graphql-typed/-/graphql-typed-0.2.0.tgz#626863bbc8d0f1562db08508601dc2439bf00dd7"
   integrity sha512-cBy1vxabkmx3G0IURSbav7Rww/eQesKvHrSWa0SJy866JyHhxUJehp7m4sgTJt5J1vNFsEaJeHA4xLZmICKHnw==
+
+graphql-typed@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-typed/-/graphql-typed-0.3.0.tgz#8faa89ae6eb90c05917caa6bc993ed12f5cc5193"
+  integrity sha512-b3NFHlTOJzEVn2AvwOKfK7+6OBmvozs8DQ4sLjufRDcu/5L+W2mhofR0cgGbcYBEtUJHHbkJgFnrCoCnyVG05g==
 
 graphql@0.13.2:
   version "0.13.2"


### PR DESCRIPTION
This just updates the dependency on `graphql-typed`, and makes the async GraphQL component conform to `GraphQLOperation`. This will allow us to infer the types from these components just as we currently do for regular GraphQL documents.