### PR TITLE
allows specification of renderLoading in consumer

### DIFF
--- a/packages/react-async/README.md
+++ b/packages/react-async/README.md
@@ -124,7 +124,13 @@ const MyComponentOnIdle = createAsyncComponent({
 });
 ```
 
-If you need to customize the deferring behaviour at runtime, the library always allows you to pass an `async` prop with some custom options for the underlying `<Async />` loader component (**note**: this library reserves the `async` prop name, so you can’t use that name for any of your component’s own props, or for the props you specify in the `renderPreload`, `renderPrefetch`, or `renderKeepFresh` options).
+#### Overwriting properties
+
+The library always allows you to pass an `async` prop with some custom options for the underlying `<Async />` loader component (**note**: this library reserves the `async` prop name, so you can’t use that name for any of your component’s own props, or for the props you specify in the `renderPreload`, `renderPrefetch`, or `renderKeepFresh` options).
+
+Currenty the library allows you to overwite two properties:
+
+##### `defer?: DeferTiming`
 
 ```tsx
 import {createAsyncComponent, DeferTiming} from '@shopify/react-async';
@@ -151,6 +157,21 @@ const MyComponent = createAsyncComponent({
 // Don’t defer at all
 <MyComponent.Preload async={{defer: undefined}} />
 <MyComponent.KeepFresh async={{defer: undefined}} />
+```
+
+##### `renderLoading?(): React.ReactNode`
+
+```tsx
+import {createAsyncComponent} from '@shopify/react-async';
+import {Spinner} from '@shopify/polaris';
+
+// No loading state
+const MyComponent = createAsyncComponent({
+  load: () => import('./MyComponent'),
+});
+
+// But this instance will render <Spinner /> as its loading state
+<MyComponent async={{renderLoading: () => <Spinner />}} />;
 ```
 
 ### `PrefetchRoute` and `Prefetcher`

--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -8,6 +8,7 @@ import {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 
 export interface AsyncPropsRuntime {
   defer?: DeferTiming;
+  renderLoading?(): React.ReactNode;
 }
 
 interface Props<Value> extends LoadProps<Value>, AsyncPropsRuntime {

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
-import {trigger, noop} from '@shopify/enzyme-utilities';
+import {trigger} from '@shopify/enzyme-utilities';
 
 import {Async} from '../Async';
 import {createAsyncComponent} from '../component';
@@ -91,7 +91,7 @@ describe('createAsyncComponent()', () => {
 
     it('allows passing custom async props', () => {
       const load = () => Promise.resolve(MockComponent);
-      const async = {defer: undefined, renderLoading: noop};
+      const async = {defer: undefined, renderLoading: () => <div />};
 
       const AsyncComponent = createAsyncComponent({load});
       const preload = mount(<AsyncComponent.Preload async={async} />);

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
-import {trigger} from '@shopify/enzyme-utilities';
+import {trigger, noop} from '@shopify/enzyme-utilities';
 
 import {Async} from '../Async';
 import {createAsyncComponent} from '../component';
@@ -91,7 +91,7 @@ describe('createAsyncComponent()', () => {
 
     it('allows passing custom async props', () => {
       const load = () => Promise.resolve(MockComponent);
-      const async = {defer: undefined};
+      const async = {defer: undefined, renderLoading: noop};
 
       const AsyncComponent = createAsyncComponent({load});
       const preload = mount(<AsyncComponent.Preload async={async} />);

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -54,7 +54,7 @@ describe('createAsyncComponent()', () => {
 
   it('allows passing custom async props', () => {
     const load = () => Promise.resolve(MockComponent);
-    const async = {defer: DeferTiming.Idle};
+    const async = {defer: DeferTiming.Idle, renderLoading: () => <div />};
 
     const AsyncComponent = createAsyncComponent({load});
     const asyncComponent = mount(<AsyncComponent async={async} />);
@@ -129,7 +129,7 @@ describe('createAsyncComponent()', () => {
 
     it('allows passing custom async props', () => {
       const load = () => Promise.resolve(MockComponent);
-      const async = {defer: undefined};
+      const async = {defer: undefined, renderLoading: () => <div />};
 
       const AsyncComponent = createAsyncComponent({load});
       const prefetch = mount(<AsyncComponent.Prefetch async={async} />);
@@ -167,7 +167,7 @@ describe('createAsyncComponent()', () => {
 
     it('allows passing custom async props', () => {
       const load = () => Promise.resolve(MockComponent);
-      const async = {defer: undefined};
+      const async = {defer: undefined, renderLoading: () => <div />};
 
       const AsyncComponent = createAsyncComponent({load});
       const keepFresh = mount(<AsyncComponent.KeepFresh async={async} />);


### PR DESCRIPTION
fixes https://github.com/Shopify/quilt/issues/556

Allows you to specify a `renderLoading` method at runtime:

```tsx
<SomeConsumer
  ...componentsOwnProps
  async={{
    renderLoading() {
      return <LoadingStateSpecificToConsumer />;
    },
  }}
>
  {children}
</SomeConsumer>
```