### PR TITLE
Fix react-form-state List component

### DIFF
--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -45,7 +45,8 @@ export default class List<Fields> extends React.Component<
       const innerFields: FieldDescriptors<Fields> = mapObject(
         fieldValues,
         (value, fieldPath) => {
-          const initialFieldValue = initialValue[index][fieldPath];
+          const initialFieldValue =
+            initialValue[index] && initialValue[index][fieldPath];
           return {
             value,
             onBlur,


### PR DESCRIPTION
Fixes: #519 

This is a fix for a regression that was introduced in this commit: https://github.com/Shopify/quilt/pull/475/files#diff-68157ac38fbcaa003b546774b1857293R48 on line 48. The bug is that initialValue[index][fieldPath] throws an exception instead of returning undefined the way it previously did when initialValue[index] is undefined. I added an extra check to see if initialValue.index is defined and return undefined if its not.

🎩  it with our form (which has a polymorphic list and uses the List from react-form-state) and now it working instead of throwing an error (relates to #11012).