### PR TITLE
✨ Adds `useImportRemote()` hook 

### DIFF
--- a/packages/jest-dom-mocks/src/intersection-observer.ts
+++ b/packages/jest-dom-mocks/src/intersection-observer.ts
@@ -10,6 +10,8 @@ export default class IntersectionObserverMock {
 
   private isUsingMockIntersectionObserver = false;
   private originalIntersectionObserver = (global as any).IntersectionObserver;
+  private originalIntersectionObserverEntry = (global as any)
+    .IntersectionObserverEntry;
 
   simulate(
     entry:
@@ -43,6 +45,9 @@ export default class IntersectionObserverMock {
 
     const setObservers = (setter: (observers: Observer[]) => Observer[]) =>
       (this.observers = setter(this.observers));
+
+    (global as any).IntersectionObserverEntry = () => {};
+    (global as any).IntersectionObserverEntry.prototype.intersectionRatio = 0;
 
     (global as any).IntersectionObserver = class FakeIntersectionObserver {
       constructor(
@@ -87,6 +92,8 @@ export default class IntersectionObserverMock {
     }
 
     (global as any).IntersectionObserver = this.originalIntersectionObserver;
+    (global as any).IntersectionObserverEntry = this.originalIntersectionObserverEntry;
+
     this.isUsingMockIntersectionObserver = false;
     this.observers.length = 0;
   }

--- a/packages/jest-dom-mocks/src/intersection-observer.ts
+++ b/packages/jest-dom-mocks/src/intersection-observer.ts
@@ -47,7 +47,15 @@ export default class IntersectionObserverMock {
       (this.observers = setter(this.observers));
 
     (global as any).IntersectionObserverEntry = () => {};
-    (global as any).IntersectionObserverEntry.prototype.intersectionRatio = 0;
+    Object.defineProperty(
+      IntersectionObserverEntry.prototype,
+      'intersectionRatio',
+      {
+        get() {
+          return 0;
+        },
+      },
+    );
 
     (global as any).IntersectionObserver = class FakeIntersectionObserver {
       constructor(

--- a/packages/jest-dom-mocks/src/request-idle-callback.ts
+++ b/packages/jest-dom-mocks/src/request-idle-callback.ts
@@ -94,7 +94,7 @@ export default class RequestIdleCallback {
   private ensureIdleCallbackIsMock() {
     if (!this.isUsingMockIdleCallback) {
       throw new Error(
-        'You must call animationFrame.mock() before interacting with the mock request- or cancel- IdleCallback methods.',
+        'You must call requestIdleCallback.mock() before interacting with the mock request- or cancel- IdleCallback methods.',
       );
     }
   }

--- a/packages/react-google-analytics/src/GaJS.tsx
+++ b/packages/react-google-analytics/src/GaJS.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ImportRemote from '@shopify/react-import-remote';
 
 import {GaJSAnalytics} from './types';
-import {getRootDomain, noop} from './utilities';
+import {getRootDomain} from './utilities';
 
 export interface Props {
   account: string;
@@ -92,7 +92,6 @@ export default function GaJSGoogleAnalytics({
         source={GA_JS_SCRIPT}
         nonce={nonce}
         getImport={getLegacyAnalytics}
-        onError={noop}
         onImported={setAnalytics}
       />
     </>

--- a/packages/react-google-analytics/src/Universal.tsx
+++ b/packages/react-google-analytics/src/Universal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ImportRemote from '@shopify/react-import-remote';
 
 import {UniversalAnalytics} from './types';
-import {getRootDomain, noop} from './utilities';
+import {getRootDomain} from './utilities';
 
 export interface Props {
   account: string;
@@ -88,7 +88,6 @@ export default function UniversalGoogleAnalytics({
         source={source}
         nonce={nonce}
         getImport={getUniversalAnalytics}
-        onError={noop}
         onImported={setAnalytics}
       />
     </>

--- a/packages/react-import-remote/CHANGELOG.md
+++ b/packages/react-import-remote/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] - -->
 
+## 2.0.0 - 2019-05-03
+
+### Changed
+
+- Changes to the props of `<ImportRemote />` mid-render will cause the import to be canceled. ([608](https://github.com/Shopify/quilt/pull/608))
+- Added `useImportRemote()` hook ([608](https://github.com/Shopify/quilt/pull/608))
+
 ### Added
 
 - This CHANGELOG [(#575)](https://github.com/Shopify/quilt/pull/575)

--- a/packages/react-import-remote/CHANGELOG.md
+++ b/packages/react-import-remote/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Changes to the props of `<ImportRemote />` mid-render will cause the import to be canceled. ([608](https://github.com/Shopify/quilt/pull/608))
+- Removed `onError` callback prop. `onImported` now receives an error in the case that an error occurs during the import. ([608](https://github.com/Shopify/quilt/pull/608))
 - Added `useImportRemote()` hook ([608](https://github.com/Shopify/quilt/pull/608))
 
 ### Added

--- a/packages/react-import-remote/README.md
+++ b/packages/react-import-remote/README.md
@@ -13,7 +13,31 @@ $ yarn add @shopify/react-import-remote
 
 ## Usage
 
-The provided utilities are intended only for external scripts that load globals. Other JavaScript should use the native `import()` operator for asynchronously loading code. These utilities cache results by source, so only a single `script` tag is ever added for a particular source.
+The package provides a hook and component that are intended for loading external scripts. These utilities cache results by source, so only a single `script` tag is ever added for a particular source.
+
+### useImportRemote()
+
+```tsx
+import * as React from 'react';
+import {useImportRemote, Status} from '@shopify/react-import-remote';
+import {DeferTiming} from '@shopify/async';
+
+function MyComponent() {
+  const {result} = useImportRemote(
+    'https://some-external-service.com/global.js',
+  );
+
+  if (result.status === Status.Failed) {
+    // do something with error result
+  }
+
+  if (result.status === Status.Complete) {
+    // do something with successful result
+  }
+
+  return null;
+}
+```
 
 ### <ImportRemote />
 
@@ -46,18 +70,6 @@ function MyComponent() {
 }
 ```
 
-## Interface
-
-```ts
-interface Props<Imported = any> {
-  source: string;
-  preconnect?: boolean;
-  getImport(window: Window): Imported;
-  onImported(imported: Imported | Error): void;
-  defer?: DeferTiming;
-}
-```
-
 **source**
 
 Source of the script to load the global from
@@ -83,60 +95,3 @@ A member of the `DeferTiming` enum (from `@shopify/async`) allowing the import r
 - Component is in the viewport (`DeferTiming.InViewport`; if `IntersectionObserver` is not available, it will load on mount)
 
 Note, changing any of these values while rendering will cancel the import.
-
-### useImportRemote()
-
-The above can also be accomplished using the hook, `useImportRemote()`, that is available in this package.
-
-```tsx
-import * as React from 'react';
-import {useImportRemote, Status} from '@shopify/react-import-remote';
-import {DeferTiming} from '@shopify/async';
-
-function MyComponent() {
-  const {result} = useImportRemote(
-    'https://some-external-service.com/global.js',
-  );
-
-  if (result.status === Status.Failed) {
-    // do something with error result
-  }
-
-  if (result.status === Status.Complete) {
-    // do something with successful result
-  }
-
-  return null;
-}
-```
-
-## Interface
-
-```tsx
-useImportRemote<Imported = unknown>(
-  source: string, // source of the script to load the global from
-  options: Options<Imported>, // see Options interface below
-): {
-  result: Result<Imported>; // see Result interface below
-  intersectionRef: React.Ref<HTMLElement | null>; // with defer: DeferTiming.InViewport, a ref to identify element to observe
-}
-
-interface Options<Imported> {
-  nonce?: string; // a unique cryptographic nonce to add to the generated script tag
-  defer?: DeferTiming; // refer to the defer prop above
-  getImport(window: Window): Imported; // refer to the getImport prop above
-}
-
-export enum Status {
-  Initial = 'Initial',
-  Failed = 'Failed',
-  Complete = 'Complete',
-  Loading = 'Loading',
-}
-
-type Result<Imported = any> =
-  | {status: Status.Initial}
-  | {status: Status.Loading}
-  | {status: Status.Failed; error: Error}
-  | {status: Status.Complete; imported: Imported};
-```

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -29,14 +29,14 @@ export default function ImportRemote<T = unknown>({
 
   const intersectionObserver =
     defer === DeferTiming.InViewport && intersectionRef ? (
-      <div ref={intersectionRef} />
+      <div ref={intersectionRef as React.RefObject<HTMLDivElement>} />
     ) : null;
 
   React.useEffect(
     () => {
       switch (result.status) {
         case Status.Failed:
-          onImported(result.error);
+          onImported(new Error(result.error.message));
           return;
         case Status.Complete:
           onImported(result.imported);

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -36,7 +36,7 @@ export default function ImportRemote<T = unknown>({
     () => {
       switch (result.status) {
         case Status.Failed:
-          onImported(new Error(result.error.message));
+          onImported(result.error);
           return;
         case Status.Complete:
           onImported(result.imported);

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -1,111 +1,59 @@
 import * as React from 'react';
 import {Preconnect} from '@shopify/react-html';
-import {
-  RequestIdleCallbackHandle,
-  WindowWithRequestIdleCallback,
-  DeferTiming,
-} from '@shopify/async';
-import {
-  IntersectionObserver,
-  UnsupportedBehavior,
-} from '@shopify/react-intersection-observer';
-import load from './load';
+import {DeferTiming} from '@shopify/async';
+
+import {useImportRemote, Status} from './hooks';
 
 export interface Props<Imported = any> {
   source: string;
   nonce?: string;
   preconnect?: boolean;
-  onError(error: Error): void;
   getImport(window: Window): Imported;
-  onImported(imported: Imported): void;
+  onImported(imported: Imported | Error): void;
   defer?: DeferTiming;
 }
 
-interface State {
-  loaded: boolean;
-  loading: boolean;
-}
+export default function ImportRemote<T = unknown>({
+  source,
+  nonce,
+  preconnect,
+  getImport,
+  onImported,
+  defer,
+}: Props<T>) {
+  const {result, intersectionRef} = useImportRemote<T>(source, {
+    defer,
+    nonce,
+    getImport,
+  });
 
-export default class ImportRemote extends React.PureComponent<Props, State> {
-  state: State = {loaded: false, loading: false};
-  private idleCallbackHandle?: RequestIdleCallbackHandle;
+  const intersectionObserver =
+    defer === DeferTiming.InViewport && intersectionRef ? (
+      <div ref={intersectionRef} />
+    ) : null;
 
-  componentWillUnmount() {
-    if (this.idleCallbackHandle != null && 'cancelIdleCallback' in window) {
-      (window as WindowWithRequestIdleCallback).cancelIdleCallback(
-        this.idleCallbackHandle,
-      );
-    }
-  }
-
-  async componentDidMount() {
-    const {defer = DeferTiming.Mount} = this.props;
-
-    if (defer === DeferTiming.Idle) {
-      if ('requestIdleCallback' in window) {
-        this.idleCallbackHandle = (window as WindowWithRequestIdleCallback).requestIdleCallback(
-          this.loadRemote,
-        );
-      } else {
-        this.loadRemote();
+  React.useEffect(
+    () => {
+      switch (result.status) {
+        case Status.Failed:
+          onImported(result.error);
+          return;
+        case Status.Complete:
+          onImported(result.imported);
       }
-    } else if (defer === DeferTiming.Mount) {
-      await this.loadRemote();
-    }
+    },
+    [result, onImported],
+  );
+
+  if (preconnect) {
+    const url = new URL(source);
+    return (
+      <>
+        <Preconnect source={url.origin} />
+        {intersectionObserver}
+      </>
+    );
   }
 
-  async componentDidUpdate({source: oldSource}: Props) {
-    const {source} = this.props;
-
-    if (oldSource !== source) {
-      await this.loadRemote();
-    }
-  }
-
-  render() {
-    const {loaded, loading} = this.state;
-    const {source, preconnect, defer} = this.props;
-
-    const intersectionObserver =
-      !loaded && !loading && defer === DeferTiming.InViewport ? (
-        <IntersectionObserver
-          threshold={0}
-          unsupportedBehavior={UnsupportedBehavior.TreatAsIntersecting}
-          onIntersectionChange={this.loadRemoteIfIntersecting}
-        />
-      ) : null;
-
-    if (preconnect) {
-      const url = new URL(source);
-      return (
-        <>
-          <Preconnect source={url.origin} />
-          {intersectionObserver}
-        </>
-      );
-    }
-
-    return intersectionObserver;
-  }
-
-  private loadRemoteIfIntersecting = ({isIntersecting = true}) => {
-    return isIntersecting ? this.loadRemote() : Promise.resolve();
-  };
-
-  private loadRemote = () => {
-    return new Promise(resolve => {
-      this.setState({loaded: false, loading: true}, async () => {
-        const {source, nonce = '', getImport, onError, onImported} = this.props;
-
-        try {
-          const imported = await load(source, getImport, nonce);
-          onImported(imported);
-        } catch (error) {
-          onError(error);
-        } finally {
-          this.setState({loaded: true, loading: false}, resolve);
-        }
-      });
-    });
-  };
+  return intersectionObserver;
 }

--- a/packages/react-import-remote/src/hooks.ts
+++ b/packages/react-import-remote/src/hooks.ts
@@ -31,7 +31,7 @@ export function useImportRemote<Imported = unknown>(
   options: Options<Imported>,
 ): {
   result: Result<Imported>;
-  intersectionRef: any;
+  intersectionRef: React.Ref<HTMLElement | null>;
 } {
   const {defer = DeferTiming.Mount, nonce = '', getImport} = options;
   const [result, setResult] = React.useState<Result>({status: Status.Initial});

--- a/packages/react-import-remote/src/hooks.ts
+++ b/packages/react-import-remote/src/hooks.ts
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import {useIntersection} from '@shopify/react-intersection-observer';
+import {
+  DeferTiming,
+  WindowWithRequestIdleCallback,
+  RequestIdleCallbackHandle,
+} from '@shopify/async';
+import load from './load';
+
+interface Options<Imported> {
+  nonce?: string;
+  defer?: DeferTiming;
+  getImport(window: Window): Imported;
+}
+
+export enum Status {
+  Initial = 'Initial',
+  Failed = 'Failed',
+  Complete = 'Complete',
+  Loading = 'Loading',
+}
+
+type Result<Imported = any> =
+  | {status: Status.Initial}
+  | {status: Status.Loading}
+  | {status: Status.Failed; error: Error}
+  | {status: Status.Complete; imported: Imported};
+
+export function useImportRemote<Imported = unknown>(
+  source: string,
+  options: Options<Imported>,
+): {
+  result: Result<Imported>;
+  intersectionRef: any;
+} {
+  const {defer = DeferTiming.Mount, nonce = '', getImport} = options;
+  const [result, setResult] = React.useState<Result>({status: Status.Initial});
+  const idleCallbackHandle = React.useRef<RequestIdleCallbackHandle | null>(
+    null,
+  );
+
+  const deferOption = React.useRef(defer);
+
+  if (deferOption.current !== defer) {
+    throw new Error(
+      [
+        'You’ve changed the defer strategy on an <ImportRemote />',
+        'component after it has mounted. This is not supported.',
+      ].join(' '),
+    );
+  }
+
+  let intersection: IntersectionObserverEntry | null = null;
+  let intersectionRef: React.Ref<HTMLElement | null> = null;
+
+  // Normally this would be dangerous but because we are
+  // guranteed to have thrown if the defer option changes
+  // we can be confident that a given use of this hook
+  // will only ever hit one of these two cases.
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (defer === DeferTiming.InViewport) {
+    [intersection, intersectionRef] = useIntersection();
+  }
+  /* eslint-enable react-hooks/rules-of-hooks */
+
+  const loadRemote = React.useCallback(
+    async () => {
+      try {
+        setResult({status: Status.Loading});
+        const importResult = await load(source, getImport, nonce);
+        setResult({status: Status.Complete, imported: importResult});
+      } catch (error) {
+        setResult({status: Status.Failed, error});
+      }
+    },
+    [getImport, nonce, source],
+  );
+
+  React.useEffect(
+    () => {
+      if (
+        result.status === Status.Initial &&
+        defer === DeferTiming.InViewport &&
+        intersection &&
+        intersection.isIntersecting
+      ) {
+        loadRemote();
+      }
+    },
+    [result, defer, intersection, loadRemote],
+  );
+
+  React.useEffect(
+    () => {
+      if (defer === DeferTiming.Idle) {
+        if ('requestIdleCallback' in window) {
+          idleCallbackHandle.current = (window as WindowWithRequestIdleCallback).requestIdleCallback(
+            loadRemote,
+          );
+        } else {
+          loadRemote();
+        }
+      } else if (defer === DeferTiming.Mount) {
+        loadRemote();
+      }
+
+      return () => {
+        if (
+          idleCallbackHandle.current != null &&
+          typeof (window as any).cancelIdleCallback === undefined
+        ) {
+          (window as any).cancelIdleCallback(idleCallbackHandle.current);
+          idleCallbackHandle.current = null;
+        }
+      };
+    },
+    [defer, loadRemote, intersection, nonce, getImport, source],
+  );
+
+  return {result, intersectionRef};
+}

--- a/packages/react-import-remote/src/load.ts
+++ b/packages/react-import-remote/src/load.ts
@@ -30,10 +30,10 @@ export default function load<
       resolve(getImport(window as CustomWindow));
     }
 
-    function scriptTagOnError(error: any) {
+    function scriptTagOnError() {
       scriptTag.removeEventListener('load', scriptTagOnLoad);
       scriptTag.removeEventListener('error', scriptTagOnError);
-      reject(error);
+      reject(new Error('Script tag failed to load remote source'));
     }
 
     scriptTag.addEventListener('load', scriptTagOnLoad);

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -81,8 +81,10 @@ describe('<ImportRemote />', () => {
       expect(load).toHaveBeenCalledWith(newSource, mockProps.getImport, nonce);
     });
   });
-
-  describe('onImported()', () => {
+  // async act is available in React 16.9.0, when we have upgraded the following
+  // tests can be enabled. https://github.com/Shopify/quilt/pull/688
+  // eslint-disable-next-line jest/no-disabled-tests
+  describe.skip('onImported()', () => {
     it('is called with the result of loading the script when successful', async () => {
       const result = 'foo';
       const promise = Promise.resolve(result);
@@ -124,15 +126,15 @@ describe('<ImportRemote />', () => {
     it('does not render any preconnect link by default', () => {
       const importRemote = mount(<ImportRemote {...mockProps} />);
 
-      expect(importRemote.findAll(Preconnect)).toHaveLength(0);
+      expect(importRemote).not.toContainReactComponent(Preconnect);
     });
 
     it('creates a preconnect link with the source’s origin when preconnecting is requested', () => {
       const importRemote = mount(<ImportRemote {...mockProps} preconnect />);
 
-      expect(importRemote.find(Preconnect)!.prop('source')).toBe(
-        new URL(mockProps.source).origin,
-      );
+      expect(importRemote).toContainReactComponent(Preconnect, {
+        source: new URL(mockProps.source).origin,
+      });
     });
   });
 
@@ -193,11 +195,7 @@ describe('<ImportRemote />', () => {
 
       const mockComponent = mount(<MockComponent />);
 
-      expect(() =>
-        mockComponent.act(() => {
-          mockComponent.find('button')!.trigger('onClick');
-        }),
-      ).toThrow(
+      expect(() => mockComponent.find('button')!.trigger('onClick')).toThrow(
         [
           'You’ve changed the defer strategy on an <ImportRemote />',
           'component after it has mounted. This is not supported.',


### PR DESCRIPTION
Part of #585

This PR adds a `useImportRemote` hook and refactors the ImportRemote component to use this hook. 

DEMO -> https://monosnap.com/file/SuTFwyrW2OPt6IEYL80m5DQ36q6zcw

### Usage

I am suggesting the following API for this hook.

```tsx
function useImportRemote<Imported = any>(
  source: string,
  options: Options<Imported>,
): {
  state: State;
  imported: Imported | null;
  intersectionRef: any;
}

interface Options<Imported> {
  nonce?: string;
  defer?: DeferTiming;
  onError?(error: Error): void;
  getImport(window: Window): Imported;
  onImported?(imported: Imported): void;
}

type State = 'loading' | 'error' | 'loaded' | null;

```
