### PR TITLE
Add an option to configure the api version on the graphql proxy

### DIFF
--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -5,13 +5,13 @@ export const PROXY_BASE_PATH = '/graphql';
 export const GRAPHQL_PATH_PREFIX = '/admin/api';
 
 export enum ApiVersion {
-  Unstable = 'unstable',
   '2019-04' = '2019-04',
   '2019-09' = '2019-09',
+  Unstable = 'unstable',
 }
 
 interface DefaultProxyOptions {
-  apiVersion?: ApiVersion;
+  apiVersion: ApiVersion;
 }
 
 interface PrivateShopOption extends DefaultProxyOptions {
@@ -21,20 +21,17 @@ interface PrivateShopOption extends DefaultProxyOptions {
 
 type ProxyOptions = PrivateShopOption | DefaultProxyOptions;
 
-export default function shopifyGraphQLProxy(proxyOptions?: ProxyOptions) {
+export default function shopifyGraphQLProxy(proxyOptions: ProxyOptions) {
   return async function shopifyGraphQLProxyMiddleware(
     ctx: Context,
     next: () => Promise<any>,
   ) {
     const {session = {}} = ctx;
 
-    const shop =
-      proxyOptions && 'shop' in proxyOptions ? proxyOptions.shop : session.shop;
+    const shop = 'shop' in proxyOptions ? proxyOptions.shop : session.shop;
     const accessToken =
-      proxyOptions && 'password' in proxyOptions
-        ? proxyOptions.password
-        : session.accessToken;
-    const apiVersion = proxyOptions ? proxyOptions.apiVersion : null;
+      'password' in proxyOptions ? proxyOptions.password : session.accessToken;
+    const apiVersion = proxyOptions.apiVersion;
 
     if (ctx.path !== PROXY_BASE_PATH || ctx.method !== 'POST') {
       await next();
@@ -56,11 +53,7 @@ export default function shopifyGraphQLProxy(proxyOptions?: ProxyOptions) {
         'X-Shopify-Access-Token': accessToken,
       },
       proxyReqPathResolver() {
-        if (apiVersion) {
-          return `https://${shop}${GRAPHQL_PATH_PREFIX}/${apiVersion}/graphql.json`;
-        }
-
-        return `https://${shop}${GRAPHQL_PATH_PREFIX}/graphql.json`;
+        return `https://${shop}${GRAPHQL_PATH_PREFIX}/${apiVersion}/graphql.json`;
       },
     })(
       ctx,

--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -5,13 +5,13 @@ export const PROXY_BASE_PATH = '/graphql';
 export const GRAPHQL_PATH_PREFIX = '/admin/api';
 
 export enum ApiVersion {
-  '2019-04' = '2019-04',
-  '2019-09' = '2019-09',
+  April19 = '2019-04',
+  July19 = '2019-07',
   Unstable = 'unstable',
 }
 
 interface DefaultProxyOptions {
-  apiVersion: ApiVersion;
+  version: ApiVersion;
 }
 
 interface PrivateShopOption extends DefaultProxyOptions {
@@ -31,7 +31,7 @@ export default function shopifyGraphQLProxy(proxyOptions: ProxyOptions) {
     const shop = 'shop' in proxyOptions ? proxyOptions.shop : session.shop;
     const accessToken =
       'password' in proxyOptions ? proxyOptions.password : session.accessToken;
-    const apiVersion = proxyOptions.apiVersion;
+    const version = proxyOptions.version;
 
     if (ctx.path !== PROXY_BASE_PATH || ctx.method !== 'POST') {
       await next();
@@ -53,7 +53,7 @@ export default function shopifyGraphQLProxy(proxyOptions: ProxyOptions) {
         'X-Shopify-Access-Token': accessToken,
       },
       proxyReqPathResolver() {
-        return `https://${shop}${GRAPHQL_PATH_PREFIX}/${apiVersion}/graphql.json`;
+        return `https://${shop}${GRAPHQL_PATH_PREFIX}/${version}/graphql.json`;
       },
     })(
       ctx,

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -18,7 +18,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('throws when no session is provided', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
       method: 'POST',
@@ -31,7 +33,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('throws when no accessToken is on session', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
 
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
@@ -46,7 +50,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('throws when no shop is on session', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
       method: 'POST',
@@ -60,7 +66,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('bails and calls next if method is not POST', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const ctx = createMockContext({
       url: '/graphql',
       method: 'GET',
@@ -76,7 +84,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('bails and calls next if path does not start with the base url', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const ctx = createMockContext({
       url: '/not/graphql',
       throw: jest.fn(),
@@ -91,7 +101,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('bails and calls next if path does not start with the base url and no session', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const ctx = createMockContext({
       url: '/not/graphql',
       throw: jest.fn(),
@@ -105,7 +117,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('does not bail or throw when request is for the graphql api', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
       method: 'POST',
@@ -121,7 +135,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('configures a custom koa-better-http-proxy', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const accessToken = 'asdfasdf';
     const shop = 'i-sell-things.myshopify.com';
 
@@ -151,6 +167,7 @@ describe('koa-shopify-graphql-proxy', () => {
     const password = 'sdfghsdghsh';
     const shop = 'i-sell-things.myshopify.com';
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
       password,
       shop,
     });
@@ -176,27 +193,8 @@ describe('koa-shopify-graphql-proxy', () => {
     });
   });
 
-  it('passes a proxyReqPathResolver that returns full shop url', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
-    const shop = 'some-shop.myshopify.com';
-
-    const ctx = createMockContext({
-      url: PROXY_BASE_PATH,
-      method: 'POST',
-      throw: jest.fn(),
-      session: {accessToken: 'sdfasdf', shop},
-    });
-
-    await koaShopifyGraphQLProxyMiddleware(ctx, jest.fn());
-
-    const {proxyReqPathResolver} = proxyFactory.mock.calls[0][1];
-    expect(proxyReqPathResolver(ctx)).toBe(
-      `https://${shop}${GRAPHQL_PATH_PREFIX}/graphql.json`,
-    );
-  });
-
   it('passes a proxyReqPathResolver that returns full shop url with the API version', async () => {
-    const apiVersion = ApiVersion['2019-04'];
+    const apiVersion = ApiVersion.Unstable;
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
       apiVersion,
     });
@@ -218,7 +216,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('terminates middleware chain when proxying (does not call next)', async () => {
-    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy();
+    const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
+      apiVersion: ApiVersion.Unstable,
+    });
     const shop = 'some-shop.myshopify.com';
 
     const ctx = createMockContext({

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -19,7 +19,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('throws when no session is provided', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
@@ -34,7 +34,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('throws when no accessToken is on session', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
 
     const ctx = createMockContext({
@@ -51,7 +51,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('throws when no shop is on session', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
@@ -67,7 +67,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('bails and calls next if method is not POST', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const ctx = createMockContext({
       url: '/graphql',
@@ -85,7 +85,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('bails and calls next if path does not start with the base url', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const ctx = createMockContext({
       url: '/not/graphql',
@@ -102,7 +102,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('bails and calls next if path does not start with the base url and no session', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const ctx = createMockContext({
       url: '/not/graphql',
@@ -118,7 +118,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('does not bail or throw when request is for the graphql api', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
@@ -136,7 +136,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('configures a custom koa-better-http-proxy', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const accessToken = 'asdfasdf';
     const shop = 'i-sell-things.myshopify.com';
@@ -167,7 +167,7 @@ describe('koa-shopify-graphql-proxy', () => {
     const password = 'sdfghsdghsh';
     const shop = 'i-sell-things.myshopify.com';
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
       password,
       shop,
     });
@@ -194,9 +194,9 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('passes a proxyReqPathResolver that returns full shop url with the API version', async () => {
-    const apiVersion = ApiVersion.Unstable;
+    const version = ApiVersion.Unstable;
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion,
+      version,
     });
     const shop = 'some-shop.myshopify.com';
 
@@ -211,13 +211,13 @@ describe('koa-shopify-graphql-proxy', () => {
 
     const {proxyReqPathResolver} = proxyFactory.mock.calls[0][1];
     expect(proxyReqPathResolver(ctx)).toBe(
-      `https://${shop}${GRAPHQL_PATH_PREFIX}/${apiVersion}/graphql.json`,
+      `https://${shop}${GRAPHQL_PATH_PREFIX}/${version}/graphql.json`,
     );
   });
 
   it('terminates middleware chain when proxying (does not call next)', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      apiVersion: ApiVersion.Unstable,
+      version: ApiVersion.Unstable,
     });
     const shop = 'some-shop.myshopify.com';
 

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -1,9 +1,10 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
+
 import koaShopifyGraphQLProxy, {
+  ApiVersion,
   PROXY_BASE_PATH,
   GRAPHQL_PATH_PREFIX,
-  GRAPHQL_PATH_SUFFIX,
-} from '..';
+} from '../shopify-graphql-proxy';
 
 jest.mock('koa-better-http-proxy', () => {
   return jest.fn(() => jest.fn());
@@ -190,12 +191,12 @@ describe('koa-shopify-graphql-proxy', () => {
 
     const {proxyReqPathResolver} = proxyFactory.mock.calls[0][1];
     expect(proxyReqPathResolver(ctx)).toBe(
-      `https://${shop}${GRAPHQL_PATH_PREFIX}${GRAPHQL_PATH_SUFFIX}`,
+      `https://${shop}${GRAPHQL_PATH_PREFIX}/graphql.json`,
     );
   });
 
   it('passes a proxyReqPathResolver that returns full shop url with the API version', async () => {
-    const apiVersion = 'unstable';
+    const apiVersion = ApiVersion['2019-04'];
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
       apiVersion,
     });
@@ -212,7 +213,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
     const {proxyReqPathResolver} = proxyFactory.mock.calls[0][1];
     expect(proxyReqPathResolver(ctx)).toBe(
-      `https://${shop}${GRAPHQL_PATH_PREFIX}${apiVersion}/${GRAPHQL_PATH_SUFFIX}`,
+      `https://${shop}${GRAPHQL_PATH_PREFIX}/${apiVersion}/graphql.json`,
     );
   });
 


### PR DESCRIPTION
Fix: #628

✨With this PR, we can now specify an API version when you create the proxy.

You can do something like:
```ts
...
proxy({version: ApiVersion.Unstable})(ctx, next),
```

Waiting for your feedback