### PR TITLE
⚡️ Deferred scripts are now in `<head>`

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Deferred scripts are now rendered in `<head>` [#605](https://github.com/Shopify/quilt/pull/605/files)
 
 ## 7.1.2 - 2019-03-02
 

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -120,6 +120,7 @@ export default function Html({
         {stylesMarkup}
         {headMarkup}
         {blockingScriptsMarkup}
+        {deferredScriptsMarkup}
       </head>
 
       <body style={bodyStyles}>
@@ -127,7 +128,6 @@ export default function Html({
 
         {bodyMarkup}
         {serializationMarkup}
-        {deferredScriptsMarkup}
       </body>
     </html>
   );


### PR DESCRIPTION
For pages with a large body payload, this may allow the DOM parser to start loading external content slightly sooner.

When testing in web, I could never get this to make a measurable difference, but it's possible that a page with many translations + Apollo data could be improved by this change.