### PR TITLE
improving the DATE_TIME_PARTS_REGEX to support fractional seconds

### DIFF
--- a/packages/dates/README.md
+++ b/packages/dates/README.md
@@ -183,6 +183,30 @@ const timeZone = 'UTC';
 const parsed = parseDateString(date, timeZone);
 ```
 
+### `parseDateStringParts`
+
+Takes in a date string. Returns parsed parts from that date string.
+
+```ts
+import {parseDateStringParts} from '@shopify/dates';
+
+const date = '2018-05-28T12:30:00.123+05:30';
+
+const {
+  year,
+  month,
+  day,
+  hour,
+  minute,
+  second,
+  millisecond,
+  timeZoneOffset,
+  sign,
+  timeZoneHour,
+  timeZoneMinute,
+} = parseDateStringParts(date);
+```
+
 ### `unapplyTimeZoneOffset`
 
 Takes in a date object and two optional time zone string parameters. Returns a new date object with the offset between the time zones subtracted from it.

--- a/packages/dates/src/index.ts
+++ b/packages/dates/src/index.ts
@@ -9,6 +9,7 @@ export * from './is-today';
 export * from './is-yesterday';
 export * from './is-tomorrow';
 export * from './parse-date-string';
+export * from './parse-date-string-parts';
 export * from './sanitise-date-string';
 export * from './unapply-time-zone-offset';
 export * from './map-deprecated-timezones';

--- a/packages/dates/src/parse-date-string-parts.ts
+++ b/packages/dates/src/parse-date-string-parts.ts
@@ -1,0 +1,46 @@
+/**
+ * Allowed date string formats
+ * yyyy-mm-dd
+ * yyyy-mm-ddThh:mm:ss.fff
+ * yyyy-mm-ddThh:mm:ss.fff+hh:mm
+ * yyyy-mm-ddThh:mm:ss.fff-hh:mm
+ * yyyy-mm-ddThh:mm:ss.fffZ
+ */
+const DATE_TIME_PARTS_REGEX = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(?:(Z|(?:(\+|-)(\d{2}):(\d{2}))))?)?$/;
+
+export function parseDateStringParts(dateString: string) {
+  const dateTimeParts = new RegExp(DATE_TIME_PARTS_REGEX).exec(dateString);
+
+  if (dateTimeParts == null) {
+    return null;
+  }
+
+  // slice the first regex part (the full match) off
+  const [
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond,
+    timeZoneOffset,
+    sign,
+    timeZoneHour,
+    timeZoneMinute,
+  ] = Array.from(dateTimeParts).slice(1);
+
+  return {
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond,
+    timeZoneOffset,
+    sign,
+    timeZoneHour,
+    timeZoneMinute,
+  };
+}

--- a/packages/dates/src/parse-date-string.ts
+++ b/packages/dates/src/parse-date-string.ts
@@ -1,36 +1,26 @@
 import {applyTimeZoneOffset} from './apply-time-zone-offset';
-
-/**
- * Allowed date string formats
- * yyyy-mm-dd
- * yyyy-mm-ddThh:mm:ss
- * yyyy-mm-ddThh:mm:ss+hh:mm
- * yyyy-mm-ddThh:mm:ss-hh:mm
- * yyyy-mm-ddThh:mm:ssZ
- */
-const DATE_TIME_PARTS_REGEX = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2})(?:(Z|(?:(\+|-)(\d{2}):(\d{2}))))?)?$/;
+import {parseDateStringParts} from './parse-date-string-parts';
 
 export function parseDateString(dateString: string, timeZone?: string) {
-  const dateTimeParts = new RegExp(DATE_TIME_PARTS_REGEX).exec(dateString);
+  const dateTimeParts = parseDateStringParts(dateString);
 
   if (dateTimeParts == null) {
     return null;
   }
 
-  const [
-    // @ts-ignore
-    _,
-    rawYear,
-    rawMonth,
-    rawDay,
-    rawHour,
-    rawMinute,
-    rawSecond,
+  const {
+    year: rawYear,
+    month: rawMonth,
+    day: rawDay,
+    hour: rawHour,
+    minute: rawMinute,
+    second: rawSecond,
+    millisecond: rawMillisecond,
     timeZoneOffset,
     sign,
-    rawTimeZoneHour,
-    rawTimeZoneMinute,
-  ] = dateTimeParts;
+    timeZoneHour: rawTimeZoneHour,
+    timeZoneMinute: rawTimeZoneMinute,
+  } = dateTimeParts;
 
   const year = parseInt(rawYear, 10);
   const month = parseInt(rawMonth, 10);
@@ -38,6 +28,7 @@ export function parseDateString(dateString: string, timeZone?: string) {
   const hour = rawHour == null ? 0 : parseInt(rawHour, 10);
   const minute = rawMinute == null ? 0 : parseInt(rawMinute, 10);
   const second = rawSecond == null ? 0 : parseInt(rawSecond, 10);
+  const millisecond = rawMillisecond == null ? 0 : parseInt(rawMillisecond, 10);
 
   const timeZoneHour =
     rawTimeZoneHour == null ? 0 : parseInt(rawTimeZoneHour, 10);
@@ -45,7 +36,7 @@ export function parseDateString(dateString: string, timeZone?: string) {
     rawTimeZoneMinute == null ? 0 : parseInt(rawTimeZoneMinute, 10);
 
   const utcDate = new Date(
-    Date.UTC(year, month - 1, day, hour, minute, second),
+    Date.UTC(year, month - 1, day, hour, minute, second, millisecond),
   );
 
   if (timeZoneOffset === 'Z') {

--- a/packages/dates/src/tests/parse-date-string-parts.test.ts
+++ b/packages/dates/src/tests/parse-date-string-parts.test.ts
@@ -1,0 +1,125 @@
+import {parseDateStringParts} from '../parse-date-string-parts';
+
+describe('parseDateStringParts()', () => {
+  it('parses yyyy-mm-dd date strings', () => {
+    expect(parseDateStringParts('2018-05-28')).toMatchObject({
+      year: '2018',
+      month: '05',
+      day: '28',
+    });
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ss date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00')).toMatchObject({
+      year: '2018',
+      month: '05',
+      day: '28',
+      hour: '12',
+      minute: '30',
+      second: '00',
+    });
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ss+hh:mm date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00+05:30')).toMatchObject({
+      year: '2018',
+      month: '05',
+      day: '28',
+      hour: '12',
+      minute: '30',
+      second: '00',
+      timeZoneOffset: '+05:30',
+      sign: '+',
+      timeZoneHour: '05',
+      timeZoneMinute: '30',
+    });
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ss-hh:mm date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00-05:15')).toMatchObject({
+      year: '2018',
+      month: '05',
+      day: '28',
+      hour: '12',
+      minute: '30',
+      second: '00',
+      timeZoneOffset: '-05:15',
+      sign: '-',
+      timeZoneHour: '05',
+      timeZoneMinute: '15',
+    });
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ssZ date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00Z')).toMatchObject({
+      year: '2018',
+      month: '05',
+      day: '28',
+      hour: '12',
+      minute: '30',
+      second: '00',
+      timeZoneOffset: 'Z',
+    });
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ss.fff date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00.123')).toMatchObject({
+      year: '2018',
+      month: '05',
+      day: '28',
+      hour: '12',
+      minute: '30',
+      second: '00',
+      millisecond: '123',
+    });
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ss.fff+hh:mm date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00.123+05:30')).toMatchObject(
+      {
+        year: '2018',
+        month: '05',
+        day: '28',
+        hour: '12',
+        minute: '30',
+        second: '00',
+        millisecond: '123',
+        timeZoneOffset: '+05:30',
+        sign: '+',
+        timeZoneHour: '05',
+        timeZoneMinute: '30',
+      },
+    );
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ss.fff-hh:mm date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00.123-05:15')).toMatchObject(
+      {
+        year: '2018',
+        month: '05',
+        day: '28',
+        hour: '12',
+        minute: '30',
+        second: '00',
+        millisecond: '123',
+        timeZoneOffset: '-05:15',
+        sign: '-',
+        timeZoneHour: '05',
+        timeZoneMinute: '15',
+      },
+    );
+  });
+
+  it('parses yyyy-mm-ddT:hh:mm:ss.fffZ date strings', () => {
+    expect(parseDateStringParts('2018-05-28T12:30:00.123Z')).toMatchObject({
+      year: '2018',
+      month: '05',
+      day: '28',
+      hour: '12',
+      minute: '30',
+      second: '00',
+      millisecond: '123',
+      timeZoneOffset: 'Z',
+    });
+  });
+});

--- a/packages/dates/src/tests/parse-date-string.test.ts
+++ b/packages/dates/src/tests/parse-date-string.test.ts
@@ -36,6 +36,34 @@ describe('parseDateString()', () => {
 
       expect(actual).toEqual(expected);
     });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fff date strings', () => {
+      const actual = parseDateString('2018-05-28T12:30:00.123', 'UTC');
+      const expected = new Date('2018-05-28T12:30:00.123+00:00');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fff+hh:mm date strings', () => {
+      const actual = parseDateString('2018-05-28T12:30:00.123+05:30', 'UTC');
+      const expected = new Date('2018-05-28T12:30:00.123+05:30');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fff-hh:mm date strings', () => {
+      const actual = parseDateString('2018-05-28T12:30:00.123-05:15', 'UTC');
+      const expected = new Date('2018-05-28T12:30:00.123-05:15');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fffZ date strings', () => {
+      const actual = parseDateString('2018-05-28T12:30:00.123Z', 'UTC');
+      const expected = new Date('2018-05-28T12:30:00.123+00:00');
+
+      expect(actual).toEqual(expected);
+    });
   });
 
   describe('not UTC timezone', () => {
@@ -76,6 +104,46 @@ describe('parseDateString()', () => {
     it('parses yyyy-mm-ddT:hh:mm:ssZ date strings', () => {
       const actual = parseDateString('2018-05-28T12:30:00Z', 'Australia/Perth');
       const expected = new Date('2018-05-28T12:30:00+00:00');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fff date strings', () => {
+      const actual = parseDateString(
+        '2018-05-28T12:30:00.123',
+        'Australia/Perth',
+      );
+      const expected = new Date('2018-05-28T12:30:00.123+08:00');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fff+hh:mm date strings', () => {
+      const actual = parseDateString(
+        '2018-05-28T12:30:00.123+05:30',
+        'Australia/Perth',
+      );
+      const expected = new Date('2018-05-28T12:30:00.123+05:30');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fff-hh:mm date strings', () => {
+      const actual = parseDateString(
+        '2018-05-28T12:30:00.123-05:15',
+        'Australia/Perth',
+      );
+      const expected = new Date('2018-05-28T12:30:00.123-05:15');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('parses yyyy-mm-ddT:hh:mm:ss.fffZ date strings', () => {
+      const actual = parseDateString(
+        '2018-05-28T12:30:00.123Z',
+        'Australia/Perth',
+      );
+      const expected = new Date('2018-05-28T12:30:00.123+00:00');
 
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

If a timestamp ever includes fractional seconds the regex will outright fail. This patch allows those seconds to be captured and inserted into the parsed date. This can be particularly useful if a date formatter emits empty data for the fractional seconds (i.e., the formatter emits `.000`), which adds no new information but causes the parse the fail.

### Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

The added new tests should cover all new inputs for this updated regex pattern.

Because this is an optional field all previous usages should not be affected.