### PR TITLE
✨ `performance` now tracks first-input-delay

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- New `fid` lifecycle event to track [first input delay](https://github.com/GoogleChromeLabs/first-input-delay) (to use this, consumers must inject [polyfill code](https://raw.githubusercontent.com/GoogleChromeLabs/first-input-delay/master/dist/first-input-delay.min.js) into their document head) [[#542](https://github.com/Shopify/quilt/pull/542)]
+
 ## [1.0.4] - 2019-02-21
 
 ### Fixed

--- a/packages/performance/src/first-input-delay.d.ts
+++ b/packages/performance/src/first-input-delay.d.ts
@@ -1,0 +1,11 @@
+// window.perfMetrics is created by a polyfill that *must* be injected into
+// the document head
+// (see https://github.com/GoogleChromeLabs/first-input-delay).
+
+interface PerfMetrics {
+  onFirstInputDelay(handler: (duration: number, event: Event) => void): void;
+}
+
+interface Window {
+  perfMetrics?: PerfMetrics;
+}

--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -16,6 +16,7 @@ const LIFECYCLE_EVENTS: LifecycleEvent['type'][] = [
   EventType.TimeToFirstPaint,
   EventType.TimeToFirstContentfulPaint,
   EventType.DomContentLoaded,
+  EventType.FirstInputDelay,
   EventType.Load,
 ];
 

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -159,6 +159,16 @@ export class Performance {
           | TimeToFirstContentfulPaintEvent);
       });
     }
+
+    if (typeof window !== undefined && window.perfMetrics !== undefined) {
+      window.perfMetrics.onFirstInputDelay(delay => {
+        this.lifecycleEvent({
+          type: EventType.FirstInputDelay,
+          start: now() - delay,
+          duration: delay,
+        });
+      });
+    }
   }
 
   on<T extends keyof EventMap>(event: T, handler: EventMap[T]) {

--- a/packages/performance/src/test/navigation.test.ts
+++ b/packages/performance/src/test/navigation.test.ts
@@ -237,6 +237,7 @@ describe('Navigation', () => {
         createLifecycleEventEvent(EventType.TimeToFirstPaint),
         createLifecycleEventEvent(EventType.TimeToFirstContentfulPaint),
         createLifecycleEventEvent(EventType.DomContentLoaded),
+        createLifecycleEventEvent(EventType.FirstInputDelay),
         createLifecycleEventEvent(EventType.Load),
         nonLifecycleEvent,
       ];
@@ -253,6 +254,7 @@ describe('Navigation', () => {
         createLifecycleEventEvent(EventType.TimeToFirstPaint),
         createLifecycleEventEvent(EventType.TimeToFirstContentfulPaint),
         createLifecycleEventEvent(EventType.DomContentLoaded),
+        createLifecycleEventEvent(EventType.FirstInputDelay),
         createLifecycleEventEvent(EventType.Load),
         nonLifecycleEvent,
       ];

--- a/packages/performance/src/test/performance.test.ts
+++ b/packages/performance/src/test/performance.test.ts
@@ -1,5 +1,9 @@
+import {FirstArgument} from '@shopify/useful-types';
 import {Performance} from '../performance';
 import {Navigation} from '../navigation';
+import {EventType} from '../types';
+
+type FirstInputDelayCallback = FirstArgument<PerfMetrics['onFirstInputDelay']>;
 
 describe('Performance', () => {
   // We are not adding all the required tests here until we have time
@@ -11,5 +15,51 @@ describe('Performance', () => {
 
     performance.finish();
     expect(spy).toHaveBeenCalledWith(expect.any(Navigation));
+  });
+
+  // This can unskip once mocks are available for either:
+  // - `performance.timing`
+  // - `PerformanceNavigationTiming` and `PerformanceObserver`
+  describe.skip('first-input-delay', () => {
+    class MockPerfMetrics implements PerfMetrics {
+      private _callback: FirstInputDelayCallback | null = null;
+
+      get callback() {
+        return this._callback;
+      }
+
+      onFirstInputDelay(callback) {
+        this._callback = callback;
+      }
+    }
+
+    it('registers a first-input-delay listener', () => {
+      const perfMetrics = new MockPerfMetrics();
+      window.perfMetrics = perfMetrics;
+
+      // eslint-disable-next-line no-new
+      new Performance();
+      expect(perfMetrics.callback).not.toBeNull();
+    });
+
+    it('sends first-interaction-delay lifecycle event', () => {
+      const perfMetrics = new MockPerfMetrics();
+      window.perfMetrics = perfMetrics;
+
+      const lifecycleSpy = jest.fn();
+      // eslint-disable-next-line no-new
+      const performance = new Performance();
+      performance.on('lifecycleEvent', lifecycleSpy);
+
+      // eslint-disable-next-line typescript/no-non-null-assertion
+      perfMetrics.callback!(1000, new Event('click'));
+
+      expect(lifecycleSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: EventType.FirstInputDelay,
+          duration: 1000,
+        }),
+      );
+    });
   });
 });

--- a/packages/performance/src/types.ts
+++ b/packages/performance/src/types.ts
@@ -3,6 +3,7 @@ export enum EventType {
   TimeToFirstPaint = 'ttfp',
   TimeToFirstContentfulPaint = 'ttfcp',
   DomContentLoaded = 'dcl',
+  FirstInputDelay = 'fid',
   Load = 'load',
   LongTask = 'longtask',
   Usable = 'usable',
@@ -35,6 +36,11 @@ export interface TimeToFirstContentfulPaintEvent extends BasicEvent {
 
 export interface DomContentLoadedEvent extends BasicEvent {
   type: EventType.DomContentLoaded;
+  metadata?: undefined;
+}
+
+export interface FirstInputDelayEvent extends BasicEvent {
+  type: EventType.FirstInputDelay;
   metadata?: undefined;
 }
 
@@ -77,6 +83,7 @@ export type LifecycleEvent =
   | TimeToFirstPaintEvent
   | TimeToFirstContentfulPaintEvent
   | DomContentLoadedEvent
+  | FirstInputDelayEvent
   | LoadEvent;
 
 export type Event =
@@ -93,6 +100,7 @@ export interface EventMap {
   [EventType.TimeToFirstPaint]: TimeToFirstPaintEvent;
   [EventType.TimeToFirstContentfulPaint]: TimeToFirstContentfulPaintEvent;
   [EventType.DomContentLoaded]: DomContentLoadedEvent;
+  [EventType.FirstInputDelay]: FirstInputDelayEvent;
   [EventType.Load]: LoadEvent;
   [EventType.ScriptDownload]: ScriptDownloadEvent;
   [EventType.StyleDownload]: StyleDownloadEvent;


### PR DESCRIPTION
Basically, this measures the milliseconds between the user's first event, and the browser passing the event on to handlers.  See https://github.com/GoogleChromeLabs/first-input-delay for more information.

Note: this is only useful when the first-input-delay polyfill is present in the document's head.