### PR TITLE
✨add defer prop for `requestIdleCallback` in `react-import-remote`

### DIFF
--- a/packages/async/README.md
+++ b/packages/async/README.md
@@ -17,6 +17,14 @@ This package contains a few types that are useful for creating async components:
 
 - `Import` represents a value that could be default or non-default export
 - `LoadProps` are an interface that describe the shape of props that must be used for a function to be processed by the Babel plugin provided by this
+- `DeferTiming` is an enum of defer timing values, either on component `Mount` or until the browser is `Idle`
+
+As well as the following types related to `window.requestIdleCallback`:
+
+- `RequestIdleCallbackHandle`
+- `RequestIdleCallbackOptions`
+- `RequestIdleCallbackDeadline`
+- `WindowWithRequestIdleCallback`
 
 It also includes a plugin for Babel that allows the module IDs that are asynchronously imported to be exposed to the application.
 

--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -4,3 +4,27 @@ export interface LoadProps<T> {
   id?(): string;
   load(): Promise<Import<T>>;
 }
+
+export enum DeferTiming {
+  Mount,
+  Idle,
+}
+
+export type RequestIdleCallbackHandle = any;
+
+export interface RequestIdleCallbackOptions {
+  timeout: number;
+}
+
+export interface RequestIdleCallbackDeadline {
+  readonly didTimeout: boolean;
+  timeRemaining: (() => number);
+}
+
+export interface WindowWithRequestIdleCallback {
+  requestIdleCallback: ((
+    callback: ((deadline: RequestIdleCallbackDeadline) => void),
+    opts?: RequestIdleCallbackOptions,
+  ) => RequestIdleCallbackHandle);
+  cancelIdleCallback: ((handle: RequestIdleCallbackHandle) => void);
+}

--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import {LoadProps} from '@shopify/async';
+import {
+  LoadProps,
+  DeferTiming,
+  RequestIdleCallbackHandle,
+  WindowWithRequestIdleCallback,
+} from '@shopify/async';
 import {Omit} from '@shopify/useful-types';
 import {Effect} from '@shopify/react-effect';
 
-import {DeferTiming} from './shared';
 import {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 
 export interface AsyncPropsRuntime {
@@ -25,25 +29,6 @@ interface State<Value> {
 declare const __webpack_require__: (id: string) => any;
 declare const __webpack_modules__: {[key: string]: any};
 /* eslint-enable camelcase */
-
-type RequestIdleCallbackHandle = any;
-
-interface RequestIdleCallbackOptions {
-  timeout: number;
-}
-
-interface RequestIdleCallbackDeadline {
-  readonly didTimeout: boolean;
-  timeRemaining: (() => number);
-}
-
-interface WindowWithRequestIdleCallback {
-  requestIdleCallback: ((
-    callback: ((deadline: RequestIdleCallbackDeadline) => void),
-    opts?: RequestIdleCallbackOptions,
-  ) => RequestIdleCallbackHandle);
-  cancelIdleCallback: ((handle: RequestIdleCallbackHandle) => void);
-}
 
 class ConnectedAsync<Value> extends React.Component<
   Props<Value>,

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import {LoadProps} from '@shopify/async';
+import {LoadProps, DeferTiming} from '@shopify/async';
 import {Props as ComponentProps} from '@shopify/useful-types';
 
 import {Async, AsyncPropsRuntime} from './Async';
-import {DeferTiming} from './shared';
 
 interface ConstantProps {
   async?: AsyncPropsRuntime;

--- a/packages/react-async/src/index.ts
+++ b/packages/react-async/src/index.ts
@@ -3,7 +3,7 @@ export {Prefetcher} from './Prefetcher';
 export {PrefetchRoute} from './PrefetchRoute';
 export {createAsyncComponent, AsyncComponentType} from './component';
 export {createAsyncContext, AsyncContextType} from './provider';
-export {DeferTiming} from './shared';
+export {DeferTiming} from '@shopify/async';
 
 export {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 export {PrefetchContext, PrefetchManager} from './context/prefetch';

--- a/packages/react-async/src/provider.tsx
+++ b/packages/react-async/src/provider.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import {LoadProps} from '@shopify/async';
+import {LoadProps, DeferTiming} from '@shopify/async';
 
 import {Async} from './Async';
-import {DeferTiming} from './shared';
 
 interface Options<Value> extends LoadProps<Value> {}
 

--- a/packages/react-async/src/shared.ts
+++ b/packages/react-async/src/shared.ts
@@ -3,8 +3,3 @@ export type Prefetchable<Props> =
       Prefetch: React.ComponentType<Props>;
     }
   | React.ComponentType<Props>;
-
-export enum DeferTiming {
-  Mount,
-  Idle,
-}

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
 import {trigger} from '@shopify/enzyme-utilities';
+import {DeferTiming} from '@shopify/async';
 
 import {Async} from '../Async';
 import {createAsyncComponent} from '../component';
-import {DeferTiming} from '../shared';
 
 jest.mock('../Async', () => ({
   Async() {

--- a/packages/react-async/src/tests/provider.test.tsx
+++ b/packages/react-async/src/tests/provider.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
 import {trigger} from '@shopify/enzyme-utilities';
+import {DeferTiming} from '@shopify/async';
 
 import {Async} from '../Async';
 import {createAsyncContext} from '../provider';
-import {DeferTiming} from '../shared';
 
 jest.mock('../Async', () => ({
   Async() {

--- a/packages/react-graphql/src/async.tsx
+++ b/packages/react-graphql/src/async.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import {LoadProps} from '@shopify/async';
-import {Async, AsyncPropsRuntime, DeferTiming} from '@shopify/react-async';
+import {LoadProps, DeferTiming} from '@shopify/async';
+import {Async, AsyncPropsRuntime} from '@shopify/react-async';
 import {Omit} from '@shopify/useful-types';
 import {DocumentNode} from 'graphql-typed';
 

--- a/packages/react-graphql/src/index.ts
+++ b/packages/react-graphql/src/index.ts
@@ -1,4 +1,4 @@
-export {DeferTiming} from '@shopify/react-async';
+export {DeferTiming} from '@shopify/async';
 export {Query} from './Query';
 export {Prefetch, Props as PrefetchProps} from './Prefetch';
 export {createAsyncQueryComponent} from './async';

--- a/packages/react-graphql/src/tests/async.test.tsx
+++ b/packages/react-graphql/src/tests/async.test.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import {mount} from 'enzyme';
 import gql from 'graphql-tag';
 
+import {DeferTiming} from '@shopify/async';
 import {trigger} from '@shopify/enzyme-utilities';
-import {Async, DeferTiming} from '@shopify/react-async';
+import {Async} from '@shopify/react-async';
 
 import {Query} from '../Query';
 import {Prefetch} from '../Prefetch';

--- a/packages/react-import-remote/README.md
+++ b/packages/react-import-remote/README.md
@@ -15,9 +15,10 @@ $ yarn add @shopify/react-import-remote
 
 The provided utilities are intended only for external scripts that load globals. Other JavaScript should use the native `import()` operator for asynchronously loading code. These utilities cache results by source, so only a single `script` tag is ever added for a particular source.
 
-```ts
+```tsx
 import * as React from 'react';
 import ImportRemote from '@shopify/react-import-remote';
+import {DeferTiming} from '@shopify/async';
 
 interface RemoteGlobal {}
 interface WindowWithGlobal extends Window {
@@ -37,6 +38,7 @@ class MyComponent extends React.Component {
         getImport={(window: WindowWithGlobal) => window.remoteGlobal}
         onError={(error: Error) => this.setState({error})}
         onImported={(remoteGlobal: RemoteGlobal) => doSomethingWithGlobal(remoteGlobal)}
+        defer={DeferTiming.Mount}
       />
     );
   }
@@ -52,6 +54,7 @@ interface Props<Imported = any> {
   onError(error: Error): void;
   getImport(window: Window): Imported;
   onImported(imported: Imported): void;
+  defer?: DeferTiming;
 }
 ```
 
@@ -74,3 +77,7 @@ Callback that takes in `window` with the added global and returns the global add
 **onImported**
 
 Callback that gets called with the imported global
+
+**defer**
+
+A member of the `DeferTiming` enum (from `@shopify/async`) allowing the import request to occur either on mount (`DeferTiming.Mount`) or until the browser is idle (`DeferTiming.Idle`; requires a polyfill for `window.requestIdleCallback`).


### PR DESCRIPTION
Part of https://github.com/Shopify/web/issues/10479

This PR adds a `defer` prop to the ImportRemote component that when set to `Idle` enum, loads the request with `requestIdelCallback`.

Some shared types have been moved to the basic `async` package from `react-async`.

## TODO
- [ ] Add tests? Will first do a separate PR to add `requestIdleCallback` to `jest-dom-mocks`.
- [x] Update Readme. Will wait for general approval of this first.