### PR TITLE
✨ Add `dimension` mock to `jest-dom-mocks

### DIFF
--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Now correctly declares a dependency on `@shopify/react-async`
 
+### Added
+
+- Added a mock for dimensions ([#625](https://github.com/Shopify/quilt/pull/625))
+
 ## 2.5.0 - 2019-03-28
 
 ### Added

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -94,6 +94,7 @@ The following standard mocks are available:
 - `timer`
 - `promise`
 - `intersectionObserver`
+- `dimension`
 
 Each of the standard mocks can be installed, for a given test, using `standardMock.mock()`, and must be restored before the end of the test using `standardMock.restore()`.
 
@@ -226,3 +227,54 @@ The storage mocks are a bit different than the other mocks, because they serve p
 - `clear`
 
 Each of these are wrapped in a jest spy, which is automatically restored at the end of the test run.
+
+### Dimension mocks
+
+The dimension mocks allow mocking the following DOM properties:
+
+- `scrollWidth`
+- `scrollHeight`
+- `offsetWidth`
+- `offsetHeight`
+
+Pass the dimension you want to mock and the value you want returned for all calls when calling `mock`:
+
+```ts
+import {dimension} from '@shopify/jest-dom-mocks';
+
+beforeEach(() => {
+  dimension.mock({
+    scrollWidth: 100,
+    offsetHeight: 200,
+  });
+});
+
+afterEach(() => dimension.restore());
+```
+
+You can also pass in a function as a mock that returns a number. The element is passed as the only argument to the function:
+
+```tsx
+beforeEach(() => {
+  dimension.mock({
+    scrollWidth(element: HTMLElement) {
+      return element.id === 'test-id' ? 200 : 0;
+    },
+  });
+});
+
+afterEach(() => dimension.restore());
+
+describe('DOM tests', () => {
+  it('returns the element width', () => {
+    function Component() {
+      return <div id="some-id" />;
+    }
+    const element = mount(<Component />);
+    const elementWidth =
+      element.domNode == null ? undefined : element.domNode.scrollWidth;
+
+    expect(elementWidth).toBe(200);
+  });
+});
+```

--- a/packages/jest-dom-mocks/src/dimension.ts
+++ b/packages/jest-dom-mocks/src/dimension.ts
@@ -1,0 +1,102 @@
+import {memoize} from '@shopify/javascript-utilities/decorators';
+
+const enum SupportedDimension {
+  OffsetWidth = 'offsetWidth',
+  OffsetHeight = 'offsetHeight',
+  ScrollWidth = 'scrollWidth',
+  ScrollHeight = 'scrollHeight',
+}
+
+type MockedGetter = (element: HTMLElement) => number;
+type Mock = MockedGetter | number;
+type Mocks = Partial<Record<string, Mock>>;
+
+type AugmentedElement = Element & {[key: string]: Mock};
+
+interface NativeImplentationMap {
+  [key: string]: Element;
+}
+
+function isGetterFunction(mock?: Mock): mock is MockedGetter {
+  return mock != null && typeof mock === 'function';
+}
+
+export default class Dimension {
+  private isUsingMock = false;
+  private overwrittenImplementations: string[] = [];
+
+  mock(mocks: Mocks) {
+    if (this.isUsingMock) {
+      throw new Error(
+        'Dimensions are already mocked, but you tried to mock them again.',
+      );
+    } else if (Object.keys(mocks).length === 0) {
+      throw new Error('No dimensions provided for mocking');
+    }
+
+    this.mockDOMMethods(mocks);
+    this.isUsingMock = true;
+  }
+
+  restore() {
+    if (!this.isUsingMock) {
+      throw new Error(
+        "Dimensions haven't been mocked, but you are trying to restore them.",
+      );
+    }
+
+    this.restoreDOMMethods();
+    this.isUsingMock = false;
+  }
+
+  isMocked() {
+    return this.isUsingMock;
+  }
+
+  @memoize()
+  private get nativeImplementations(): NativeImplentationMap {
+    return {
+      [SupportedDimension.OffsetWidth]: HTMLElement.prototype,
+      [SupportedDimension.OffsetHeight]: HTMLElement.prototype,
+      [SupportedDimension.ScrollWidth]: Element.prototype,
+      [SupportedDimension.ScrollHeight]: Element.prototype,
+    };
+  }
+
+  private mockDOMMethods(mocks: Mocks) {
+    Object.keys(mocks).forEach(method => {
+      const nativeSource = this.nativeImplementations[method];
+      const mock: Mock | undefined = mocks[method];
+
+      this.overwrittenImplementations.push(method);
+
+      if (isGetterFunction(mock)) {
+        Object.defineProperty(nativeSource, method, {
+          get() {
+            return mock.call(this, this);
+          },
+          configurable: true,
+        });
+      } else {
+        Object.defineProperty(nativeSource, method, {
+          value: mocks[method],
+          configurable: true,
+        });
+      }
+    });
+  }
+
+  private restoreDOMMethods() {
+    this.overwrittenImplementations.forEach(method => {
+      const nativeSource = this.nativeImplementations[method];
+
+      if (nativeSource == null) {
+        return;
+      }
+
+      delete (nativeSource as AugmentedElement)[method];
+    });
+
+    this.overwrittenImplementations = [];
+  }
+}

--- a/packages/jest-dom-mocks/src/index.ts
+++ b/packages/jest-dom-mocks/src/index.ts
@@ -9,6 +9,7 @@ import Timer from './timer';
 import UserTiming from './user-timing';
 import IntersectionObserver from './intersection-observer';
 import Promise from './promise';
+import Dimension from './dimension';
 
 export const animationFrame = new AnimationFrame();
 export const requestIdleCallback = new RequestIdleCallback();
@@ -29,6 +30,8 @@ export const timer = new Timer();
 export const userTiming = new UserTiming();
 export const intersectionObserver = new IntersectionObserver();
 export const promise = new Promise();
+
+export const dimension = new Dimension();
 
 export function installMockStorage() {
   if (typeof window !== 'undefined') {

--- a/packages/jest-dom-mocks/src/test/dimension.test.ts
+++ b/packages/jest-dom-mocks/src/test/dimension.test.ts
@@ -1,0 +1,116 @@
+import Dimension from '../dimension';
+
+describe('Dimension mocks', () => {
+  describe('mock', () => {
+    it('sets isMocked()', () => {
+      const dimension = new Dimension();
+
+      dimension.mock({
+        scrollWidth: 200,
+      });
+
+      expect(dimension.isMocked()).toBe(true);
+    });
+
+    it('throws if it is already mocked', () => {
+      const dimension = new Dimension();
+
+      dimension.mock({
+        scrollWidth: 200,
+      });
+
+      expect(() => {
+        dimension.mock({
+          scrollWidth: 200,
+        });
+      }).toThrow(
+        'Dimensions are already mocked, but you tried to mock them again.',
+      );
+    });
+
+    it('throws if it no properties mocked', () => {
+      const dimension = new Dimension();
+
+      expect(() => dimension.mock({})).toThrow(
+        'No dimensions provided for mocking',
+      );
+    });
+
+    it('allows mocking all supported properties', () => {
+      const dimension = new Dimension();
+
+      expect(() => {
+        dimension.mock({
+          scrollWidth: 200,
+          scrollHeight: 200,
+          offsetWidth: 200,
+          offsetHeight: 200,
+        });
+      }).not.toThrow();
+    });
+
+    it('mocks provided dimensions with a number', () => {
+      const dimension = new Dimension();
+      const testEl = document.createElement('div');
+
+      dimension.mock({
+        scrollWidth: 200,
+      });
+
+      expect(testEl.scrollWidth).toBe(200);
+    });
+
+    it('mocks provided dimensions with a discriminant function', () => {
+      const dimension = new Dimension();
+
+      const targetEl = document.createElement('div');
+      const otherEl = document.createElement('div');
+
+      targetEl.id = 'testId';
+
+      dimension.mock({
+        scrollWidth(element: HTMLElement) {
+          return element.id === 'testId' ? 200 : 0;
+        },
+      });
+
+      expect(targetEl.scrollWidth).toBe(200);
+      expect(otherEl.scrollWidth).toBe(0);
+    });
+  });
+
+  describe('restore', () => {
+    it('unsets isMocked', () => {
+      const dimension = new Dimension();
+      dimension.mock({
+        scrollWidth: 200,
+      });
+      dimension.restore();
+
+      expect(dimension.isMocked()).toBe(false);
+    });
+
+    it('throws an error if it has not yet been mocked', () => {
+      const dimension = new Dimension();
+
+      expect(() => {
+        dimension.restore();
+      }).toThrow(
+        "Dimensions haven't been mocked, but you are trying to restore them.",
+      );
+    });
+
+    it('restores original dimension methods', () => {
+      const dimension = new Dimension();
+      const testEl = document.createElement('div');
+
+      dimension.mock({
+        scrollWidth: 200,
+      });
+      dimension.restore();
+
+      expect(testEl.scrollWidth).not.toBe(200);
+      expect(testEl.scrollWidth).toBeUndefined();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,7 +2965,7 @@ eslint-plugin-react@7.13.0:
     prop-types "^15.7.2"
     resolve "^1.10.1"
 
-eslint-plugin-shopify@29.0.2:
+eslint-plugin-shopify@^29.0.2:
   version "29.0.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-29.0.2.tgz#84de55f4c0ea293b1505ed85bbddd021be53f966"
   integrity sha512-ahAv+49UzLba4b67OnihWm7S3xHRvkSay+EYVsPHkvRXVQCIqGijyujs5htyr78EUJKZWXuL1qoPdmEK+hVtbg==


### PR DESCRIPTION
Brings over dimension mocking utilities [from Web](https://github.com/Shopify/web/commit/957427ac4781f5d7d6dbfe7b6a2dd083ac126fd3#diff-2ef125a18ab2b913aba925a64386d260R1) per @TheMallen's [recommendation](https://github.com/Shopify/web/pull/8822#discussion_r238352729).

This allows mocking `scrollWidth`, `scrollHeight`, `offsetWidth`, and `offsetHeight` in tests.

Once released, I'll remove the corresponding mocks in Web and use these instead.