### PR TITLE
[FormState] Pass lastSubmitErrors to render prop

### DIFF
--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -396,6 +396,8 @@ function MyComponent() {
 }
 ```
 
+In addition to being propagated down to their respective `fields`, these client-side validation errors can be accessed together at the top level via the `errors` array, in the same way as your remote errors (returned from `onSubmit`) and external errors (see below).
+
 To learn more about building validators, and the built in functions exposed by this package, check out the [validators guide](validators.md).
 
 ## External errors

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -50,3 +50,13 @@ export function set<InputType extends Object>(
     } as InputType;
   }
 }
+
+export function flatMap<T>(
+  array: any[],
+  mapper: (item: any, index?: number) => T | T[],
+): T[] {
+  return array.reduce(
+    (acc, item, index) => acc.concat(mapper(item, index)),
+    [],
+  );
+}


### PR DESCRIPTION
### What is this PR doing?

This PR adds client-side submission errors into the `errors` array passed to the render prop.

When users try to submit a form with `FormState` and `validateOnSubmit` is set to `true`, the validators will run on the form and block a call to `onSubmit` if any errors arise.

These errors are then surfaced in `errors`, in the same way remote and external errors are.

This is helpful in cases where specific UI (such as `ErrorBanner`) may need to be updated on submit attempts, but not on field changes. (e.g. [here](https://github.com/Shopify/web/issues/11901) and [here](https://github.com/Shopify/web/issues/12060))