### PR TITLE
Revert "Add optional prop to <FormState.Nested> and <FormState.List> to re-render"

### DIFF
--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -508,21 +508,6 @@ export function ProductPage() {
 }
 ```
 
-#### Performance
-
-`<FormState.Nested />` will only re-render its children if `value`, `initialValue` or `error` on `field` change for performance reasons. While this is highly recommended, there are cased in where you might want to by-pass this check. To force it to always re-render its children, you can pass `update`:
-
-```tsx
-<FormState.Nested field={fields.firstVariant} update>
-  {fields => (
-    <>
-      <TextField label="Option" {...fields.option} />
-      <TextField label="Value" {...fields.value} />
-    </>
-  )}
-</FormState.Nested>
-```
-
 ### `<FormState.List />`
 
 Sometimes your data might be best represented using an array of objects.
@@ -607,21 +592,6 @@ For our example above, it makes sense to assume that each combination of `option
   field={fields.variants}
   getChildKey={(variant) => `${variant.option}-${variant.value}`}
 >
-```
-
-#### Performance
-
-`<FormState.List />` will only re-render its children if `value`, `initialValue` or `error` on `field` change for performance reasons. While this is highly recommended, there are cased in where you might want to by-pass this check. To force it to always re-render its children, you can pass `update`:
-
-```tsx
-<FormState.List field={fields.variants} update>
-  {fields => (
-    <>
-      <TextField label="Option" {...fields.option} />
-      <TextField label="Value" {...fields.value} />
-    </>
-  )}
-</FormState.List>
 ```
 
 ## Putting it all together

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -7,7 +7,6 @@ interface Props<Fields> {
   field: FieldDescriptor<Fields[]>;
   children(fields: FieldDescriptors<Fields>, index: number): React.ReactNode;
   getChildKey?(item: Fields): string;
-  update?: boolean;
 }
 
 export default class List<Fields> extends React.Component<
@@ -26,14 +25,12 @@ export default class List<Fields> extends React.Component<
     } = nextProps;
     const {
       field: {value, error, initialValue},
-      update,
     } = this.props;
 
     return (
-      update ||
-      (nextValue !== value ||
-        nextError !== error ||
-        nextInitialValue !== initialValue)
+      nextValue !== value ||
+      nextError !== error ||
+      nextInitialValue !== initialValue
     );
   }
 

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -6,7 +6,6 @@ import {mapObject} from '../utilities';
 interface Props<Fields> {
   field: FieldDescriptor<Fields>;
   children(fields: FieldDescriptors<Fields>): React.ReactNode;
-  update?: boolean;
 }
 
 export default class Nested<Fields> extends React.Component<
@@ -25,14 +24,12 @@ export default class Nested<Fields> extends React.Component<
     } = nextProps;
     const {
       field: {value, error, initialValue},
-      update,
     } = this.props;
 
     return (
-      update ||
-      (nextValue !== value ||
-        nextError !== error ||
-        nextInitialValue !== initialValue)
+      nextValue !== value ||
+      nextError !== error ||
+      nextInitialValue !== initialValue
     );
   }
 

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -366,32 +366,4 @@ describe('<FormState.List />', () => {
 
     expect(renderSpy).toHaveBeenCalledTimes(1);
   });
-
-  it('forces re-render if `update` is set to `true`', () => {
-    const products = [{title: faker.commerce.productName()}];
-    const adjective = faker.commerce.productAdjective();
-    const newAdjective = faker.commerce.productAdjective();
-
-    const renderSpy = jest.fn(() => null);
-
-    const form = mount(
-      <FormState initialValues={{products, adjective}}>
-        {({fields}) => {
-          return (
-            <>
-              <Input {...fields.adjective} />
-              <FormState.List field={fields.products} update>
-                {renderSpy}
-              </FormState.List>
-            </>
-          );
-        }}
-      </FormState>,
-    );
-
-    const input = form.find(Input);
-    trigger(input, 'onChange', newAdjective);
-
-    expect(renderSpy).toHaveBeenCalledTimes(2);
-  });
 });

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -303,32 +303,4 @@ describe('<Nested />', () => {
     expect(titleSpy).toHaveBeenCalledTimes(1);
     expect(adjectiveSpy).toHaveBeenCalledTimes(2);
   });
-
-  it('forces re-render if `update` is set to `true`', () => {
-    const products = [{title: faker.commerce.productName()}];
-    const adjective = faker.commerce.productAdjective();
-    const newAdjective = faker.commerce.productAdjective();
-
-    const renderSpy = jest.fn(() => null);
-
-    const form = mount(
-      <FormState initialValues={{products, adjective}}>
-        {({fields}) => {
-          return (
-            <>
-              <Input {...fields.adjective} />
-              <FormState.List field={fields.products} update>
-                {renderSpy}
-              </FormState.List>
-            </>
-          );
-        }}
-      </FormState>,
-    );
-
-    const input = form.find(Input);
-    trigger(input, 'onChange', newAdjective);
-
-    expect(renderSpy).toHaveBeenCalledTimes(2);
-  });
 });


### PR DESCRIPTION
Reverts Shopify/quilt#558

Based on further discussion, this new prop `update` will no be released, and instead, I'll open a new PR removing the updating logic on these components.