### PR TITLE
Fix polyfills in browser

### DIFF
--- a/packages/polyfills/src/baseline.node.ts
+++ b/packages/polyfills/src/baseline.node.ts
@@ -2,5 +2,3 @@ import '@babel/polyfill';
 
 // eslint-disable-next-line import/extensions
 import '@shopify/polyfills/fetch.node';
-
-export = {};

--- a/packages/polyfills/src/baseline.ts
+++ b/packages/polyfills/src/baseline.ts
@@ -1,8 +1,3 @@
-import '@babel/polyfill';
-import {auto as unhandledRejectionPolyfill} from 'browser-unhandled-rejection';
-
-import '@shopify/polyfills/fetch';
-
-unhandledRejectionPolyfill();
-
-export = {};
+require('@babel/polyfill');
+require('browser-unhandled-rejection').auto();
+require('@shopify/polyfills/fetch');

--- a/packages/polyfills/src/fetch.node.ts
+++ b/packages/polyfills/src/fetch.node.ts
@@ -1,3 +1,1 @@
 import 'isomorphic-fetch';
-
-export = {};

--- a/packages/polyfills/src/fetch.ts
+++ b/packages/polyfills/src/fetch.ts
@@ -1,3 +1,1 @@
-import 'whatwg-fetch';
-
-export = {};
+require('whatwg-fetch');

--- a/packages/polyfills/src/intl.ts
+++ b/packages/polyfills/src/intl.ts
@@ -1,3 +1,1 @@
-import 'intl-pluralrules';
-
-export = {};
+require('intl-pluralrules');

--- a/packages/polyfills/src/url.node.ts
+++ b/packages/polyfills/src/url.node.ts
@@ -11,5 +11,3 @@ declare global {
 
 global.URL = URL;
 global.URLSearchParams = URLSearchParams;
-
-export = {};

--- a/packages/polyfills/src/url.ts
+++ b/packages/polyfills/src/url.ts
@@ -1,3 +1,1 @@
-import 'url-search-params-polyfill';
-
-export = {};
+require('url-search-params-polyfill');


### PR DESCRIPTION
As it turns out, there was a problem with the standard import method that lead to a ReferenceError for `exports` and there was a problem with the `exports = {}` syntax, because `module.exports` is read-only, but the `require()` approach works well for the browser environment and the previous approach (with imports) is sufficient for node environments.