### PR TITLE
Allow custom error handling for i18n errors

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -23,6 +23,7 @@ This library requires a provider component which supplies i18n details to the re
 - `timezone`: the default timezone to use for timezone-aware formatting.
 - `currency`: the default currency to use for currency-aware formatting.
 - `pseudolocalize`: whether to perform [pseudolocalization](https://github.com/Shopify/pseudolocalization) on your translations.
+- `onError`: a callback to use when recoverable i18n-related errors happen. If not provided, these errors will be re-thrown wherever they occur. If it is provided and it does not re-throw the passed error, the translation or formatting that caused the error will return an empty string. This function will be called with the error object.
 
 ```ts
 import {
@@ -31,7 +32,12 @@ import {
 } from '@shopify/react-i18n';
 
 const locale = 'en';
-const i18nManager = new I18nManager({locale});
+const i18nManager = new I18nManager({
+  locale,
+  onError(error) {
+    Bugsnag.notify(error);
+  },
+});
 
 export default function App() {
   return (

--- a/packages/react-i18n/src/errors.ts
+++ b/packages/react-i18n/src/errors.ts
@@ -3,3 +3,10 @@ export class MissingReplacementError extends Error {}
 export class MissingCurrencyCodeError extends Error {}
 export class MissingCountryError extends Error {}
 export class InvalidI18nConnectionError extends Error {}
+
+export type I18nError =
+  | MissingTranslationError
+  | MissingReplacementError
+  | MissingCurrencyCodeError
+  | MissingCountryError
+  | InvalidI18nConnectionError;

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -17,7 +17,11 @@ import {
   currencyDecimalPlaces,
   DEFAULT_DECIMAL_PLACES,
 } from './constants';
-import {MissingCurrencyCodeError, MissingCountryError} from './errors';
+import {
+  MissingCurrencyCodeError,
+  MissingCountryError,
+  I18nError,
+} from './errors';
 import {
   getCurrencySymbol,
   translate,
@@ -43,6 +47,7 @@ export default class I18n {
   readonly defaultCountry?: string;
   readonly defaultCurrency?: string;
   readonly defaultTimezone?: string;
+  readonly onError: NonNullable<I18nDetails['onError']>;
 
   get language() {
     return languageFromLocale(this.locale);
@@ -75,13 +80,21 @@ export default class I18n {
 
   constructor(
     public translations: TranslationDictionary[],
-    {locale, currency, timezone, country, pseudolocalize = false}: I18nDetails,
+    {
+      locale,
+      currency,
+      timezone,
+      country,
+      pseudolocalize = false,
+      onError,
+    }: I18nDetails,
   ) {
     this.locale = locale;
     this.defaultCountry = country;
     this.defaultCurrency = currency;
     this.defaultTimezone = timezone;
     this.pseudolocalize = pseudolocalize;
+    this.onError = onError || defaultOnError;
   }
 
   translate(
@@ -129,7 +142,12 @@ export default class I18n {
       };
     }
 
-    return translate(id, normalizedOptions, this.translations, this.locale);
+    try {
+      return translate(id, normalizedOptions, this.translations, this.locale);
+    } catch (error) {
+      this.onError(error);
+      return '';
+    }
   }
 
   formatNumber(
@@ -139,9 +157,13 @@ export default class I18n {
     const {locale, defaultCurrency: currency} = this;
 
     if (as === 'currency' && currency == null && options.currency == null) {
-      throw new MissingCurrencyCodeError(
-        `No currency code provided. formatNumber(amount, {as: 'currency'}) cannot be called without a currency code.`,
+      this.onError(
+        new MissingCurrencyCodeError(
+          `No currency code provided. formatNumber(amount, {as: 'currency'}) cannot be called without a currency code.`,
+        ),
       );
+
+      return '';
     }
 
     return new Intl.NumberFormat(locale, {
@@ -236,9 +258,13 @@ export default class I18n {
   getCurrencySymbol = (currencyCode?: string) => {
     const currency = currencyCode || this.defaultCurrency;
     if (currency == null) {
-      throw new MissingCurrencyCodeError(
-        `No currency code provided. formatCurrency cannot be called without a currency code.`,
+      this.onError(
+        new MissingCurrencyCodeError(
+          `No currency code provided. formatCurrency cannot be called without a currency code.`,
+        ),
       );
+
+      return '';
     }
     return this.getCurrencySymbolLocalized(this.locale, currency);
   };
@@ -305,4 +331,8 @@ function isYesterday(date: Date) {
   yesterday.setDate(yesterday.getDate() - 1);
 
   return isSameDate(yesterday, date);
+}
+
+function defaultOnError(error: I18nError) {
+  throw error;
 }

--- a/packages/react-i18n/src/types.ts
+++ b/packages/react-i18n/src/types.ts
@@ -1,3 +1,5 @@
+import {I18nError} from './errors';
+
 export enum LanguageDirection {
   Rtl,
   Ltr,
@@ -10,6 +12,7 @@ export interface I18nDetails {
   timezone?: string;
   pseudolocalize?: boolean;
   fallbackLocale?: string;
+  onError?(error: I18nError): void;
 }
 
 export interface TranslationDictionary {

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -201,7 +201,7 @@ function updateStringWithReplacements(
 
       if (replacement) {
         if (!replacements.hasOwnProperty(replacement)) {
-          throw new Error(
+          throw new MissingReplacementError(
             `No replacement found for key '${replacement}'. The following replacements were passed: ${Object.keys(
               replacements,
             )

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,18 +597,10 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.2", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.8.2", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.8.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
   integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@>=16.4.0":
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"
-  integrity sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -3801,11 +3793,6 @@ got@^6.7.1:
     timed-out "^4.0.0"
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
-
-gql-tag@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gql-tag/-/gql-tag-1.0.1.tgz#25294dc23986db5b950b81a8bc8debfb0acf6140"
-  integrity sha512-eVxldTiOtJJ3ySNgYbfRwyIyDDMATJ/ykojlQng5ihX1V0Xpr4C7ZXSZuWo7tg+kf+GS8lzhlbZmKSDjbYGhyA==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"


### PR DESCRIPTION
Right now, when a translation is missing (or in a few other cases), we throw an error from the i18n library and are done with it. IMO this is the proper default; React provides ways to catch this error in the tree and recover gracefully. However, Web has been bitten a few times by this where incomplete test coverage/ being a little careless with the translations + no additional error handling means that the whole page gets wiped.

This PR adds the necessary hook for us to catch the error. With this PR, if the error is not re-thrown by the `onError` handler, it will return an empty string instead. IMO this is not really better than the default (since the content will not make sense), and it means that in some cases we still have errors thrown (where we can't return any sensible "default" result), but I seem to be in the minority opinion on this.