### PR TITLE
Add pass information to react-effect callbacks

### DIFF
--- a/packages/jest-dom-mocks/src/user-timing.ts
+++ b/packages/jest-dom-mocks/src/user-timing.ts
@@ -4,7 +4,7 @@ type UserTimingMock = typeof window.performance.timing;
 
 export default class Performance {
   private isUsingMockUserTiming = false;
-  private originalUserTiming?: UserTimingMock = window.performance.timing;
+  private originalUserTiming?: UserTimingMock;
 
   mock(timing: Partial<UserTimingMock> = {}) {
     if (this.isUsingMockUserTiming) {
@@ -12,6 +12,8 @@ export default class Performance {
         'You tried to mock window.performance.timing when it was already mocked.',
       );
     }
+
+    this.originalUserTiming = window.performance.timing;
 
     const mockTiming: Partial<UserTimingMock> = {
       navigationStart: 0,

--- a/packages/react-effect/CHANGELOG.md
+++ b/packages/react-effect/CHANGELOG.md
@@ -7,6 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.0]
+
+### Added
+
+- Added a `maxPasses` option to `extract()` in order to limit the potential for infinite loops. This option defaults to 5 max render/ resolve cycles [#574](https://github.com/Shopify/quilt/pull/574)
+- All `afterEachPass`/ `betweenEachPass` callbacks now receive an argument detailing the current pass index, whether the extraction process is complete, and the duration of the render/ resolve phases [#574](https://github.com/Shopify/quilt/pull/574)
+
 ## [2.0.0]
 
 ### Changed

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -69,9 +69,11 @@ You may optionally pass an options object that contains the following keys (all 
   }
   ```
 
-- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected). This function can return a promise, and it will be waited on before continuing.
+- `maxPasses`: a number that limits the number of render/ resolve cycles `extract` is allowed to perform. This option defaults to `5`.
 
-- `afterEachPass`: a function that is called after each pass of your tree, regardless of whether traversal is "finished". This function can return a promise, and it will be waited on before continuing.
+- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected). This function can return a promise, and it will be waited on before continuing. It is called with a single argument: a `Pass` object, which contains the `index`, `finished`, `renderDuration` and `resolveDuration` of the just-completed pass.
+
+- `afterEachPass`: a function that is called after each pass of your tree, regardless of whether traversal is "finished". This function can return a promise, and it will be waited on before continuing. This function is called with the same argument as the `betweenEachPass` option.
 
 - `decorate`: a function that takes the root React element in your tree and returns a new tree to use. You can use this to wrap your application in context providers that only your server render requires.
 

--- a/packages/react-effect/src/context.ts
+++ b/packages/react-effect/src/context.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {EffectKind} from './types';
+import {EffectKind, Pass} from './types';
 
 interface Options {
   include?: symbol[] | boolean;
@@ -34,18 +34,18 @@ export class EffectManager {
     await Promise.all(this.effects);
   }
 
-  betweenEachPass() {
+  betweenEachPass(pass: Pass) {
     for (const kind of this.kinds) {
       if (typeof kind.betweenEachPass === 'function') {
-        kind.betweenEachPass();
+        kind.betweenEachPass(pass);
       }
     }
   }
 
-  afterEachPass() {
+  afterEachPass(pass: Pass) {
     for (const kind of this.kinds) {
       if (typeof kind.afterEachPass === 'function') {
-        kind.afterEachPass();
+        kind.afterEachPass(pass);
       }
     }
 

--- a/packages/react-effect/src/types.ts
+++ b/packages/react-effect/src/types.ts
@@ -1,5 +1,12 @@
+export interface Pass {
+  index: number;
+  finished: boolean;
+  renderDuration: number;
+  resolveDuration: number;
+}
+
 export interface EffectKind {
   readonly id: symbol;
-  betweenEachPass?(): any;
-  afterEachPass?(): any;
+  betweenEachPass?(pass: Pass): any;
+  afterEachPass?(pass: Pass): any;
 }


### PR DESCRIPTION
This PR introduces two features to `@shopify/react-effect`:

1. A `maxPasses` to limit possible spinning forever. This defaults to `5` max iterations
2. `afterEachPass`/ `betweenEachPass` now provide information about the pass, including which iteration we are on, and how long the render/ resolution parts took.

I want to use these to try to remove some possibilities of render-related weirdness in the Web.