### PR TITLE
✨ add a small memoize decorator

### DIFF
--- a/packages/decorators/CHANGELOG.md
+++ b/packages/decorators/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/decorators` package

--- a/packages/decorators/README.md
+++ b/packages/decorators/README.md
@@ -1,0 +1,107 @@
+# `@shopify/decorators`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fdecorators.svg)](https://badge.fury.io/js/%40shopify%2Fdecorators.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/decorators.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/decorators.svg)
+
+A set of decorators to aid your javascript journey.
+
+## Installation
+
+```bash
+$ yarn add @shopify/decorators
+```
+
+## Usage
+
+### `memoize`
+
+The memoize decorator creates a function that memoizes the results of the function it is decorating.
+The cache key for storing the results are based on the first argument provided to the memoized function.
+If the memoization key cannot be inferred from the first argument alone, a `resolver` should be passed in to ensure a unique key. (ex: the unique key is in the second argument, or the unique key is a combination of a few arguments)
+
+Know that memoization will be skipped on server process and the cached results have a maximum limit of 50 entries on a first in first out basis.
+
+#### Memoizing a simple function
+
+```ts
+import {memoize} from '@shopify/decorators';
+
+class MyClass {
+  @memoize()
+  addOne(number: number) {
+    return number + 1;
+  }
+}
+
+const myClass = new MyClass();
+
+myClass.addOne(1); // -> 2, addOne is executed
+myClass.addOne(1); // -> 2, result is from cache
+```
+
+#### Memoizing a function with object as argument
+
+When memoizing a function with object as first argument, make sure the object is immutable.
+
+```ts
+import {memoize} from '@shopify/decorators';
+
+class MyClass {
+  @memoize()
+  getValues(someObject: {one: string; two: string}) {
+    return;
+  }
+}
+
+const myClass = new MyClass();
+
+const testObject1 = {one: 1, two: 2};
+myClass.getValues(testObject1); // -> [1, 2], getValues is executed
+myClass.getValues(testObject1); // -> [1, 2], result is from cache
+
+testObject1.two = 3;
+myClass.getValues(testObject1); // -> [1, 2], result is from cache, BAD
+```
+
+#### Memoizing a function while providing a resolver
+
+The resolver takes in the same arguments as the function it is decorating.
+Be sure that the resolver returns a unique identifer.
+
+```ts
+import {memoize} from '@shopify/decorators';
+
+class MyClass {
+  @memoize((command: string, value: string) => `${command}${value}`)
+  getByCommand(command: string, value: string) {
+    // implementation for getByCommand
+  }
+}
+
+const myClass = new MyClass();
+
+myClass.getByCommand('command name 1', 'command value 1'); // runCommand is executed
+myClass.getByCommand('command name 1', 'command value 2'); // runCommand is executed
+```
+
+Next let's fix the example from [above](#memoizing-a-function-with-object-as-argument) so the results will always be correct.
+
+```ts
+import {memoize} from '@shopify/decorators';
+
+class MyClass {
+  @memoize((someObject: {id: string; value: string}) => `${id}${value}`)
+  getValues(someObject: {id: string; value: string}) {
+    return Object.values(someObject);
+  }
+}
+
+const myClass = new MyClass();
+
+const testObject1 = {id: 1, value: 2};
+myClass.getValues(testObject1); // -> [1, 2], getValues is executed
+myClass.getValues(testObject1); // -> [1, 2], result is from cache
+
+testObject1.value = 3;
+myClass.getValues(testObject1); // -> [1, 3], getValues is executed
+```

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shopify/decorators",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A set of decorators to aid your JavaScript journey.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/decorators/README.md",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "~3.0.1"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/decorators/src/index.ts
+++ b/packages/decorators/src/index.ts
@@ -1,0 +1,1 @@
+export {default as memoize} from './memoize';

--- a/packages/decorators/src/memoize.ts
+++ b/packages/decorators/src/memoize.ts
@@ -1,0 +1,74 @@
+interface MemoizeMap<T, U> {
+  get(key: T): U;
+  has(key: T): boolean;
+  set(key: T, value: U): MemoizeMap<T, U>;
+}
+
+type Resolver<T extends Function> = T;
+
+export const MAX_MAP_ENTRIES = 50;
+
+export default function memoize<Method extends Function>(
+  resolver?: Resolver<Method>,
+): MethodDecorator {
+  return function<T>(
+    _target: Object,
+    _propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<T>,
+  ) {
+    const method = descriptor.value;
+
+    if (!method || !(method instanceof Function)) {
+      return descriptor;
+    }
+
+    descriptor.value = memoized(method as any, resolver);
+    return descriptor;
+  };
+}
+
+function memoized<F extends Function>(method: F, resolver?: Resolver<F>): F {
+  const weakMapCache = new WeakMap();
+  const mapCache = new Map();
+  const mapKeys: any[] = [];
+
+  return (function memoized(...args) {
+    if (typeof window === 'undefined') {
+      return method.apply(this, args);
+    }
+
+    const useWeakMap =
+      args.length === 1 && typeof args[0] === 'object' && !resolver;
+
+    let key;
+    if (useWeakMap) {
+      key = args[0];
+    } else if (resolver && resolver instanceof Function) {
+      key = resolver(...args);
+    } else {
+      key = args[0];
+    }
+
+    const cache: MemoizeMap<any, any> = useWeakMap ? weakMapCache : mapCache;
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+
+    const result = method.apply(this, args);
+
+    if (useWeakMap) {
+      weakMapCache.set(key, result);
+    } else {
+      mapCache.set(key, result);
+      mapKeys.push(key);
+
+      if (mapCache.size > MAX_MAP_ENTRIES) {
+        const oldestKey = mapKeys[0];
+        mapCache.delete(oldestKey);
+        mapKeys.shift();
+      }
+    }
+
+    return result;
+  } as unknown) as F;
+}

--- a/packages/decorators/src/tests/memoize-server.test.ts
+++ b/packages/decorators/src/tests/memoize-server.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+
+import memoize from '../memoize';
+
+describe('memoize()', () => {
+  describe('server', () => {
+    it('recalculates the result when first argument changed', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        addOne(number: number) {
+          spy();
+          return number + 1;
+        }
+      }
+
+      const myClass = new MyClass();
+
+      expect(myClass.addOne(1)).toEqual(2);
+      expect(myClass.addOne(2)).toEqual(3);
+      expect(spy).toBeCalledTimes(2);
+    });
+
+    it('recalculates the result when the first argument stay the same', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        addOne(number: number) {
+          spy();
+          return number + 1;
+        }
+      }
+
+      const myClass = new MyClass();
+
+      expect(myClass.addOne(1)).toEqual(2);
+      expect(myClass.addOne(1)).toEqual(2);
+      expect(spy).toBeCalledTimes(2);
+    });
+  });
+});

--- a/packages/decorators/src/tests/memoize.test.ts
+++ b/packages/decorators/src/tests/memoize.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import memoize, {MAX_MAP_ENTRIES} from '../memoize';
+
+describe('memoize()', () => {
+  describe('client', () => {
+    it('recalculates the result when first argument changed', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        addOne(number: number) {
+          spy();
+          return number + 1;
+        }
+      }
+
+      const myClass = new MyClass();
+
+      expect(myClass.addOne(1)).toEqual(2);
+      expect(myClass.addOne(2)).toEqual(3);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('gets the result from cache when the first argument stay the same', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        addOne(number: number) {
+          spy();
+          return number + 1;
+        }
+      }
+
+      const myClass = new MyClass();
+
+      expect(myClass.addOne(1)).toEqual(2);
+      expect(myClass.addOne(1)).toEqual(2);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes oldest cache item when the cache limit is reached', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        addOne(number: number) {
+          spy();
+          return number + 1;
+        }
+      }
+
+      const myClass = new MyClass();
+
+      for (let i = 0; i < MAX_MAP_ENTRIES; i++) {
+        expect(myClass.addOne(i)).toEqual(i + 1);
+      }
+
+      // 0 is in the cache
+      expect(myClass.addOne(0)).toEqual(1);
+      expect(myClass.addOne(1)).toEqual(2);
+      expect(spy).toHaveBeenCalledTimes(MAX_MAP_ENTRIES);
+
+      expect(myClass.addOne(MAX_MAP_ENTRIES)).toEqual(MAX_MAP_ENTRIES + 1);
+      expect(spy).toHaveBeenCalledTimes(MAX_MAP_ENTRIES + 1);
+
+      // 0 is no longer in the cache
+      expect(myClass.addOne(0)).toEqual(1);
+      expect(spy).toHaveBeenCalledTimes(MAX_MAP_ENTRIES + 2);
+    });
+  });
+
+  describe('only argument is object', () => {
+    it('recalculates the result when the first argument changed', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        getValues(someObject: Object) {
+          spy();
+          return Object.values(someObject);
+        }
+      }
+
+      const myClass = new MyClass();
+
+      expect(myClass.getValues({one: 1, two: 2})).toEqual([1, 2]);
+      expect(myClass.getValues({one: 3, four: 4})).toEqual([3, 4]);
+      expect(spy).toBeCalledTimes(2);
+    });
+
+    it('gets the result from cache when the first argument stay the same', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        getValues(someObject: Object) {
+          spy();
+          return Object.values(someObject);
+        }
+      }
+
+      const myClass = new MyClass();
+
+      const testObject1 = {one: 1, two: 2};
+      expect(myClass.getValues(testObject1)).toEqual([1, 2]);
+      expect(myClass.getValues(testObject1)).toEqual([1, 2]);
+      expect(spy).toBeCalledTimes(1);
+    });
+
+    it('does not change the result when the argument was changed in value only', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize()
+        getValues(someObject: Object) {
+          spy();
+          return Object.values(someObject);
+        }
+      }
+
+      const myClass = new MyClass();
+
+      const testObject1 = {one: 1, two: 2};
+      expect(myClass.getValues(testObject1)).toEqual([1, 2]);
+
+      testObject1.one = 2;
+      expect(myClass.getValues(testObject1)).toEqual([1, 2]);
+
+      expect(spy).toBeCalledTimes(1);
+    });
+  });
+
+  describe('customized resolver', () => {
+    it('recalculates the result when the resolver result was changed', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize((_name: string, id: string) => id)
+        getName(name: string, _id: string) {
+          spy();
+          return name;
+        }
+      }
+
+      const myClass = new MyClass();
+
+      expect(myClass.getName('Lisa', '1')).toEqual('Lisa');
+      expect(myClass.getName('Lisa', '2')).toEqual('Lisa');
+      expect(spy).toBeCalledTimes(2);
+    });
+
+    it('gets the result from cache when the resolver result was not changed', () => {
+      const spy = jest.fn();
+      class MyClass {
+        @memoize((_name: string, id: string) => id)
+        getName(name: string, _id: string) {
+          spy();
+          return name;
+        }
+      }
+
+      const myClass = new MyClass();
+
+      expect(myClass.getName('Lisa', '1')).toEqual('Lisa');
+      expect(myClass.getName('Lisa', '1')).toEqual('Lisa');
+      expect(spy).toBeCalledTimes(1);
+    });
+  });
+});

--- a/packages/decorators/tsconfig.build.json
+++ b/packages/decorators/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
Part of https://github.com/Shopify/web/issues/10480 and https://github.com/Shopify/quilt/issues/136

The memoize utility should do the following:
* When the method run in server => return identity function
* When the method run in client =>
  
  * Use `WeakMap` when there is only 1 argument and it is an object (ideally not immutable, other wise this is useless)
  * Use `Map` with 50-100 limit on everything else including having resolver.

It will also replace `@shopify/javascript-utilities/decorators/memoize`