### PR TITLE
Add hook-ey `react-intersection-observer` API

### DIFF
--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -99,7 +99,7 @@ class ConnectedAsync<Value> extends React.Component<
         <IntersectionObserver
           threshold={0}
           unsupportedBehavior={UnsupportedBehavior.TreatAsIntersecting}
-          onIntersecting={this.load}
+          onIntersectionChange={this.loadIfIntersecting}
         />
       ) : null;
 
@@ -111,6 +111,10 @@ class ConnectedAsync<Value> extends React.Component<
       </>
     );
   }
+
+  private loadIfIntersecting = ({isIntersecting = true}) => {
+    return isIntersecting ? this.load() : Promise.resolve();
+  };
 
   private load = async () => {
     try {

--- a/packages/react-async/src/tests/Async.test.tsx
+++ b/packages/react-async/src/tests/Async.test.tsx
@@ -142,7 +142,8 @@ describe('<Async />', () => {
 
       const intersectingPromise = trigger(
         async.find(IntersectionObserver),
-        'onIntersecting',
+        'onIntersectionChange',
+        {isIntersecting: true},
       );
 
       await promise.resolve();

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -71,7 +71,7 @@ export default class ImportRemote extends React.PureComponent<Props, State> {
         <IntersectionObserver
           threshold={0}
           unsupportedBehavior={UnsupportedBehavior.TreatAsIntersecting}
-          onIntersecting={this.loadRemote}
+          onIntersectionChange={this.loadRemoteIfIntersecting}
         />
       ) : null;
 
@@ -87,6 +87,10 @@ export default class ImportRemote extends React.PureComponent<Props, State> {
 
     return intersectionObserver;
   }
+
+  private loadRemoteIfIntersecting = ({isIntersecting = true}) => {
+    return isIntersecting ? this.loadRemote() : Promise.resolve();
+  };
 
   private loadRemote = () => {
     return new Promise(resolve => {

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -168,7 +168,12 @@ describe('<ImportRemote />', () => {
         0,
       );
 
-      await trigger(importRemote.find(IntersectionObserver), 'onIntersecting');
+      await trigger(
+        importRemote.find(IntersectionObserver),
+        'onIntersectionChange',
+        {isIntersecting: true},
+      );
+
       expect(importRemote.find(IntersectionObserver)).toHaveLength(0);
       expect(load).toHaveBeenCalled();
     });

--- a/packages/react-intersection-observer/README.md
+++ b/packages/react-intersection-observer/README.md
@@ -13,13 +13,37 @@ $ yarn add @shopify/react-intersection-observer
 
 ## Usage
 
-This package exports an `IntersectionObserver` component. This component will create its own DOM node that will be observed, with optional `onIntersecting` and `onNotIntersecting` props being called as appropriate. `onIntersecting` and `onNotIntersecting` will be called with an `IntersectionObserverEntry` object, which describes the state of the intersection. The component also accepts a few additional props that correspond to the options used to construct an `IntersectionObserver`:
+### `useIntersection(options: Options)`
 
-- `threshold`: a number or array of number indicating the `intersectionRatio` that must be met before the observer is triggered
+The `useIntersection` hook takes in `IntersectionObserver` options, and returns a tuple of:
+
+- The most recent `IntersectionObserverEntry` value, which details the most recent state of the observer.
+- An object that you can pass as a `ref` to the DOM element you wish to track.
+
+```tsx
+function MyComponent() {
+  const [intersection, intersectionRef] = useIntersection();
+
+  return (
+    <div ref={intersectionRef}>Intersection: {intersection.isIntersecting}</div>
+  );
+}
+```
+
+You can pass additional options to this hook that are used to create the underlying `IntersectionObserver`:
+
+- `threshold`: a number or array of number indicating the `intersectionRatio` that must be met before the observer is triggered.
 - `root`: a string or element that is used as the viewport for visibility testing. If a string is passed, it will be treated as a selector.
 - `rootMargin`: a string representing the margins by which to shrink the root’s bounding box before computing intersections.
 
-This component also allows you to customize the rendered markup. You can pass `children`, which will be rendered inside of the node being observed for intersections. You can also pass a `wrapperComponent` prop that changes the DOM node being wrapped around those children (defaults to a `div`). Regardless of the passed `wrapperComponent`, the `IntersectionObserver` component will always add a `display: contents` style to that node in order to reduce the styling impact of the additional nesting.
+### `<IntersectionObserver />`
+
+This package also exports an `IntersectionObserver` component, which is a fairly minimal component wrapper around the `useIntersection` hook, and accepts the same `threshold`, `root`, and `rootMargin` values as props. The `onIntersectionChange` prop you pass to this component will be called with an `IntersectionObserverEntry` object, which describes the state of the intersection (and is equivalent to the first value of the tuple returned from the hook).
+
+Unlike the `useIntersection` hook, this component will create its own DOM node that will be observed, rather than requiring you to pass a `ref` to a DOM node you already control. You can customize the rendered markup by passing either of the following props:
+
+- `children`, which will be rendered inside of the node being observed for intersections.
+- `wrapperComponent`, which changes the DOM node being wrapped around those children (defaults to a `div`).
 
 ```tsx
 <div ref={this.parentElement}>
@@ -35,15 +59,15 @@ This component also allows you to customize the rendered markup. You can pass `c
 
 ### Lifecycle
 
-You may change any prop on an `IntersectionObserver` component, and the component will do the minimum amount of work to unobserve/ re-observe with the new fields. The most expensive updates to make are changing `threshold`, `root`, `rootMargin`, and `wrapperComponent`, as these require disconnecting the old observer and recreating a new one.
+You may change any option on a `useIntersection` hook, or any prop on an `IntersectionObserver` component, and the minimum amount of work will be performed to unobserve/ re-observe with the new fields. The most expensive updates to make are changing `threshold`, `root`, `rootMargin`, and, in the case of the component version, `wrapperComponent`, as these require disconnecting the old observer and recreating a new one.
 
-When this component is unmounted, it disconnects the current observer.
+When a component consuming the `useIntersection` hook is unmounted, the intersection observer is disconnected. The same applies if you unmount an `IntersectionObserver` component.
 
 ### Browser support
 
 To polyfill `IntersectionObserver`, please use the `@shopify/polyfills/intersection-observer` package.
 
-If you do not polyfill the feature and it is not supported in the current browser, the `IntersectionObserver` component will decide what to do based on the `unsupportedBehavior` prop. This prop should be a member of the `UnsupportedBehavior` enum (exported from this package). Currently, there are two options:
+If you do not polyfill the feature and it is not supported in the current browser, the `useIntersection` hook and the `IntersectionObserver` component will decide what to do based on the `unsupportedBehavior` option. This value should be a member of the `UnsupportedBehavior` enum (exported from this package). Currently, there are two options:
 
-- `UnsupportedBehavior.TreatAsIntersecting`: immediately calls `onIntersecting` on mount, if it is provided (this is the default).
-- `UnsupportedBehavior.Ignore`: never calls `onIntersecting` or `onNotIntersecting`.
+- `UnsupportedBehavior.TreatAsIntersecting`: immediately sets state/ calls `onIntersectionChange` on mount with a non-0 `intersectionRatio` (this is the default).
+- `UnsupportedBehavior.Ignore`: never calls marks the intersection observer as being intersecting.

--- a/packages/react-intersection-observer/README.md
+++ b/packages/react-intersection-observer/README.md
@@ -17,7 +17,7 @@ $ yarn add @shopify/react-intersection-observer
 
 The `useIntersection` hook takes in `IntersectionObserver` options, and returns a tuple of:
 
-- The most recent `IntersectionObserverEntry` value, which details the most recent state of the observer.
+- The state of the observer.
 - An object that you can pass as a `ref` to the DOM element you wish to track.
 
 ```tsx
@@ -59,7 +59,7 @@ Unlike the `useIntersection` hook, this component will create its own DOM node t
 
 ### Lifecycle
 
-You may change any option on a `useIntersection` hook, or any prop on an `IntersectionObserver` component, and the minimum amount of work will be performed to unobserve/ re-observe with the new fields. The most expensive updates to make are changing `threshold`, `root`, `rootMargin`, and, in the case of the component version, `wrapperComponent`, as these require disconnecting the old observer and recreating a new one.
+When `useIntersection` is passed new options (or, when `IntersectionObserver` receives new props), this library will do the minimum amount of work to unobserve/ re-observe with the new fields. The most expensive updates to make are changing `threshold`, `root`, `rootMargin`, and, in the case of the component version, `wrapperComponent`, as these require disconnecting the old observer and recreating a new one.
 
 When a component consuming the `useIntersection` hook is unmounted, the intersection observer is disconnected. The same applies if you unmount an `IntersectionObserver` component.
 

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -12,7 +12,7 @@ interface Props {
   onIntersectionChange(entry: IntersectionObserverEntry): void;
 }
 
-export function IntersectionObserver({
+export const IntersectionObserver = React.memo(function IntersectionObserver({
   children,
   root,
   rootMargin,
@@ -31,4 +31,4 @@ export function IntersectionObserver({
   useValueTracking(intersection, newValue => onIntersectionChange(newValue));
 
   return <Wrapper ref={ref}>{children}</Wrapper>;
-}
+});

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import {isSupported} from './utilities';
-
-export enum UnsupportedBehavior {
-  Ignore,
-  TreatAsIntersecting,
-}
+import {useIntersection, useValueTracking} from './hooks';
+import {UnsupportedBehavior} from './types';
 
 interface Props {
   root?: Element | string | null;
@@ -13,141 +9,26 @@ interface Props {
   children?: React.ReactNode;
   wrapperComponent?: string;
   unsupportedBehavior?: UnsupportedBehavior;
-  onIntersecting?(entries: IntersectionObserverEntry): void;
-  onNotIntersecting?(entries: IntersectionObserverEntry): void;
+  onIntersectionChange(entry: IntersectionObserverEntry): void;
 }
 
-export default class IntersectionObserverDom extends React.Component<Props> {
-  private observed = React.createRef<HTMLElement>();
-  private observer?: IntersectionObserver;
-
-  componentDidMount() {
-    this.observe();
-  }
-
-  shouldComponentUpdate(nextProps: Props) {
-    // If any of the values required to construct an IntersectionObserver
-    // change, we need to disconnect it altogether. If only the callbacks changed,
-    // we can skip doing anything at all, because they are already dynamically
-    // looked up in the IntersectionObserver callback.
-    return (
-      nextProps.root !== this.props.root ||
-      nextProps.rootMargin !== this.props.rootMargin ||
-      nextProps.children !== this.props.children ||
-      nextProps.wrapperComponent !== this.props.wrapperComponent ||
-      !equalThresholds(nextProps.threshold, this.props.threshold)
-    );
-  }
-
-  componentDidUpdate() {
-    this.disconnect();
-    this.observe();
-  }
-
-  componentWillUnmount() {
-    this.disconnect();
-  }
-
-  render() {
-    const {wrapperComponent: Wrapper = 'div' as any, children} = this.props;
-    return <Wrapper ref={this.observed}>{children}</Wrapper>;
-  }
-
-  private disconnect() {
-    const {observer} = this;
-
-    if (observer != null) {
-      observer.disconnect();
-      this.observer = undefined;
-    }
-  }
-
-  private observe() {
-    const {props, observed} = this;
-
-    if (observed.current == null) {
-      return;
-    }
-
-    if (!isSupported()) {
-      const {
-        unsupportedBehavior = UnsupportedBehavior.TreatAsIntersecting,
-        onIntersecting,
-      } = props;
-
-      if (
-        unsupportedBehavior === UnsupportedBehavior.TreatAsIntersecting &&
-        onIntersecting != null
-      ) {
-        const boundingClientRect = observed.current.getBoundingClientRect();
-
-        onIntersecting({
-          boundingClientRect,
-          intersectionRatio: 1,
-          intersectionRect: boundingClientRect,
-          isIntersecting: true,
-          rootBounds: boundingClientRect,
-          target: observed.current,
-          time: Date.now(),
-        });
-      }
-
-      return;
-    }
-
-    this.observer = observe(
-      observed.current,
-      this.intersectionObserverCallback,
-      props,
-    );
-  }
-
-  private intersectionObserverCallback = ([
-    intersectionEntry,
-  ]: IntersectionObserverEntry[]) => {
-    const {onIntersecting, onNotIntersecting} = this.props;
-
-    if (intersectionEntry.intersectionRatio > 0) {
-      if (onIntersecting) {
-        onIntersecting(intersectionEntry);
-      }
-    } else if (onNotIntersecting) {
-      onNotIntersecting(intersectionEntry);
-    }
-  };
-}
-
-function observe(
-  element: HTMLElement,
-  callback: IntersectionObserverCallback,
-  {
+export function IntersectionObserver({
+  children,
+  root,
+  rootMargin,
+  threshold,
+  unsupportedBehavior,
+  wrapperComponent: Wrapper = 'div',
+  onIntersectionChange,
+}: Props) {
+  const [intersection, ref] = useIntersection({
     root,
     rootMargin,
     threshold,
-  }: Pick<Props, 'root' | 'rootMargin' | 'threshold'>,
-) {
-  const resolvedRoot =
-    typeof root === 'string' ? document.querySelector(root) : root;
-
-  const observer = new IntersectionObserver(callback, {
-    root: resolvedRoot,
-    rootMargin,
-    threshold,
+    unsupportedBehavior,
   });
 
-  observer.observe(element);
-  return observer;
-}
+  useValueTracking(intersection, newValue => onIntersectionChange(newValue));
 
-function equalThresholds(
-  oldThreshold: Props['threshold'],
-  newThreshold: Props['threshold'],
-) {
-  return (
-    oldThreshold === newThreshold ||
-    (Array.isArray(oldThreshold) &&
-      Array.isArray(newThreshold) &&
-      oldThreshold.length === newThreshold.length &&
-      oldThreshold.every((item, index) => item === newThreshold[index]))
-  );
+  return <Wrapper ref={ref}>{children}</Wrapper>;
 }

--- a/packages/react-intersection-observer/src/hooks.ts
+++ b/packages/react-intersection-observer/src/hooks.ts
@@ -1,0 +1,147 @@
+import {useState, useRef, useEffect, Ref} from 'react';
+
+import {isSupported} from './utilities';
+import {UnsupportedBehavior} from './types';
+
+interface Options {
+  root?: Element | string | null;
+  rootMargin?: string;
+  threshold?: number | number[];
+  children?: React.ReactNode;
+  wrapperComponent?: string;
+  unsupportedBehavior?: UnsupportedBehavior;
+}
+
+const emptyBoundingClientRect = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  top: 0,
+  width: 0,
+};
+
+export function useIntersection({
+  root,
+  rootMargin,
+  threshold,
+  unsupportedBehavior = UnsupportedBehavior.TreatAsIntersecting,
+}: Options = {}): [IntersectionObserverEntry, Ref<HTMLElement | null>] {
+  const node = useRef<HTMLElement | null>(null);
+  const lastNode = useRef<HTMLElement | null>(null);
+  const observer = useRef<IntersectionObserver | null>(null);
+  const lastObserver = useRef<IntersectionObserver | null>(null);
+
+  const [intersectionEntry, setIntersectingEntry] = useState<
+    IntersectionObserverEntry
+  >(() => ({
+    boundingClientRect: emptyBoundingClientRect,
+    intersectionRatio: 0,
+    intersectionRect: emptyBoundingClientRect,
+    isIntersecting: false,
+    rootBounds: emptyBoundingClientRect,
+    target: null as any,
+    time: Date.now(),
+  }));
+
+  useEffect(
+    () => {
+      if (!isSupported()) {
+        return;
+      }
+
+      const resolvedRoot =
+        typeof root === 'string' ? document.querySelector(root) : root;
+
+      const intersectionObserver = new IntersectionObserver(
+        ([entry]) =>
+          setIntersectingEntry({
+            ...entry,
+            // Normalizes for inconsistent browser support
+            isIntersecting: entry.intersectionRatio > 0,
+          }),
+        {
+          root: resolvedRoot,
+          rootMargin,
+          threshold,
+        },
+      );
+
+      observer.current = intersectionObserver;
+
+      // eslint-disable-next-line consistent-return
+      return () => {
+        intersectionObserver.disconnect();
+      };
+    },
+    [root, rootMargin, Array.isArray(threshold) ? threshold.join() : threshold],
+  );
+
+  useEffect(() => {
+    if (
+      lastNode.current === node.current &&
+      lastObserver.current === observer.current
+    ) {
+      return;
+    }
+
+    lastNode.current = node.current;
+
+    if (node.current == null) {
+      return;
+    }
+
+    if (
+      !isSupported() &&
+      unsupportedBehavior === UnsupportedBehavior.TreatAsIntersecting
+    ) {
+      const boundingClientRect = node.current.getBoundingClientRect();
+
+      setIntersectingEntry({
+        boundingClientRect,
+        intersectionRatio: 1,
+        intersectionRect: boundingClientRect,
+        isIntersecting: true,
+        rootBounds: boundingClientRect,
+        target: node.current,
+        time: Date.now(),
+      });
+
+      return;
+    }
+
+    if (observer.current != null) {
+      lastObserver.current = observer.current;
+      observer.current.observe(node.current);
+    }
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      if (
+        lastNode.current == null ||
+        lastObserver.current == null ||
+        (lastNode.current === node.current &&
+          lastObserver.current === observer.current)
+      ) {
+        return;
+      }
+
+      lastObserver.current.unobserve(lastNode.current);
+    };
+  });
+
+  return [intersectionEntry, node];
+}
+
+export function useValueTracking<T>(
+  value: T,
+  onChange: (value: T, oldValue: T) => void,
+) {
+  const tracked = useRef(value);
+  const oldValue = tracked.current;
+
+  if (value !== oldValue) {
+    tracked.current = value;
+    onChange(value, oldValue);
+  }
+}

--- a/packages/react-intersection-observer/src/index.ts
+++ b/packages/react-intersection-observer/src/index.ts
@@ -1,4 +1,3 @@
-export {
-  default as IntersectionObserver,
-  UnsupportedBehavior,
-} from './IntersectionObserver';
+export {default as IntersectionObserver} from './IntersectionObserver';
+export {UnsupportedBehavior} from './types';
+export {useIntersection} from './hooks';

--- a/packages/react-intersection-observer/src/index.ts
+++ b/packages/react-intersection-observer/src/index.ts
@@ -1,3 +1,3 @@
-export {default as IntersectionObserver} from './IntersectionObserver';
+export {IntersectionObserver} from './IntersectionObserver';
 export {UnsupportedBehavior} from './types';
 export {useIntersection} from './hooks';

--- a/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
+++ b/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
+import {mount} from '@shopify/react-testing';
 import {intersectionObserver as intersectionObserverMock} from '@shopify/jest-dom-mocks';
 
-import IntersectionObserver, {
-  UnsupportedBehavior,
-} from '../IntersectionObserver';
+import {IntersectionObserver} from '../IntersectionObserver';
+import {UnsupportedBehavior} from '../types';
 
 jest.mock('../utilities', () => ({
   isSupported: jest.fn(),
@@ -13,6 +12,8 @@ jest.mock('../utilities', () => ({
 const {isSupported} = require.requireMock('../utilities') as {
   isSupported: jest.Mock;
 };
+
+const defaultProps = {onIntersectionChange() {}};
 
 describe('<IntersectionObserver />', () => {
   beforeEach(() => {
@@ -27,42 +28,52 @@ describe('<IntersectionObserver />', () => {
 
   describe('wrapperComponent', () => {
     it('uses a div by default', () => {
-      const intersectionObserver = mount(<IntersectionObserver />);
-      const child = intersectionObserver.childAt(0);
-      expect(child.type()).toBe('div');
+      const intersectionObserver = mount(
+        <IntersectionObserver {...defaultProps} />,
+      );
+      const child = intersectionObserver.children[0];
+      expect(child).toHaveProperty('type', 'div');
     });
 
     it('uses a custom element', () => {
       const wrapperComponent = 'span';
       const intersectionObserver = mount(
-        <IntersectionObserver wrapperComponent={wrapperComponent} />,
+        <IntersectionObserver
+          {...defaultProps}
+          wrapperComponent={wrapperComponent}
+        />,
       );
-      const child = intersectionObserver.childAt(0);
-      expect(child.type()).toBe(wrapperComponent);
+      const child = intersectionObserver.children[0];
+      expect(child).toHaveProperty('type', wrapperComponent);
     });
 
     it('attaches the observer to the top-level node', () => {
       isSupported.mockReturnValue(true);
 
-      const intersectionObserver = mount(<IntersectionObserver />);
-      const child = intersectionObserver.childAt(0);
-      const node = child.getDOMNode();
+      const intersectionObserver = mount(
+        <IntersectionObserver {...defaultProps} />,
+      );
+      const child = intersectionObserver.children[0];
 
       expect(intersectionObserverMock.observers[0]).toHaveProperty(
         'target',
-        node,
+        child.domNode,
       );
     });
   });
 
   describe('children', () => {
     it('includes the children inside the top-level element', () => {
-      const children = <div>Hello world</div>;
+      const children = <div id="HelloWorld" />;
       const intersectionObserver = mount(
-        <IntersectionObserver>{children}</IntersectionObserver>,
+        <IntersectionObserver {...defaultProps}>
+          {children}
+        </IntersectionObserver>,
       );
 
-      expect(intersectionObserver.childAt(0).contains(children)).toBe(true);
+      expect(intersectionObserver.children[0]).toContainReactComponent('div', {
+        id: 'HelloWorld',
+      });
     });
   });
 
@@ -74,7 +85,7 @@ describe('<IntersectionObserver />', () => {
     it('is used to create the IntersectionObserver', () => {
       const threshold = [0, 0.5, 1];
 
-      mount(<IntersectionObserver threshold={threshold} />);
+      mount(<IntersectionObserver {...defaultProps} threshold={threshold} />);
 
       expect(intersectionObserverMock.observers[0]).toMatchObject({
         options: {
@@ -92,7 +103,7 @@ describe('<IntersectionObserver />', () => {
     it('is used to create the IntersectionObserver', () => {
       const rootMargin = '10%';
 
-      mount(<IntersectionObserver rootMargin={rootMargin} />);
+      mount(<IntersectionObserver {...defaultProps} rootMargin={rootMargin} />);
 
       expect(intersectionObserverMock.observers[0]).toMatchObject({
         options: {
@@ -109,7 +120,7 @@ describe('<IntersectionObserver />', () => {
 
     it('uses an HTML element for the root IntersectionObserver option', () => {
       withHtmlElement(root => {
-        mount(<IntersectionObserver root={root} />);
+        mount(<IntersectionObserver {...defaultProps} root={root} />);
 
         expect(intersectionObserverMock.observers[0]).toMatchObject({
           options: {
@@ -124,7 +135,7 @@ describe('<IntersectionObserver />', () => {
         const id = 'MyRootElement';
         root.setAttribute('id', id);
 
-        mount(<IntersectionObserver root={`#${id}`} />);
+        mount(<IntersectionObserver {...defaultProps} root={`#${id}`} />);
 
         expect(intersectionObserverMock.observers[0]).toMatchObject({
           options: {
@@ -135,14 +146,15 @@ describe('<IntersectionObserver />', () => {
     });
   });
 
-  describe('onIntersecting()', () => {
+  describe('onIntersectionChange()', () => {
     it('is not called when IntersectionObserver is not supported and the unsupportedBehavior is to ignore', () => {
       isSupported.mockReturnValue(false);
       const spy = jest.fn();
 
       mount(
         <IntersectionObserver
-          onIntersecting={spy}
+          {...defaultProps}
+          onIntersectionChange={spy}
           unsupportedBehavior={UnsupportedBehavior.Ignore}
         />,
       );
@@ -154,7 +166,9 @@ describe('<IntersectionObserver />', () => {
       isSupported.mockReturnValue(false);
       const spy = jest.fn();
 
-      mount(<IntersectionObserver onIntersecting={spy} />);
+      mount(
+        <IntersectionObserver {...defaultProps} onIntersectionChange={spy} />,
+      );
 
       expect(spy).toHaveBeenCalledWith({
         boundingClientRect: expect.any(Object),
@@ -173,7 +187,8 @@ describe('<IntersectionObserver />', () => {
 
       mount(
         <IntersectionObserver
-          onIntersecting={spy}
+          {...defaultProps}
+          onIntersectionChange={spy}
           unsupportedBehavior={UnsupportedBehavior.TreatAsIntersecting}
         />,
       );
@@ -189,49 +204,19 @@ describe('<IntersectionObserver />', () => {
       });
     });
 
-    it('is called when the IntersectionObserver gets called with a non-0 intersectionRatio', () => {
+    it('is called when the IntersectionObserver is updated', () => {
       isSupported.mockReturnValue(true);
       const spy = jest.fn();
       const entry = {intersectionRatio: 0.2};
 
-      mount(<IntersectionObserver onIntersecting={spy} />);
+      const intersectionObserver = mount(
+        <IntersectionObserver {...defaultProps} onIntersectionChange={spy} />,
+      );
 
-      intersectionObserverMock.simulate(entry);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining(entry));
-    });
+      intersectionObserver.act(() => {
+        intersectionObserverMock.simulate(entry);
+      });
 
-    it('is not called when the IntersectionObserver gets called with a 0 intersectionRatio', () => {
-      isSupported.mockReturnValue(true);
-      const spy = jest.fn();
-      const entry = {intersectionRatio: 0};
-
-      mount(<IntersectionObserver onIntersecting={spy} />);
-
-      intersectionObserverMock.simulate(entry);
-      expect(spy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('onNotIntersecting()', () => {
-    it('is not called when the IntersectionObserver gets called with a non-0 intersectionRatio', () => {
-      isSupported.mockReturnValue(true);
-      const spy = jest.fn();
-      const entry = {intersectionRatio: 0.2};
-
-      mount(<IntersectionObserver onNotIntersecting={spy} />);
-
-      intersectionObserverMock.simulate(entry);
-      expect(spy).not.toHaveBeenCalled();
-    });
-
-    it('is called when the IntersectionObserver gets called with a 0 intersectionRatio', () => {
-      isSupported.mockReturnValue(true);
-      const spy = jest.fn();
-      const entry = {intersectionRatio: 0};
-
-      mount(<IntersectionObserver onNotIntersecting={spy} />);
-
-      intersectionObserverMock.simulate(entry);
       expect(spy).toHaveBeenCalledWith(expect.objectContaining(entry));
     });
   });
@@ -242,30 +227,32 @@ describe('<IntersectionObserver />', () => {
     });
 
     it('disconnects observers when unmounting', () => {
-      const intersectionObserver = mount(<IntersectionObserver />);
+      const intersectionObserver = mount(
+        <IntersectionObserver {...defaultProps} />,
+      );
       intersectionObserver.unmount();
       expect(intersectionObserverMock.observers).toHaveLength(0);
     });
 
-    it('un-observes and re-observes when the root prop changes', () => {
+    it('un-observes and re-observes when the wrapperComponent changes', () => {
       const intersectionObserver = mount(
-        <IntersectionObserver threshold={0.5} />,
+        <IntersectionObserver {...defaultProps} wrapperComponent="div" />,
       );
 
-      const threshold = 1;
-      intersectionObserver.setProps({threshold});
+      const wrapperComponent = 'span';
+      intersectionObserver.setProps({wrapperComponent});
 
       expect(intersectionObserverMock.observers).toHaveLength(1);
       expect(intersectionObserverMock.observers[0]).toHaveProperty(
-        'options.threshold',
-        threshold,
+        'target',
+        expect.any(HTMLSpanElement),
       );
     });
 
-    it('un-observes and re-observes when the threshold changes', () => {
+    it('un-observes and re-observes when the root changes', () => {
       withHtmlElement(firstRoot => {
         const intersectionObserver = mount(
-          <IntersectionObserver root={firstRoot} />,
+          <IntersectionObserver {...defaultProps} root={firstRoot} />,
         );
 
         withHtmlElement(secondRoot => {
@@ -280,24 +267,44 @@ describe('<IntersectionObserver />', () => {
       });
     });
 
-    it('re-uses the same intersection observer when only the callbacks change', () => {
+    it('re-uses the same intersection observer when only the callback changes', () => {
       const firstSpy = jest.fn();
       const secondSpy = jest.fn();
       const intersectionObserver = mount(
-        <IntersectionObserver onIntersecting={firstSpy} />,
+        <IntersectionObserver
+          {...defaultProps}
+          onIntersectionChange={firstSpy}
+        />,
       );
 
-      intersectionObserver.setProps({onIntersecting: secondSpy});
-      intersectionObserverMock.simulate({intersectionRatio: 1});
+      intersectionObserver.setProps({onIntersectionChange: secondSpy});
+      intersectionObserver.act(() => {
+        intersectionObserverMock.simulate({intersectionRatio: 1});
+      });
 
       expect(firstSpy).not.toHaveBeenCalled();
       expect(secondSpy).toHaveBeenCalled();
     });
 
+    it('un-observes and re-observes when the threshold changes', () => {
+      const intersectionObserver = mount(
+        <IntersectionObserver {...defaultProps} threshold={0.5} />,
+      );
+
+      const threshold = 1;
+      intersectionObserver.setProps({threshold});
+
+      expect(intersectionObserverMock.observers).toHaveLength(1);
+      expect(intersectionObserverMock.observers[0]).toHaveProperty(
+        'options.threshold',
+        threshold,
+      );
+    });
+
     it('re-uses the same intersection observer when the threshold changes to a new equivalent array', () => {
       const threshold = [0, 0.5, 1];
       const intersectionObserver = mount(
-        <IntersectionObserver threshold={threshold} />,
+        <IntersectionObserver {...defaultProps} threshold={threshold} />,
       );
 
       const observer = intersectionObserverMock.observers[0];

--- a/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
+++ b/packages/react-intersection-observer/src/test/IntersectionObserver.test.tsx
@@ -64,15 +64,15 @@ describe('<IntersectionObserver />', () => {
 
   describe('children', () => {
     it('includes the children inside the top-level element', () => {
-      const children = <div id="HelloWorld" />;
+      const id = 'HelloWorld';
       const intersectionObserver = mount(
         <IntersectionObserver {...defaultProps}>
-          {children}
+          <div id={id} />
         </IntersectionObserver>,
       );
 
       expect(intersectionObserver.children[0]).toContainReactComponent('div', {
-        id: 'HelloWorld',
+        id,
       });
     });
   });

--- a/packages/react-intersection-observer/src/types.ts
+++ b/packages/react-intersection-observer/src/types.ts
@@ -1,0 +1,4 @@
+export enum UnsupportedBehavior {
+  Ignore,
+  TreatAsIntersecting,
+}

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -43,6 +43,10 @@ export class Element<Props> {
   }
 
   get domNodes(): HTMLElement[] {
+    if (this.isDOM) {
+      return [this.instance];
+    }
+
     return this.elementChildren
       .filter(element => element.isDOM)
       .map(element => element.instance);

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -154,7 +154,11 @@ describe('Element', () => {
   });
 
   describe('#domNodes', () => {
-    it('returns the instances associated with each child DOM node', () => {
+    it('returns the DOM node for the element itself if it is a DOM element', () => {
+      expect(divOne.domNodes).toEqual([divOne.instance]);
+    });
+
+    it('returns the instances associated with each child DOM element', () => {
       const element = new Element(
         defaultTree,
         [divOne, divTwo],
@@ -189,6 +193,10 @@ describe('Element', () => {
   });
 
   describe('#domNode', () => {
+    it('returns the DOM node for the element itself if it is a DOM element', () => {
+      expect(divOne.domNodes).toBe(divOne.instance);
+    });
+
     it('returns null if there is no direct child DOM node', () => {
       const element = new Element(
         defaultTree,

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -194,7 +194,7 @@ describe('Element', () => {
 
   describe('#domNode', () => {
     it('returns the DOM node for the element itself if it is a DOM element', () => {
-      expect(divOne.domNodes).toBe(divOne.instance);
+      expect(divOne.domNode).toBe(divOne.instance);
     });
 
     it('returns null if there is no direct child DOM node', () => {


### PR DESCRIPTION
This PR adds a new `useIntersection` hook to `react-intersection-observer`, and slightly reworks the API of the component version to feel more closely related. The README has all of the goods, but basically, the hook version just gives you the state + a ref to throw on a DOM node, so it's quite simple to use the hook version:

```tsx
function MyComponent() {
  const [intersection, intersectionRef] = useIntersection();

  return (
    <div ref={intersectionRef}>Intersection: {intersection.isIntersecting}</div>
  );
}
```