### PR TITLE
Preserve existing link and meta elements when possible

### DIFF
--- a/packages/react-html/src/tests/context.test.tsx
+++ b/packages/react-html/src/tests/context.test.tsx
@@ -56,4 +56,62 @@ describe('<Provider />', () => {
       document.querySelector(`title[${MANAGED_ATTRIBUTE}]`)!.textContent,
     ).toBe(title);
   });
+
+  it('does not remove matching link elements on subsequent changes', () => {
+    const linkOne = {src: 'foo'};
+    const linkTwo = {src: 'bar'};
+    const manager = new Manager();
+
+    mount(
+      <Provider manager={manager}>
+        <div />
+      </Provider>,
+    );
+
+    manager.addLink(linkOne);
+    animationFrame.runFrame();
+
+    // eslint-disable-next-line typescript/no-non-null-assertion
+    const linkElement = document.querySelector(`link[${MANAGED_ATTRIBUTE}]`)!;
+
+    manager.addLink(linkTwo);
+    animationFrame.runFrame();
+
+    const allLinks = Array.from(
+      document.querySelectorAll(`link[${MANAGED_ATTRIBUTE}]`),
+    );
+
+    expect(linkElement.getAttribute('src')).toBe(linkOne.src);
+    expect(linkElement).toBe(allLinks[0]);
+    expect(allLinks[1].getAttribute('src')).toBe(linkTwo.src);
+  });
+
+  it('does not remove matching meta elements on subsequent changes', () => {
+    const metaOne = {content: 'foo'};
+    const metaTwo = {content: 'bar'};
+    const manager = new Manager();
+
+    mount(
+      <Provider manager={manager}>
+        <div />
+      </Provider>,
+    );
+
+    manager.addMeta(metaOne);
+    animationFrame.runFrame();
+
+    // eslint-disable-next-line typescript/no-non-null-assertion
+    const metaElement = document.querySelector(`meta[${MANAGED_ATTRIBUTE}]`)!;
+
+    manager.addMeta(metaTwo);
+    animationFrame.runFrame();
+
+    const allMetas = Array.from(
+      document.querySelectorAll(`meta[${MANAGED_ATTRIBUTE}]`),
+    );
+
+    expect(metaElement.getAttribute('content')).toBe(metaOne.content);
+    expect(metaElement).toBe(allMetas[0]);
+    expect(allMetas[1].getAttribute('content')).toBe(metaTwo.content);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/Shopify/quilt/issues/516. This preserves existing `link` and `meta` elements that `react-html` adds where possible, using the handy `isEqualNode` that I had never seen before.