### PR TITLE
📝 update typo in readme

### DIFF
--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.1.1]
+## Unreleased
 
 ### Fixed
 
@@ -13,7 +13,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.1.0]
 
-### Added
+### Changed
 
 - Updates webhook registration to use GraphQL
 

--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.1]
+
+### Fixed
+
+- Fixed a typo in the README
+
 ## [1.1.0]
+
+### Added
 
 - Updates webhook registration to use GraphQL
 

--- a/packages/koa-shopify-webhooks/README.md
+++ b/packages/koa-shopify-webhooks/README.md
@@ -73,7 +73,7 @@ app.use(
       const registration = await registerWebhook({
         // for local dev you probably want ngrok or something similar
         address: 'www.mycool-app.com/webhooks/products/create',
-        topic: 'products/create',
+        topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
       });
@@ -138,14 +138,14 @@ app.use(
 
       await registerWebhook({
         address: 'www.mycool-app.com/webhooks/products/create',
-        topic: 'products/create',
+        topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
       });
 
       await registerWebhook({
         address: 'www.mycool-app.com/webhooks/orders/create',
-        topic: 'orders/create',
+        topic: 'ORDERS_CREATE',
         accessToken,
         shop,
       });


### PR DESCRIPTION
Apologies, but the README needs to be updated to use the UPPERCASE_UPPERCASE format for [GraphQL topics](https://help.shopify.com/en/api/graphql-admin-api/reference/enum/webhooksubscriptiontopic).

I've implemented it in a test app, and we have a PR up to [update the guide to use the package in our tutorial](https://github.com/Shopify/help/pull/6086) if you're curious.

cc: @katiedavis 