### PR TITLE
Fix duplicate translation dictionaries when locale === fallbackLocale

### DIFF
--- a/packages/react-i18n/src/manager.ts
+++ b/packages/react-i18n/src/manager.ts
@@ -130,7 +130,10 @@ export default class Manager {
       };
     }
 
-    const possibleLocales = getPossibleLocales(this.details.locale);
+    const possibleLocales = getPossibleLocales(this.details.locale, {
+      exclude: this.details.fallbackLocale,
+    });
+
     const translations = possibleLocales.map(locale => {
       const id = localeId(connection, locale);
       return (
@@ -234,12 +237,24 @@ function localeIdsForConnection(
   ];
 }
 
-function getPossibleLocales(locale: string) {
+function getPossibleLocales(
+  locale: string,
+  {exclude}: {exclude?: string} = {},
+) {
   const normalizedLocale = locale.toLowerCase();
   const split = normalizedLocale.split('-');
-  return split.length > 1
-    ? [`${split[0]}-${split[1].toUpperCase()}`, normalizedLocale, split[0]]
-    : [normalizedLocale];
+
+  if (split.length > 1) {
+    const locales = [`${split[0]}-${split[1].toUpperCase()}`, normalizedLocale];
+
+    if (split[0] !== exclude) {
+      locales.push(split[0]);
+    }
+
+    return locales;
+  } else {
+    return normalizedLocale === exclude ? [] : [normalizedLocale];
+  }
 }
 
 function isPromise<T>(

--- a/packages/react-i18n/src/test/manager.test.ts
+++ b/packages/react-i18n/src/test/manager.test.ts
@@ -197,7 +197,7 @@ describe('Manager', () => {
         expect(spy).not.toHaveBeenCalled();
       });
 
-      fit('does not include fallback translations if they are the same language as the request', () => {
+      it('does not include fallback translations if they are the same language as the request', () => {
         const connection = new Connection({
           id: createID(),
           fallback: en,

--- a/packages/react-i18n/src/test/manager.test.ts
+++ b/packages/react-i18n/src/test/manager.test.ts
@@ -196,6 +196,30 @@ describe('Manager', () => {
         );
         expect(spy).not.toHaveBeenCalled();
       });
+
+      fit('does not include fallback translations if they are the same language as the request', () => {
+        const connection = new Connection({
+          id: createID(),
+          fallback: en,
+          translations: () => en,
+        });
+
+        const manager = new Manager({
+          ...basicDetails,
+          locale: 'en',
+          fallbackLocale: 'en',
+        });
+
+        manager.connect(
+          connection,
+          noop,
+        );
+
+        expect(manager.state(connection)).toMatchObject({
+          loading: false,
+          translations: [en],
+        });
+      });
     });
 
     describe('async', () => {


### PR DESCRIPTION
When troubleshooting an unrelated issue, I noticed that every translation dictionary was included twice for each `I18n` instance. This was the case because we were not deduping the translation dictionaries against the fallback ones, even though we know what locale the fallback is (with `fallbackLocale`). This means that the `translate` method needed to do a bunch of unnecessary work when the translation was not found until "high up" dictionaries.

This PR fixes it by removing translation dictionaries if they are the same locale as the fallback.