### PR TITLE
Fix memoize

### DIFF
--- a/packages/decorators/src/tests/memoize.test.ts
+++ b/packages/decorators/src/tests/memoize.test.ts
@@ -163,4 +163,28 @@ describe('memoize()', () => {
       expect(spy).toBeCalledTimes(1);
     });
   });
+
+  it('does not share cache result in two instances of the same class', () => {
+    const spy = jest.fn();
+    class MyClass {
+      extraNumber = 0;
+      constructor(extraNumber: number) {
+        this.extraNumber = extraNumber;
+      }
+
+      @memoize()
+      addExtraNumber(number: number) {
+        spy();
+        return number + this.extraNumber + 1;
+      }
+    }
+
+    const myClass1 = new MyClass(1);
+    expect(myClass1.addExtraNumber(1)).toEqual(3);
+
+    const myClass2 = new MyClass(3);
+    expect(myClass2.addExtraNumber(1)).toEqual(5);
+
+    expect(spy).toBeCalledTimes(2);
+  });
 });


### PR DESCRIPTION
While using the decorator in Polaris, I discover a problem with the decorator.
That it does not distinguish between different instances of the class.

I fixed this by modifying the initial call descriptor to be a getter so it have access to the correct instance, then redefining the property with the decorated method.