### PR TITLE
Add optional prop to <FormState.Nested> and <FormState.List> to re-render

### DIFF
--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -508,6 +508,21 @@ export function ProductPage() {
 }
 ```
 
+#### Performance
+
+`<FormState.Nested />` will only re-render its children if `value`, `initialValue` or `error` on `field` change for performance reasons. While this is highly recommended, there are cased in where you might want to by-pass this check. To force it to always re-render its children, you can pass `update`:
+
+```tsx
+<FormState.Nested field={fields.firstVariant} update>
+  {fields => (
+    <>
+      <TextField label="Option" {...fields.option} />
+      <TextField label="Value" {...fields.value} />
+    </>
+  )}
+</FormState.Nested>
+```
+
 ### `<FormState.List />`
 
 Sometimes your data might be best represented using an array of objects.
@@ -592,6 +607,21 @@ For our example above, it makes sense to assume that each combination of `option
   field={fields.variants}
   getChildKey={(variant) => `${variant.option}-${variant.value}`}
 >
+```
+
+#### Performance
+
+`<FormState.List />` will only re-render its children if `value`, `initialValue` or `error` on `field` change for performance reasons. While this is highly recommended, there are cased in where you might want to by-pass this check. To force it to always re-render its children, you can pass `update`:
+
+```tsx
+<FormState.List field={fields.variants} update>
+  {fields => (
+    <>
+      <TextField label="Option" {...fields.option} />
+      <TextField label="Value" {...fields.value} />
+    </>
+  )}
+</FormState.List>
 ```
 
 ## Putting it all together

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -7,6 +7,7 @@ interface Props<Fields> {
   field: FieldDescriptor<Fields[]>;
   children(fields: FieldDescriptors<Fields>, index: number): React.ReactNode;
   getChildKey?(item: Fields): string;
+  update?: boolean;
 }
 
 export default class List<Fields> extends React.Component<
@@ -25,12 +26,14 @@ export default class List<Fields> extends React.Component<
     } = nextProps;
     const {
       field: {value, error, initialValue},
+      update,
     } = this.props;
 
     return (
-      nextValue !== value ||
-      nextError !== error ||
-      nextInitialValue !== initialValue
+      update ||
+      (nextValue !== value ||
+        nextError !== error ||
+        nextInitialValue !== initialValue)
     );
   }
 

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -6,6 +6,7 @@ import {mapObject} from '../utilities';
 interface Props<Fields> {
   field: FieldDescriptor<Fields>;
   children(fields: FieldDescriptors<Fields>): React.ReactNode;
+  update?: boolean;
 }
 
 export default class Nested<Fields> extends React.Component<
@@ -24,12 +25,14 @@ export default class Nested<Fields> extends React.Component<
     } = nextProps;
     const {
       field: {value, error, initialValue},
+      update,
     } = this.props;
 
     return (
-      nextValue !== value ||
-      nextError !== error ||
-      nextInitialValue !== initialValue
+      update ||
+      (nextValue !== value ||
+        nextError !== error ||
+        nextInitialValue !== initialValue)
     );
   }
 

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -366,4 +366,32 @@ describe('<FormState.List />', () => {
 
     expect(renderSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('forces re-render if `update` is set to `true`', () => {
+    const products = [{title: faker.commerce.productName()}];
+    const adjective = faker.commerce.productAdjective();
+    const newAdjective = faker.commerce.productAdjective();
+
+    const renderSpy = jest.fn(() => null);
+
+    const form = mount(
+      <FormState initialValues={{products, adjective}}>
+        {({fields}) => {
+          return (
+            <>
+              <Input {...fields.adjective} />
+              <FormState.List field={fields.products} update>
+                {renderSpy}
+              </FormState.List>
+            </>
+          );
+        }}
+      </FormState>,
+    );
+
+    const input = form.find(Input);
+    trigger(input, 'onChange', newAdjective);
+
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -303,4 +303,32 @@ describe('<Nested />', () => {
     expect(titleSpy).toHaveBeenCalledTimes(1);
     expect(adjectiveSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('forces re-render if `update` is set to `true`', () => {
+    const products = [{title: faker.commerce.productName()}];
+    const adjective = faker.commerce.productAdjective();
+    const newAdjective = faker.commerce.productAdjective();
+
+    const renderSpy = jest.fn(() => null);
+
+    const form = mount(
+      <FormState initialValues={{products, adjective}}>
+        {({fields}) => {
+          return (
+            <>
+              <Input {...fields.adjective} />
+              <FormState.List field={fields.products} update>
+                {renderSpy}
+              </FormState.List>
+            </>
+          );
+        }}
+      </FormState>,
+    );
+
+    const input = form.find(Input);
+    trigger(input, 'onChange', newAdjective);
+
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## What's the problem
As described in #557, `<FormState.Nested>` and `<FormState.List>` are not updating their children, unless the passed `field` changes.

While this is the expected behaviour (introduced in #312 to improve the performance of these components), there are cases in which it's necessary for the children to be updated. For example, if any of the child form elements also depend on a state change or a prop other than `field` changing.

## How it's solved
I considered changing the logic within `shouldComponentUpdate`, but ended up going with a non-intrusive solution:

- ✨ Added a new prop `update` to both `<FormState.Nested>` and `<FormState.List>`
   - `update` is optional, therefore falsy by default.
   - Setting this to `true` will by-pass the logic in `shouldComponentUpdate`
- ✅ Added new tests to cover the use of this prop
- 📝 Added info to the docs on why the children don't update (which could be unexpected) and instructions on how to use the prop

## Tophatting 🎩

I tophatted the changes in my app using `yarn tophat`. I'd recommend testing this in any app that's using either `<FormState.Nested>` or `<FormState.List>` and making sure that by using `update`, the child form elements get re-rendered. 

The tests should cover this case and can also be used as a playground to 🎩 it!