### PR TITLE
Minor i18n tweaks

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -102,7 +102,7 @@ import {withI18n, WithI18nProps} from '@shopify/react-i18n';
 export interface Props {}
 type ComposedProps = Props & WithI18nProps;
 
-class NorFound extends React.Component<ComposedProps> {
+class NotFound extends React.Component<ComposedProps> {
   render() {
     const {i18n} = this.props;
 
@@ -118,6 +118,26 @@ class NorFound extends React.Component<ComposedProps> {
 }
 
 export default withI18n()(NotFound);
+```
+
+If you only need access to parent translations and/ or the various formatting utilities found on the `I18n` object, you can instead use the `useSimpleI18n` hook. This hook does not support providing any internationalization details for the component itself, but is a very performant way to access i18n utilities that are tied to the global locale.
+
+```tsx
+import * as React from 'react';
+import {EmptyState} from '@shopify/polaris';
+import {useSimpleI18n} from '@shopify/react-i18n';
+
+export default function NotFound() {
+  const i18n = useSimpleI18n();
+  return (
+    <EmptyState
+      heading={i18n.translate('NotFound.heading')}
+      action={{content: i18n.translate('Common.back'), url: '/'}}
+    >
+      <p>{i18n.translate('NotFound.content')}</p>
+    </EmptyState>
+  );
+}
 ```
 
 #### `i18n`

--- a/packages/react-i18n/src/context.ts
+++ b/packages/react-i18n/src/context.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {I18nManager} from './manager';
+import {I18n} from './i18n';
 
 export const I18nContext = React.createContext<I18nManager | null>(null);
-export const I18nParentsContext = React.createContext<string[]>([]);
+export const I18nParentsContext = React.createContext<I18n | null>(null);

--- a/packages/react-i18n/src/decorator.tsx
+++ b/packages/react-i18n/src/decorator.tsx
@@ -9,22 +9,19 @@ export interface WithI18nProps {
 }
 
 export function withI18n(i18nOptions?: RegisterOptions) {
-  return <P extends WithI18nProps>(
-    WrappedComponent: React.ComponentType<P>,
-  ): React.ComponentType<P> => {
-    function WithTranslations(props: any) {
+  return <OwnProps, C>(
+    WrappedComponent: React.ComponentType<OwnProps & WithI18nProps> & C,
+  ): React.ComponentType<OwnProps> & C => {
+    function WithTranslations(props: OwnProps) {
       const [i18n, ShareTranslations] = useI18n(i18nOptions);
-      const {children} = props;
 
       return (
         <ShareTranslations>
-          <WrappedComponent {...props} i18n={i18n}>
-            {children}
-          </WrappedComponent>
+          <WrappedComponent {...props} i18n={i18n} />
         </ShareTranslations>
       );
     }
 
-    return hoistStatics(WithTranslations, WrappedComponent);
+    return hoistStatics(WithTranslations, WrappedComponent) as any;
   };
 }

--- a/packages/react-i18n/src/hooks.tsx
+++ b/packages/react-i18n/src/hooks.tsx
@@ -15,10 +15,13 @@ export function useI18n({
   const manager = React.useContext(I18nContext);
 
   if (manager == null) {
-    throw new Error('Missing manager');
+    throw new Error(
+      'Missing i18n manager. Make sure to use an <I18nContext.Provider /> somewhere in your React tree.',
+    );
   }
 
-  const parentIds = React.useContext(I18nParentsContext);
+  const parentI18n = React.useContext(I18nParentsContext);
+  const parentIds = parentI18n ? parentI18n.ids || [] : [];
   const ids = React.useMemo(() => (id ? [id, ...parentIds] : parentIds), [
     id,
     ...parentIds,
@@ -46,7 +49,7 @@ export function useI18n({
     () =>
       function ShareTranslations({children}: {children: React.ReactNode}) {
         return (
-          <I18nParentsContext.Provider value={ids}>
+          <I18nParentsContext.Provider value={i18n}>
             {children}
           </I18nParentsContext.Provider>
         );
@@ -55,4 +58,19 @@ export function useI18n({
   );
 
   return [i18n, ShareTranslations];
+}
+
+export function useSimpleI18n() {
+  const manager = React.useContext(I18nContext);
+
+  if (manager == null) {
+    throw new Error(
+      'Missing i18n manager. Make sure to use an <I18nContext.Provider /> somewhere in your React tree.',
+    );
+  }
+
+  const i18n =
+    React.useContext(I18nParentsContext) || new I18n([], manager.details);
+
+  return i18n;
 }

--- a/packages/react-i18n/src/hooks.tsx
+++ b/packages/react-i18n/src/hooks.tsx
@@ -33,13 +33,13 @@ export function useI18n({
 
   const [i18n, setI18n] = React.useState(() => {
     const {translations} = manager.state(ids);
-    return new I18n(translations, manager.details);
+    return new I18n(translations, manager.details, ids);
   });
 
   React.useEffect(
     () => {
       return manager.subscribe(ids, ({translations}, details) => {
-        setI18n(new I18n(translations, details));
+        setI18n(new I18n(translations, details, ids));
       });
     },
     [manager],

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -93,7 +93,7 @@ export class I18n {
   }
 
   constructor(
-    public translations: TranslationDictionary[],
+    public readonly translations: TranslationDictionary[],
     {
       locale,
       currency,
@@ -102,6 +102,7 @@ export class I18n {
       pseudolocalize = false,
       onError,
     }: I18nDetails,
+    public readonly ids?: string[],
   ) {
     this.locale = locale;
     this.defaultCountry = country;

--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -1,7 +1,7 @@
 export {I18nManager, ExtractedTranslations} from './manager';
 export {I18nContext} from './context';
 export {I18n} from './i18n';
-export {useI18n} from './hooks';
+export {useI18n, useSimpleI18n} from './hooks';
 export {withI18n, WithI18nProps} from './decorator';
 export {translate} from './utilities';
 export {I18nDetails, LanguageDirection, CurrencyCode} from './types';


### PR DESCRIPTION
Two small tweaks:

- Restored some of the previous typing of `withI18n`. Not having this typing was leading to hundreds of type errors in Web, and while they can conceivably be dealt with, it's not worth it for the update.
- Added a `useSimpleI18n` hook. This hook just re-uses a parent i18n object, or creates a new one. It does not subscribe for updates, and you can't provide translations or anything to it. This is useful for leaf components that just need access to things like formatting, and where performance is a particular concern. I would have loved to make the regular i18n component work like this, but I don't think it's possible to avoid the complexity in that hook while still supporting async and nested translations :(