### PR TITLE
🐛 useServerDomEffect now returns a result

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- useServerDomEffect now returns a result ([#636](https://github.com/Shopify/quilt/pull/636))
+
 ## 8.0.3 - 2019-04-09
 
 - Fixed `useTitle`, `useLink`, `useMeta`, `usePreconnect`, and `useFavicon` not being exported.

--- a/packages/react-html/src/hooks.ts
+++ b/packages/react-html/src/hooks.ts
@@ -67,7 +67,5 @@ export function useServerDomEffect(
 ) {
   const manager = useContext(HtmlContext);
 
-  useServerEffect(() => {
-    perform(manager);
-  }, manager.effect);
+  useServerEffect(() => perform(manager), manager.effect);
 }

--- a/packages/react-html/src/tests/serializer.test.tsx
+++ b/packages/react-html/src/tests/serializer.test.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import {extract} from '@shopify/react-effect/server';
+import {useSerialized, HtmlContext, HtmlManager} from '..';
+import {render, Html} from '../server';
+
+describe('useSerialized', () => {
+  it('serializes promise results', async () => {
+    function MockComponent() {
+      const [foo, Serialize] = useSerialized('foo');
+      return <Serialize data={() => foo || Promise.resolve('foo_value')} />;
+    }
+
+    const manager = new HtmlManager({isServer: true});
+    const app = <MockComponent />;
+    await extract(app, {
+      decorate: element => (
+        <HtmlContext.Provider value={manager}>{element}</HtmlContext.Provider>
+      ),
+    });
+
+    expect(render(<Html manager={manager}>{app}</Html>)).toContain(
+      `<script type="text/json" data-serialized-id="foo">"foo_value"</script>`,
+    );
+  });
+});


### PR DESCRIPTION
Previously, `perform`'s return value was discarded, causing `useServerEffect` to add `undefined` to the effect queue.  With no pending promises in the queue, react-html erroneously flagged its render as complete, and finished extraction after the first pass.

(My use case is `<Serialize data={() => data || getDataFromNetwork()} />`, with the network call never having a chance to resolve). 