### PR TITLE
[React-i18n] Allow translate function to return object

### DIFF
--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -26,6 +26,7 @@ import {
 import {
   getCurrencySymbol,
   translate,
+  getTranslationTree,
   TranslateOptions as RootTranslateOptions,
 } from './utilities';
 
@@ -161,6 +162,15 @@ export class I18n {
 
     try {
       return translate(id, normalizedOptions, this.translations, this.locale);
+    } catch (error) {
+      this.onError(error);
+      return '';
+    }
+  }
+
+  getTranslationTree(id: string): string | object {
+    try {
+      return getTranslationTree(id, this.translations);
     } catch (error) {
       this.onError(error);
       return '';

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   translate,
+  getTranslationTree,
   PSEUDOTRANSLATE_OPTIONS,
   getCurrencySymbol,
 } from '../utilities';
@@ -14,6 +15,24 @@ const locale = 'en-us';
 jest.mock('@shopify/i18n', () => ({
   pseudotranslate: jest.fn(),
 }));
+
+describe('getTranslationTree()', () => {
+  it('returns the translation keys if it has nested values', () => {
+    expect(getTranslationTree('foo', {foo: {bar: 'one'}})).toMatchObject({
+      bar: 'one',
+    });
+  });
+
+  it('returns the leaf string', () => {
+    expect(getTranslationTree('foo.bar', {foo: {bar: 'one'}})).toBe('one');
+  });
+
+  it('throws a MissingTranslationError when no translation is found', () => {
+    expect(() =>
+      getTranslationTree('foo.bar.baz', {foo: {bar: 'one'}}),
+    ).toThrow();
+  });
+});
 
 describe('translate()', () => {
   beforeEach(() => {

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -4,6 +4,7 @@ import {
   PSEUDOTRANSLATE_OPTIONS,
   TranslateOptions,
   translate,
+  getTranslationTree,
 } from './translate';
 
 export {
@@ -11,5 +12,6 @@ export {
   noop,
   PSEUDOTRANSLATE_OPTIONS,
   translate,
+  getTranslationTree,
   TranslateOptions,
 };

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -32,6 +32,31 @@ export interface TranslateOptions<
   pseudotranslate?: boolean | string;
 }
 
+export function getTranslationTree(
+  id: string,
+  translations: TranslationDictionary | TranslationDictionary[],
+): string | object {
+  const normalizedTranslations = Array.isArray(translations)
+    ? translations
+    : [translations];
+
+  let result: string | TranslationDictionary;
+
+  for (const translationDictionary of normalizedTranslations) {
+    result = translationDictionary;
+
+    for (const part of id.split(SEPARATOR)) {
+      result = result[part];
+    }
+
+    if (result) {
+      return result;
+    }
+  }
+
+  throw new MissingTranslationError();
+}
+
 export function translate(
   id: string,
   options: TranslateOptions<PrimitiveReplacementDictionary>,


### PR DESCRIPTION
Allow translate function to return object. For example, if I have:

```json
{
  "selectFieldOptions": {
    "volume": {
      "label": "Volume",
      "units": {
        "ml": "ml",
        "cl": "cl",
        "L": "L",
        "m3": "m3"
      }
    }
  }
}
```
```tsx
i18n.translate("selectFieldOptions.volume.units")
// => { "ml": "ml", "cl": "cl", "L": "L", "m3": "m3" }
```


This makes the behavior of the translate function to be similar to the one we have in Rails.

We could use it for countries as well for example, see: https://github.com/Shopify/web/blob/master/app/locales/en.json#L2784

@adjnor has a similar use case on a feature he is building currently.