### PR TITLE
🐛 check success via valid webhookSubscription field

### DIFF
--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Check success via valid webhookSubscription field
 
 ## [1.1.3] - 2019-03-22
 

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -1,4 +1,4 @@
-import {Method, StatusCode, Header} from '@shopify/network';
+import {Method, Header} from '@shopify/network';
 import {WebhookHeader, Topic} from './types';
 
 export interface Options {
@@ -23,15 +23,15 @@ export async function registerWebhook({
     },
   });
 
-  const data = await response.json();
+  const result = await response.json();
 
   if (
-    response.status === StatusCode.Created ||
-    response.status === StatusCode.Ok
+    result.data &&
+    result.data.webhookSubscriptionCreate.webhookSubscription
   ) {
-    return {success: true, data};
+    return {success: true, result};
   } else {
-    return {success: false, data};
+    return {success: false, result};
   }
 }
 

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -27,6 +27,7 @@ export async function registerWebhook({
 
   if (
     result.data &&
+    result.data.webhookSubscriptionCreate &&
     result.data.webhookSubscriptionCreate.webhookSubscription
   ) {
     return {success: true, result};

--- a/packages/koa-shopify-webhooks/src/test/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/register.test.ts
@@ -1,10 +1,17 @@
-import {StatusCode, Header} from '@shopify/network';
+import {Header} from '@shopify/network';
 import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
 
 import {registerWebhook, Options, WebhookHeader} from '..';
 
-const successResponse = {status: StatusCode.Created, body: {foo: 'bar'}};
-const failResponse = {status: StatusCode.UnprocessableEntity, body: {}};
+const successResponse = {
+  data: {
+    webhookSubscriptionCreate: {
+      userErrors: [],
+      webhookSubscription: {id: 'gid://shopify/WebhookSubscription/12345'},
+    },
+  },
+};
+const failResponse = {data: {}};
 
 describe('registerWebhook', () => {
   afterEach(async () => {
@@ -48,7 +55,7 @@ describe('registerWebhook', () => {
     });
   });
 
-  it('returns a result with success set to true when the server returns a status of Created', async () => {
+  it('returns a result with success set to true when the server returns a webhookSubscription field', async () => {
     fetchMock.mock('*', successResponse);
     const webhook: Options = {
       address: 'myapp.com/webhooks',
@@ -62,8 +69,7 @@ describe('registerWebhook', () => {
   });
 
   it('returns the parsed response body on result.data', async () => {
-    const data = {foo: 'bar', baz: true};
-    fetchMock.mock('*', {...successResponse, body: data});
+    fetchMock.mock('*', failResponse);
     const webhook: Options = {
       address: 'myapp.com/webhooks',
       topic: 'PRODUCTS_CREATE',
@@ -71,11 +77,11 @@ describe('registerWebhook', () => {
       shop: 'shop1.myshopify.io',
     };
 
-    const result = await registerWebhook(webhook);
-    expect(result.data).toMatchObject(data);
+    const registerResponse = await registerWebhook(webhook);
+    expect(registerResponse.result.data).toMatchObject({});
   });
 
-  it('returns a result with success set to true when the server returns a status of Created', async () => {
+  it('returns a result with success set to true when the server returns a webhookSubscription field', async () => {
     fetchMock.mock('*', successResponse);
     const webhook: Options = {
       address: 'myapp.com/webhooks',
@@ -88,7 +94,7 @@ describe('registerWebhook', () => {
     expect(result.success).toBe(true);
   });
 
-  it('returns a result with success set to false when the server returns a bad status', async () => {
+  it('returns a result with success set to false when the server doesn’t return a webhookSubscriptionCreate field', async () => {
     fetchMock.mock('*', failResponse);
     const webhook: Options = {
       address: 'myapp.com/webhooks',


### PR DESCRIPTION
The package was returning successful with invalid topics and missing permissions. By checking for `result.data && result.data.webhookSubscriptionCreate.webhookSubscription` the package can now catch these errors.



