### PR TITLE
Add IntersectionObserver users

### DIFF
--- a/packages/async/README.md
+++ b/packages/async/README.md
@@ -17,13 +17,14 @@ This package contains a few types that are useful for creating async components:
 
 - `Import` represents a value that could be default or non-default export
 - `LoadProps` are an interface that describe the shape of props that must be used for a function to be processed by the Babel plugin provided by this
-- `DeferTiming` is an enum of defer timing values, either on component `Mount` or until the browser is `Idle`
+- `DeferTiming` is an enum of defer timing values; has values for component `Mount`, browser `Idle`, or element `InViewport`
 
 As well as the following types related to `window.requestIdleCallback`:
 
 - `RequestIdleCallbackHandle`
 - `RequestIdleCallbackOptions`
 - `RequestIdleCallbackDeadline`
+- `RequestIdleCallback`
 - `WindowWithRequestIdleCallback`
 
 It also includes a plugin for Babel that allows the module IDs that are asynchronously imported to be exposed to the application.

--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -8,6 +8,7 @@ export interface LoadProps<T> {
 export enum DeferTiming {
   Mount,
   Idle,
+  InViewport,
 }
 
 export type RequestIdleCallbackHandle = any;
@@ -18,13 +19,17 @@ export interface RequestIdleCallbackOptions {
 
 export interface RequestIdleCallbackDeadline {
   readonly didTimeout: boolean;
-  timeRemaining: (() => number);
+  timeRemaining(): number;
 }
 
+export type RequestIdleCallback = (
+  deadline: RequestIdleCallbackDeadline,
+) => void;
+
 export interface WindowWithRequestIdleCallback {
-  requestIdleCallback: ((
-    callback: ((deadline: RequestIdleCallbackDeadline) => void),
+  requestIdleCallback(
+    callback: RequestIdleCallback,
     opts?: RequestIdleCallbackOptions,
-  ) => RequestIdleCallbackHandle);
+  ): RequestIdleCallbackHandle;
   cancelIdleCallback: ((handle: RequestIdleCallbackHandle) => void);
 }

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -87,6 +87,7 @@ The mocks provided can be divided into 3 primary categories:
 The following standard mocks are available:
 
 - `animationFrame`
+- `requestIdleCallback`
 - `clock`
 - `location`
 - `matchMedia`
@@ -132,6 +133,18 @@ Some of the standard mocks include additional features:
 #### `AnimationFrame.runFrame(): void`
 
 Executes all queued animation callbacks.
+
+#### `RequestIdleCallback.runIdleCallbacks(timeRemaining?: number, didTimeout?: boolean): void`
+
+Runs all currently-scheduled idle callbacks. If provided, `timeRemaining`/ `didTimeout` will be used to construct the argument for these callbacks. Once called, all callbacks are removed from the queue.
+
+#### `RequestIdleCallback.cancelIdleCallbacks(): void`
+
+Cancels all currently-scheduled idle callbacks.
+
+#### `RequestIdleCallback.cancelIdleCallback(callback: any): void`
+
+Cancels the idle callback specified by the passed argument. This value should be the one returned from a call to `window.requestIdleCallback`.
 
 #### `Clock.mock(now: number | Date): void`
 

--- a/packages/jest-dom-mocks/src/index.ts
+++ b/packages/jest-dom-mocks/src/index.ts
@@ -1,4 +1,5 @@
 import AnimationFrame from './animation-frame';
+import RequestIdleCallback from './request-idle-callback';
 import Clock from './clock';
 import fetch from './fetch';
 import Location from './location';
@@ -9,6 +10,7 @@ import UserTiming from './user-timing';
 import IntersectionObserver from './intersection-observer';
 
 export const animationFrame = new AnimationFrame();
+export const requestIdleCallback = new RequestIdleCallback();
 
 export const clock = new Clock();
 

--- a/packages/jest-dom-mocks/src/request-idle-callback.ts
+++ b/packages/jest-dom-mocks/src/request-idle-callback.ts
@@ -1,0 +1,100 @@
+import {
+  RequestIdleCallback as IdleCallback,
+  WindowWithRequestIdleCallback,
+} from '@shopify/async';
+
+export default class RequestIdleCallback {
+  private isUsingMockIdleCallback = false;
+  private queued: {
+    [key: string]: IdleCallback;
+  } = {};
+  private originalRequestIdleCallback: any;
+  private originalCancelIdleCallback: any;
+  private currentIdleCallback = 0;
+
+  mock() {
+    if (this.isUsingMockIdleCallback) {
+      throw new Error(
+        'requestIdleCallback is already mocked, but you tried to mock it again.',
+      );
+    }
+
+    this.isUsingMockIdleCallback = true;
+
+    const windowWithIdle: WindowWithRequestIdleCallback = window as any;
+
+    this.originalRequestIdleCallback = windowWithIdle.requestIdleCallback;
+    windowWithIdle.requestIdleCallback = this.requestIdleCallback;
+
+    this.originalCancelIdleCallback = windowWithIdle.cancelIdleCallback;
+    windowWithIdle.cancelIdleCallback = this.cancelIdleCallback;
+  }
+
+  restore() {
+    if (!this.isUsingMockIdleCallback) {
+      throw new Error(
+        'requestIdleCallback is already real, but you tried to restore it again.',
+      );
+    }
+
+    if (Object.keys(this.queued).length > 0) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'You are restoring requestIdleCallback, but some idle callbacks have not been run. You can run requestIdleCallback.cancelIdleCallback() to clear them all and avoid this warning.',
+      );
+
+      this.cancelIdleCallbacks();
+    }
+
+    this.isUsingMockIdleCallback = false;
+
+    (window as any).requestIdleCallback = this.originalRequestIdleCallback;
+    (window as any).cancelIdleCallback = this.originalCancelIdleCallback;
+  }
+
+  isMocked() {
+    return this.isUsingMockIdleCallback;
+  }
+
+  runIdleCallbacks(timeRemaining: number = Infinity, didTimeout = false) {
+    this.ensureIdleCallbackIsMock();
+
+    // We need to do it this way so that frames that queue other frames
+    // don't get removed
+    Object.keys(this.queued).forEach((frame: any) => {
+      const callback = this.queued[frame];
+      delete this.queued[frame];
+      callback({timeRemaining: () => timeRemaining, didTimeout});
+    });
+  }
+
+  cancelIdleCallbacks() {
+    this.ensureIdleCallbackIsMock();
+
+    for (const id of Object.keys(this.queued)) {
+      this.cancelIdleCallback(id);
+    }
+  }
+
+  private requestIdleCallback = (
+    callback: IdleCallback,
+  ): ReturnType<WindowWithRequestIdleCallback['requestIdleCallback']> => {
+    this.currentIdleCallback += 1;
+    this.queued[this.currentIdleCallback] = callback;
+    return this.currentIdleCallback;
+  };
+
+  private cancelIdleCallback = (
+    callback: ReturnType<WindowWithRequestIdleCallback['requestIdleCallback']>,
+  ) => {
+    delete this.queued[callback];
+  };
+
+  private ensureIdleCallbackIsMock() {
+    if (!this.isUsingMockIdleCallback) {
+      throw new Error(
+        'You must call animationFrame.mock() before interacting with the mock request- or cancel- IdleCallback methods.',
+      );
+    }
+  }
+}

--- a/packages/react-async/README.md
+++ b/packages/react-async/README.md
@@ -101,7 +101,11 @@ const MyComponent = createAsyncComponent({
 
 By default, components are loaded as early as possible. This means that, if the library can load your component synchronously, it will try to do so. If that is not possible, it will instead load it in `componentDidMount`. In some cases, a component may not be important enough to warrant being loaded early. This library exposes a few ways of "deferring" the loading of the component to an appropriate time.
 
-If a component should always be deferred in some way, you can pass a custom `defer` option to `createAsyncComponent`. This property should be a member of the `DeferTiming` enum, which currently allows you to force deferring the component to either mount (`DeferTiming.Mount`) or until the browser is idle (`DeferTiming.Idle`; requires a polyfill for `window.requestIdleCallback`).
+If a component should always be deferred in some way, you can pass a custom `defer` option to `createAsyncComponent`. This property should be a member of the `DeferTiming` enum, which currently allows you to force deferring the component until:
+
+- Component mount (`DeferTiming.Mount`; this is the default)
+- Browser idle (`DeferTiming.Idle`; if `window.requestIdleCallback` is not available, it will load on mount), or
+- Component is in the viewport (`DeferTiming.InViewport`; if `IntersectionObserver` is not available, it will load on mount)
 
 ```tsx
 import {createAsyncComponent, DeferTiming} from '@shopify/react-async';
@@ -121,6 +125,13 @@ const MyComponentOnMount = createAsyncComponent({
 const MyComponentOnIdle = createAsyncComponent({
   load: () => import('./MyComponent'),
   defer: DeferTiming.Idle,
+});
+
+// Never load synchronously, always start load in when any part of
+// the component is intersecting the viewport
+const MyComponentOnIdle = createAsyncComponent({
+  load: () => import('./MyComponent'),
+  defer: DeferTiming.InViewport,
 });
 ```
 

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -27,6 +27,7 @@
     "@shopify/async": "^1.2.1",
     "@shopify/javascript-utilities": "^2.4.0",
     "@shopify/react-effect": "^2.1.0",
+    "@shopify/react-intersection-observer": "^1.0.0",
     "@shopify/useful-types": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/react-async/src/tests/Async.test.tsx
+++ b/packages/react-async/src/tests/Async.test.tsx
@@ -125,7 +125,7 @@ describe('<Async />', () => {
       expect(load).toHaveBeenCalled();
     });
 
-    it('loads the module in on viewport intersection when defer is DeferTiming.InViewport', () => {
+    it('loads the module on viewport intersection when defer is DeferTiming.InViewport', () => {
       const promise = createResolvablePromise({default: MockComponent});
       const load = jest.fn(() => promise.promise);
 
@@ -141,6 +141,7 @@ describe('<Async />', () => {
       expect(async.find(IntersectionObserver)).toHaveProp('threshold', 0);
 
       trigger(async.find(IntersectionObserver), 'onIntersecting');
+      expect(async.find(IntersectionObserver)).toHaveLength(0);
       expect(load).toHaveBeenCalled();
     });
   });

--- a/packages/react-async/src/tests/Async.test.tsx
+++ b/packages/react-async/src/tests/Async.test.tsx
@@ -125,7 +125,7 @@ describe('<Async />', () => {
       expect(load).toHaveBeenCalled();
     });
 
-    it('loads the module on viewport intersection when defer is DeferTiming.InViewport', () => {
+    it('loads the module on viewport intersection when defer is DeferTiming.InViewport', async () => {
       const promise = createResolvablePromise({default: MockComponent});
       const load = jest.fn(() => promise.promise);
 
@@ -140,7 +140,14 @@ describe('<Async />', () => {
       expect(load).not.toHaveBeenCalled();
       expect(async.find(IntersectionObserver)).toHaveProp('threshold', 0);
 
-      trigger(async.find(IntersectionObserver), 'onIntersecting');
+      const intersectingPromise = trigger(
+        async.find(IntersectionObserver),
+        'onIntersecting',
+      );
+
+      await promise.resolve();
+      await intersectingPromise;
+
       expect(async.find(IntersectionObserver)).toHaveLength(0);
       expect(load).toHaveBeenCalled();
     });

--- a/packages/react-import-remote/README.md
+++ b/packages/react-import-remote/README.md
@@ -80,4 +80,8 @@ Callback that gets called with the imported global
 
 **defer**
 
-A member of the `DeferTiming` enum (from `@shopify/async`) allowing the import request to occur either on mount (`DeferTiming.Mount`) or until the browser is idle (`DeferTiming.Idle`; requires a polyfill for `window.requestIdleCallback`).
+A member of the `DeferTiming` enum (from `@shopify/async`) allowing the import request to wait until:
+
+- Component mount (`DeferTiming.Mount`; this is the default)
+- Browser idle (`DeferTiming.Idle`; if `window.requestIdleCallback` is not available, it will load on mount), or
+- Component is in the viewport (`DeferTiming.InViewport`; if `IntersectionObserver` is not available, it will load on mount)

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-import-remote/README.md",
   "dependencies": {
     "@shopify/react-html": "^7.1.5",
+    "@shopify/react-intersection-observer": "^1.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -27,7 +27,7 @@ interface State {
 }
 
 export default class ImportRemote extends React.PureComponent<Props, State> {
-  state: State = {loaded: false, loading: true};
+  state: State = {loaded: false, loading: false};
   private idleCallbackHandle?: RequestIdleCallbackHandle;
 
   componentWillUnmount() {

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -5,6 +5,10 @@ import {
   WindowWithRequestIdleCallback,
   DeferTiming,
 } from '@shopify/async';
+import {
+  IntersectionObserver,
+  UnsupportedBehavior,
+} from '@shopify/react-intersection-observer';
 import load from './load';
 
 export interface Props<Imported = any> {
@@ -17,7 +21,12 @@ export interface Props<Imported = any> {
   defer?: DeferTiming;
 }
 
-export default class ImportRemote extends React.PureComponent<Props, never> {
+interface State {
+  loaded: boolean;
+}
+
+export default class ImportRemote extends React.PureComponent<Props, State> {
+  state: State = {loaded: false};
   private idleCallbackHandle?: RequestIdleCallbackHandle;
 
   componentWillUnmount() {
@@ -29,14 +38,17 @@ export default class ImportRemote extends React.PureComponent<Props, never> {
   }
 
   async componentDidMount() {
-    if (
-      this.props.defer === DeferTiming.Idle &&
-      'requestIdleCallback' in window
-    ) {
-      this.idleCallbackHandle = (window as WindowWithRequestIdleCallback).requestIdleCallback(
-        this.loadRemote,
-      );
-    } else {
+    const {defer = DeferTiming.Mount} = this.props;
+
+    if (defer === DeferTiming.Idle) {
+      if ('requestIdleCallback' in window) {
+        this.idleCallbackHandle = (window as WindowWithRequestIdleCallback).requestIdleCallback(
+          this.loadRemote,
+        );
+      } else {
+        this.loadRemote();
+      }
+    } else if (defer === DeferTiming.Mount) {
       await this.loadRemote();
     }
   }
@@ -50,24 +62,45 @@ export default class ImportRemote extends React.PureComponent<Props, never> {
   }
 
   render() {
-    const {source, preconnect} = this.props;
+    const {loaded} = this.state;
+    const {source, preconnect, defer} = this.props;
+
+    const intersectionObserver =
+      !loaded && defer === DeferTiming.InViewport ? (
+        <IntersectionObserver
+          threshold={0}
+          unsupportedBehavior={UnsupportedBehavior.TreatAsIntersecting}
+          onIntersecting={this.loadRemote}
+        />
+      ) : null;
 
     if (preconnect) {
       const url = new URL(source);
-      return <Preconnect source={url.origin} />;
+      return (
+        <>
+          <Preconnect source={url.origin} />
+          {intersectionObserver}
+        </>
+      );
     }
 
-    return null;
+    return intersectionObserver;
   }
 
-  async loadRemote() {
-    const {source, nonce = '', getImport, onError, onImported} = this.props;
+  private loadRemote = () => {
+    return new Promise(resolve => {
+      this.setState({loaded: false}, async () => {
+        const {source, nonce = '', getImport, onError, onImported} = this.props;
 
-    try {
-      const imported = await load(source, getImport, nonce);
-      onImported(imported);
-    } catch (error) {
-      onError(error);
-    }
-  }
+        try {
+          const imported = await load(source, getImport, nonce);
+          onImported(imported);
+        } catch (error) {
+          onError(error);
+        } finally {
+          this.setState({loaded: true}, resolve);
+        }
+      });
+    });
+  };
 }

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -23,10 +23,11 @@ export interface Props<Imported = any> {
 
 interface State {
   loaded: boolean;
+  loading: boolean;
 }
 
 export default class ImportRemote extends React.PureComponent<Props, State> {
-  state: State = {loaded: false};
+  state: State = {loaded: false, loading: true};
   private idleCallbackHandle?: RequestIdleCallbackHandle;
 
   componentWillUnmount() {
@@ -62,11 +63,11 @@ export default class ImportRemote extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {loaded} = this.state;
+    const {loaded, loading} = this.state;
     const {source, preconnect, defer} = this.props;
 
     const intersectionObserver =
-      !loaded && defer === DeferTiming.InViewport ? (
+      !loaded && !loading && defer === DeferTiming.InViewport ? (
         <IntersectionObserver
           threshold={0}
           unsupportedBehavior={UnsupportedBehavior.TreatAsIntersecting}
@@ -89,7 +90,7 @@ export default class ImportRemote extends React.PureComponent<Props, State> {
 
   private loadRemote = () => {
     return new Promise(resolve => {
-      this.setState({loaded: false}, async () => {
+      this.setState({loaded: false, loading: true}, async () => {
         const {source, nonce = '', getImport, onError, onImported} = this.props;
 
         try {
@@ -98,7 +99,7 @@ export default class ImportRemote extends React.PureComponent<Props, State> {
         } catch (error) {
           onError(error);
         } finally {
-          this.setState({loaded: true}, resolve);
+          this.setState({loaded: true, loading: false}, resolve);
         }
       });
     });

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -1,12 +1,23 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
 import {Preconnect} from '@shopify/react-html';
+import {DeferTiming} from '@shopify/async';
+import {IntersectionObserver} from '@shopify/react-intersection-observer';
 import {noop} from '@shopify/javascript-utilities/other';
+import {requestIdleCallback} from '@shopify/jest-dom-mocks';
+import {trigger} from '@shopify/enzyme-utilities';
 
 import ImportRemote, {Props} from '../ImportRemote';
 
 jest.mock('@shopify/react-html', () => ({
   Preconnect() {
+    return null;
+  },
+}));
+
+jest.mock('@shopify/react-intersection-observer', () => ({
+  ...require.requireActual('@shopify/react-intersection-observer'),
+  IntersectionObserver() {
     return null;
   },
 }));
@@ -17,7 +28,12 @@ const load: jest.Mock = require.requireMock('../load');
 
 describe('<ImportRemote />', () => {
   beforeEach(() => {
+    requestIdleCallback.mock();
     load.mockClear();
+  });
+
+  afterEach(() => {
+    requestIdleCallback.restore();
   });
 
   const mockProps: Props = {
@@ -130,6 +146,30 @@ describe('<ImportRemote />', () => {
       expect(importRemote.find(Preconnect).prop('source')).toBe(
         new URL(mockProps.source).origin,
       );
+    });
+  });
+
+  describe('defer', () => {
+    it('does not call load until idle when defer is DeferTiming.Idle', () => {
+      mount(<ImportRemote {...mockProps} defer={DeferTiming.Idle} />);
+      expect(load).not.toHaveBeenCalled();
+      requestIdleCallback.runIdleCallbacks();
+      expect(load).toHaveBeenCalled();
+    });
+
+    it('does not call load until the IntersectionObserver’s onIntersecting when defer is DeferTiming.InViewport', () => {
+      const importRemote = mount(
+        <ImportRemote {...mockProps} defer={DeferTiming.InViewport} />,
+      );
+      expect(load).not.toHaveBeenCalled();
+
+      expect(importRemote.find(IntersectionObserver)).toHaveProp(
+        'threshold',
+        0,
+      );
+
+      trigger(importRemote.find(IntersectionObserver), 'onIntersecting');
+      expect(load).toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -157,7 +157,7 @@ describe('<ImportRemote />', () => {
       expect(load).toHaveBeenCalled();
     });
 
-    it('does not call load until the IntersectionObserver’s onIntersecting when defer is DeferTiming.InViewport', () => {
+    it('does not call load until the IntersectionObserver’s onIntersecting when defer is DeferTiming.InViewport', async () => {
       const importRemote = mount(
         <ImportRemote {...mockProps} defer={DeferTiming.InViewport} />,
       );
@@ -168,7 +168,8 @@ describe('<ImportRemote />', () => {
         0,
       );
 
-      trigger(importRemote.find(IntersectionObserver), 'onIntersecting');
+      await trigger(importRemote.find(IntersectionObserver), 'onIntersecting');
+      expect(importRemote.find(IntersectionObserver)).toHaveLength(0);
       expect(load).toHaveBeenCalled();
     });
   });

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -50,11 +50,7 @@ export default class IntersectionObserverDom extends React.Component<Props> {
 
   render() {
     const {wrapperComponent: Wrapper = 'div' as any, children} = this.props;
-    return (
-      <Wrapper style={{display: 'contents'}} ref={this.observed}>
-        {children}
-      </Wrapper>
-    );
+    return <Wrapper ref={this.observed}>{children}</Wrapper>;
   }
 
   private disconnect() {

--- a/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
+++ b/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
@@ -26,22 +26,19 @@ describe('<IntersectionObserver />', () => {
   });
 
   describe('wrapperComponent', () => {
-    it('uses a div with display: contents by default', () => {
+    it('uses a div by default', () => {
       const intersectionObserver = mount(<IntersectionObserver />);
       const child = intersectionObserver.childAt(0);
       expect(child.type()).toBe('div');
-      expect(child.prop('style')).toMatchObject({display: 'contents'});
     });
 
-    it('uses a custom element with display: contents by default', () => {
+    it('uses a custom element', () => {
       const wrapperComponent = 'span';
       const intersectionObserver = mount(
         <IntersectionObserver wrapperComponent={wrapperComponent} />,
       );
       const child = intersectionObserver.childAt(0);
-
       expect(child.type()).toBe(wrapperComponent);
-      expect(child.prop('style')).toMatchObject({display: 'contents'});
     });
 
     it('attaches the observer to the top-level node', () => {


### PR DESCRIPTION
This PR adds a couple consumers for the new `IntersectionObserver` component. I added `DeferTiming.InViewport`, which meant that it was natural to add "only load in viewport" to `react-async` and `react-import-remote`. While adding tests, I noticed that we didn't actually test the "load on idle" bits, so I added a mock for `requestIdleCallback` as well.