### PR TITLE
[Performance] Memoize Intl.DateTimeFormat & Int.NumberFormat

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] - -->
+## [Unreleased]
+
+- Memoize `Intl.DateTimeFormat` and `Intl.NumberFormat` [#596](https://github.com/Shopify/quilt/pull/596)
 
 ## [0.11.5] - 2019-03-22
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -305,6 +305,36 @@ describe('I18n', () => {
       expect(i18n.formatNumber(0.12345, options)).toBe(expected);
     });
 
+    it('updates format on multiple calls', () => {
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      const options: Partial<Intl.NumberFormatOptions> = {
+        currencyDisplay: 'code',
+        minimumIntegerDigits: 1,
+        maximumFractionDigits: 1,
+      };
+
+      const expected = new Intl.NumberFormat(
+        defaultDetails.locale,
+        options,
+      ).format(0.12345);
+
+      expect(i18n.formatNumber(0.12345, options)).toBe(expected);
+
+      const newOptions: Partial<Intl.NumberFormatOptions> = {
+        currencyDisplay: 'symbol',
+        minimumIntegerDigits: 1,
+        maximumFractionDigits: 1,
+      };
+      const expectedWithNewOptions = new Intl.NumberFormat(
+        defaultDetails.locale,
+        newOptions,
+      ).format(0.12345);
+
+      expect(i18n.formatNumber(0.12345, newOptions)).toBe(
+        expectedWithNewOptions,
+      );
+    });
+
     describe('currency', () => {
       const currency = 'USD';
 
@@ -827,6 +857,38 @@ describe('I18n', () => {
       });
 
       expect(i18n.formatDate(date, {style: DateStyle.Time})).toBe('11:00 AM');
+    });
+
+    it('updates format on multiple calls', () => {
+      const date = new Date('2012-12-20T00:00:00-00:00');
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        timezone: defaultTimezone,
+      });
+
+      const expected = new Intl.DateTimeFormat(defaultDetails.locale, {
+        timeZone: defaultTimezone,
+      }).format(date);
+
+      expect(
+        i18n.formatDate(date, {
+          timeZone: defaultTimezone,
+        }),
+      ).toBe(expected);
+
+      const newTimezone = 'Asia/Shanghai';
+      const expectedWithNewTimezone = new Intl.DateTimeFormat(
+        defaultDetails.locale,
+        {
+          timeZone: newTimezone,
+        },
+      ).format(date);
+
+      expect(
+        i18n.formatDate(date, {
+          timeZone: newTimezone,
+        }),
+      ).toBe(expectedWithNewTimezone);
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/Shopify/marketing-technology/issues/4130

We recently made some updates to the StartEndDates component to make it render much faster. PR for that https://github.com/Shopify/web/pull/11956. One of the big performance hits was creating a new `Int.DateTimeFormat` instance every time we were going to format instead of just referencing the same instance and calling the `.format` method.

I ran some tests here: https://jsperf.com/intl-datetimeformat-instantiation-vs-reference-same-one and it's significantly faster to reference the same instance.

I feel like a lot of parts in Shopify will use the same locale and same options for formatting when using the i18n library. Memoizing this is a good idea so that we can reference the same instance.