### PR TITLE
react-shortcuts: Remove prop-types as a dependency

### DIFF
--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -29,7 +29,6 @@
     "typescript": "~3.0.1"
   },
   "dependencies": {
-    "prop-types": "^15.6.2",
     "tslib": "^1.9.3"
   },
   "sideEffects": false


### PR DESCRIPTION
PR #295 refactored react-shortcuts to use the modern context API which
means prop-types is no longer needed

Pinging @kyledurand for review as they reviewed the original PR