### PR TITLE
Support unexpected usage of decimal symbols

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] - -->
 
+## [0.11.2] - 2019-03-19
+
+### Fixed
+
+- Support unexpected usage of decimal symbols in `I18n#unformatCurrency` [#577](https://github.com/Shopify/quilt/pull/577)
+
 ## [0.11.1] - 2019-03-08
 
 ### Fixed

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -191,8 +191,8 @@ export default class I18n {
     // and expect it to be treated as the decimal symbol for their locale.
     const hasExpectedDecimalSymbol = input.lastIndexOf(expectedDecimal) !== -1;
     const hasPeriodAsDecimal = input.lastIndexOf(PERIOD) !== -1;
-    const usePeriodDecimal = !hasExpectedDecimalSymbol && hasPeriodAsDecimal;
-    const decimalSymbolToUse = usePeriodDecimal ? PERIOD : expectedDecimal;
+    const usesPeriodDecimal = !hasExpectedDecimalSymbol && hasPeriodAsDecimal;
+    const decimalSymbolToUse = usesPeriodDecimal ? PERIOD : expectedDecimal;
     const lastDecimalIndex = input.lastIndexOf(decimalSymbolToUse);
 
     const integerValue = input

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -184,9 +184,16 @@ export default class I18n {
     // This decimal symbol will always be '.' regardless of the locale
     // since it's our internal representation of the string
     const symbol = this.decimalSymbol(currencyCode);
-    const decimal = symbol === DECIMAL_NOT_SUPPORTED ? '.' : symbol;
+    const expectedDecimal = symbol === DECIMAL_NOT_SUPPORTED ? '.' : symbol;
 
-    const lastDecimalIndex = input.lastIndexOf(decimal);
+    // For locales that use non-period symbols as the decimal symbol, users may still input a period
+    // and expect it to be treated as the decimal symbol for their locale.
+    const usesExpectedDecimalSymbol = input.lastIndexOf(expectedDecimal) !== -1;
+    const usesPeriodAsDecimal = input.lastIndexOf('.') !== -1;
+    const usePeriodDecimal = !usesExpectedDecimalSymbol && usesPeriodAsDecimal;
+    const decimalToUse = usePeriodDecimal ? '.' : expectedDecimal;
+    const lastDecimalIndex = input.lastIndexOf(decimalToUse);
+
     const integerValue = input
       .substring(0, lastDecimalIndex)
       .replace(nonDigits, '');

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -39,6 +39,7 @@ export interface TranslateOptions {
 
 // Used for currecies that don't use fractional units (eg. JPY)
 const DECIMAL_NOT_SUPPORTED = 'N/A';
+const PERIOD = '.';
 const DECIMAL_VALUE_FOR_CURRENCIES_WITHOUT_DECIMALS = '00';
 
 export default class I18n {
@@ -184,15 +185,15 @@ export default class I18n {
     // This decimal symbol will always be '.' regardless of the locale
     // since it's our internal representation of the string
     const symbol = this.decimalSymbol(currencyCode);
-    const expectedDecimal = symbol === DECIMAL_NOT_SUPPORTED ? '.' : symbol;
+    const expectedDecimal = symbol === DECIMAL_NOT_SUPPORTED ? PERIOD : symbol;
 
     // For locales that use non-period symbols as the decimal symbol, users may still input a period
     // and expect it to be treated as the decimal symbol for their locale.
-    const usesExpectedDecimalSymbol = input.lastIndexOf(expectedDecimal) !== -1;
-    const usesPeriodAsDecimal = input.lastIndexOf('.') !== -1;
-    const usePeriodDecimal = !usesExpectedDecimalSymbol && usesPeriodAsDecimal;
-    const decimalToUse = usePeriodDecimal ? '.' : expectedDecimal;
-    const lastDecimalIndex = input.lastIndexOf(decimalToUse);
+    const hasExpectedDecimalSymbol = input.lastIndexOf(expectedDecimal) !== -1;
+    const hasPeriodAsDecimal = input.lastIndexOf(PERIOD) !== -1;
+    const usePeriodDecimal = !hasExpectedDecimalSymbol && hasPeriodAsDecimal;
+    const decimalSymbolToUse = usePeriodDecimal ? PERIOD : expectedDecimal;
+    const lastDecimalIndex = input.lastIndexOf(decimalSymbolToUse);
 
     const integerValue = input
       .substring(0, lastDecimalIndex)
@@ -201,9 +202,9 @@ export default class I18n {
       .substring(lastDecimalIndex + 1)
       .replace(nonDigits, '');
 
-    const normalizedDecimal = lastDecimalIndex === -1 ? '' : '.';
+    const normalizedDecimal = lastDecimalIndex === -1 ? '' : PERIOD;
     const normalizedValue = `${integerValue}${normalizedDecimal}${decimalValue}`;
-    const invalidValue = normalizedValue === '' || normalizedValue === '.';
+    const invalidValue = normalizedValue === '' || normalizedValue === PERIOD;
 
     if (symbol === DECIMAL_NOT_SUPPORTED) {
       const roundedAmount = parseFloat(normalizedValue).toFixed(0);

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -581,7 +581,7 @@ describe('I18n', () => {
             ...defaultDetails,
             locale: 'fr',
           });
-          expect(i18n.unformatCurrency('1 234,50', 'CAD')).toBe('1234.50');
+          expect(i18n.unformatCurrency('1 234,50', 'USD')).toBe('1234.50');
         });
 
         it('treats . as the decimal symbol if , is not used as a decimal symbol', () => {
@@ -595,7 +595,36 @@ describe('I18n', () => {
             ...defaultDetails,
             locale: 'fr',
           });
-          expect(i18n.unformatCurrency('1234.50', 'CAD')).toBe('1234.50');
+          expect(i18n.unformatCurrency('1234.50', 'USD')).toBe('1234.50');
+        });
+      });
+      describe('it locale', () => {
+        it('treats , as the decimal symbol', () => {
+          formatCurrency.mockImplementationOnce(() => '1,00 $');
+          getCurrencySymbol.mockReturnValue({
+            symbol: '$',
+            prefixed: false,
+          });
+
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'it',
+          });
+          expect(i18n.unformatCurrency('1.234,50', 'USD')).toBe('1234.50');
+        });
+
+        it('treats . as the decimal symbol if , is not used as a decimal symbol', () => {
+          formatCurrency.mockImplementationOnce(() => '1,00 $');
+          getCurrencySymbol.mockReturnValue({
+            symbol: '$',
+            prefixed: false,
+          });
+
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'it',
+          });
+          expect(i18n.unformatCurrency('1234.50', 'USD')).toBe('1234.50');
         });
       });
     });

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -568,6 +568,36 @@ describe('I18n', () => {
         });
         expect(i18n.unformatCurrency('1,233.45', 'EUR')).toBe('1233.45');
       });
+
+      describe('fr locale', () => {
+        it('treats , as the decimal symbol', () => {
+          formatCurrency.mockImplementationOnce(() => '1,00 $');
+          getCurrencySymbol.mockReturnValue({
+            symbol: '$',
+            prefixed: false,
+          });
+
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'fr',
+          });
+          expect(i18n.unformatCurrency('1 234,50', 'CAD')).toBe('1234.50');
+        });
+
+        it('treats . as the decimal symbol if , is not used as a decimal symbol', () => {
+          formatCurrency.mockImplementationOnce(() => '1,00 $');
+          getCurrencySymbol.mockReturnValue({
+            symbol: '$',
+            prefixed: false,
+          });
+
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'fr',
+          });
+          expect(i18n.unformatCurrency('1234.50', 'CAD')).toBe('1234.50');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This PR improves `i18n.unformatCurrency` to handle the usage of `.` as the decimal symbol for locales where the `.` is not actually the expected decimal symbol. This is because users may input numbers with a `.` as the decimal symbol and expect to to work even though the formatted version of the input yields `,` as the decimal symbol. A good example of this is the `fr` locale. 

As per a conversation with @Korri, we should support this workflow for users. 
 
> Although some poeple might still use a `.` in France instead of a `,`
> I know some bank interface that allow `.`, some others that don’t (in Québec)


Related to https://github.com/Shopify/web/issues/10999
cc/ @loic-d 