### PR TITLE
Remove updating logic in FormState.Nested and FormState.List

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.9.0]
+
+### Removed
+
+- `<Nested />` and `<List />`: removed logic in `shouldComponentUpdate()` limiting updates
+
 ## [0.8.0]
 
 ### Added

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -9,30 +9,11 @@ interface Props<Fields> {
   getChildKey?(item: Fields): string;
 }
 
-export default class List<Fields> extends React.Component<
+export default class List<Fields> extends React.PureComponent<
   Props<Fields>,
   never
 > {
   private changeHandlers = new Map<string, {(newValue: any): void}>();
-
-  shouldComponentUpdate(nextProps) {
-    const {
-      field: {
-        value: nextValue,
-        error: nextError,
-        initialValue: nextInitialValue,
-      },
-    } = nextProps;
-    const {
-      field: {value, error, initialValue},
-    } = this.props;
-
-    return (
-      nextValue !== value ||
-      nextError !== error ||
-      nextInitialValue !== initialValue
-    );
-  }
 
   render() {
     const {

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -8,30 +8,11 @@ interface Props<Fields> {
   children(fields: FieldDescriptors<Fields>): React.ReactNode;
 }
 
-export default class Nested<Fields> extends React.Component<
+export default class Nested<Fields> extends React.PureComponent<
   Props<Fields>,
   never
 > {
   private changeHandlers = new Map<keyof Fields, Function>();
-
-  shouldComponentUpdate(nextProps) {
-    const {
-      field: {
-        value: nextValue,
-        error: nextError,
-        initialValue: nextInitialValue,
-      },
-    } = nextProps;
-    const {
-      field: {value, error, initialValue},
-    } = this.props;
-
-    return (
-      nextValue !== value ||
-      nextError !== error ||
-      nextInitialValue !== initialValue
-    );
-  }
 
   render() {
     const {

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -338,32 +338,4 @@ describe('<FormState.List />', () => {
     expect(updatedFields.title.value).toBe(newTitle);
     expect(updatedFields.department.value).toBe(newDepartment);
   });
-
-  it('Does not re-render when children have not changed', () => {
-    const products = [{title: faker.commerce.productName()}];
-    const adjective = faker.commerce.productAdjective();
-    const newAdjective = faker.commerce.productAdjective();
-
-    const renderSpy = jest.fn(() => null);
-
-    const form = mount(
-      <FormState initialValues={{products, adjective}}>
-        {({fields}) => {
-          return (
-            <>
-              <Input {...fields.adjective} />
-              <FormState.List field={fields.products}>
-                {renderSpy}
-              </FormState.List>
-            </>
-          );
-        }}
-      </FormState>,
-    );
-
-    const input = form.find(Input);
-    trigger(input, 'onChange', newAdjective);
-
-    expect(renderSpy).toHaveBeenCalledTimes(1);
-  });
 });

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -267,40 +267,4 @@ describe('<Nested />', () => {
     expect(updatedFields.title.value).toBe(newTitle);
     expect(updatedFields.department.value).toBe(newDepartment);
   });
-
-  it('Does not re-render when children have not changed', () => {
-    const titleSpy = jest.fn(() => null);
-    const adjectiveSpy = jest.fn(({adjective}) => <Input {...adjective} />);
-    const newAdjective = faker.commerce.productAdjective();
-
-    const productTitle = {
-      title: faker.commerce.productName(),
-    };
-    const productAdjective = {
-      adjective: faker.commerce.productAdjective(),
-    };
-
-    const form = mount(
-      <FormState initialValues={{productTitle, productAdjective}}>
-        {({fields}) => {
-          return (
-            <>
-              <FormState.Nested field={fields.productTitle}>
-                {titleSpy}
-              </FormState.Nested>
-
-              <FormState.Nested field={fields.productAdjective}>
-                {adjectiveSpy}
-              </FormState.Nested>
-            </>
-          );
-        }}
-      </FormState>,
-    );
-    const input = form.find(Input);
-    trigger(input, 'onChange', newAdjective);
-
-    expect(titleSpy).toHaveBeenCalledTimes(1);
-    expect(adjectiveSpy).toHaveBeenCalledTimes(2);
-  });
 });


### PR DESCRIPTION
## What's the problem
As described in #557, `<FormState.Nested>` and `<FormState.List>` are not updating their children, unless the passed `field` changes.

While this is the expected behaviour (introduced in #312 to improve the performance of these components), there are cases in which it's necessary for the children to be updated. For example, if any of the child form elements also depend on a state change or a prop other than `field` changing.

I first attempted to solve this problem in #558 by adding a new prop to these components which would enable the consumer to "by-pass" the check. However, [it was brought up](https://github.com/Shopify/quilt/pull/558#issuecomment-471034178) by @lemonmade that the checks might not need to be there at all since it breaks the expected behaviour of how a React component should work.

☝️ _The changes introduced in #558 were later reverted in #564._

## How it's solved
This PR is basically reverting the changes introduced in #312:

- :zap: Use `React.PureComponent` instead of `React.Component`
- :fire: Removed `shouldComponentUpdate()` from `<FormState.Nested>` and `<FormState.List>` altogether
- :fire: Removed tests for the updating logic
- :memo: Updated CHANGELOG with proposed release (minor version)

## Tophatting 🎩

I tophatted the changes in my app using `yarn tophat`. I'd recommend testing this in any app that's using either `<FormState.Nested>` or `<FormState.List>` and making sure the child form elements get re-rendered. 