### PR TITLE
IntersectionObserver components and utilities

### DIFF
--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -15,8 +15,8 @@ $ yarn add @shopify/jest-dom-mocks
 
 This package provides two methods that should be included in the jest setup files:
 
-* `ensureMocksReset`
-* `installMockStorage`
+- `ensureMocksReset`
+- `installMockStorage`
 
 ### `ensureMocksReset`
 
@@ -78,19 +78,20 @@ it('transitions to the next number after being updated', () => {
 
 The mocks provided can be divided into 3 primary categories:
 
-* standard mocks
-* fetch mock
-* storage mocks
+- standard mocks
+- fetch mock
+- storage mocks
 
 ### Standard Mocks
 
 The following standard mocks are available:
 
-* `animationFrame`
-* `clock`
-* `location`
-* `matchMedia`
-* `timer`
+- `animationFrame`
+- `clock`
+- `location`
+- `matchMedia`
+- `timer`
+- `intersectionObserver`
 
 Each of the standard mocks can be installed, for a given test, using `standardMock.mock()`, and must be restored before the end of the test using `standardMock.restore()`.
 
@@ -181,6 +182,14 @@ Runs all system timers to completion.
 
 Runs all system timers to the given `time`.
 
+#### `IntersectionObserver.observers`
+
+Returns an array of records representing elements currently being observed with an `IntersectionObserver`. Each record contains a `target` (the element being observed), `callback` (the function used when constructing the observer), `options` (optional object used when constructing the observer), and a `source` (the fake `IntersectionObserver` instance that was used to observe).
+
+#### `IntersectionObserver.simulate(entry: Partial<IntersectionObserverEntry> | Partial<IntersectionObserverEntry>[]): void`
+
+Simulates a call on all matching observers. If you pass a `target` on the passed entry/ entries, only observers with a matching `target` element will be triggered. Otherwise, all observers will be triggered. If you do not provide a full `IntersectionObserverEntry` in any case, the missing fields will be filled out with sensible defaults.
+
 ### Fetch Mock
 
 We use a version of `fetch-mock` that is augmented to ensure that it is properly unmocked after each test run. See the [API of `fetch-mock`](http://www.wheresrhys.co.uk/fetch-mock/api) for more details.
@@ -189,9 +198,9 @@ We use a version of `fetch-mock` that is augmented to ensure that it is properly
 
 The storage mocks are a bit different than the other mocks, because they serve primarily as a polyfill for the `localStorage` and `sessionStorage` APIs. The following standard API methods are implemented:
 
-* `getItem`
-* `setItem`
-* `removeItrem`
-* `clear`
+- `getItem`
+- `setItem`
+- `removeItrem`
+- `clear`
 
 Each of these are wrapped in a jest spy, which is automatically restored at the end of the test run.

--- a/packages/jest-dom-mocks/src/index.ts
+++ b/packages/jest-dom-mocks/src/index.ts
@@ -6,6 +6,7 @@ import MatchMedia from './match-media';
 import Storage from './storage';
 import Timer from './timer';
 import UserTiming from './user-timing';
+import IntersectionObserver from './intersection-observer';
 
 export const animationFrame = new AnimationFrame();
 
@@ -23,6 +24,7 @@ export const sessionStorage = new Storage();
 
 export const timer = new Timer();
 export const userTiming = new UserTiming();
+export const intersectionObserver = new IntersectionObserver();
 
 export function installMockStorage() {
   if (typeof window !== 'undefined') {
@@ -45,6 +47,7 @@ const mocksToEnsureReset = {
   fetch,
   matchMedia,
   userTiming,
+  intersectionObserver,
 };
 
 export function ensureMocksReset() {

--- a/packages/jest-dom-mocks/src/intersection-observer.ts
+++ b/packages/jest-dom-mocks/src/intersection-observer.ts
@@ -1,0 +1,122 @@
+interface Observer {
+  source: unknown;
+  target: Element;
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+}
+
+export default class IntersectionObserverMock {
+  observers: Observer[] = [];
+
+  private isUsingMockIntersectionObserver = false;
+  private originalIntersectionObserver = (global as any).IntersectionObserver;
+
+  simulate(
+    entry:
+      | Partial<IntersectionObserverEntry>
+      | Partial<IntersectionObserverEntry>[],
+  ) {
+    this.ensureMocked();
+
+    const arrayOfEntries = Array.isArray(entry) ? entry : [entry];
+    const targets = arrayOfEntries.map(({target}) => target);
+    const noCustomTargets = targets.every(target => target == null);
+
+    for (const observer of this.observers) {
+      if (noCustomTargets || targets.includes(observer.target)) {
+        observer.callback(
+          arrayOfEntries.map(entry => normalizeEntry(entry, observer.target)),
+          observer as any,
+        );
+      }
+    }
+  }
+
+  mock() {
+    if (this.isUsingMockIntersectionObserver) {
+      throw new Error(
+        'IntersectionObserver is already mocked, but you tried to mock it again.',
+      );
+    }
+
+    this.isUsingMockIntersectionObserver = true;
+
+    const setObservers = (setter: (observers: Observer[]) => Observer[]) =>
+      (this.observers = setter(this.observers));
+
+    (global as any).IntersectionObserver = class FakeIntersectionObserver {
+      constructor(
+        private callback: IntersectionObserverCallback,
+        private options?: IntersectionObserverInit,
+      ) {}
+
+      observe(target: Element) {
+        setObservers(observers => [
+          ...observers,
+          {
+            source: this,
+            target,
+            callback: this.callback,
+            options: this.options,
+          },
+        ]);
+      }
+
+      disconnect() {
+        setObservers(observers =>
+          observers.filter(observer => observer.source !== this),
+        );
+      }
+
+      unobserve(target: Element) {
+        setObservers(observers =>
+          observers.filter(
+            observer =>
+              !(observer.target === target && observer.source === this),
+          ),
+        );
+      }
+    };
+  }
+
+  restore() {
+    if (!this.isUsingMockIntersectionObserver) {
+      throw new Error(
+        'IntersectionObserver is already real, but you tried to restore it again.',
+      );
+    }
+
+    (global as any).IntersectionObserver = this.originalIntersectionObserver;
+    this.isUsingMockIntersectionObserver = false;
+    this.observers.length = 0;
+  }
+
+  isMocked() {
+    return this.isUsingMockIntersectionObserver;
+  }
+
+  private ensureMocked() {
+    if (!this.isUsingMockIntersectionObserver) {
+      throw new Error(
+        'You must call intersectionObserver.mock() before interacting with the fake IntersectionObserver.',
+      );
+    }
+  }
+}
+
+function normalizeEntry(
+  entry: Partial<IntersectionObserverEntry>,
+  target: Element,
+): IntersectionObserverEntry {
+  return {
+    boundingClientRect:
+      entry.boundingClientRect || target.getBoundingClientRect(),
+    intersectionRatio:
+      entry.intersectionRatio == null ? 1 : entry.intersectionRatio,
+    intersectionRect: entry.intersectionRect || target.getBoundingClientRect(),
+    isIntersecting: entry.isIntersecting == null ? true : entry.isIntersecting,
+    rootBounds: entry.rootBounds || document.body.getBoundingClientRect(),
+    target,
+    time: entry.time || Date.now(),
+  };
+}

--- a/packages/polyfills/README.md
+++ b/packages/polyfills/README.md
@@ -17,6 +17,7 @@ The following polyfills are currently exported:
 - `fetch` (`fetch.node`): Polyfills whatwg-fetch in the browser and node-fetch in node
 - `url` (`url.node`): Polyfills URLSearchParams
 - `intl`: Browser only, polyfills Intl.PluralRules
+- `intersection-observer`: Browser only, polyfills [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
 
 ## Installation
 

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -26,6 +26,7 @@
     "@babel/polyfill": "^7.0.0",
     "browser-unhandled-rejection": "^1.0.2",
     "caniuse-api": "^3.0.0",
+    "intersection-observer": "^0.5.1",
     "intl-pluralrules": "^0.2.1",
     "node-fetch": "^2.3.0",
     "tslib": "^1.9.3",

--- a/packages/polyfills/src/config.ts
+++ b/packages/polyfills/src/config.ts
@@ -21,6 +21,10 @@ export const polyfills: {[polyfill: string]: PolyfillDescriptor} = {
     supportsNode: true,
     featureTest: 'urlsearchparams',
   },
+  'intersection-observer': {
+    supportsNode: false,
+    featureTest: 'intersectionobserver',
+  },
 };
 
 export function mappedPolyfillsForEnv(browser: 'node' | string | string[]) {

--- a/packages/polyfills/src/intersection-observer.ts
+++ b/packages/polyfills/src/intersection-observer.ts
@@ -1,0 +1,1 @@
+require('intersection-observer');

--- a/packages/react-intersection-observer/CHANGELOG.md
+++ b/packages/react-intersection-observer/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/react-intersection-observer` package

--- a/packages/react-intersection-observer/README.md
+++ b/packages/react-intersection-observer/README.md
@@ -1,0 +1,49 @@
+# `@shopify/react-intersection-observer`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg)](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-intersection-observer.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-intersection-observer.svg)
+
+A simple React wrapper around the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-intersection-observer
+```
+
+## Usage
+
+This package exports an `IntersectionObserver` component. This component will create its own DOM node that will be observed, with optional `onIntersecting` and `onNotIntersecting` props being called as appropriate. `onIntersecting` and `onNotIntersecting` will be called with an `IntersectionObserverEntry` object, which describes the state of the intersection. The component also accepts a few additional props that correspond to the options used to construct an `IntersectionObserver`:
+
+- `threshold`: a number or array of number indicating the `intersectionRatio` that must be met before the observer is triggered
+- `root`: a string or element that is used as the viewport for visibility testing. If a string is passed, it will be treated as a selector.
+- `rootMargin`: a string representing the margins by which to shrink the root’s bounding box before computing intersections.
+
+This component also allows you to customize the rendered markup. You can pass `children`, which will be rendered inside of the element being observed for intersections. You can also pass an `element` prop that changes the DOM node being wrapped around those children (defaults to a `div`). Regardless of the passed `element`, the `IntersectionObserver` component will always add a `display: contents` style to that element in order to reduce the styling impact of the additional nesting.
+
+```tsx
+<div ref={this.parentElement}>
+  <IntersectionObserver
+    root={this.parentElement.current}
+    rootMargin="10px 10%"
+    threshold={1}
+    onIntersecting={entry => console.log('intersectionRatio > 0', entry)}
+    onNotIntersecting={entry => console.log('intersectionRatio = 0', entry)}
+  />
+</div>
+```
+
+### Lifecycle
+
+You may change any prop on an `IntersectionObserver` component, and the component will do the minimum amount of work to unobserve/ re-observe with the new fields. The most expensive updates to make are changing `threshold`, `root`, `rootMargin`, and `element`, as these require disconnecting the old observer and recreating a new one.
+
+When this component is unmounted, it disconnects the current observer.
+
+### Browser support
+
+To polyfill `IntersectionObserver`, please use the `@shopify/polyfills/intersection-observer` package.
+
+If you do not polyfill the feature and it is not supported in the current browser, the `IntersectionObserver` component will decide what to do based on the `unsupportedBehavior` prop. This prop should be a member of the `UnsupportedBehavior` enum (exported from this package). Currently, there are two options:
+
+- `UnsupportedBehavior.Ignore`: never calls `onIntersecting` or `onNotIntersecting`.
+- `UnsupportedBehavior.TreatAsIntersecting`: immediately calls `onIntersecting` on mount, if it is provided (this is the default).

--- a/packages/react-intersection-observer/README.md
+++ b/packages/react-intersection-observer/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg)](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-intersection-observer.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-intersection-observer.svg)
 
-A simple React wrapper around the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+A React wrapper around the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
 
 ## Installation
 
@@ -19,7 +19,7 @@ This package exports an `IntersectionObserver` component. This component will cr
 - `root`: a string or element that is used as the viewport for visibility testing. If a string is passed, it will be treated as a selector.
 - `rootMargin`: a string representing the margins by which to shrink the root’s bounding box before computing intersections.
 
-This component also allows you to customize the rendered markup. You can pass `children`, which will be rendered inside of the element being observed for intersections. You can also pass an `element` prop that changes the DOM node being wrapped around those children (defaults to a `div`). Regardless of the passed `element`, the `IntersectionObserver` component will always add a `display: contents` style to that element in order to reduce the styling impact of the additional nesting.
+This component also allows you to customize the rendered markup. You can pass `children`, which will be rendered inside of the node being observed for intersections. You can also pass a `wrapperComponent` prop that changes the DOM node being wrapped around those children (defaults to a `div`). Regardless of the passed `wrapperComponent`, the `IntersectionObserver` component will always add a `display: contents` style to that node in order to reduce the styling impact of the additional nesting.
 
 ```tsx
 <div ref={this.parentElement}>
@@ -35,7 +35,7 @@ This component also allows you to customize the rendered markup. You can pass `c
 
 ### Lifecycle
 
-You may change any prop on an `IntersectionObserver` component, and the component will do the minimum amount of work to unobserve/ re-observe with the new fields. The most expensive updates to make are changing `threshold`, `root`, `rootMargin`, and `element`, as these require disconnecting the old observer and recreating a new one.
+You may change any prop on an `IntersectionObserver` component, and the component will do the minimum amount of work to unobserve/ re-observe with the new fields. The most expensive updates to make are changing `threshold`, `root`, `rootMargin`, and `wrapperComponent`, as these require disconnecting the old observer and recreating a new one.
 
 When this component is unmounted, it disconnects the current observer.
 
@@ -45,5 +45,5 @@ To polyfill `IntersectionObserver`, please use the `@shopify/polyfills/intersect
 
 If you do not polyfill the feature and it is not supported in the current browser, the `IntersectionObserver` component will decide what to do based on the `unsupportedBehavior` prop. This prop should be a member of the `UnsupportedBehavior` enum (exported from this package). Currently, there are two options:
 
-- `UnsupportedBehavior.Ignore`: never calls `onIntersecting` or `onNotIntersecting`.
 - `UnsupportedBehavior.TreatAsIntersecting`: immediately calls `onIntersecting` on mount, if it is provided (this is the default).
+- `UnsupportedBehavior.Ignore`: never calls `onIntersecting` or `onNotIntersecting`.

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shopify/react-intersection-observer",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A simple React wrapper around the IntersectionObserver API",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-intersection-observer/README.md",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "~3.0.1"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-intersection-observer",
   "version": "0.0.0",
   "license": "MIT",
-  "description": "A simple React wrapper around the IntersectionObserver API",
+  "description": "A React wrapper around the IntersectionObserver API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -9,16 +9,16 @@ export enum UnsupportedBehavior {
 interface Props {
   root?: Element | string | null;
   rootMargin?: string;
-  element?: string;
   threshold?: number | number[];
   children?: React.ReactNode;
+  wrapperComponent?: string;
   unsupportedBehavior?: UnsupportedBehavior;
   onIntersecting?(entries: IntersectionObserverEntry): void;
   onNotIntersecting?(entries: IntersectionObserverEntry): void;
 }
 
 export default class IntersectionObserverDom extends React.Component<Props> {
-  private element = React.createRef<HTMLElement>();
+  private observed = React.createRef<HTMLElement>();
   private observer?: IntersectionObserver;
 
   componentDidMount() {
@@ -33,8 +33,8 @@ export default class IntersectionObserverDom extends React.Component<Props> {
     return (
       nextProps.root !== this.props.root ||
       nextProps.rootMargin !== this.props.rootMargin ||
-      nextProps.element !== this.props.element ||
       nextProps.children !== this.props.children ||
+      nextProps.wrapperComponent !== this.props.wrapperComponent ||
       !equalThresholds(nextProps.threshold, this.props.threshold)
     );
   }
@@ -49,11 +49,11 @@ export default class IntersectionObserverDom extends React.Component<Props> {
   }
 
   render() {
-    const {element: Element = 'div' as any, children} = this.props;
+    const {wrapperComponent: Wrapper = 'div' as any, children} = this.props;
     return (
-      <Element style={{display: 'contents'}} ref={this.element}>
+      <Wrapper style={{display: 'contents'}} ref={this.observed}>
         {children}
-      </Element>
+      </Wrapper>
     );
   }
 
@@ -67,9 +67,9 @@ export default class IntersectionObserverDom extends React.Component<Props> {
   }
 
   private observe() {
-    const {props, element} = this;
+    const {props, observed} = this;
 
-    if (element.current == null) {
+    if (observed.current == null) {
       return;
     }
 
@@ -83,7 +83,7 @@ export default class IntersectionObserverDom extends React.Component<Props> {
         unsupportedBehavior === UnsupportedBehavior.TreatAsIntersecting &&
         onIntersecting != null
       ) {
-        const boundingClientRect = element.current.getBoundingClientRect();
+        const boundingClientRect = observed.current.getBoundingClientRect();
 
         onIntersecting({
           boundingClientRect,
@@ -91,7 +91,7 @@ export default class IntersectionObserverDom extends React.Component<Props> {
           intersectionRect: boundingClientRect,
           isIntersecting: true,
           rootBounds: boundingClientRect,
-          target: element.current,
+          target: observed.current,
           time: Date.now(),
         });
       }
@@ -100,7 +100,7 @@ export default class IntersectionObserverDom extends React.Component<Props> {
     }
 
     this.observer = observe(
-      element.current,
+      observed.current,
       this.intersectionObserverCallback,
       props,
     );

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import {isSupported} from './utilities';
+
+export enum UnsupportedBehavior {
+  Ignore,
+  TreatAsIntersecting,
+}
+
+interface Props {
+  root?: Element | string | null;
+  rootMargin?: string;
+  element?: string;
+  threshold?: number | number[];
+  children?: React.ReactNode;
+  unsupportedBehavior?: UnsupportedBehavior;
+  onIntersecting?(entries: IntersectionObserverEntry): void;
+  onNotIntersecting?(entries: IntersectionObserverEntry): void;
+}
+
+export default class IntersectionObserverDom extends React.Component<Props> {
+  private element = React.createRef<HTMLElement>();
+  private observer?: IntersectionObserver;
+
+  componentDidMount() {
+    this.observe();
+  }
+
+  shouldComponentUpdate(nextProps: Props) {
+    // If any of the values required to construct an IntersectionObserver
+    // change, we need to disconnect it altogether. If only the callbacks changed,
+    // we can skip doing anything at all, because they are already dynamically
+    // looked up in the IntersectionObserver callback.
+    return (
+      nextProps.root !== this.props.root ||
+      nextProps.rootMargin !== this.props.rootMargin ||
+      nextProps.element !== this.props.element ||
+      nextProps.children !== this.props.children ||
+      !equalThresholds(nextProps.threshold, this.props.threshold)
+    );
+  }
+
+  componentDidUpdate() {
+    this.disconnect();
+    this.observe();
+  }
+
+  componentWillUnmount() {
+    this.disconnect();
+  }
+
+  render() {
+    const {element: Element = 'div' as any, children} = this.props;
+    return (
+      <Element style={{display: 'contents'}} ref={this.element}>
+        {children}
+      </Element>
+    );
+  }
+
+  private disconnect() {
+    const {observer} = this;
+
+    if (observer != null) {
+      observer.disconnect();
+      this.observer = undefined;
+    }
+  }
+
+  private observe() {
+    const {props, element} = this;
+
+    if (element.current == null) {
+      return;
+    }
+
+    if (!isSupported()) {
+      const {
+        unsupportedBehavior = UnsupportedBehavior.TreatAsIntersecting,
+        onIntersecting,
+      } = props;
+
+      if (
+        unsupportedBehavior === UnsupportedBehavior.TreatAsIntersecting &&
+        onIntersecting != null
+      ) {
+        const boundingClientRect = element.current.getBoundingClientRect();
+
+        onIntersecting({
+          boundingClientRect,
+          intersectionRatio: 1,
+          intersectionRect: boundingClientRect,
+          isIntersecting: true,
+          rootBounds: boundingClientRect,
+          target: element.current,
+          time: Date.now(),
+        });
+      }
+
+      return;
+    }
+
+    this.observer = observe(
+      element.current,
+      this.intersectionObserverCallback,
+      props,
+    );
+  }
+
+  private intersectionObserverCallback = ([
+    intersectionEntry,
+  ]: IntersectionObserverEntry[]) => {
+    const {onIntersecting, onNotIntersecting} = this.props;
+
+    if (intersectionEntry.intersectionRatio > 0) {
+      if (onIntersecting) {
+        onIntersecting(intersectionEntry);
+      }
+    } else if (onNotIntersecting) {
+      onNotIntersecting(intersectionEntry);
+    }
+  };
+}
+
+function observe(
+  element: HTMLElement,
+  callback: IntersectionObserverCallback,
+  {
+    root,
+    rootMargin,
+    threshold,
+  }: Pick<Props, 'root' | 'rootMargin' | 'threshold'>,
+) {
+  const resolvedRoot =
+    typeof root === 'string' ? document.querySelector(root) : root;
+
+  const observer = new IntersectionObserver(callback, {
+    root: resolvedRoot,
+    rootMargin,
+    threshold,
+  });
+
+  observer.observe(element);
+  return observer;
+}
+
+function equalThresholds(
+  oldThreshold: Props['threshold'],
+  newThreshold: Props['threshold'],
+) {
+  return (
+    oldThreshold === newThreshold ||
+    (Array.isArray(oldThreshold) &&
+      Array.isArray(newThreshold) &&
+      oldThreshold.length === newThreshold.length &&
+      oldThreshold.every((item, index) => item === newThreshold[index]))
+  );
+}

--- a/packages/react-intersection-observer/src/index.ts
+++ b/packages/react-intersection-observer/src/index.ts
@@ -1,0 +1,4 @@
+export {
+  default as IntersectionObserver,
+  UnsupportedBehavior,
+} from './IntersectionObserver';

--- a/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
+++ b/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
@@ -1,0 +1,328 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import {intersectionObserver as intersectionObserverMock} from '@shopify/jest-dom-mocks';
+
+import IntersectionObserver, {
+  UnsupportedBehavior,
+} from '../IntersectionObserver';
+
+jest.mock('../utilities', () => ({
+  isSupported: jest.fn(),
+}));
+
+const {isSupported} = require.requireMock('../utilities') as {
+  isSupported: jest.Mock;
+};
+
+describe('<IntersectionObserver />', () => {
+  beforeEach(() => {
+    isSupported.mockClear();
+    isSupported.mockImplementation(() => false);
+    intersectionObserverMock.mock();
+  });
+
+  afterEach(() => {
+    intersectionObserverMock.restore();
+  });
+
+  describe('element', () => {
+    it('uses a div with display: contents by default', () => {
+      const intersectionObserver = mount(<IntersectionObserver />);
+      const child = intersectionObserver.childAt(0);
+      expect(child.type()).toBe('div');
+      expect(child.prop('style')).toMatchObject({display: 'contents'});
+    });
+
+    it('uses a custom element with display: contents by default', () => {
+      const element = 'span';
+      const intersectionObserver = mount(
+        <IntersectionObserver element={element} />,
+      );
+      const child = intersectionObserver.childAt(0);
+
+      expect(child.type()).toBe(element);
+      expect(child.prop('style')).toMatchObject({display: 'contents'});
+    });
+
+    it('attaches the observer to the top-level element', () => {
+      isSupported.mockReturnValue(true);
+
+      const intersectionObserver = mount(<IntersectionObserver />);
+      const child = intersectionObserver.childAt(0);
+      const node = child.getDOMNode();
+
+      expect(intersectionObserverMock.observers[0]).toHaveProperty(
+        'target',
+        node,
+      );
+    });
+  });
+
+  describe('children', () => {
+    it('includes the children inside the top-level element', () => {
+      const children = <div>Hello world</div>;
+      const intersectionObserver = mount(
+        <IntersectionObserver>{children}</IntersectionObserver>,
+      );
+
+      expect(intersectionObserver.childAt(0).contains(children)).toBe(true);
+    });
+  });
+
+  describe('threshold', () => {
+    beforeEach(() => {
+      isSupported.mockReturnValue(true);
+    });
+
+    it('is used to create the IntersectionObserver', () => {
+      const threshold = [0, 0.5, 1];
+
+      mount(<IntersectionObserver threshold={threshold} />);
+
+      expect(intersectionObserverMock.observers[0]).toMatchObject({
+        options: {
+          threshold,
+        },
+      });
+    });
+  });
+
+  describe('rootMargin', () => {
+    beforeEach(() => {
+      isSupported.mockReturnValue(true);
+    });
+
+    it('is used to create the IntersectionObserver', () => {
+      const rootMargin = '10%';
+
+      mount(<IntersectionObserver rootMargin={rootMargin} />);
+
+      expect(intersectionObserverMock.observers[0]).toMatchObject({
+        options: {
+          rootMargin,
+        },
+      });
+    });
+  });
+
+  describe('root', () => {
+    beforeEach(() => {
+      isSupported.mockReturnValue(true);
+    });
+
+    it('uses an HTML element for the root IntersectionObserver option', () => {
+      withHtmlElement(root => {
+        mount(<IntersectionObserver root={root} />);
+
+        expect(intersectionObserverMock.observers[0]).toMatchObject({
+          options: {
+            root,
+          },
+        });
+      });
+    });
+
+    it('resolves a string to an HTML element for the root IntersectionObserver option', () => {
+      withHtmlElement(root => {
+        const id = 'MyRootElement';
+        root.setAttribute('id', id);
+
+        mount(<IntersectionObserver root={`#${id}`} />);
+
+        expect(intersectionObserverMock.observers[0]).toMatchObject({
+          options: {
+            root,
+          },
+        });
+      });
+    });
+  });
+
+  describe('onIntersecting()', () => {
+    it('is not called when IntersectionObserver is not supported and the unsupportedBehavior is to ignore', () => {
+      isSupported.mockReturnValue(false);
+      const spy = jest.fn();
+
+      mount(
+        <IntersectionObserver
+          onIntersecting={spy}
+          unsupportedBehavior={UnsupportedBehavior.Ignore}
+        />,
+      );
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('is called immediately when IntersectionObserver is not supported and no unsupportedBehavior is set', () => {
+      isSupported.mockReturnValue(false);
+      const spy = jest.fn();
+
+      mount(<IntersectionObserver onIntersecting={spy} />);
+
+      expect(spy).toHaveBeenCalledWith({
+        boundingClientRect: expect.any(Object),
+        intersectionRatio: 1,
+        intersectionRect: expect.any(Object),
+        isIntersecting: true,
+        rootBounds: expect.any(Object),
+        target: expect.any(HTMLDivElement),
+        time: expect.any(Number),
+      });
+    });
+
+    it('is called immediately when IntersectionObserver is not supported and unsupportedBehavior is set to TreatAsIntersecting', () => {
+      isSupported.mockReturnValue(false);
+      const spy = jest.fn();
+
+      mount(
+        <IntersectionObserver
+          onIntersecting={spy}
+          unsupportedBehavior={UnsupportedBehavior.TreatAsIntersecting}
+        />,
+      );
+
+      expect(spy).toHaveBeenCalledWith({
+        boundingClientRect: expect.any(Object),
+        intersectionRatio: 1,
+        intersectionRect: expect.any(Object),
+        isIntersecting: true,
+        rootBounds: expect.any(Object),
+        target: expect.any(HTMLDivElement),
+        time: expect.any(Number),
+      });
+    });
+
+    it('is called when the IntersectionObserver gets called with a non-0 intersectionRatio', () => {
+      isSupported.mockReturnValue(true);
+      const spy = jest.fn();
+      const entry = {intersectionRatio: 0.2};
+
+      mount(<IntersectionObserver onIntersecting={spy} />);
+
+      intersectionObserverMock.simulate(entry);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining(entry));
+    });
+
+    it('is not called when the IntersectionObserver gets called with a 0 intersectionRatio', () => {
+      isSupported.mockReturnValue(true);
+      const spy = jest.fn();
+      const entry = {intersectionRatio: 0};
+
+      mount(<IntersectionObserver onIntersecting={spy} />);
+
+      intersectionObserverMock.simulate(entry);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onNotIntersecting()', () => {
+    it('is called when the IntersectionObserver gets called with a 0 intersectionRatio', () => {
+      isSupported.mockReturnValue(true);
+      const spy = jest.fn();
+      const entry = {intersectionRatio: 0.2};
+
+      mount(<IntersectionObserver onNotIntersecting={spy} />);
+
+      intersectionObserverMock.simulate(entry);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('is not called when the IntersectionObserver gets called with a non-0 intersectionRatio', () => {
+      isSupported.mockReturnValue(true);
+      const spy = jest.fn();
+      const entry = {intersectionRatio: 0};
+
+      mount(<IntersectionObserver onNotIntersecting={spy} />);
+
+      intersectionObserverMock.simulate(entry);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining(entry));
+    });
+  });
+
+  describe('lifecycle', () => {
+    beforeEach(() => {
+      isSupported.mockReturnValue(true);
+    });
+
+    it('disconnects observers when unmounting', () => {
+      const intersectionObserver = mount(<IntersectionObserver />);
+      intersectionObserver.unmount();
+      expect(intersectionObserverMock.observers).toHaveLength(0);
+    });
+
+    it('un-observes and re-observes when options change', () => {
+      withHtmlElement(firstRoot => {
+        const intersectionObserver = mount(
+          <IntersectionObserver root={firstRoot} />,
+        );
+
+        withHtmlElement(secondRoot => {
+          intersectionObserver.setProps({root: secondRoot});
+
+          expect(intersectionObserverMock.observers).toHaveLength(1);
+          expect(intersectionObserverMock.observers[0]).toHaveProperty(
+            'options.root',
+            secondRoot,
+          );
+        });
+      });
+    });
+
+    it('re-uses the same intersection observer when only the callbacks change', () => {
+      const firstSpy = jest.fn();
+      const secondSpy = jest.fn();
+      const intersectionObserver = mount(
+        <IntersectionObserver onIntersecting={firstSpy} />,
+      );
+
+      intersectionObserver.setProps({onIntersecting: secondSpy});
+      intersectionObserverMock.simulate({intersectionRatio: 1});
+
+      expect(firstSpy).not.toHaveBeenCalled();
+      expect(secondSpy).toHaveBeenCalled();
+    });
+
+    it('re-uses the same intersection observer when the threshold changes to a new equivalent array', () => {
+      const threshold = [0, 0.5, 1];
+      const intersectionObserver = mount(
+        <IntersectionObserver threshold={threshold} />,
+      );
+
+      const observer = intersectionObserverMock.observers[0];
+
+      intersectionObserver.setProps({threshold: [...threshold]});
+
+      expect(observer).toBe(intersectionObserverMock.observers[0]);
+    });
+  });
+});
+
+function withHtmlElement<T>(
+  callback: (element: HTMLDivElement) => T | Promise<T>,
+) {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const remove = () => element.remove();
+
+  try {
+    const result: any = callback(element);
+
+    if (result == null || !('then' in result)) {
+      remove();
+      return result;
+    } else {
+      return (result as Promise<T>)
+        .then(result => {
+          remove();
+          return result;
+        })
+        .catch(error => {
+          remove();
+          throw error;
+        });
+    }
+  } catch (error) {
+    remove();
+    throw error;
+  }
+}

--- a/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
+++ b/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
@@ -25,7 +25,7 @@ describe('<IntersectionObserver />', () => {
     intersectionObserverMock.restore();
   });
 
-  describe('element', () => {
+  describe('wrapperComponent', () => {
     it('uses a div with display: contents by default', () => {
       const intersectionObserver = mount(<IntersectionObserver />);
       const child = intersectionObserver.childAt(0);
@@ -34,17 +34,17 @@ describe('<IntersectionObserver />', () => {
     });
 
     it('uses a custom element with display: contents by default', () => {
-      const element = 'span';
+      const wrapperComponent = 'span';
       const intersectionObserver = mount(
-        <IntersectionObserver element={element} />,
+        <IntersectionObserver wrapperComponent={wrapperComponent} />,
       );
       const child = intersectionObserver.childAt(0);
 
-      expect(child.type()).toBe(element);
+      expect(child.type()).toBe(wrapperComponent);
       expect(child.prop('style')).toMatchObject({display: 'contents'});
     });
 
-    it('attaches the observer to the top-level element', () => {
+    it('attaches the observer to the top-level node', () => {
       isSupported.mockReturnValue(true);
 
       const intersectionObserver = mount(<IntersectionObserver />);
@@ -216,7 +216,7 @@ describe('<IntersectionObserver />', () => {
   });
 
   describe('onNotIntersecting()', () => {
-    it('is called when the IntersectionObserver gets called with a 0 intersectionRatio', () => {
+    it('is not called when the IntersectionObserver gets called with a non-0 intersectionRatio', () => {
       isSupported.mockReturnValue(true);
       const spy = jest.fn();
       const entry = {intersectionRatio: 0.2};
@@ -227,7 +227,7 @@ describe('<IntersectionObserver />', () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
-    it('is not called when the IntersectionObserver gets called with a non-0 intersectionRatio', () => {
+    it('is called when the IntersectionObserver gets called with a 0 intersectionRatio', () => {
       isSupported.mockReturnValue(true);
       const spy = jest.fn();
       const entry = {intersectionRatio: 0};
@@ -250,7 +250,22 @@ describe('<IntersectionObserver />', () => {
       expect(intersectionObserverMock.observers).toHaveLength(0);
     });
 
-    it('un-observes and re-observes when options change', () => {
+    it('un-observes and re-observes when the root prop changes', () => {
+      const intersectionObserver = mount(
+        <IntersectionObserver threshold={0.5} />,
+      );
+
+      const threshold = 1;
+      intersectionObserver.setProps({threshold});
+
+      expect(intersectionObserverMock.observers).toHaveLength(1);
+      expect(intersectionObserverMock.observers[0]).toHaveProperty(
+        'options.threshold',
+        threshold,
+      );
+    });
+
+    it('un-observes and re-observes when the threshold changes', () => {
       withHtmlElement(firstRoot => {
         const intersectionObserver = mount(
           <IntersectionObserver root={firstRoot} />,

--- a/packages/react-intersection-observer/src/utilities.ts
+++ b/packages/react-intersection-observer/src/utilities.ts
@@ -1,0 +1,8 @@
+export function isSupported() {
+  return (
+    typeof window !== 'undefined' &&
+    'IntersectionObserver' in window &&
+    'IntersectionObserverEntry' in window &&
+    'intersectionRatio' in IntersectionObserverEntry.prototype
+  );
+}

--- a/packages/react-intersection-observer/tsconfig.build.json
+++ b/packages/react-intersection-observer/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4235,6 +4235,11 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
+intersection-observer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.1.tgz#e340fc56ce74290fe2b2394d1ce88c4353ac6dfa"
+  integrity sha512-Zd7Plneq82kiXFixs7bX62YnuZ0BMRci9br7io88LwDyF3V43cQMI+G5IiTlTNTt+LsDUppl19J/M2Fp9UkH6g==
+
 intl-pluralrules@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/intl-pluralrules/-/intl-pluralrules-0.2.1.tgz#ebb5395ae18e4e60912ece3e04b692ac1ea85708"


### PR DESCRIPTION
This PR adds a new `react-intersection-observer` package, as well as `IntersectionObserver` mocks for `jest-dom-mocks` and a polyfill in `polyfills`. I think this is all the places we need to provide some sort of intersection observer niceties (which I want to use for some additional async-related components).

The `IntersectionObserver` component is the biggest part of this, but honestly I think it's fairly minimal and straightforward. It is mostly a wrapper around the raw `IntersectionObserver` API, with configurable fallback behaviour for browsers that don't support it. It's basically 100% tested so I am feeling pretty good about it.