### PR TITLE
[polyfills] Fix typescript generated code referencing exports

### DIFF
--- a/packages/polyfills/src/baseline.node.ts
+++ b/packages/polyfills/src/baseline.node.ts
@@ -3,4 +3,4 @@ import '@babel/polyfill';
 // eslint-disable-next-line import/extensions
 import '@shopify/polyfills/fetch.node';
 
-export = null;
+export = {};

--- a/packages/polyfills/src/baseline.node.ts
+++ b/packages/polyfills/src/baseline.node.ts
@@ -2,3 +2,5 @@ import '@babel/polyfill';
 
 // eslint-disable-next-line import/extensions
 import '@shopify/polyfills/fetch.node';
+
+export = null;

--- a/packages/polyfills/src/baseline.ts
+++ b/packages/polyfills/src/baseline.ts
@@ -4,3 +4,5 @@ import {auto as unhandledRejectionPolyfill} from 'browser-unhandled-rejection';
 import '@shopify/polyfills/fetch';
 
 unhandledRejectionPolyfill();
+
+export = null;

--- a/packages/polyfills/src/baseline.ts
+++ b/packages/polyfills/src/baseline.ts
@@ -5,4 +5,4 @@ import '@shopify/polyfills/fetch';
 
 unhandledRejectionPolyfill();
 
-export = null;
+export = {};

--- a/packages/polyfills/src/fetch.node.ts
+++ b/packages/polyfills/src/fetch.node.ts
@@ -1,3 +1,3 @@
 import 'isomorphic-fetch';
 
-export = null;
+export = {};

--- a/packages/polyfills/src/fetch.node.ts
+++ b/packages/polyfills/src/fetch.node.ts
@@ -1,1 +1,3 @@
 import 'isomorphic-fetch';
+
+export = null;

--- a/packages/polyfills/src/fetch.ts
+++ b/packages/polyfills/src/fetch.ts
@@ -1,3 +1,3 @@
 import 'whatwg-fetch';
 
-export = null;
+export = {};

--- a/packages/polyfills/src/fetch.ts
+++ b/packages/polyfills/src/fetch.ts
@@ -1,1 +1,3 @@
 import 'whatwg-fetch';
+
+export = null;

--- a/packages/polyfills/src/intl.ts
+++ b/packages/polyfills/src/intl.ts
@@ -1,1 +1,3 @@
 import 'intl-pluralrules';
+
+export = null;

--- a/packages/polyfills/src/intl.ts
+++ b/packages/polyfills/src/intl.ts
@@ -1,3 +1,3 @@
 import 'intl-pluralrules';
 
-export = null;
+export = {};

--- a/packages/polyfills/src/url.node.ts
+++ b/packages/polyfills/src/url.node.ts
@@ -12,4 +12,4 @@ declare global {
 global.URL = URL;
 global.URLSearchParams = URLSearchParams;
 
-export = null;
+export = {};

--- a/packages/polyfills/src/url.node.ts
+++ b/packages/polyfills/src/url.node.ts
@@ -11,3 +11,5 @@ declare global {
 
 global.URL = URL;
 global.URLSearchParams = URLSearchParams;
+
+export = null;

--- a/packages/polyfills/src/url.ts
+++ b/packages/polyfills/src/url.ts
@@ -1,3 +1,3 @@
 import 'url-search-params-polyfill';
 
-export = null;
+export = {};

--- a/packages/polyfills/src/url.ts
+++ b/packages/polyfills/src/url.ts
@@ -1,1 +1,3 @@
 import 'url-search-params-polyfill';
+
+export = null;


### PR DESCRIPTION
See https://stackoverflow.com/questions/42497479/uncaught-referenceerror-exports-is-not-defined-in-filed-generated-by-typescript for a description of the problem.

Essentially, without this, we get a runtime error from the generated typescript code which includes:

```
Object.defineProperty(exports, "__esModule", { value: true });
```

although the `exports` variable is not defined.