### PR TITLE
🐛 return a GraphQL formatted topic

### DIFF
--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Return a GraphQL formatted topic
 
 ## [1.1.2]
 

--- a/packages/koa-shopify-webhooks/src/receive.ts
+++ b/packages/koa-shopify-webhooks/src/receive.ts
@@ -38,11 +38,13 @@ export function receiveWebhook({
       .update(rawBody, 'utf8')
       .digest('base64');
 
+    const graphqlTopic = topic.toUpperCase().replace(/\//g, '_');
+
     if (safeCompare(generatedHash, hmac)) {
       ctx.res.statusCode = StatusCode.Accepted;
 
       ctx.state.webhook = {
-        topic: topic as Topic,
+        topic: graphqlTopic as Topic,
         domain,
       };
 

--- a/packages/koa-shopify-webhooks/src/test/receive.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/receive.test.ts
@@ -66,7 +66,27 @@ describe('receiveWebhook', () => {
       expect(onReceived).toBeCalledWith(context);
     });
 
-    it('adds webhook data to state', async () => {
+    it('transforms webhook topic and adds to state', async () => {
+      const onReceived = jest.fn();
+      const middleware = receiveWebhook({secret, onReceived});
+
+      const context = createMockContext({
+        rawBody,
+        headers: headers({
+          hmac: hmac(secret, rawBody),
+          topic: 'foo/bar/baz',
+          domain: 'cool-store.com',
+        }),
+      });
+
+      await middleware(context, noop);
+
+      expect(context.state.webhook).toMatchObject({
+        topic: 'FOO_BAR_BAZ',
+      });
+    });
+
+    it('adds webhook domain to state', async () => {
       const onReceived = jest.fn();
       const middleware = receiveWebhook({secret, onReceived});
 
@@ -82,7 +102,6 @@ describe('receiveWebhook', () => {
       await middleware(context, noop);
 
       expect(context.state.webhook).toMatchObject({
-        topic: 'foo',
         domain: 'cool-store.com',
       });
     });


### PR DESCRIPTION
From my understanding the `WebhookHeader` doesn't know if we're getting a response from REST or GraphQL, and by default it returns a REST formatted response.

<img width="343" alt="Screen Shot 2019-03-19 at 11 12 14 AM" src="https://user-images.githubusercontent.com/3484321/54618093-d09bb480-4a38-11e9-8142-28010ff3a96d.png">

since we're now using GraphQL in the package it's clearer to show a GraphQL formatted topic

<img width="326" alt="Screen Shot 2019-03-19 at 11 11 57 AM" src="https://user-images.githubusercontent.com/3484321/54618159-ee691980-4a38-11e9-9b4b-abff3ae14357.png">

However, I have a feeling there can be a much better implementation then what I provided here. 