### PR TITLE
[WIP] adds `requestIdleCallback` mock

### DIFF
--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -16,6 +16,10 @@ export interface RequestIdleCallbackOptions {
   timeout: number;
 }
 
+export type RequestIdleCallbackCallback = (
+  deadline: RequestIdleCallbackDeadline,
+) => void;
+
 export interface RequestIdleCallbackDeadline {
   readonly didTimeout: boolean;
   timeRemaining: (() => number);
@@ -23,7 +27,7 @@ export interface RequestIdleCallbackDeadline {
 
 export interface WindowWithRequestIdleCallback {
   requestIdleCallback: ((
-    callback: ((deadline: RequestIdleCallbackDeadline) => void),
+    callback: RequestIdleCallbackCallback,
     opts?: RequestIdleCallbackOptions,
   ) => RequestIdleCallbackHandle);
   cancelIdleCallback: ((handle: RequestIdleCallbackHandle) => void);

--- a/packages/jest-dom-mocks/src/idle-callback.ts
+++ b/packages/jest-dom-mocks/src/idle-callback.ts
@@ -1,0 +1,89 @@
+import {
+  WindowWithRequestIdleCallback,
+  RequestIdleCallbackCallback,
+} from '@shopify/async';
+
+export default class IdleCallback {
+  private isUsingMockRequestIdleCallback = false;
+  private callbacks: {
+    [key: number]: {
+      callback: RequestIdleCallbackCallback;
+      called: boolean;
+    };
+  } = {};
+  private originalRequestIdleCallback: WindowWithRequestIdleCallback['requestIdleCallback'];
+  private originalCancelIdleCallback: WindowWithRequestIdleCallback['cancelIdleCallback'];
+  private currentIdleCallbackId = 0;
+
+  mock() {
+    if (this.isUsingMockRequestIdleCallback) {
+      throw new Error(
+        'You tried to mock window.requestIdleCallback when it was already mocked.',
+      );
+    }
+
+    this.originalRequestIdleCallback = (window as any).requestIdleCallback;
+    (window as any).requestIdleCallback = this.requestIdleCallback;
+
+    this.originalCancelIdleCallback = (window as any).cancelIdleCallback;
+    (window as any).cancelIdleCallback = this.cancelIdleCallback;
+
+    this.isUsingMockRequestIdleCallback = true;
+  }
+
+  restore() {
+    if (!this.isUsingMockRequestIdleCallback) {
+      throw new Error(
+        'You tried to restore window.requestIdleCallback when it was already restored.',
+      );
+    }
+
+    (window as any).requestIdleCallback = this.originalRequestIdleCallback;
+    (window as any).cancelIdleCallback = this.originalCancelIdleCallback;
+    this.isUsingMockRequestIdleCallback = false;
+  }
+
+  isMocked() {
+    return this.isUsingMockRequestIdleCallback;
+  }
+
+  private requestIdleCallback = (
+    callback: RequestIdleCallbackCallback,
+    timeout: number,
+  ): number => {
+    const mockHandler = {
+      didTimeout: false,
+      timeRemaining() {
+        return 1;
+      },
+    };
+    this.currentIdleCallbackId += 1;
+    this.callbacks[this.currentIdleCallbackId] = Object.assign(
+      {},
+      this.callbacks[this.currentIdleCallbackId],
+      {
+        callback,
+      },
+    );
+
+    setTimeout(() => {
+      if (timeout) {
+        if (!this.callbacks[this.currentIdleCallbackId].called) {
+          setTimeout(() => {
+            callback(mockHandler);
+            this.callbacks[this.currentIdleCallbackId].called = true;
+          }, timeout);
+        }
+      } else {
+        callback(mockHandler);
+        this.callbacks[this.currentIdleCallbackId].called = true;
+      }
+    }, 1);
+
+    return this.currentIdleCallbackId;
+  };
+
+  private cancelIdleCallback = (handle: number) => {
+    delete this.callbacks[handle];
+  };
+}

--- a/packages/jest-dom-mocks/src/index.ts
+++ b/packages/jest-dom-mocks/src/index.ts
@@ -6,6 +6,7 @@ import MatchMedia from './match-media';
 import Storage from './storage';
 import Timer from './timer';
 import UserTiming from './user-timing';
+import IdleCallback from './idle-callback';
 
 export const animationFrame = new AnimationFrame();
 
@@ -23,6 +24,8 @@ export const sessionStorage = new Storage();
 
 export const timer = new Timer();
 export const userTiming = new UserTiming();
+
+export const idleCallback = new IdleCallback();
 
 export function installMockStorage() {
   if (typeof window !== 'undefined') {
@@ -45,6 +48,7 @@ const mocksToEnsureReset = {
   fetch,
   matchMedia,
   userTiming,
+  idleCallback,
 };
 
 export function ensureMocksReset() {

--- a/packages/jest-dom-mocks/src/test/idle-callback.ts
+++ b/packages/jest-dom-mocks/src/test/idle-callback.ts
@@ -1,0 +1,40 @@
+import IdleCallback from '../idle-callback';
+
+describe('IdleCallback', () => {
+  describe('mock', () => {
+    it('sets isMocked()', () => {
+      const idleCallback = new IdleCallback();
+      idleCallback.mock();
+
+      expect(idleCallback.isMocked()).toBe(true);
+    });
+
+    it('throws if it is already mocked', () => {
+      const idleCallback = new IdleCallback();
+
+      idleCallback.mock();
+
+      expect(() => {
+        idleCallback.mock();
+      }).toThrow();
+    });
+  });
+
+  describe('restore', () => {
+    it('sets isMocked', () => {
+      const idleCallback = new IdleCallback();
+      idleCallback.mock();
+      idleCallback.restore();
+
+      expect(idleCallback.isMocked()).toBe(false);
+    });
+
+    it('throws if it has not yet been mocked', () => {
+      const idleCallback = new IdleCallback();
+
+      expect(() => {
+        idleCallback.restore();
+      }).toThrow();
+    });
+  });
+});

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -34,7 +34,7 @@ export default class ImportRemote extends React.PureComponent<Props, never> {
       'requestIdleCallback' in window
     ) {
       this.idleCallbackHandle = (window as WindowWithRequestIdleCallback).requestIdleCallback(
-        this.loadRemote,
+        this.loadRemote.bind(this),
       );
     } else {
       await this.loadRemote();

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
 import {Preconnect} from '@shopify/react-html';
+import {idleCallback} from '@shopify/jest-dom-mocks';
+import {DeferTiming} from '@shopify/async';
+
 import {noop} from '@shopify/javascript-utilities/other';
 
 import ImportRemote, {Props} from '../ImportRemote';
@@ -130,6 +133,28 @@ describe('<ImportRemote />', () => {
       expect(importRemote.find(Preconnect).prop('source')).toBe(
         new URL(mockProps.source).origin,
       );
+    });
+  });
+
+  describe('defer', () => {
+    it('calls load on mount by default', () => {
+      mount(<ImportRemote {...mockProps} />);
+
+      expect(load).toHaveBeenCalled();
+    });
+
+    it('calls load later on when using DeferTiming.Idle', done => {
+      idleCallback.mock();
+
+      mount(<ImportRemote {...mockProps} defer={DeferTiming.Idle} />);
+
+      expect(load).not.toHaveBeenCalled();
+
+      setTimeout(() => {
+        expect(load).toHaveBeenCalled();
+        done();
+        idleCallback.restore();
+      }, 0);
     });
   });
 });


### PR DESCRIPTION
This PR follows up on https://github.com/Shopify/quilt/pull/561 by adding a `requestIdleCallback` mock in order to test the `defer` prop of `ImportRemote`.
