### PR TITLE
Adds `useShortcut` hook

### DIFF
--- a/packages/react-shortcuts/CHANGELOG.md
+++ b/packages/react-shortcuts/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
- <!-- Unreleased changes should go to UNRELEASED.md -->
-
 ---
 
 ## [Unreleased]
+
+### Changed
+
+- **Breaking** - Require `react@16.8.1` or higher to support React hooks. ([#615](https://github.com/Shopify/quilt/pull/615))
 
 ### Added
 

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import {Consumer, Context} from '../ShortcutProvider';
+import useShortcut from './hooks';
 import Key, {HeldKey} from '../keys';
 
 export interface Props {
@@ -11,55 +10,10 @@ export interface Props {
   allowDefault?: boolean;
 }
 
-export interface Subscription {
-  unsubscribe(): void;
-}
-
 export default function Shortcut(props: Props) {
-  return (
-    <Consumer>
-      {(context: Context) => <ShortcutConsumer {...props} {...context} />}
-    </Consumer>
-  );
-}
+  const {ordered, onMatch, ...rest} = props;
 
-class ShortcutConsumer extends React.Component<Props & Context, never> {
-  public data = {
-    node: this.props.node,
-    ordered: this.props.ordered,
-    held: this.props.held,
-    ignoreInput: this.props.ignoreInput || false,
-    onMatch: this.props.onMatch,
-    allowDefault: this.props.allowDefault || false,
-  };
+  useShortcut(ordered, onMatch, {...rest});
 
-  public subscription!: Subscription;
-
-  componentDidMount() {
-    const {node} = this.data;
-
-    if (node != null) {
-      return;
-    }
-
-    const {shortcutManager} = this.props;
-
-    if (shortcutManager == null) {
-      return;
-    }
-
-    this.subscription = shortcutManager.subscribe(this.data);
-  }
-
-  componentWillUnmount() {
-    if (this.subscription == null) {
-      return;
-    }
-
-    this.subscription.unsubscribe();
-  }
-
-  render() {
-    return null;
-  }
+  return null;
 }

--- a/packages/react-shortcuts/src/Shortcut/hooks.ts
+++ b/packages/react-shortcuts/src/Shortcut/hooks.ts
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import {ShortcutContext} from '../ShortcutProvider';
+import Key, {HeldKey} from '../keys';
+
+export interface Subscription {
+  unsubscribe(): void;
+}
+
+export interface Options {
+  held?: HeldKey;
+  node?: HTMLElement | null;
+  ignoreInput?: boolean;
+  allowDefault?: boolean;
+}
+
+export default function useShortcut(
+  ordered: Key[],
+  onMatch: (matched: {ordered: Key[]; held?: HeldKey}) => void,
+  options: Options = {},
+) {
+  const shortcutManager = React.useContext(ShortcutContext);
+  const subscription = React.useRef<Subscription | null>(null);
+  const {node, held, ignoreInput, allowDefault} = options;
+
+  React.useEffect(
+    () => {
+      if (node != null) {
+        return;
+      }
+
+      if (shortcutManager == null) {
+        return;
+      }
+
+      subscription.current = shortcutManager.subscribe({
+        onMatch,
+        ordered,
+        node,
+        held,
+        ignoreInput: ignoreInput || false,
+        allowDefault: allowDefault || false,
+      });
+
+      // eslint-disable-next-line consistent-return
+      return () => {
+        if (subscription.current == null) {
+          return;
+        }
+
+        subscription.current.unsubscribe();
+      };
+    },
+    [node, ordered, onMatch, held, ignoreInput, allowDefault],
+  );
+}

--- a/packages/react-shortcuts/src/Shortcut/index.ts
+++ b/packages/react-shortcuts/src/Shortcut/index.ts
@@ -1,4 +1,5 @@
 import Shortcut from './Shortcut';
 
+export {default as useShortcut} from './hooks';
 export * from './Shortcut';
 export default Shortcut;

--- a/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
+++ b/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import ShortcutManager from '../ShortcutManager';
 
-export interface Context {
-  shortcutManager?: ShortcutManager;
-}
-
 export interface Props {
   children?: React.ReactNode;
 }
 
-export const {Provider, Consumer} = React.createContext<Context>({});
+export const ShortcutContext = React.createContext<ShortcutManager | null>(
+  null,
+);
 
+export const {Consumer, Provider} = ShortcutContext;
 export default class ShortcutProvider extends React.Component<Props, never> {
   private shortcutManager = new ShortcutManager();
 
@@ -19,10 +18,10 @@ export default class ShortcutProvider extends React.Component<Props, never> {
   }
 
   render() {
-    const context: Context = {
-      shortcutManager: this.shortcutManager,
-    };
-
-    return <Provider value={context}>{this.props.children}</Provider>;
+    return (
+      <ShortcutContext.Provider value={this.shortcutManager}>
+        {this.props.children}
+      </ShortcutContext.Provider>
+    );
   }
 }

--- a/packages/react-shortcuts/src/ShortcutProvider/index.ts
+++ b/packages/react-shortcuts/src/ShortcutProvider/index.ts
@@ -1,4 +1,4 @@
 import ShortcutProvider from './ShortcutProvider';
 
-export {Props, Context, Provider, Consumer} from './ShortcutProvider';
+export {Props, ShortcutContext} from './ShortcutProvider';
 export default ShortcutProvider;

--- a/packages/react-shortcuts/src/index.ts
+++ b/packages/react-shortcuts/src/index.ts
@@ -1,10 +1,12 @@
-export {default as Shortcut, Props as ShortcutProps} from './Shortcut';
+export {
+  default as Shortcut,
+  Props as ShortcutProps,
+  useShortcut,
+} from './Shortcut';
 
 export {
   default as ShortcutProvider,
   Props as ProviderProps,
-  Context,
-  Provider as ContextProvider,
 } from './ShortcutProvider';
 
 export {default as ShortcutManager} from './ShortcutManager';

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
+import {mount} from '@shopify/react-testing';
 import {timer} from '@shopify/jest-dom-mocks';
 
 import Key, {HeldKey, ModifierKey} from '../keys';
@@ -125,9 +125,10 @@ describe('ShortcutManager', () => {
         <ShortcutWithFocus spy={spy} />
       </ShortcutProvider>,
     );
-    app.update();
 
+    app.forceUpdate();
     keydown('z');
+
     expect(spy).toBeCalled();
   });
 

--- a/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
@@ -5,39 +5,24 @@ interface Props {
   spy: jest.Mock<{}>;
 }
 
-interface State {
-  node?: HTMLElement | null;
-}
+export default function ShortcutWithFocus(props: Props) {
+  const {spy} = props;
+  const node = React.useRef<HTMLButtonElement | null>(null);
 
-export default class ShortcutWithFocus extends React.Component<Props, State> {
-  state: State = {
-    node: null,
-  };
+  React.useEffect(
+    () => {
+      if (!node || !node.current) {
+        return;
+      }
 
-  componentWillUpdate() {
-    const {node} = this.state;
-
-    if (!node) {
-      return;
-    }
-
-    node.focus();
-  }
-
-  render() {
-    const {spy} = this.props;
-    const {node} = this.state;
-    return (
-      <div className="app">
-        <button type="button" ref={this.setRef} />
-        <Shortcut ordered={['z']} onMatch={spy} node={node} />
-      </div>
-    );
-  }
-
-  private setRef = (node: HTMLElement | null) => {
-    this.setState({
-      node,
-    });
-  };
+      node.current.focus();
+    },
+    [node],
+  );
+  return (
+    <div className="app">
+      <button type="button" ref={node} />
+      <Shortcut ordered={['z']} onMatch={spy} node={node.current} />
+    </div>
+  );
 }


### PR DESCRIPTION
This PR adds a `useShortcut()` hook to `react-shortcuts`. https://github.com/Shopify/quilt/issues/585

### Usage

```
useShortcut(
    ['F', 'O', 'O'],
    ({ordered, held}) => {
      console.table(ordered);
      console.table(held);
    },
    {
      held: [['Shift']],
     //... other options passed to shortcutManager
    },
  );
```