### PR TITLE
Fix navigation start tracking

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.2] - 2019-03-27
+
+### Fixed
+
+- Fixed an issue where changing only the hash/ query parameters would cause navigations to be recorded
+
 ## [1.1.1] - 2019-03-04
 
 ### Fixed

--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -11,7 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Fixed an issue where changing only the hash/ query parameters would cause navigations to be recorded
+- Fixed an issue where changing only the hash/ query parameters would cause navigations to be recorded [[#610](https://github.com/Shopify/quilt/pull/610)]
 
 ## [1.1.1] - 2019-03-04
 


### PR DESCRIPTION
Fixes navigation start tracking by also watching for `replaceState`, and by only triggering when the pathname actually changes.