### PR TITLE
Upgrade to typescript 3.2.1 and fix react-compose static fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,11 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^23.10.4",
     "tslib": "^1.9.3",
+<<<<<<< HEAD
     "typescript": "~3.1.6"
+=======
+    "typescript": "~3.2.1"
+>>>>>>> Upgrade to typescript 3.2.1 and fix react-compose static fields
   },
   "dependencies": {},
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -61,11 +61,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^23.10.4",
     "tslib": "^1.9.3",
-<<<<<<< HEAD
-    "typescript": "~3.1.6"
-=======
     "typescript": "~3.2.1"
->>>>>>> Upgrade to typescript 3.2.1 and fix react-compose static fields
   },
   "dependencies": {},
   "resolutions": {

--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@shopify/address": "^2.6.8",
     "@shopify/jest-dom-mocks": "^2.5.2",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@shopify/address-mocks": "^1.2.8",
     "@shopify/jest-dom-mocks": "^2.5.2",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/admin-graphql-api-utilities/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -30,7 +30,7 @@
     "@types/babel__core": "^7.0.4",
     "@types/babel__traverse": "^7.0.5",
     "@types/webpack": "^4.4.24",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*",

--- a/packages/csrf-token-fetcher/package.json
+++ b/packages/csrf-token-fetcher/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/csrf-token-fetcher/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.5.2",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/decorators/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -28,7 +28,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "peerDependencies": {

--- a/packages/function-enhancers/package.json
+++ b/packages/function-enhancers/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/function-enhancers/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -33,7 +33,7 @@
     "@shopify/useful-types": "^1.2.3",
     "@types/graphql": "^14.0.0",
     "graphql-typed": "^0.4.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/i18n/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -32,7 +32,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/express": "^4.11.1",
     "@types/koa": "^2.0.44",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -33,7 +33,7 @@
     "react": "^16.8.1",
     "react-apollo": "^2.2.3",
     "react-dom": "^16.8.1",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.3.6",

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -27,7 +27,7 @@
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-router": "^3.2.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "greenkeeper": {
     "ignore": [

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -28,7 +28,7 @@
     "@types/koa-mount": "^3.0.1",
     "koa": "^2.5.0",
     "koa-mount": "^3.0.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -31,7 +31,7 @@
     "@shopify/with-env": "^1.0.10",
     "@types/koa": "^2.0.44",
     "koa": "^2.5.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -33,7 +33,7 @@
     "@types/koa": "^2.0.44",
     "@types/safe-compare": "^1.1.0",
     "koa": "^2.5.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -27,7 +27,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/koa-shopify-webhooks/package.json
+++ b/packages/koa-shopify-webhooks/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/koa-bodyparser": "^4.2.1",
     "@types/koa-compose": "^3.2.2",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,7 +29,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/network/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/performance/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/caniuse-api": "^3.0.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "*.js",

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -31,7 +31,7 @@
     "@shopify/useful-types": "^1.2.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-compose-enhancers/README.md",
   "dependencies": {
+    "@shopify/useful-types": "^1.2.3",
     "hoist-non-react-statics": "^3.0.1",
     "tslib": "^1.9.3"
   },

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.10",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/react-compose/src/index.ts
+++ b/packages/react-compose/src/index.ts
@@ -4,6 +4,11 @@ import hoistStatics from 'hoist-non-react-statics';
 export type ReactComponent<P> = React.ComponentType<P>;
 export type ComponentClass = React.ComponentClass<any>;
 
+export type StaticFields<Object> = {
+  [Key in keyof Object]: Key extends 'prototype' ? never : Key
+}[keyof Object];
+export type Statics<Object> = Pick<Object, StaticFields<Object>>;
+
 export type WrappingFunction = (
   Component: ReactComponent<any>,
 ) => ReactComponent<any>;
@@ -13,7 +18,7 @@ export default function compose<Props>(
 ) {
   return function wrapComponent<ComposedProps, C>(
     OriginalComponent: ReactComponent<ComposedProps> & C,
-  ): ReactComponent<Props> & C {
+  ): ReactComponent<Props> & Statics<typeof OriginalComponent> {
     const result: ReactComponent<ComposedProps> = wrappingFunctions.reduceRight(
       (component: ReactComponent<any>, wrappingFunction: WrappingFunction) =>
         wrappingFunction(component),
@@ -23,6 +28,6 @@ export default function compose<Props>(
     return hoistStatics(
       result as ComponentClass,
       OriginalComponent as ComponentClass,
-    ) as ReactComponent<Props> & C;
+    ) as ReactComponent<Props> & Statics<typeof OriginalComponent>;
   };
 }

--- a/packages/react-compose/src/index.ts
+++ b/packages/react-compose/src/index.ts
@@ -4,7 +4,7 @@ import hoistStatics from 'hoist-non-react-statics';
 export type ReactComponent<P> = React.ComponentType<P>;
 export type ComponentClass = React.ComponentClass<any>;
 
-export type StaticFields<Object> = {
+type StaticFields<Object> = {
   [Key in keyof Object]: Key extends 'prototype' ? never : Key
 }[keyof Object];
 export type Statics<Object> = Pick<Object, StaticFields<Object>>;

--- a/packages/react-compose/src/index.ts
+++ b/packages/react-compose/src/index.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
-import {NonReactStatics} from 'packages/useful-types/src';
+import {NonReactStatics} from '@shopify/useful-types';
 
 export type ReactComponent<P> = React.ComponentType<P>;
 export type ComponentClass = React.ComponentClass<any>;

--- a/packages/react-compose/src/index.ts
+++ b/packages/react-compose/src/index.ts
@@ -1,13 +1,9 @@
 import * as React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
+import {NonReactStatics} from 'packages/useful-types/src';
 
 export type ReactComponent<P> = React.ComponentType<P>;
 export type ComponentClass = React.ComponentClass<any>;
-
-type StaticFields<Object> = {
-  [Key in keyof Object]: Key extends 'prototype' ? never : Key
-}[keyof Object];
-export type Statics<Object> = Pick<Object, StaticFields<Object>>;
 
 export type WrappingFunction = (
   Component: ReactComponent<any>,
@@ -18,7 +14,7 @@ export default function compose<Props>(
 ) {
   return function wrapComponent<ComposedProps, C>(
     OriginalComponent: ReactComponent<ComposedProps> & C,
-  ): ReactComponent<Props> & Statics<typeof OriginalComponent> {
+  ): ReactComponent<Props> & NonReactStatics<typeof OriginalComponent> {
     const result: ReactComponent<ComposedProps> = wrappingFunctions.reduceRight(
       (component: ReactComponent<any>, wrappingFunction: WrappingFunction) =>
         wrappingFunction(component),
@@ -28,6 +24,6 @@ export default function compose<Props>(
     return hoistStatics(
       result as ComponentClass,
       OriginalComponent as ComponentClass,
-    ) as ReactComponent<Props> & Statics<typeof OriginalComponent>;
+    ) as ReactComponent<Props> & NonReactStatics<typeof OriginalComponent>;
   };
 }

--- a/packages/react-compose/src/test/compose.test.tsx
+++ b/packages/react-compose/src/test/compose.test.tsx
@@ -117,7 +117,8 @@ interface Props {
 type ComposedProps = FooProps & BarProps & Props;
 
 class ClassicalComponent extends React.Component<ComposedProps, never> {
-  private static someStatic = 'some static';
+  // eslint-disable-next-line shopify/react-prefer-private-members
+  static someStatic = 'some static';
 
   render() {
     return <div>classical component</div>;

--- a/packages/react-effect-apollo/package.json
+++ b/packages/react-effect-apollo/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "react-apollo": "^2.2.3",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/react-dom": "^16.0.11",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*",

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -33,7 +33,7 @@
     "@shopify/enzyme-utilities": "^2.0.2",
     "@types/enzyme": "^3.1.10",
     "faker": "^4.1.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -30,12 +30,7 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-<<<<<<< HEAD
     "@shopify/enzyme-utilities": "^2.0.2",
-    "typescript": "~3.1.6"
-=======
-    "@shopify/enzyme-utilities": "^1.1.7",
     "typescript": "~3.2.1"
->>>>>>> Upgrade to typescript 3.2.1 and fix react-compose static fields
   }
 }

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -30,7 +30,12 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
+<<<<<<< HEAD
     "@shopify/enzyme-utilities": "^2.0.2",
     "typescript": "~3.1.6"
+=======
+    "@shopify/enzyme-utilities": "^1.1.7",
+    "typescript": "~3.2.1"
+>>>>>>> Upgrade to typescript 3.2.1 and fix react-compose static fields
   }
 }

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^14.0.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-hooks/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -33,8 +33,8 @@
     "react-dom": "^16.3.2"
   },
   "devDependencies": {
-    "@shopify/with-env": "^1.0.10",
-    "typescript": "~3.1.6"
+    "@shopify/with-env": "^1.0.9",
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/react-html/src/components/HeadUpdater.tsx
+++ b/packages/react-html/src/components/HeadUpdater.tsx
@@ -32,7 +32,7 @@ function updateOnClient(state: State) {
   } else {
     if (titleElement == null) {
       titleElement = document.createElement('title');
-      document.head!.appendChild(titleElement);
+      document.head.appendChild(titleElement);
     }
 
     titleElement.setAttribute(MANAGED_ATTRIBUTE, 'true');
@@ -42,7 +42,7 @@ function updateOnClient(state: State) {
   const fragment = document.createDocumentFragment();
 
   const oldMetas = Array.from(
-    document.head!.querySelectorAll(`meta[${MANAGED_ATTRIBUTE}]`),
+    document.head.querySelectorAll(`meta[${MANAGED_ATTRIBUTE}]`),
   );
 
   for (const meta of metas) {
@@ -65,7 +65,7 @@ function updateOnClient(state: State) {
   }
 
   const oldLinks = Array.from(
-    document.head!.querySelectorAll(`link[${MANAGED_ATTRIBUTE}]`),
+    document.head.querySelectorAll(`link[${MANAGED_ATTRIBUTE}]`),
   );
 
   for (const link of links) {
@@ -95,5 +95,5 @@ function updateOnClient(state: State) {
     meta.remove();
   }
 
-  document.head!.appendChild(fragment);
+  document.head.appendChild(fragment);
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -30,7 +30,7 @@
     "@types/babel__template": "^7.0.1",
     "@types/babel__traverse": "^7.0.5",
     "intl-pluralrules": "^0.2.1",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "dependencies": {
     "@shopify/i18n": "^0.1.4",

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -36,6 +36,7 @@
     "@shopify/i18n": "^0.1.4",
     "@shopify/react-effect": "^3.0.2",
     "@shopify/react-hooks": "^1.1.1",
+    "@shopify/useful-types": "^1.2.3",
     "@types/hoist-non-react-statics": "^3.0.1",
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.6.2",

--- a/packages/react-i18n/src/decorator.tsx
+++ b/packages/react-i18n/src/decorator.tsx
@@ -3,6 +3,7 @@ import hoistStatics from 'hoist-non-react-statics';
 import {RegisterOptions} from './manager';
 import {useI18n} from './hooks';
 import {I18n} from './i18n';
+import {NonReactStatics} from '@shopify/useful-types';
 
 export interface WithI18nProps {
   i18n: I18n;
@@ -11,13 +12,13 @@ export interface WithI18nProps {
 export function withI18n(i18nOptions?: RegisterOptions) {
   return <OwnProps, C>(
     WrappedComponent: React.ComponentType<OwnProps & WithI18nProps> & C,
-  ): React.ComponentType<OwnProps> & StaticFields<typeof WrappedComponent> => {
+  ): React.ComponentType<OwnProps> & NonReactStatics<typeof WrappedComponent> => {
     function WithTranslations(props: OwnProps) {
       const [i18n, ShareTranslations] = useI18n(i18nOptions);
 
       return (
         <ShareTranslations>
-          <WrappedComponent {...props} i18n={i18n} />
+          <WrappedComponent {...props as any} i18n={i18n} />
         </ShareTranslations>
       );
     }

--- a/packages/react-i18n/src/decorator.tsx
+++ b/packages/react-i18n/src/decorator.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
+import {NonReactStatics} from '@shopify/useful-types';
 import {RegisterOptions} from './manager';
 import {useI18n} from './hooks';
 import {I18n} from './i18n';
-import {NonReactStatics} from '@shopify/useful-types';
 
 export interface WithI18nProps {
   i18n: I18n;
@@ -12,7 +12,8 @@ export interface WithI18nProps {
 export function withI18n(i18nOptions?: RegisterOptions) {
   return <OwnProps, C>(
     WrappedComponent: React.ComponentType<OwnProps & WithI18nProps> & C,
-  ): React.ComponentType<OwnProps> & NonReactStatics<typeof WrappedComponent> => {
+  ): React.ComponentType<OwnProps> &
+    NonReactStatics<typeof WrappedComponent> => {
     function WithTranslations(props: OwnProps) {
       const [i18n, ShareTranslations] = useI18n(i18nOptions);
 

--- a/packages/react-i18n/src/decorator.tsx
+++ b/packages/react-i18n/src/decorator.tsx
@@ -11,7 +11,7 @@ export interface WithI18nProps {
 export function withI18n(i18nOptions?: RegisterOptions) {
   return <OwnProps, C>(
     WrappedComponent: React.ComponentType<OwnProps & WithI18nProps> & C,
-  ): React.ComponentType<OwnProps> & C => {
+  ): React.ComponentType<OwnProps> & StaticFields<typeof WrappedComponent> => {
     function WithTranslations(props: OwnProps) {
       const [i18n, ShareTranslations] = useI18n(i18nOptions);
 

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@shopify/javascript-utilities": "^2.1.0",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "peerDependencies": {
     "react": "^16.4.1"

--- a/packages/react-import-remote/src/load.ts
+++ b/packages/react-import-remote/src/load.ts
@@ -61,5 +61,5 @@ function scriptTagFor(source: string, nonce: string) {
 }
 
 function appendScriptTag(scriptTag: HTMLScriptElement) {
-  document.head!.appendChild(scriptTag);
+  document.head.appendChild(scriptTag);
 }

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-intersection-observer/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -30,5 +30,5 @@ export const IntersectionObserver = React.memo(function IntersectionObserver({
 
   useValueTracking(intersection, newValue => onIntersectionChange(newValue));
 
-  return <Wrapper ref={ref}>{children}</Wrapper>;
+  return React.createElement(Wrapper, {ref}, children);
 });

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -30,7 +30,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*",

--- a/packages/react-preconnect/package.json
+++ b/packages/react-preconnect/package.json
@@ -27,7 +27,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -30,7 +30,7 @@
     "react": "^16.0.0"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -27,7 +27,7 @@
     "react": "^16.0.0"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -26,7 +26,7 @@
     "react": "^16.3.2"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "dependencies": {
     "tslib": "^1.9.3"

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -29,7 +29,7 @@
     "react-reconciler": "^0.20.2"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*",

--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -27,7 +27,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "peerDependencies": {
     "react": "^16.4.1"

--- a/packages/sewing-kit-koa/package.json
+++ b/packages/sewing-kit-koa/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/app-root-path": "^1.2.4",
     "@types/fs-extra": "^5.0.4",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/useful-types/package.json
+++ b/packages/useful-types/package.json
@@ -27,7 +27,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": [
     "dist/*"

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -54,6 +54,7 @@ export type NonNullableKeys<T> = {
   [K in keyof T]-?: null extends T[K] ? never : K
 }[keyof T];
 
+// Reference https://github.com/mridgway/hoist-non-react-statics/blob/master/src/index.js#L6
 type ReactStatics =
   | 'displayName'
   | 'getDerivedStateFromProps'

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -53,3 +53,8 @@ export type NonOptionalKeys<T> = {
 export type NonNullableKeys<T> = {
   [K in keyof T]-?: null extends T[K] ? never : K
 }[keyof T];
+
+type StaticFields<Object> = {
+  [Key in keyof Object]: Key extends 'prototype' ? never : Key
+}[keyof Object];
+export type Statics<Object> = Pick<Object, StaticFields<Object>>;

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -54,5 +54,13 @@ export type NonNullableKeys<T> = {
   [K in keyof T]-?: null extends T[K] ? never : K
 }[keyof T];
 
-type ReactStatics = 'displayName' | 'getDerivedStateFromProps' | 'getDerivedStateFromErrors' | 'childContextTypes' | 'contextType' | 'contextTypes' | 'getDefaultProps' | 'propTypes';
+type ReactStatics =
+  | 'displayName'
+  | 'getDerivedStateFromProps'
+  | 'getDerivedStateFromErrors'
+  | 'childContextTypes'
+  | 'contextType'
+  | 'contextTypes'
+  | 'getDefaultProps'
+  | 'propTypes';
 export type NonReactStatics<T> = Pick<T, Exclude<keyof T, ReactStatics>>;

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -54,7 +54,5 @@ export type NonNullableKeys<T> = {
   [K in keyof T]-?: null extends T[K] ? never : K
 }[keyof T];
 
-type StaticFields<Object> = {
-  [Key in keyof Object]: Key extends 'prototype' ? never : Key
-}[keyof Object];
-export type Statics<Object> = Pick<Object, StaticFields<Object>>;
+type ReactStatics = 'displayName' | 'getDerivedStateFromProps' | 'getDerivedStateFromErrors' | 'childContextTypes' | 'contextType' | 'contextTypes' | 'getDefaultProps' | 'propTypes';
+export type NonReactStatics<T> = Pick<T, Exclude<keyof T, ReactStatics>>;

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/with-env/README.md",
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "sideEffects": false,
   "dependencies": {

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/{{name}}/README.md",
   "dependencies": {},
   "devDependencies": {
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   },
   "files": ["dist/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8468,11 +8468,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
-
 typescript@~3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8468,10 +8468,25 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+<<<<<<< HEAD
 typescript@~3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+=======
+typescript-eslint-parser@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-17.0.1.tgz#ddc681a3afa51a9baa6746a001eb5f29fb1365d3"
+  integrity sha512-EPCOjxjnGqu9kQwH3CAwa1Jjty2Dn0FnehksVEmfZxXtkEK2Jerb2lnd/htsj1XooqEkKC5AzCaK+qOxHaBDBQ==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
+typescript@~3.2.1:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+>>>>>>> Upgrade to typescript 3.2.1 and fix react-compose static fields
 
 ua-parser-js@^0.7.18:
   version "0.7.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8468,25 +8468,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-<<<<<<< HEAD
 typescript@~3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
-=======
-typescript-eslint-parser@17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-17.0.1.tgz#ddc681a3afa51a9baa6746a001eb5f29fb1365d3"
-  integrity sha512-EPCOjxjnGqu9kQwH3CAwa1Jjty2Dn0FnehksVEmfZxXtkEK2Jerb2lnd/htsj1XooqEkKC5AzCaK+qOxHaBDBQ==
-  dependencies:
-    lodash.unescape "4.0.1"
-    semver "5.5.0"
 
 typescript@~3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
->>>>>>> Upgrade to typescript 3.2.1 and fix react-compose static fields
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
This PR fix react-compose static fields in typescript > 3.2.1.

Reference https://github.com/Shopify/quilt/issues/489