### PR TITLE
🐛 Make the webpack plugins return regular objects intead of Modules

### DIFF
--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -29,7 +29,7 @@ export default function injectWithI18nArguments({
       fallback: ${fallbackID},
       async translations(locale) {
         const dictionary = await import(/* webpackChunkName: "${id}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-        return dictionary.default;
+        return dictionary && dictionary.default;
       },
     })`,
       {

--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -28,7 +28,8 @@ export default function injectWithI18nArguments({
       id: '${id}',
       fallback: ${fallbackID},
       async translations(locale) {
-        return await import(/* webpackChunkName: "${id}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+        const dictionary = await import(/* webpackChunkName: "${id}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+        return {...dictionary};
       },
     })`,
       {

--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -29,7 +29,7 @@ export default function injectWithI18nArguments({
       fallback: ${fallbackID},
       async translations(locale) {
         const dictionary = await import(/* webpackChunkName: "${id}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-        return {...dictionary};
+        return dictionary.default;
       },
     })`,
       {

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -37,7 +37,8 @@ describe('babel-pluin-react-i18n', () => {
           id: 'MyComponent_${defaultHash}',
           fallback: _en,
           async translations(locale) {
-            return await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            return {...dictionary};
           },
         })(MyComponent);
         `,
@@ -107,7 +108,8 @@ describe('babel-pluin-react-i18n', () => {
           id: 'MyComponent_${defaultHash}',
           fallback: _en,
           async translations(locale) {
-            return await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            return {...dictionary};
           },
         })(MyComponent);
         `,
@@ -159,7 +161,8 @@ describe('babel-pluin-react-i18n', () => {
           id: 'MyComponent_${defaultHash}',
           fallback: _en,
           async translations(locale) {
-            return await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            return {...dictionary};
           },
         })(MyComponent);
         `,

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -38,7 +38,7 @@ describe('babel-pluin-react-i18n', () => {
           fallback: _en,
           async translations(locale) {
             const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return dictionary.default;
+            return dictionary && dictionary.default;
           },
         })(MyComponent);
         `,
@@ -109,7 +109,7 @@ describe('babel-pluin-react-i18n', () => {
           fallback: _en,
           async translations(locale) {
             const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return dictionary.default;
+            return dictionary && dictionary.default;
           },
         })(MyComponent);
         `,
@@ -162,7 +162,7 @@ describe('babel-pluin-react-i18n', () => {
           fallback: _en,
           async translations(locale) {
             const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return dictionary.default;
+            return dictionary && dictionary.default;
           },
         })(MyComponent);
         `,

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -38,7 +38,7 @@ describe('babel-pluin-react-i18n', () => {
           fallback: _en,
           async translations(locale) {
             const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return {...dictionary};
+            return dictionary.default;
           },
         })(MyComponent);
         `,
@@ -109,7 +109,7 @@ describe('babel-pluin-react-i18n', () => {
           fallback: _en,
           async translations(locale) {
             const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return {...dictionary};
+            return dictionary.default;
           },
         })(MyComponent);
         `,
@@ -162,7 +162,7 @@ describe('babel-pluin-react-i18n', () => {
           fallback: _en,
           async translations(locale) {
             const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return {...dictionary};
+            return dictionary.default;
           },
         })(MyComponent);
         `,


### PR DESCRIPTION
Currently the webpack plugin in `react-i18n` gives consumers a `Module` object to work with. This isn't what's expected, and this PR changes it to return a simple Object instead.

Dynamic `import` statements return object-like data primitives called `Modules`. These modules behave roughly like an object in terms of access, but don't have any of the standard `Object` functions since they're not created with an `Object` as a prototype.

I believe the expectation here is that react-i18n return a standard object for people to manipulate, not a Module, hence this change. For example, this caused a regression in `web` when `@shopify/polaris` was updated to use a custom simplified `merge` function, instead of `lodash`'s merge function. `lodash` could deal with `Modules`, but the new simplified function expects simple `Objects`.