### PR TITLE
React testing improvements

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,9 @@ module.exports = {
   coverageDirectory: './coverage/',
   collectCoverage: true,
   moduleNameMapper,
+  globals: {
+    'ts-jest': {diagnostics: false},
+  },
 };
 
 function getPackageNames() {

--- a/packages/react-html/src/components/tests/AppleHomeScreen.test.tsx
+++ b/packages/react-html/src/components/tests/AppleHomeScreen.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {mount, Root} from '@shopify/react-testing';
-import {Props} from '@shopify/useful-types';
+import {mount} from '@shopify/react-testing';
 
 import Link from '../Link';
 import Meta from '../Meta';
@@ -10,24 +9,18 @@ import AppleHomeScreen, {IconSize} from '../AppleHomeScreen';
 describe('<AppleHomeScreen />', () => {
   it('renders a <Meta /> with `name="apple-mobile-web-app-capable" content="yes"` by default', () => {
     const appleHomeScreen = mount(<AppleHomeScreen />);
-
-    expect(
-      findMeta(appleHomeScreen, {
-        name: 'apple-mobile-web-app-capable',
-        content: 'yes',
-      }),
-    ).not.toBeNull();
+    expect(appleHomeScreen).toContainReactComponent(Meta, {
+      name: 'apple-mobile-web-app-capable',
+      content: 'yes',
+    });
   });
 
   it('renders a <Meta /> with `name="apple-mobile-web-app-status-bar-style" content="black"` by default', () => {
     const appleHomeScreen = mount(<AppleHomeScreen />);
-
-    expect(
-      findMeta(appleHomeScreen, {
-        name: 'apple-mobile-web-app-status-bar-style',
-        content: 'black',
-      }),
-    ).not.toBeNull();
+    expect(appleHomeScreen).toContainReactComponent(Meta, {
+      name: 'apple-mobile-web-app-status-bar-style',
+      content: 'black',
+    });
   });
 
   it('renders a <Link /> for each item in the icons prop', () => {
@@ -49,34 +42,21 @@ describe('<AppleHomeScreen />', () => {
     const appleHomeScreen = mount(<AppleHomeScreen icons={icons} />);
 
     icons.forEach(({size, url}, index) => {
-      expect(appleHomeScreen.findAll(Link)[index].props).toMatchObject({
+      expect(appleHomeScreen.findAll(Link)[index]).toHaveReactProps({
         sizes: `${size}x${size}`,
         href: url,
       });
     });
   });
+
   it('renders a <Link /> for the startUpImage prop', () => {
     const startUpImage = 'path/to/startup.png';
     const appleHomeScreen = mount(
       <AppleHomeScreen startUpImage={startUpImage} />,
     );
 
-    expect(appleHomeScreen.find(Link)!.props).toMatchObject({
+    expect(appleHomeScreen).toContainReactComponent(Link, {
       href: startUpImage,
     });
   });
 });
-
-export function findMeta(wrapper: Root<any>, props: Props<typeof Meta>) {
-  return wrapper.findWhere(element => {
-    if (!element.is(Meta)) {
-      return false;
-    }
-
-    const propsArray: (keyof typeof props)[] = Object.keys(props) as any;
-    return (
-      propsArray.filter(prop => element.prop(prop) === props[prop]).length ===
-      propsArray.length
-    );
-  });
-}

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -9,4 +9,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `@shopify/react-testing` package
+- Added a `@shopify/react-testing/matchers` directory, which adds `.toHaveReactProps` and `.toContainReactComponent` assertions for Jest
+- `Element#find` and `Element#findAll` now accept a second optional argument for required props on matched elements
+
+## 1.0.0 - 2019-03-29
+
+Initial release.

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -9,6 +9,7 @@ A library for testing React components according to [Shopify conventions](https:
 
 1. [Installation](#installation)
 1. [Usage](#usage)
+1. [Matchers](#matchers)
 1. [FAQ](#faq)
 
 ## Installation
@@ -294,6 +295,40 @@ const myComponent = mount(
 );
 myComponent.triggerKeypath('action.onAction');
 expect(spy).toHaveBeenCalled();
+```
+
+## Matchers
+
+This library ships with a few useful custom matchers for Jest. To include these matchers, import `@shopify/react-testing/matchers` in any file that is included as part of the `setupFilesAfterEnv` option passed to Jest. The following matchers are available:
+
+### `.toHaveReactProp(prop: string, value?: any)`
+
+Checks whether a `Root` or `Element` object has a prop with the passed name. If a value is passed, this expectation will also ensure that the value is equal to the actual prop value (asymmetric matchers like `expect.objectContaining` are fully supported). Strict type checking is enforced, so the `prop` you pass must be a valid prop name for the component you are running the expectation on, and if `value` is provided, it must be of the same type as the actual prop value.
+
+```tsx
+const myComponent = mount(<MyComponent />);
+expect(myComponent.find('div')).toHaveReactProp('aria-label', 'Hello world');
+expect(myComponent.find('div')).toHaveReactProp(
+  'onClick',
+  expect.any(Function),
+);
+```
+
+### `.toHaveReactProps(props: object)`
+
+Like `.toHaveReactProp()`, but you pass an object that matches a subset of the props for the component.
+
+### `.toContainReactComponent(type: string | React.ComponentType, props?: object)`
+
+Asserts that at least one component matching `type` is in the descendants of the passed node. If the second argument is passed, this expectation will further filter the matches by components whose props are equal to the passed object (again, asymmetric matchers are fully supported).
+
+```tsx
+const myComponent = mount(<MyComponent />);
+
+expect(myComponent).toContainReactComponent('div', {
+  'aria-label': 'Hello world',
+  onClick: expect.any(Function),
+});
 ```
 
 ## FAQ

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -184,7 +184,7 @@ function isMatch(element: Element<unknown>) {
 }
 ```
 
-#### <a name="find"></a> `find(type: Type): Element<PropsForComponent<Type>> | null`
+#### <a name="find"></a> `find(type: Type, props?: Partial<PropsForComponent<Type>>): Element<PropsForComponent<Type>> | null`
 
 Finds a descendant component that matches `type`, where `type` is either a string or React component. If no matching element is found, `null` is returned. If a match is found, the returned `Element` will have the correct prop typing, which provides excellent type safety while navigating the React tree.
 
@@ -206,7 +206,33 @@ expect(wrapper.find(MyComponent)).not.toBeNull();
 expect(wrapper.find(YourComponent)).toBe(null);
 ```
 
-#### <a name="findAll"></a> `findAll(type: Type): Element<PropsForComponent<Type>>[]`
+You can optionally pass a second argument to this function, which is a set of props that will be used to further filter the matching elements. These props will be shallow compared to the props of each element.
+
+```tsx
+function MyComponent({name}: {name: string}) {
+  return <div>Hello, {name}!</div>;
+}
+
+function YourComponent() {
+  return <div>Goodbye, friend!</div>;
+}
+
+function Wrapper() {
+  return (
+    <>
+      <MyComponent name="Michelle" />
+      <MyComponent name="Gord" />
+    </>
+  );
+}
+
+const wrapper = mount(<Wrapper />);
+expect(wrapper.find(MyComponent, {name: 'Gord'})!.props).toMatchObject({
+  name: 'Gord',
+});
+```
+
+#### <a name="findAll"></a> `findAll(type: Type, props?: Partial<PropsForComponent<Type>>): Element<PropsForComponent<Type>>[]`
 
 Like `find()`, but returns all matches as an array.
 

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -301,22 +301,18 @@ expect(spy).toHaveBeenCalled();
 
 This library ships with a few useful custom matchers for Jest. To include these matchers, import `@shopify/react-testing/matchers` in any file that is included as part of the `setupFilesAfterEnv` option passed to Jest. The following matchers are available:
 
-### `.toHaveReactProp(prop: string, value?: any)`
+### `.toHaveReactProps(props: object)`
 
-Checks whether a `Root` or `Element` object has a prop with the passed name. If a value is passed, this expectation will also ensure that the value is equal to the actual prop value (asymmetric matchers like `expect.objectContaining` are fully supported). Strict type checking is enforced, so the `prop` you pass must be a valid prop name for the component you are running the expectation on, and if `value` is provided, it must be of the same type as the actual prop value.
+Checks whether a `Root` or `Element` object has specified props (asymmetric matchers like `expect.objectContaining` are fully supported). Strict type checking is enforced, so the `props` you pass must be a valid subset of the actual props for the component.
 
 ```tsx
 const myComponent = mount(<MyComponent />);
-expect(myComponent.find('div')).toHaveReactProp('aria-label', 'Hello world');
-expect(myComponent.find('div')).toHaveReactProp(
-  'onClick',
-  expect.any(Function),
-);
+
+expect(myComponent.find('div')).toHaveReactProps({'aria-label': 'Hello world'});
+expect(myComponent.find('div')).toHaveReactProps({
+  onClick: expect.any(Function),
+});
 ```
-
-### `.toHaveReactProps(props: object)`
-
-Like `.toHaveReactProp()`, but you pass an object that matches a subset of the props for the component.
 
 ### `.toContainReactComponent(type: string | React.ComponentType, props?: object)`
 

--- a/packages/react-testing/matchers.d.ts
+++ b/packages/react-testing/matchers.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/matchers';

--- a/packages/react-testing/matchers.js
+++ b/packages/react-testing/matchers.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/matchers');

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -25,13 +25,16 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-testing/README.md",
   "dependencies": {
     "@shopify/useful-types": "^1.2.0",
+    "jest-matcher-utils": "^24.5.0",
     "react-reconciler": "^0.20.2"
   },
   "devDependencies": {
     "typescript": "~3.0.1"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "matchers.js",
+    "matchers.d.ts"
   ],
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0",

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -134,16 +134,23 @@ export class Element<Props> {
 
   find<Type extends React.ComponentType<any> | string>(
     type: Type,
+    props?: Partial<PropsForComponent<Type>>,
   ): Element<PropsForComponent<Type>> | null {
-    return (this.elementDescendants.find(element => element.type === type) ||
-      null) as Element<PropsForComponent<Type>> | null;
+    return (this.elementDescendants.find(
+      element =>
+        element.type === type &&
+        (props == null || equalSubset(props, element.props as object)),
+    ) || null) as Element<PropsForComponent<Type>> | null;
   }
 
   findAll<Type extends React.ComponentType<any> | string>(
     type: Type,
+    props?: Partial<PropsForComponent<Type>>,
   ): Element<PropsForComponent<Type>>[] {
     return this.elementDescendants.filter(
-      element => element.type === type,
+      element =>
+        element.type === type &&
+        (props == null || equalSubset(props, element.props as object)),
     ) as Element<PropsForComponent<Type>>[];
   }
 
@@ -200,4 +207,10 @@ export class Element<Props> {
       return currentProp(...args);
     });
   }
+}
+
+function equalSubset(subset: object, full: object) {
+  return Object.keys(subset).every(
+    key => key in full && full[key] === subset[key],
+  );
 }

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -207,6 +207,19 @@ export class Element<Props> {
       return currentProp(...args);
     });
   }
+
+  toString() {
+    const {type} = this;
+
+    if (type == null) {
+      return '<Element />';
+    }
+
+    const name =
+      typeof type === 'string' ? type : type.displayName || type.name;
+
+    return `<${name} />`;
+  }
 }
 
 function equalSubset(subset: object, full: object) {

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -1,0 +1,99 @@
+import {ComponentType} from 'react';
+import {
+  matcherHint,
+  printExpected,
+  EXPECTED_COLOR as expectedColor,
+  RECEIVED_COLOR as receivedColor,
+} from 'jest-matcher-utils';
+import {Props} from '@shopify/useful-types';
+
+import {Element} from '../element';
+import {Node} from './types';
+import {assertIsNode, diffPropsForNode} from './utilities';
+
+export function toContainReactComponent<
+  Type extends string | ComponentType<any>
+>(
+  this: jest.MatcherUtils,
+  node: Node<unknown>,
+  type: Type,
+  props?: Partial<Props<Type>>,
+) {
+  assertIsNode(node, {
+    expectation: 'toContainReactComponent',
+    isNot: this.isNot,
+  });
+
+  const foundByType = node.findAll(type);
+  const foundByProps =
+    props == null
+      ? foundByType
+      : foundByType.filter(element =>
+          Object.keys(props).every(key =>
+            this.equals(props[key], element.props[key]),
+          ),
+        );
+
+  const pass = foundByProps.length > 0;
+
+  const message = pass
+    ? () =>
+        `${matcherHint('.not.toContainReactComponent')}\n\n` +
+        `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+        `Not to contain component:\n  ${expectedColor(printType(type))}\n${
+          props ? `With props matching:\n  ${printExpected(props)}\n` : ''
+        }` +
+        `But ${foundByProps.length} matching ${printType(type)} ${
+          foundByProps.length === 1 ? 'elements were' : 'element was'
+        } found.\n`
+    : () =>
+        `${`${matcherHint('.toContainReactComponent')}\n\n` +
+          `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+          `To contain component:\n  ${expectedColor(printType(type))}\n${
+            props ? `With props matching:\n  ${printExpected(props)}\n` : ''
+          }`}${
+          foundByType.length === 0
+            ? `But no matching ${printType(type)} elements were found.\n`
+            : `But the ${
+                foundByType.length === 1
+                  ? 'found element has'
+                  : 'found elements have'
+              } the following prop differences:\n\n${diffs(
+                foundByType,
+                props!,
+                this.expand,
+              )}`
+        }`;
+
+  return {pass, message};
+}
+
+function diffs(element: Element<any>[], props: object, expand?: boolean) {
+  return element.reduce<string>(
+    (diffs, element, index) =>
+      `${diffs}${index === 0 ? '' : '\n\n'}${normalizedDiff(element, props, {
+        expand,
+        showLegend: index === 0,
+      })}`,
+    '',
+  );
+}
+
+function normalizedDiff(
+  element: Element<any>,
+  props: object,
+  {expand = false, showLegend = false},
+) {
+  const result =
+    diffPropsForNode(element, props, {
+      expand,
+    }) || '';
+
+  return showLegend ? result : result.split('\n\n')[1];
+}
+
+function printType(type: string | React.ComponentType<any>) {
+  return `<${
+    typeof type === 'string' ? type : type.displayName || type.name
+  } />`;
+}

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,0 +1,26 @@
+import {ComponentType} from 'react';
+import {Props} from '@shopify/useful-types';
+
+import {toHaveReactProp, toHaveReactProps} from './props';
+import {toContainReactComponent} from './components';
+import {Node} from './types';
+
+type PropsFromNode<T> = T extends Node<infer U> ? U : never;
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveReactProp<Prop extends keyof PropsFromNode<R>>(
+        prop: Prop,
+        value?: PropsFromNode<R>[Prop],
+      ): void;
+      toHaveReactProps(props: Partial<PropsFromNode<R>>): void;
+      toContainReactComponent<Type extends string | ComponentType<any>>(
+        type: Type,
+        props?: Partial<Props<Type>>,
+      ): void;
+    }
+  }
+}
+
+expect.extend({toHaveReactProp, toHaveReactProps, toContainReactComponent});

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,7 +1,7 @@
 import {ComponentType} from 'react';
 import {Props} from '@shopify/useful-types';
 
-import {toHaveReactProp, toHaveReactProps} from './props';
+import {toHaveReactProps} from './props';
 import {toContainReactComponent} from './components';
 import {Node} from './types';
 
@@ -10,10 +10,6 @@ type PropsFromNode<T> = T extends Node<infer U> ? U : never;
 declare global {
   namespace jest {
     interface Matchers<R> {
-      toHaveReactProp<Prop extends keyof PropsFromNode<R>>(
-        prop: Prop,
-        value?: PropsFromNode<R>[Prop],
-      ): void;
       toHaveReactProps(props: Partial<PropsFromNode<R>>): void;
       toContainReactComponent<Type extends string | ComponentType<any>>(
         type: Type,
@@ -23,4 +19,4 @@ declare global {
   }
 }
 
-expect.extend({toHaveReactProp, toHaveReactProps, toContainReactComponent});
+expect.extend({toHaveReactProps, toContainReactComponent});

--- a/packages/react-testing/src/matchers/props.ts
+++ b/packages/react-testing/src/matchers/props.ts
@@ -1,0 +1,102 @@
+import {
+  matcherHint,
+  printReceived,
+  printExpected,
+  RECEIVED_COLOR as receivedColor,
+} from 'jest-matcher-utils';
+import {Node} from './types';
+import {assertIsNode, diffPropsForNode} from './utilities';
+
+export function toHaveReactProp<Props>(
+  this: jest.MatcherUtils,
+  node: Node<Props>,
+  prop: keyof Props,
+  value?: unknown,
+) {
+  assertIsNode(node, {
+    expectation: 'toHaveReactProp',
+    isNot: this.isNot,
+  });
+
+  const valuePassed = arguments.length > 2;
+  const hasProp = Reflect.has(node.props as any, prop);
+  const pass = valuePassed ? this.equals(value, node.prop(prop)) : hasProp;
+
+  const message = pass
+    ? () =>
+        `${matcherHint('.not.toHaveReactProp', node.toString(), 'prop', {
+          secondArgument: valuePassed ? 'value' : undefined,
+          isNot: true,
+        })}\n\n` +
+        `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+        `Not to have prop:\n  ${printExpected(prop)}\n${
+          valuePassed ? `With a value of\n  ${printExpected(value)}\n` : ''
+        }` +
+        `${
+          valuePassed
+            ? `But it does have a '${prop}' prop with that value.\n`
+            : `But it does have a '${prop}' prop.\n`
+        }`
+    : () =>
+        `${`${matcherHint('.toHaveReactProp', node.toString(), 'prop', {
+          secondArgument: valuePassed ? 'value' : undefined,
+        })}\n\n` +
+          `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+          `To have prop:\n  ${printExpected(prop)}\n${
+            valuePassed ? `With a value of:\n  ${printExpected(value)}\n` : ''
+          }`}${
+          hasProp
+            ? `Received:\n  ${printReceived(node.prop(prop))}\n`
+            : `But it does not have a '${prop}' prop.\n`
+        }`;
+
+  return {pass, message};
+}
+
+export function toHaveReactProps<Props>(
+  this: jest.MatcherUtils,
+  node: Node<Props>,
+  props: Partial<Props>,
+) {
+  assertIsNode(node, {
+    expectation: 'toHaveReactProps',
+    isNot: this.isNot,
+  });
+
+  if (props == null || typeof props !== 'object') {
+    return {
+      pass: false,
+      message: () =>
+        `You passed ${
+          props == null ? String(props) : `a ${typeof props}`
+        } as props, but it must be an object.`,
+    };
+  }
+
+  const pass = Object.keys(props).every(key =>
+    this.equals(props[key], node.props[key]),
+  );
+
+  const message = pass
+    ? () =>
+        `${matcherHint('.not.toHaveReactProps', node.toString())}\n\n` +
+        `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+        `Not to have props:\n  ${printExpected(props)}\n` +
+        `Received:\n  ${printReceived(node.props)}\n`
+    : () => {
+        const diffString = diffPropsForNode(node, props, {
+          expand: this.expand,
+        });
+
+        return (
+          `${matcherHint('.toHaveReactProps', node.toString())}\n\n` +
+          `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+          `To have props:\n  ${printExpected(props)}\n` +
+          `Received:\n  ${printReceived(node.props)}\n${
+            diffString ? `Difference:\n${diffString}\n` : ''
+          }`
+        );
+      };
+
+  return {pass, message};
+}

--- a/packages/react-testing/src/matchers/props.ts
+++ b/packages/react-testing/src/matchers/props.ts
@@ -7,52 +7,6 @@ import {
 import {Node} from './types';
 import {assertIsNode, diffPropsForNode} from './utilities';
 
-export function toHaveReactProp<Props>(
-  this: jest.MatcherUtils,
-  node: Node<Props>,
-  prop: keyof Props,
-  value?: unknown,
-) {
-  assertIsNode(node, {
-    expectation: 'toHaveReactProp',
-    isNot: this.isNot,
-  });
-
-  const valuePassed = arguments.length > 2;
-  const hasProp = Reflect.has(node.props as any, prop);
-  const pass = valuePassed ? this.equals(value, node.prop(prop)) : hasProp;
-
-  const message = pass
-    ? () =>
-        `${matcherHint('.not.toHaveReactProp', node.toString(), 'prop', {
-          secondArgument: valuePassed ? 'value' : undefined,
-          isNot: true,
-        })}\n\n` +
-        `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
-        `Not to have prop:\n  ${printExpected(prop)}\n${
-          valuePassed ? `With a value of\n  ${printExpected(value)}\n` : ''
-        }` +
-        `${
-          valuePassed
-            ? `But it does have a '${prop}' prop with that value.\n`
-            : `But it does have a '${prop}' prop.\n`
-        }`
-    : () =>
-        `${`${matcherHint('.toHaveReactProp', node.toString(), 'prop', {
-          secondArgument: valuePassed ? 'value' : undefined,
-        })}\n\n` +
-          `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
-          `To have prop:\n  ${printExpected(prop)}\n${
-            valuePassed ? `With a value of:\n  ${printExpected(value)}\n` : ''
-          }`}${
-          hasProp
-            ? `Received:\n  ${printReceived(node.prop(prop))}\n`
-            : `But it does not have a '${prop}' prop.\n`
-        }`;
-
-  return {pass, message};
-}
-
 export function toHaveReactProps<Props>(
   this: jest.MatcherUtils,
   node: Node<Props>,

--- a/packages/react-testing/src/matchers/types.ts
+++ b/packages/react-testing/src/matchers/types.ts
@@ -1,0 +1,6 @@
+import {Root} from '../root';
+import {Element} from '../element';
+
+export {Root, Element};
+
+export type Node<Props> = Root<Props> | Element<Props>;

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -1,0 +1,99 @@
+import {
+  diff,
+  matcherErrorMessage,
+  matcherHint,
+  RECEIVED_COLOR as receivedColor,
+  printWithType,
+  printReceived,
+} from 'jest-matcher-utils';
+import {Node, Root, Element} from './types';
+
+export function assertIsNode(
+  node: unknown,
+  {expectation, isNot}: {expectation: string; isNot: boolean},
+) {
+  if (node == null) {
+    throw new Error(
+      matcherErrorMessage(
+        matcherHint(`.${expectation}`, undefined, undefined, {isNot}),
+        `${receivedColor(
+          'received',
+        )} value must be an @shopify/react-testing Root or Element object`,
+        `Received ${receivedColor(
+          'null',
+        )}.\nThis usually means that your \`.findX\` method failed to find any matching elements.`,
+      ),
+    );
+  }
+
+  if (
+    Array.isArray(node) &&
+    node.length > 1 &&
+    (node[0] instanceof Root || node[0] instanceof Element)
+  ) {
+    throw new Error(
+      matcherErrorMessage(
+        matcherHint(`.${expectation}`, undefined, undefined, {isNot}),
+        `${receivedColor(
+          'received',
+        )} value must be an @shopify/react-testing Root or Element object`,
+        `Received an ${receivedColor(
+          'array of Root or Element objects',
+        )}.\nThis usually means that you passed in the result of \`.findAllX\`. Pass the result of \`.findX\` instead.`,
+      ),
+    );
+  }
+
+  if (!(node instanceof Root) && !(node instanceof Element)) {
+    throw new Error(
+      matcherErrorMessage(
+        matcherHint(`.${expectation}`, undefined, undefined, {isNot}),
+        `${receivedColor(
+          'received',
+        )} value must be an @shopify/react-testing Root or Element object`,
+        printWithType('Received', node, printReceived),
+      ),
+    );
+  }
+}
+
+export function diffPropsForNode(
+  node: Node<any>,
+  props: object,
+  {expand = false},
+) {
+  return diff(props, getObjectSubset(node.props, props), {
+    expand,
+  });
+}
+
+// Original from https://github.com/facebook/jest/blob/master/packages/expect/src/utils.ts#L107
+function getObjectSubset(object: any, subset: any): any {
+  if (Array.isArray(object)) {
+    if (Array.isArray(subset) && subset.length === object.length) {
+      return subset.map((sub: any, i: number) =>
+        getObjectSubset(object[i], sub),
+      );
+    }
+  } else if (object instanceof Date) {
+    return object;
+  } else if (
+    typeof object === 'object' &&
+    object !== null &&
+    typeof subset === 'object' &&
+    subset !== null
+  ) {
+    const trimmed: any = {};
+    Object.keys(subset)
+      .filter(key => Reflect.has(object, key))
+      .forEach(
+        key => (trimmed[key] = getObjectSubset(object[key], subset[key])),
+      );
+
+    if (Object.keys(trimmed).length > 0) {
+      return trimmed;
+    }
+  }
+
+  return object;
+}

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -26,6 +26,10 @@ export class Root<Props> {
     return this.withRoot(root => root.isDOM);
   }
 
+  get type() {
+    return this.withRoot(root => root.type);
+  }
+
   get instance() {
     return this.withRoot(root => root.instance);
   }
@@ -179,6 +183,10 @@ export class Root<Props> {
   forceUpdate() {
     this.ensureRoot();
     this.act(() => this.wrapper!.forceUpdate());
+  }
+
+  toString() {
+    return this.withRoot(root => root.toString());
   }
 
   private update() {

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -92,12 +92,18 @@ export class Root<Props> {
     return this.withRoot(root => root.prop(key));
   }
 
-  find<Type extends React.ComponentType<any> | string>(type: Type) {
-    return this.withRoot(root => root.find(type));
+  find<Type extends React.ComponentType<any> | string>(
+    type: Type,
+    props?: Partial<PropsForComponent<Type>>,
+  ) {
+    return this.withRoot(root => root.find(type, props));
   }
 
-  findAll<Type extends React.ComponentType<any> | string>(type: Type) {
-    return this.withRoot(root => root.findAll(type));
+  findAll<Type extends React.ComponentType<any> | string>(
+    type: Type,
+    props?: Partial<PropsForComponent<Type>>,
+  ) {
+    return this.withRoot(root => root.findAll(type, props));
   }
 
   findWhere(predicate: Predicate) {

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -372,6 +372,62 @@ describe('Element', () => {
       expect(element.find(DummyComponent)).toBe(componentOne);
     });
 
+    it('restricts found elements to those with shallow-matching props when props are passed', () => {
+      const divOne = new Element(
+        {
+          ...defaultTree,
+          props: {className: 'foo'},
+          type: 'div',
+          tag: Tag.HostComponent,
+          instance: document.createElement('div'),
+        },
+        [],
+        [],
+        defaultRoot,
+      );
+
+      const divTwo = new Element(
+        {
+          ...defaultTree,
+          props: {className: 'bar'},
+          type: 'div',
+          tag: Tag.HostComponent,
+          instance: document.createElement('div'),
+        },
+        [],
+        [],
+        defaultRoot,
+      );
+
+      const span = new Element(
+        {
+          ...defaultTree,
+          props: {className: 'baz'},
+          type: 'span',
+          tag: Tag.HostComponent,
+          instance: document.createElement('span'),
+        },
+        [],
+        [],
+        defaultRoot,
+      );
+
+      const element = new Element(
+        defaultTree,
+        [divOne, divTwo, span],
+        [divOne, divTwo, span],
+        defaultRoot,
+      );
+
+      expect(element.find('div', {className: divTwo.props.className})).toBe(
+        divTwo,
+      );
+
+      expect(
+        element.find('span', {className: span.props.className}),
+      ).toBeNull();
+    });
+
     it('returns null when no match is found', () => {
       const element = new Element(defaultTree, [], [], defaultRoot);
       expect(element.find(DummyComponent)).toBeNull();
@@ -402,6 +458,62 @@ describe('Element', () => {
         componentOne,
         componentTwo,
       ]);
+    });
+
+    it('restricts found elements to those with shallow-matching props when props are passed', () => {
+      const divOne = new Element(
+        {
+          ...defaultTree,
+          props: {className: 'foo'},
+          type: 'div',
+          tag: Tag.HostComponent,
+          instance: document.createElement('div'),
+        },
+        [],
+        [],
+        defaultRoot,
+      );
+
+      const divTwo = new Element(
+        {
+          ...defaultTree,
+          props: {className: 'bar'},
+          type: 'div',
+          tag: Tag.HostComponent,
+          instance: document.createElement('div'),
+        },
+        [],
+        [],
+        defaultRoot,
+      );
+
+      const span = new Element(
+        {
+          ...defaultTree,
+          props: {className: 'baz'},
+          type: 'span',
+          tag: Tag.HostComponent,
+          instance: document.createElement('span'),
+        },
+        [],
+        [],
+        defaultRoot,
+      );
+
+      const element = new Element(
+        defaultTree,
+        [divOne, divTwo, span],
+        [divOne, divTwo, span],
+        defaultRoot,
+      );
+
+      expect(element.findAll('div', {className: divTwo.props.className})).toBe([
+        divTwo,
+      ]);
+
+      expect(
+        element.findAll('span', {className: span.props.className}),
+      ).toHaveLength(0);
     });
 
     it('returns an empty array when no matches are found', () => {

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -423,9 +423,7 @@ describe('Element', () => {
         divTwo,
       );
 
-      expect(
-        element.find('span', {className: span.props.className}),
-      ).toBeNull();
+      expect(element.find('div', {className: span.props.className})).toBeNull();
     });
 
     it('returns null when no match is found', () => {
@@ -512,7 +510,7 @@ describe('Element', () => {
       ]);
 
       expect(
-        element.findAll('span', {className: span.props.className}),
+        element.findAll('div', {className: span.props.className}),
       ).toHaveLength(0);
     });
 

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -505,9 +505,9 @@ describe('Element', () => {
         defaultRoot,
       );
 
-      expect(element.findAll('div', {className: divTwo.props.className})).toBe([
-        divTwo,
-      ]);
+      expect(
+        element.findAll('div', {className: divTwo.props.className}),
+      ).toEqual([divTwo]);
 
       expect(
         element.findAll('div', {className: span.props.className}),

--- a/packages/react-testing/src/tests/root.test.tsx
+++ b/packages/react-testing/src/tests/root.test.tsx
@@ -1,22 +1,13 @@
 import * as React from 'react';
-import {FirstArgument} from '@shopify/useful-types';
 
 import {Root} from '../root';
 import {Element} from '../element';
 import {Tag} from '../types';
 import {destroyAll} from '../api';
 
-jest.mock('react-dom/test-utils', () => ({
-  act: jest.fn((callback: Function) => callback()),
-}));
-
-const {act} = require.requireMock('react-dom/test-utils') as {act: jest.Mock};
-
 describe('Root', () => {
   afterEach(() => {
     destroyAll();
-    act.mockReset();
-    act.mockImplementation((callback: Function) => callback());
   });
 
   it('delegates calls to the root element', () => {
@@ -190,28 +181,6 @@ describe('Root', () => {
 
       expect(componentWillUnmount).not.toHaveBeenCalled();
       expect(componentDidUpdate).toHaveBeenCalled();
-    });
-  });
-
-  describe('#act()', () => {
-    it('runs the callback in an act block', () => {
-      const root = new Root(<div />);
-
-      const queue = new Set<FirstArgument<Root<any>['act']>>();
-      act.mockImplementation((action: FirstArgument<Root<any>['act']>) =>
-        queue.add(action),
-      );
-
-      const action = jest.fn();
-
-      root.act(action);
-      expect(action).not.toHaveBeenCalled();
-
-      for (const queued of queue) {
-        queued();
-      }
-
-      expect(action).toHaveBeenCalled();
     });
   });
 

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -20,9 +20,11 @@ export type DeepPartial<T> = {
       : DeepPartial<T[P]>
 };
 
-export type Props<T> = T extends string
-  ? HTMLAttributes<T>
-  : T extends ComponentType<infer Props> ? Props : never;
+export type Props<T> = T extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[T]
+  : T extends string
+    ? HTMLAttributes<T>
+    : T extends ComponentType<infer Props> ? Props : never;
 
 export type IfEmptyObject<Object, If, Else = never> = keyof Object extends {
   length: 0;

--- a/test/each-test.ts
+++ b/test/each-test.ts
@@ -1,6 +1,14 @@
-import './matchers';
 import addClosest from 'element-closest';
+
+import './matchers';
+import '../packages/react-testing/src/matchers';
+
+import {destroyAll} from '../packages/react-testing/src/api';
 
 if (typeof window !== 'undefined') {
   addClosest(window);
 }
+
+afterEach(() => {
+  destroyAll();
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,7 @@
     "strictNullChecks": true,
     "noImplicitAny": false,
     "sourceMap": false,
-    "noEmitOnError": true,
+    "noEmitOnError": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,6 +265,14 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@jest/types@^24.5.0":
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.5.0.tgz#feee214a4d0167b0ca447284e95a57aa10b3ee95"
+  integrity sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^1.1.0"
+    "@types/yargs" "^12.0.9"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -462,6 +470,11 @@
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.2.2.tgz#17dfe5a82184a8898935d96fe2eaedd37d22d9a4"
   integrity sha512-x1553BFcgBVOD6y3tC/2SOVcNaf6b9eH3BvqniAZZwmHWYhyr8ffXTYygQC/hQxNI4Yfc3q0gGUvyiAHV4tRNg==
 
+"@types/istanbul-lib-coverage@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
+  integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
+
 "@types/jest@^23.3.5":
   version "23.3.5"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.5.tgz#870a1434208b60603745bfd214fc3fc675142364"
@@ -644,6 +657,11 @@
     "@types/uglify-js" "*"
     source-map "^0.6.0"
 
+"@types/yargs@^12.0.9":
+  version "12.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.10.tgz#17a8ec65cd8e88f51b418ceb271af18d3137df67"
+  integrity sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==
+
 "@types/zen-observable@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
@@ -777,6 +795,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2491,6 +2514,11 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+
+diff-sequences@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
+  integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
 diff@^3.2.0:
   version "3.5.0"
@@ -4818,6 +4846,16 @@ jest-diff@^23.6.0:
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
 
+jest-diff@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.5.0.tgz#a2d8627964bb06a91893c0fbcb28ab228c257652"
+  integrity sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.3.0"
+    jest-get-type "^24.3.0"
+    pretty-format "^24.5.0"
+
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
@@ -4885,6 +4923,11 @@ jest-get-type@^22.1.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
   integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
 
+jest-get-type@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.3.0.tgz#582cfd1a4f91b5cdad1d43d2932f816d543c65da"
+  integrity sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==
+
 jest-haste-map@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.6.0.tgz#2e3eb997814ca696d62afdb3f2529f5bbc935e16"
@@ -4932,6 +4975,16 @@ jest-matcher-utils@^23.6.0:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
+
+jest-matcher-utils@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz#5995549dcf09fa94406e89526e877b094dad8770"
+  integrity sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.5.0"
+    jest-get-type "^24.3.0"
+    pretty-format "^24.5.0"
 
 jest-message-util@^22.4.3:
   version "22.4.3"
@@ -6760,6 +6813,16 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.5.0.tgz#cc69a0281a62cd7242633fc135d6930cd889822d"
+  integrity sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==
+  dependencies:
+    "@jest/types" "^24.5.0"
+    ansi-regex "^4.0.0"
+    ansi-styles "^3.2.0"
+    react-is "^16.8.4"
+
 pretty-ms@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-3.2.0.tgz#87a8feaf27fc18414d75441467d411d6e6098a25"
@@ -7008,6 +7071,11 @@ react-is@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-is@^16.8.4:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-reconciler@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
Adds a few more things I missed in the first one:

* `.find` and `.findAll` accept a second props argument for a subset of props to match.
* Added the `.toContainReactComponent` and `.toHaveReactProps` assertions