### PR TITLE
Fix @shopify/react-i18n changelog

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] - -->
 
-## [0.11.2] - 2019-03-19
+## [0.11.3] - 2019-03-19
 
 ### Fixed
 


### PR DESCRIPTION
There was a `0.11.2` release that was not documented in the changelog. This PR adds that release in.  