### PR TITLE
Add a promise mock

### DIFF
--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added a mock for `Promise` ([#614](https://github.com/Shopify/quilt/pull/614))
+
 ## 2.4.0
 
 ### Added

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -92,6 +92,7 @@ The following standard mocks are available:
 - `location`
 - `matchMedia`
 - `timer`
+- `promise`
 - `intersectionObserver`
 
 Each of the standard mocks can be installed, for a given test, using `standardMock.mock()`, and must be restored before the end of the test using `standardMock.restore()`.
@@ -194,6 +195,10 @@ Runs all system timers to completion.
 #### `Timer.runTimersToTime(time: number): void`
 
 Runs all system timers to the given `time`.
+
+#### `Promise.runPending(): void`
+
+Runs all promise resolvers that have been queued.
 
 #### `IntersectionObserver.observers`
 

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -28,6 +28,7 @@
     "@types/lolex": "^2.1.3",
     "fetch-mock": "^6.3.0",
     "lolex": "^2.7.5",
+    "promise": "^8.0.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/jest-dom-mocks/src/index.ts
+++ b/packages/jest-dom-mocks/src/index.ts
@@ -8,6 +8,7 @@ import Storage from './storage';
 import Timer from './timer';
 import UserTiming from './user-timing';
 import IntersectionObserver from './intersection-observer';
+import Promise from './promise';
 
 export const animationFrame = new AnimationFrame();
 export const requestIdleCallback = new RequestIdleCallback();
@@ -27,6 +28,7 @@ export const sessionStorage = new Storage();
 export const timer = new Timer();
 export const userTiming = new UserTiming();
 export const intersectionObserver = new IntersectionObserver();
+export const promise = new Promise();
 
 export function installMockStorage() {
   if (typeof window !== 'undefined') {
@@ -45,6 +47,7 @@ const mocksToEnsureReset = {
   clock,
   location,
   timer,
+  promise,
   animationFrame,
   fetch,
   matchMedia,

--- a/packages/jest-dom-mocks/src/promise.ts
+++ b/packages/jest-dom-mocks/src/promise.ts
@@ -1,0 +1,47 @@
+import FakePromise from 'promise';
+
+export default class Promise {
+  private OriginalPromise = global.Promise;
+  private isUsingFakePromise = false;
+
+  mock() {
+    if (this.isUsingFakePromise) {
+      throw new Error(
+        'Promise is already mocked, but you tried to mock it again.',
+      );
+    }
+
+    jest.useFakeTimers();
+    global.Promise = FakePromise;
+    this.isUsingFakePromise = true;
+  }
+
+  restore() {
+    if (!this.isUsingFakePromise) {
+      throw new Error(
+        'Promise is already real, but you tried to restore it again.',
+      );
+    }
+
+    jest.useRealTimers();
+    global.Promise = this.OriginalPromise;
+    this.isUsingFakePromise = false;
+  }
+
+  isMocked() {
+    return this.isUsingFakePromise;
+  }
+
+  runPending() {
+    this.ensureUsingFakePromise();
+    jest.runAllTimers();
+  }
+
+  private ensureUsingFakePromise() {
+    if (!this.isUsingFakePromise) {
+      throw new Error(
+        'You must call Promise.mock() before interacting with the mock Promise.',
+      );
+    }
+  }
+}

--- a/packages/jest-dom-mocks/src/promise.ts
+++ b/packages/jest-dom-mocks/src/promise.ts
@@ -1,7 +1,7 @@
 import FakePromise from 'promise';
 
 export default class Promise {
-  private OriginalPromise = global.Promise;
+  private originalPromise = global.Promise;
   private isUsingFakePromise = false;
 
   mock() {
@@ -24,7 +24,7 @@ export default class Promise {
     }
 
     jest.useRealTimers();
-    global.Promise = this.OriginalPromise;
+    global.Promise = this.originalPromise;
     this.isUsingFakePromise = false;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,7 +1007,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3:
+asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -6780,6 +6780,13 @@ promise@^7.1.1:
   integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
   dependencies:
     asap "~2.0.3"
+
+promise@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.3.tgz#f592e099c6cddc000d538ee7283bb190452b0bf6"
+  integrity sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==
+  dependencies:
+    asap "~2.0.6"
 
 prompts@^0.1.9:
   version "0.1.9"


### PR DESCRIPTION
This PR adds a mocked version of the global `Promise`. When mocked, it uses the `promise` module, which uses timers instead of all the node micro queue stuff. This means that, by mocking and then running timers, we can have promises synchronously resolve. This will be necessary in order to stuff all the promise-resolve-causing-React-update stuff we do (most notably, `resolveAllGraphQL`) to be able to run in an `act` block. This approach is detailed here: https://github.com/facebook/react/issues/14769#issuecomment-462528230 (it's what Facebook folks say they do).

Hopefully the need for this in React land will be temporary, but it's probably generally useful anyways.