### PR TITLE
Fix is numeric string regex

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.9.1]
+
+### Changed
+
+- `isNumeric` function ReGex now matches for negative numbers. This impacts users of `isNumericString` validator function relying on its previous behaviour of only allowing positive numbers. To reintroduce that behaviour please use `isPostiveNumericString`
+
 ## [0.9.0]
 
 ### Removed

--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -265,6 +265,25 @@ describe('validation helpers', () => {
       });
     });
 
+    describe('positiveNumericString', () => {
+      const error = faker.lorem.word();
+
+      it('returns a function that returns undefined when the input is a positive numeric string', () => {
+        const validator = validators.positiveNumericString(error);
+        expect(validator('2')).toBeUndefined();
+      });
+
+      it('returns a function that returns errorContent when the input is a non-numeric string', () => {
+        const validator = validators.positiveNumericString(error);
+        expect(validator(faker.lorem.words())).toBe(error);
+      });
+
+      it('returns a function that returns errorContent when the input is a negative numeric string', () => {
+        const validator = validators.positiveNumericString(error);
+        expect(validator('-2')).toBe(error);
+      });
+    });
+
     describe('numericString', () => {
       const error = faker.lorem.word();
 
@@ -290,6 +309,11 @@ describe('validation helpers', () => {
       it('returns a function that returns undefined when the input is a numeric string', () => {
         const validator = validators.numericString(error);
         expect(validator('2')).toBeUndefined();
+      });
+
+      it('returns a function that returns undefined when the input is a negative numeric string', () => {
+        const validator = validators.numericString(error);
+        expect(validator('-2')).toBeUndefined();
       });
     });
 

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -19,7 +19,7 @@ export function lengthLessThan(length: number) {
 }
 
 export function isNumericString(input: string) {
-  return input !== '' && (input.match(/[^0-9.,]/g) || []).length === 0;
+  return input !== '' && (input.match(/[^0-9.,-]/g) || []).length === 0;
 }
 
 export function isEmpty(input: any) {

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -18,6 +18,10 @@ export function lengthLessThan(length: number) {
   return (input: {length: number}) => input.length < length;
 }
 
+export function isPositiveNumericString(input: string) {
+  return input !== '' && (input.match(/[^0-9.,]/g) || []).length === 0;
+}
+
 export function isNumericString(input: string) {
   return input !== '' && (input.match(/[^0-9.,-]/g) || []).length === 0;
 }
@@ -161,6 +165,10 @@ const validators = {
   },
 
   numericString(errorContent: ErrorContent) {
+    return validate(isNumericString, errorContent);
+  },
+
+  positiveNumericString(errorContent: ErrorContent) {
     return validate(isNumericString, errorContent);
   },
 

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -169,7 +169,7 @@ const validators = {
   },
 
   positiveNumericString(errorContent: ErrorContent) {
-    return validate(isNumericString, errorContent);
+    return validate(isPositiveNumericString, errorContent);
   },
 
   nonNumericString(errorContent: ErrorContent) {


### PR DESCRIPTION
It is confusing that the regex is checking for only positive numbers, while the method name is "isNumericString"

Changes included in this pr: 

- Adds a `isPositiveNumericString` function and `positiveNumericString` validator that specifically checks for positive numeric strings. 
 > If `numericString` validator was used to only accept positive numeric values purpose, then this method can be used to reintroduce expected behaviour. 
- Add `-` as valid character in `isNumericValue` function's regex check

