### PR TITLE
Promisify .distribute and .closeClient

### DIFF
--- a/packages/koa-metrics/CHANGELOG.md
+++ b/packages/koa-metrics/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- Unreleased changes should go to UNRELEASED.md -->
 
+* Wrapping all the calls in a Promise and awaiting them at the end of the middleware.
+* Remove .measure because it wasn't used anymore.
+* Update hot-shots to support optional arguments for .distribution.
+
 ---
 
 ## 0.1.12 - 2019-01-09

--- a/packages/koa-metrics/README.md
+++ b/packages/koa-metrics/README.md
@@ -49,10 +49,6 @@ An instance of the `Metrics` object will be available on `ctx.metrics` further d
 
 Sends a distribution command with the specified `value` in milliseconds.
 
-#### `.measure(name: string, value: number, sampleRate?: number, tags?: Tags)`
-
-Sends data for non-timing stats (measurements). We do this through the distributions feature in DogStatsD. You'll need to ensure that your DogStatsD server supports the distributions feature in order to make use of these metrics.
-
 #### `.initTimer(): Timer`
 
 Returns a new `Timer` started at the current `process.hrtime()`

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/shopify/quilt/blob/master/packages/koa-metrics/README.md",
   "dependencies": {
-    "hot-shots": "^5.4.1",
+    "hot-shots": "^5.9.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/koa-metrics/src/Metrics.ts
+++ b/packages/koa-metrics/src/Metrics.ts
@@ -44,13 +44,15 @@ export default class Metrics {
   public distribution(name: string, value: number, tags?: TagsMap) {
     this.log(MetricType.Distribution, name, value, tags);
     // the any type below is to fix the improper typing on the histogram method
-    this.client.distribution(name, value, tags as any);
-  }
+    return new Promise<void>((resolve, reject) => {
+      this.client.distribution(name, value, tags, (error?: Error) => {
+        if (error) {
+          reject(error);
+        }
 
-  public measure(name: string, value: number, tags?: TagsMap) {
-    this.log(MetricType.Measure, name, value, tags);
-    // the any type below is to fix the improper typing on the distribution method
-    this.client.distribution(name, value, tags as any);
+        resolve();
+      });
+    });
   }
 
   public initTimer(): Timer {
@@ -73,9 +75,15 @@ export default class Metrics {
   }
 
   public closeClient() {
-    // @ts-ignore According to the hot-shots documentation, callback
-    // is not required.
-    this.rootClient.close();
+    return new Promise<void>((resolve, reject) => {
+      this.rootClient.close((error?: Error) => {
+        if (error) {
+          reject(error);
+        }
+
+        resolve();
+      });
+    });
   }
 
   private log(type: MetricType, name: string, value: number, tags?: TagsMap) {

--- a/packages/koa-metrics/src/test/Metrics.test.ts
+++ b/packages/koa-metrics/src/test/Metrics.test.ts
@@ -40,7 +40,12 @@ describe('Metrics', () => {
       const stats = StatsDMock.mock.instances[0];
       const distributionFn = stats.distribution;
       expect(distributionFn).toHaveBeenCalledTimes(1);
-      expect(distributionFn).toHaveBeenCalledWith(name, value, tags);
+      expect(distributionFn).toHaveBeenCalledWith(
+        name,
+        value,
+        tags,
+        expect.any(Function),
+      );
     });
 
     it('logs distribution metrics to the logger in development', () => {
@@ -72,52 +77,6 @@ describe('Metrics', () => {
         const logger = jest.fn();
         const metrics = new Metrics(defaultOptions, logger);
         metrics.distribution(name, value, tags);
-
-        expect(logger).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('measure', () => {
-    it('passes measure metrics to the statsd client as distribution', () => {
-      const metrics = new Metrics(defaultOptions);
-      metrics.measure(name, value, tags);
-
-      const stats = StatsDMock.mock.instances[0];
-      const measureFn = stats.distribution;
-      expect(measureFn).toHaveBeenCalledTimes(1);
-      expect(measureFn).toHaveBeenCalledWith(name, value, tags);
-    });
-
-    it('logs measure metrics to the logger in development', () => {
-      withEnv('development', () => {
-        const logger = jest.fn();
-        const metrics = new Metrics(defaultOptions, logger);
-        metrics.measure(name, value);
-
-        expect(logger).toHaveBeenCalledTimes(1);
-        expect(logger).toHaveBeenCalledWith(`measure ${name}:${value}`);
-      });
-    });
-
-    it('logs tags with measure metrics to the logger in development', () => {
-      withEnv('development', () => {
-        const logger = jest.fn();
-        const metrics = new Metrics(defaultOptions, logger);
-        metrics.measure(name, value, tags);
-
-        expect(logger).toHaveBeenCalledTimes(1);
-        expect(logger).toHaveBeenCalledWith(
-          `measure ${name}:${value} #${tagName}:${tags[tagName]}`,
-        );
-      });
-    });
-
-    it('does not log measure metrics to the logger in production', () => {
-      withEnv('production', () => {
-        const logger = jest.fn();
-        const metrics = new Metrics(defaultOptions, logger);
-        metrics.measure(name, value, tags);
 
         expect(logger).not.toHaveBeenCalled();
       });

--- a/packages/koa-metrics/src/test/Metrics.test.ts
+++ b/packages/koa-metrics/src/test/Metrics.test.ts
@@ -48,6 +48,20 @@ describe('Metrics', () => {
       );
     });
 
+    it('rejects on the promise when the client returns an error', async () => {
+      const metrics = new Metrics(defaultOptions);
+      const stats = StatsDMock.mock.instances[0];
+
+      stats.distribution.mockImplementation(
+        (_name, _value, _tags, callback) => {
+          callback('Something went wrong!');
+        },
+      );
+
+      const result = metrics.distribution(name, value, tags);
+      await expect(result).rejects.toEqual('Something went wrong!');
+    });
+
     it('logs distribution metrics to the logger in development', () => {
       withEnv('development', () => {
         const logger = jest.fn();
@@ -113,6 +127,18 @@ describe('Metrics', () => {
       const stats = StatsDMock.mock.instances[0];
       const closeFn = stats.close;
       expect(closeFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects on the promise when the client returns an error', async () => {
+      const metrics = new Metrics(defaultOptions);
+      const stats = StatsDMock.mock.instances[0];
+
+      stats.close.mockImplementation(callback => {
+        callback('Something went wrong!');
+      });
+
+      const result = metrics.closeClient();
+      await expect(result).rejects.toEqual('Something went wrong!');
     });
   });
 

--- a/packages/koa-metrics/src/test/index.test.ts
+++ b/packages/koa-metrics/src/test/index.test.ts
@@ -241,7 +241,7 @@ describe('koa-metrics', () => {
         };
       });
 
-      expect(MetricsMock.mock.instances[0].measure).toHaveBeenCalledWith(
+      expect(MetricsMock.mock.instances[0].distribution).toHaveBeenCalledWith(
         CustomMetrics.ContentLength,
         length,
       );
@@ -253,12 +253,11 @@ describe('koa-metrics', () => {
 
       await metricsMiddleware(ctx, () => {});
 
-      const measureFn = MetricsMock.mock.instances[0].measure as jest.Mock<
-        Metrics['measure']
-      >;
+      const distributionFn = MetricsMock.mock.instances[0]
+        .distribution as jest.Mock<Metrics['distribution']>;
 
       expect(
-        measureFn.mock.calls.map(([metricName]) => metricName),
+        distributionFn.mock.calls.map(([metricName]) => metricName),
       ).not.toContain(CustomMetrics.ContentLength);
     });
   });
@@ -297,7 +296,6 @@ describe('koa-metrics', () => {
       });
 
       expect(MetricsMock.mock.instances[0].distribution).not.toHaveBeenCalled();
-      expect(MetricsMock.mock.instances[0].measure).not.toHaveBeenCalled();
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,10 +4073,10 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
   integrity sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==
 
-hot-shots@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-5.4.1.tgz#60f0a11c3d824257fa35b0769f308761b406296b"
-  integrity sha512-Wffw6kQzXI1a6ZBismu8ksuf36OiCOFwwyQb07pDSDd0t1haipYp9gDT+VYEIoINvjqerX1rA/q91HNdzclVPg==
+hot-shots@^5.9.1:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-5.9.2.tgz#1cff097706f40ba2c1350d4806deebbd16a5e8c8"
+  integrity sha512-ruHZvHaxZRVUCoCleiwwCcjdr9A2/Y97C7oc9LpyMg9ae39blHvsJJQQ0QtMtxKX+i4lig/7/BqZBjUUZPUp3A==
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Context 

Data was not sent properly while using `.distribution` with Datadog v6.

## Problem

When using `hot-shots@5.4.1`, the statsd client is being close before all the sockets finished emitting their messages.

I experimented by commenting out this https://github.com/Shopify/quilt/blob/master/packages/koa-metrics/src/index.ts#L74

My initial assumption was that bumping the gem would fix the problem but that was just a unexpected side effect of a better handling of `close` in this https://github.com/brightcove/hot-shots/commit/54ef3348d34da4d1d75f277a3e2b9faf7bcc1d36 which was introduced in `6.1.0`

## Changes

* Wrapping all the calls in a `Promise` and awaiting them at the end of the middleware.
* Removed `.measure` because it wasn't used anymore.
* Bump `hot-shots` to support optional arguments for `.distribution`.
