### PR TITLE
Add a set of apollo hooks

### DIFF
--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -173,6 +173,71 @@ function App() {
 render(<App />, document.getElementById('root'));
 ```
 
+### `useQuery`
+
+Here is an example of how to use `useQuery` with a query document.
+
+```tsx
+import React from 'react';
+import {useQuery} from '@shopify/react-graphql';
+
+import customerListQuery from './graphql/CustomerListQuery.graphql';
+
+function CustomerList() {
+  const {data, loading, refetch} = useQuery(customerListQuery);
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  const customers = data && data.customers ? data.customers : [];
+  return (
+    <ul>
+      {customers.map(customer => (
+        <li key={customer.id}>{customer.displayName}</li>
+      ))}
+    </ul>
+    <button onClick={async () => {
+        await refetch();
+    }}>Refetch Customers Data</button>
+  );
+}
+```
+
+You can also use `useQuery` with an async query component created from `@shopify/react-graphql`
+
+Note that because the `.graphql` document is being asynchronously loaded, `refetch` and other helper methods may not be available until the query document is loaded.
+
+```tsx
+import React from 'react';
+import {createAsyncQueryComponent, useQuery} from '@shopify/react-graphql';
+
+const CustomerListQuery = createAsyncQueryComponent({
+  load: () => import('./graphql/CustomerListQuery.graphql'),
+});
+
+function CustomerList() {
+  const {data, loading, refetch} = useQuery(CustomerListQuery);
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  const customers = data && data.customers ? data.customers : [];
+  return (
+    <ul>
+      {customers.map(customer => (
+        <li key={customer.id}>{customer.displayName}</li>
+      ))}
+    </ul>
+    <button onClick={async () => {
+        if (!refetch) {
+            return;
+        }
+        await refetch();
+    }}>Refetch Customers Data</button>
+  );
+}
+```
+
 ### `useMutation`
 
 This hook accepts two arguments: the mutation document, and optionally, a set of options to pass to the underlying mutation. It will return a function that will trigger the mutation when invoked.

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -1,0 +1,55 @@
+import {useState, useEffect, useCallback} from 'react';
+import {OperationVariables} from 'apollo-client';
+import {DocumentNode} from 'graphql-typed';
+
+import {AsyncQueryComponentType} from '..';
+
+export default function useGraphQLDocument<
+  Data = any,
+  Variables = OperationVariables,
+  DeepPartial = {}
+>(
+  documentOrComponent:
+    | DocumentNode<Data, Variables>
+    | AsyncQueryComponentType<Data, Variables, DeepPartial>,
+) {
+  const [document, setDocument] = useState<DocumentNode<
+    Data,
+    Variables
+  > | null>(() => {
+    if (isDocumentNode(documentOrComponent)) {
+      return documentOrComponent;
+    } else {
+      return documentOrComponent.resolved || null;
+    }
+  });
+
+  const loadDocument = useCallback(
+    async () => {
+      if (!isDocumentNode(documentOrComponent)) {
+        try {
+          const resolved = await documentOrComponent.resolve();
+          setDocument(resolved);
+        } catch (error) {
+          throw Error('error loading GraphQL document');
+        }
+      }
+    },
+    [documentOrComponent],
+  );
+
+  useEffect(
+    () => {
+      if (!document) {
+        loadDocument();
+      }
+    },
+    [document, documentOrComponent, loadDocument],
+  );
+
+  return document;
+}
+
+function isDocumentNode(arg: any): arg is DocumentNode {
+  return Boolean(arg && arg.kind && arg.kind === 'Document');
+}

--- a/packages/react-graphql/src/hooks/index.ts
+++ b/packages/react-graphql/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export {ApolloProvider} from './ApolloProvider';
 export {useApolloClient} from './apollo-client';
+export {default as useQuery} from './query';
 export {default as useMutation} from './mutation';
 export * from './types';

--- a/packages/react-graphql/src/hooks/query-cache.ts
+++ b/packages/react-graphql/src/hooks/query-cache.ts
@@ -1,0 +1,48 @@
+import ApolloClient, {ObservableQuery, WatchQueryOptions} from 'apollo-client';
+import {print} from 'graphql/language/printer';
+
+import {objectToKey} from './utilities';
+
+const cachedQueriesByClient = new WeakMap<
+  ApolloClient<any>,
+  Map<any, ObservableQuery<any, any>>
+>();
+
+export function getCachedObservableQuery<TData, TVariables>(
+  client: ApolloClient<any>,
+  options: WatchQueryOptions<TVariables>,
+): ObservableQuery<TData, TVariables> {
+  const queriesForClient = getCachedQueriesForClient(client);
+  const cacheKey = getCacheKey(options);
+  let observableQuery = queriesForClient.get(cacheKey);
+  if (observableQuery == null) {
+    observableQuery = client.watchQuery(options);
+    queriesForClient.set(cacheKey, observableQuery);
+  }
+  return observableQuery;
+}
+
+export function invalidateCachedObservableQuery<TVariables>(
+  client: ApolloClient<any>,
+  options: WatchQueryOptions<TVariables>,
+): void {
+  const queriesForClient = getCachedQueriesForClient(client);
+  const cacheKey = getCacheKey(options);
+  queriesForClient.delete(cacheKey);
+}
+
+function getCachedQueriesForClient(client: ApolloClient<any>) {
+  let queriesForClient = cachedQueriesByClient.get(client);
+  if (queriesForClient == null) {
+    queriesForClient = new Map();
+    cachedQueriesByClient.set(client, queriesForClient);
+  }
+  return queriesForClient;
+}
+
+function getCacheKey<TVariables>({
+  query,
+  ...options
+}: WatchQueryOptions<TVariables>): string {
+  return `${print(query)}@@${objectToKey(options)}`;
+}

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -1,0 +1,157 @@
+import {
+  OperationVariables,
+  ApolloError,
+  WatchQueryOptions,
+} from 'apollo-client';
+import {DocumentNode} from 'graphql-typed';
+import {useEffect, useMemo, useState} from 'react';
+
+import {AsyncQueryComponentType} from '..';
+
+import {QueryHookOptions, QueryHookResult} from './types';
+import {useApolloClient} from './apollo-client';
+import useGraphQLDocument from './graphql-document';
+import {
+  getCachedObservableQuery,
+  invalidateCachedObservableQuery,
+} from './query-cache';
+import {compact, objectToKey} from './utilities';
+
+export default function useQuery<
+  Data = any,
+  Variables = OperationVariables,
+  DeepPartial = {}
+>(
+  queryOrComponent:
+    | DocumentNode<Data, Variables>
+    | AsyncQueryComponentType<Data, Variables, DeepPartial>,
+  options: QueryHookOptions<Data, Variables> = {},
+): QueryHookResult<Data, Variables> {
+  const {
+    skip = false,
+    pollInterval,
+    notifyOnNetworkStatusChange = false,
+    client: overrideClient,
+    context,
+    variables,
+    fetchPolicy,
+    errorPolicy,
+  } = options;
+
+  const [responseId, setResponseId] = useState(0);
+  const client = useApolloClient(overrideClient);
+  const query = useGraphQLDocument(queryOrComponent);
+
+  const watchQueryOptions: WatchQueryOptions<Variables> = useMemo(
+    () =>
+      compact({
+        context,
+        errorPolicy,
+        fetchPolicy,
+        notifyOnNetworkStatusChange,
+        pollInterval,
+        query,
+        variables,
+      }),
+    [
+      context,
+      errorPolicy,
+      fetchPolicy,
+      notifyOnNetworkStatusChange,
+      pollInterval,
+      query,
+      variables,
+    ],
+  );
+
+  const observableQuery = useMemo(
+    () => {
+      if (!query) {
+        return;
+      }
+
+      return getCachedObservableQuery<Data, Variables>(
+        client,
+        watchQueryOptions,
+      );
+    },
+    [query, client, watchQueryOptions],
+  );
+
+  useEffect(
+    () => {
+      if (skip || !observableQuery) {
+        return;
+      }
+
+      const invalidateCurrentResult = () => {
+        setResponseId(x => x + 1);
+      };
+      const subscription = observableQuery.subscribe(
+        invalidateCurrentResult,
+        invalidateCurrentResult,
+      );
+
+      invalidateCachedObservableQuery(client, watchQueryOptions);
+
+      return () => {
+        subscription.unsubscribe();
+      };
+    },
+    [skip, observableQuery, client, watchQueryOptions],
+  );
+
+  const currentResult = useMemo<QueryHookResult<Data, Variables>>(
+    () => {
+      if (!observableQuery) {
+        return {
+          data: undefined,
+          error: undefined,
+          loading: true,
+          networkStatus: undefined,
+          variables,
+          refetch: noop as any,
+          fetchMore: noop as any,
+          updateQuery: noop as any,
+          startPolling: noop as any,
+          stopPolling: noop as any,
+          subscribeToMore: noop as any,
+          client,
+        };
+      }
+
+      const result = observableQuery.currentResult();
+
+      // return the old result data when there is an error
+      let data = result.data;
+      if (result.error || result.errors) {
+        data = {
+          ...(result.data || {}),
+          ...(observableQuery.getLastResult() || {}),
+        };
+      }
+
+      return {
+        ...result,
+        data,
+        error:
+          result.errors && result.errors.length > 0
+            ? new ApolloError({graphQLErrors: result.errors})
+            : result.error,
+        variables: observableQuery.variables,
+        refetch: observableQuery.refetch.bind(observableQuery),
+        fetchMore: observableQuery.fetchMore.bind(observableQuery),
+        updateQuery: observableQuery.updateQuery.bind(observableQuery),
+        startPolling: observableQuery.startPolling.bind(observableQuery),
+        stopPolling: observableQuery.stopPolling.bind(observableQuery),
+        subscribeToMore: observableQuery.subscribeToMore.bind(observableQuery),
+        client,
+      };
+    },
+    [observableQuery, client, variables],
+  );
+
+  return currentResult;
+}
+
+function noop() {}

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -1,0 +1,192 @@
+import * as React from 'react';
+import gql from 'graphql-tag';
+import ApolloClient from 'apollo-client';
+import {createGraphQLFactory} from '@shopify/graphql-testing';
+
+import {createAsyncQueryComponent} from '../../async';
+import useQuery from '../query';
+import {
+  mountWithGraphQL,
+  prepareAsyncReactTasks,
+  teardownAsyncReactTasks,
+} from './utilities';
+
+const petQuery = gql`
+  query PetQuery {
+    pets {
+      name
+    }
+  }
+`;
+
+const createGraphQL = createGraphQLFactory();
+const mockData = {
+  pets: [
+    {
+      __typename: 'Cat',
+      name: 'Garfield',
+    },
+  ],
+};
+
+describe('useQuery', () => {
+  beforeEach(() => {
+    prepareAsyncReactTasks();
+  });
+
+  afterEach(() => {
+    teardownAsyncReactTasks();
+  });
+
+  describe('document', () => {
+    it('resolves mock query and return data', async () => {
+      const MockQuery = ({children}) => {
+        const results = useQuery(petQuery);
+        return children(results);
+      };
+
+      const graphQL = createGraphQL({PetQuery: mockData});
+      const renderPropSpy = jest.fn(() => null);
+
+      await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
+        graphQL,
+        skipInitialGraphQL: true,
+      });
+
+      expect(renderPropSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: true,
+        }),
+      );
+
+      await graphQL.resolveAll();
+
+      const lastQuery = graphQL.operations.last({operationName: 'PetQuery'});
+      expect(lastQuery).toMatchObject({operationName: 'PetQuery'});
+
+      expect(renderPropSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+          data: mockData,
+        }),
+      );
+    });
+  });
+
+  describe('async query component', () => {
+    it('returns loading=false during the document loading state', async () => {
+      const resolvableQuery = createResolvablePromise(petQuery);
+      const MockQueryComponent = createAsyncQueryComponent({
+        load: () => resolvableQuery.promise,
+      });
+      const MockQuery = ({children}) => {
+        const results = useQuery(MockQueryComponent);
+        return children(results);
+      };
+      const graphQL = createGraphQL({PetQuery: mockData});
+      const renderPropSpy = jest.fn(() => null);
+      await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
+        graphQL,
+        skipInitialGraphQL: true,
+      });
+
+      expect(renderPropSpy).toHaveBeenLastCalledWith({
+        data: undefined,
+        error: undefined,
+        loading: true,
+        networkStatus: undefined,
+        variables: undefined,
+        refetch: expect.any(Function),
+        fetchMore: expect.any(Function),
+        updateQuery: expect.any(Function),
+        startPolling: expect.any(Function),
+        stopPolling: expect.any(Function),
+        subscribeToMore: expect.any(Function),
+        client: expect.any(ApolloClient),
+      });
+    });
+
+    it('returns loading=true after the query document had been loaded, the query is now in loading state', async () => {
+      const resolvableQuery = createResolvablePromise(petQuery);
+      const MockQueryComponent = createAsyncQueryComponent({
+        load: () => resolvableQuery.promise,
+      });
+
+      const MockQuery = ({children}) => {
+        const results = useQuery(MockQueryComponent);
+        return children(results);
+      };
+      const graphQL = createGraphQL({PetQuery: mockData});
+      const renderPropSpy = jest.fn(() => null);
+      const mockQuery = await mountWithGraphQL(
+        <MockQuery>{renderPropSpy}</MockQuery>,
+        {
+          graphQL,
+          skipInitialGraphQL: true,
+        },
+      );
+
+      mockQuery.act(() => {
+        resolvableQuery.resolve();
+      });
+
+      expect(renderPropSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: true,
+        }),
+      );
+    });
+
+    it('returns loading=false with the query data after the query is done loading', async () => {
+      const MockQueryComponent = createAsyncQueryComponent({
+        load: () => Promise.resolve(petQuery),
+      });
+
+      await MockQueryComponent.resolve();
+
+      const MockQuery = ({children}) => {
+        const results = useQuery(MockQueryComponent);
+        return children(results);
+      };
+      const graphQL = createGraphQL({PetQuery: mockData});
+      const renderPropSpy = jest.fn(() => null);
+      await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
+        graphQL,
+      });
+
+      expect(renderPropSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: mockData,
+          loading: false,
+        }),
+      );
+    });
+  });
+
+  it.todo('re-quering something, the result changed');
+});
+
+function createResolvablePromise<T>(value: T) {
+  let resolver!: () => Promise<T>;
+  let rejecter!: () => void;
+
+  const promise = new Promise<T>((resolve, reject) => {
+    resolver = () => {
+      resolve(value);
+      return promise;
+    };
+    rejecter = reject;
+  });
+
+  return {
+    resolve: async () => {
+      const value = await resolver();
+      // If we just resolve, the tick that actually processes the promise
+      // has not finished yet.
+      await new Promise(resolve => process.nextTick(resolve));
+      return value;
+    },
+    reject: rejecter,
+    promise,
+  };
+}

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -1,5 +1,23 @@
 import ApolloClient from 'apollo-client';
-import {MutationOptions, FetchResult, OperationVariables} from 'react-apollo';
+import {
+  QueryProps,
+  QueryResult,
+  MutationOptions,
+  FetchResult,
+  OperationVariables,
+} from 'react-apollo';
+import {Omit} from '@shopify/useful-types';
+
+export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<
+  QueryProps<Data, Variables>,
+  'children' | 'query'
+>;
+
+export interface QueryHookResult<Data, Variables>
+  extends Omit<QueryResult<Data, Variables>, 'networkStatus' | 'variables'> {
+  networkStatus: QueryResult<Data, Variables>['networkStatus'] | undefined;
+  variables: QueryResult<Data, Variables>['variables'] | undefined;
+}
 
 export interface MutationHookOptions<
   Data = any,

--- a/packages/react-graphql/src/hooks/utilities.ts
+++ b/packages/react-graphql/src/hooks/utilities.ts
@@ -1,0 +1,27 @@
+import isPlainObject from 'lodash/isPlainObject';
+
+export function objectToKey<T extends Record<string, any>>(obj: T): T | string {
+  if (!isPlainObject(obj)) {
+    return obj;
+  }
+  const sortedObj = Object.keys(obj)
+    .sort()
+    .reduce((result: Record<string, any>, key) => {
+      result[key] = objectToKey(obj[key]);
+      return result;
+    }, {});
+  return JSON.stringify(sortedObj);
+}
+
+export function compact(obj: any) {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      if (obj[key] !== undefined) {
+        acc[key] = obj[key];
+      }
+
+      return acc;
+    },
+    {} as any,
+  );
+}

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -58,4 +58,6 @@ export interface AsyncQueryComponentType<Data, Variables, DeepPartial>
   KeepFresh(
     props: VariableOptions<Variables> & {pollInterval?: number} & ConstantProps,
   ): React.ReactElement<{}>;
+  resolve(): Promise<DocumentNode<Data, Variables, DeepPartial>>;
+  resolved: DocumentNode<Data, Variables, DeepPartial> | null;
 }


### PR DESCRIPTION
Close https://github.com/Shopify/quilt/issues/586

🎩 instructions:

1. get [this branch](https://github.com/Shopify/web-proving-ground/tree/apollo-query-hook) on `web-proving-ground` locally
2. run `yarn` in `web-proving-ground`
3. in `quilt`, do `yarn && yarn tophat react-graphql ../web-proving-ground`
4. once it complied, go to `web-proving-ground` and do `yarn dev`
5. goto `localhost:8081` to see the query & mutation working properly
