### PR TITLE
[polyfills] Fix conflict with isomorphic fetch

### DIFF
--- a/packages/polyfills/README.md
+++ b/packages/polyfills/README.md
@@ -14,7 +14,7 @@ The following polyfills are currently exported:
 - `baseline.node` - The minimum required polyfills for a Shopify app to work in node. This includes:
   - `@babel/polyfill`
   - `fetch`
-- `fetch` (`fetch.node`): Polyfills whatwg-fetch in the browser and isomorphic-fetch in node
+- `fetch` (`fetch.node`): Polyfills whatwg-fetch in the browser and node-fetch in node
 - `url` (`url.node`): Polyfills URLSearchParams
 - `intl`: Browser only, polyfills Intl.PluralRules
 

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -27,7 +27,7 @@
     "browser-unhandled-rejection": "^1.0.2",
     "caniuse-api": "^3.0.0",
     "intl-pluralrules": "^0.2.1",
-    "isomorphic-fetch": "^2.2.1",
+    "node-fetch": "^2.3.0",
     "tslib": "^1.9.3",
     "url-search-params-polyfill": "^5.0.0",
     "whatwg-fetch": "^3.0.0"

--- a/packages/polyfills/src/fetch.node.ts
+++ b/packages/polyfills/src/fetch.node.ts
@@ -1,1 +1,16 @@
-import 'isomorphic-fetch';
+// general logic and approach taken from
+// https://github.com/matthew-andrews/isomorphic-fetch/blob/master/fetch-npm-node.js
+
+const nodeFetch = require('node-fetch');
+
+function wrappedFetch(url: string, options) {
+  const finalURL = /^\/\//.test(url) ? `https:${url}` : url;
+  return nodeFetch.call(this, finalURL, options);
+}
+
+if (!(global as any).fetch) {
+  (global as any).fetch = wrappedFetch;
+  (global as any).Response = nodeFetch.Response;
+  (global as any).Headers = nodeFetch.Headers;
+  (global as any).Request = nodeFetch.Request;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6107,6 +6107,11 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
The version of `whatwg-fetch` used by `isomorphic-fetch` is version `2.0.4`. This line in our package.json caused a conflict in node environments that use `isomorphic-fetch`, as they end up running code from `whatwg-fetch@3.0.0` that only works in a browser environment.