### PR TITLE
✨ add `useMutation`

### DIFF
--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -142,3 +142,78 @@ const MyQuery = createAsyncQueryComponent({
 <MyQuery.Prefetch async={{defer: undefined}} />
 <MyQuery.KeepFresh pollInterval={20_000} async={{defer: undefined}} />
 ```
+
+## Using Apollo Hooks
+
+Using Apollo Hooks assume the usage of [`react-apollo`](https://github.com/apollographql/react-apollo))
+
+### `ApolloProvider`
+
+Before using the individual hooks, you will need to wrap your application with `ApolloProvider` at root of your React component tree.
+
+You can it instead of `react-apollo`'s [`ApolloProvider`](https://www.apollographql.com/docs/react/api/react-apollo#ApolloProvider).
+
+```tsx
+import React from 'react';
+import {render} from 'react-dom';
+
+import ApolloClient from 'apollo-client';
+import {ApolloProvider} from 'react-graphql';
+
+const client = new ApolloClient();
+
+function App() {
+  return (
+    <ApolloProvider client={client}>
+      <MyRootComponent />
+    </ApolloProvider>
+  );
+}
+
+render(<App />, document.getElementById('root'));
+```
+
+### `useMutation`
+
+This hook accepts two arguments: the mutation document, and optionally, a set of options to pass to the underlying mutation. It will return a function that will trigger the mutation when invoked.
+
+Note the set of options can be pass directly into the hook, or pass in while triggering the mutation function.
+If options exist in both places, they will be shallowly merge together with per-mutate options being the priority.
+
+```tsx
+import React from 'react';
+import {Form, TextField, Button, Banner} from '@shopify/polaris';
+import {useQuery} from '@shopify/react-graphql';
+
+import createCustomerMutation from './graphql/CreateCustomerMutation.graphql';
+
+function CustomerDetail() {
+  const [name, setName] = React.useState('');
+  const createCustomer = useMutation(createCustomerMutation, {
+    fetchPolicy: 'network-only',
+  });
+
+  async function handleFormSubmit() {
+    try {
+      await createCustomer({
+        variables: {name},
+      });
+
+      // do something when the mutation is successful
+    } catch (error) {
+      // do something when the mutation fails
+    }
+  }
+
+  return (
+    <Form onSubmit={handleCreateCustomer}>
+      <TextField label="Name" value={name} onChange={(value) => {
+        setName(value);
+      }}>
+      <Button submit>
+        Create Customer
+      </Button>
+    </Form>
+  );
+}
+```

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -39,6 +39,6 @@
     "dist/*"
   ],
   "peerDependencies": {
-    "react": "^16.6.0"
+    "react": ">=16.8.0 <17.0.0"
   }
 }

--- a/packages/react-graphql/src/hooks/ApolloContext.ts
+++ b/packages/react-graphql/src/hooks/ApolloContext.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+import ApolloClient from 'apollo-client';
+import {DocumentNode} from 'graphql-typed';
+
+export interface ApolloContextValue<CacheShape = any> {
+  client?: ApolloClient<CacheShape>;
+  operations?: Map<string, {query: DocumentNode; variables: any}>;
+}
+
+export const ApolloContext = React.createContext<
+  ApolloContextValue | undefined
+>(undefined);

--- a/packages/react-graphql/src/hooks/ApolloProvider.tsx
+++ b/packages/react-graphql/src/hooks/ApolloProvider.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ApolloClient from 'apollo-client';
+import {ApolloProvider as OriginalApolloProvider} from 'react-apollo';
+
+import {ApolloContext} from './ApolloContext';
+
+export interface Props<CacheShape> {
+  readonly client: ApolloClient<CacheShape>;
+  readonly children?: React.ReactNode;
+}
+
+export function ApolloProvider<CacheShape = any>({
+  client,
+  children,
+}: Props<CacheShape>) {
+  return (
+    <OriginalApolloProvider client={client}>
+      <ApolloContext.Provider
+        value={{
+          client,
+          operations: (client as any).__operations_cache__,
+        }}
+      >
+        {children}
+      </ApolloContext.Provider>
+    </OriginalApolloProvider>
+  );
+}

--- a/packages/react-graphql/src/hooks/apollo-client.tsx
+++ b/packages/react-graphql/src/hooks/apollo-client.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import ApolloClient from 'apollo-client';
+import {ApolloContext} from './ApolloContext';
+
+export function useApolloClient<CacheShape>(
+  overrideClient?: ApolloClient<CacheShape>,
+): ApolloClient<CacheShape> {
+  const context = React.useContext(ApolloContext);
+
+  // Ensures that the number of hooks called from one render to another remains
+  // constant, despite the Apollo client read from context being swapped for
+  // one passed directly as prop.
+  if (overrideClient) {
+    return overrideClient;
+  }
+
+  if (!context || !context.client) {
+    // https://github.com/apollographql/react-apollo/blob/5cb63b3625ce5e4a3d3e4ba132eaec2a38ef5d90/src/component-utils.tsx#L19-L22
+    throw new Error(
+      [
+        'Could not find "client" in the context or passed in as a prop. ',
+        'Wrap the root component in an <ApolloProvider>, or pass an ',
+        'ApolloClient instance in via props.',
+      ].join(),
+    );
+  }
+
+  return context.client;
+}

--- a/packages/react-graphql/src/hooks/index.ts
+++ b/packages/react-graphql/src/hooks/index.ts
@@ -1,0 +1,4 @@
+export {ApolloProvider} from './ApolloProvider';
+export {useApolloClient} from './apollo-client';
+export {default as useMutation} from './mutation';
+export * from './types';

--- a/packages/react-graphql/src/hooks/mutation.ts
+++ b/packages/react-graphql/src/hooks/mutation.ts
@@ -1,0 +1,63 @@
+import {OperationVariables} from 'apollo-client';
+import {MutationOptions} from 'react-apollo';
+import {DocumentNode} from 'graphql-typed';
+import {useCallback} from 'react';
+
+import {MutationHookOptions, MutationHookResult} from './types';
+import {useApolloClient} from './apollo-client';
+
+export default function useMutation<Data = any, Variables = OperationVariables>(
+  mutation: DocumentNode<Data, Variables>,
+  options: MutationHookOptions<Data, Variables> = {},
+): MutationHookResult<Data, Variables> {
+  const {
+    client: overrideClient,
+    variables,
+    optimisticResponse,
+    refetchQueries,
+    awaitRefetchQueries,
+    update,
+    context,
+    fetchPolicy,
+  } = options;
+
+  const client = useApolloClient(overrideClient);
+
+  const runMutation = useCallback(
+    (perMutationOptions: MutationOptions<Data, Variables> = {}) => {
+      const mutateVariables = {
+        ...(variables || {}),
+        ...(perMutationOptions.variables || {}),
+      };
+      delete perMutationOptions.variables;
+
+      return client.mutate({
+        mutation,
+        variables: mutateVariables,
+        optimisticResponse,
+        refetchQueries,
+        awaitRefetchQueries,
+        update,
+        context,
+        fetchPolicy,
+        ...perMutationOptions,
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      client,
+      mutation,
+      refetchQueries,
+      awaitRefetchQueries,
+      update,
+      context,
+      fetchPolicy,
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      JSON.stringify(variables),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      JSON.stringify(optimisticResponse),
+    ],
+  );
+
+  return runMutation;
+}

--- a/packages/react-graphql/src/hooks/tests/mutation.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/mutation.test.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import gql from 'graphql-tag';
+import {createGraphQLFactory} from '@shopify/graphql-testing';
+
+import useMutation from '../mutation';
+import {
+  mountWithGraphQL,
+  prepareAsyncReactTasks,
+  teardownAsyncReactTasks,
+} from './utilities';
+
+const updatePetMutation = gql`
+  mutation UpdatePetMutation($name: String!) {
+    updatePet(name: $name) {
+      id
+    }
+  }
+`;
+
+const createGraphQL = createGraphQLFactory();
+
+function MockMutation({children}: {children: Function}) {
+  const mutate = useMutation(updatePetMutation);
+  const [response, setResponse] = React.useState();
+
+  async function runMutation() {
+    const response = await mutate();
+    setResponse(response);
+  }
+
+  return (
+    <>
+      <button type="button" onClick={runMutation} />
+      {children(response)}
+    </>
+  );
+}
+
+const mockMutationData = {
+  updatePet: {id: 'new-pet-id-123', __typename: 'Cat'},
+};
+
+// This is skip because current `act` wrapper does not support async operation
+// The test will pass if we update to `react-dom` v16.9.0-alpha.0
+// and wrap `graphQL.resolveAll()` in an `act`
+// https://github.com/facebook/react/issues/14769#issuecomment-481251431
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('useMutation', () => {
+  beforeEach(() => {
+    prepareAsyncReactTasks();
+  });
+
+  afterEach(() => {
+    teardownAsyncReactTasks();
+  });
+
+  it('returns result that contains the loaded data once the mutation finished running', async () => {
+    const renderPropSpy = jest.fn(() => null);
+    const graphQL = createGraphQL({UpdatePetMutation: mockMutationData});
+    const mockMutation = await mountWithGraphQL(
+      <MockMutation>{renderPropSpy}</MockMutation>,
+      {graphQL},
+    );
+
+    mockMutation.find('button')!.trigger('onClick', undefined as any);
+    await graphQL.resolveAll();
+
+    expect(renderPropSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({data: mockMutationData}),
+    );
+  });
+});

--- a/packages/react-graphql/src/hooks/tests/utilities.tsx
+++ b/packages/react-graphql/src/hooks/tests/utilities.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+
+import {createGraphQLFactory, GraphQL} from '@shopify/graphql-testing';
+import {createMount} from '@shopify/react-testing';
+import {promise} from '@shopify/jest-dom-mocks';
+
+import {ApolloProvider} from '../ApolloProvider';
+
+const createGraphQL = createGraphQLFactory();
+
+interface Options {
+  graphQL?: GraphQL;
+  skipInitialGraphQL?: boolean;
+}
+
+interface Context {
+  graphQL: GraphQL;
+}
+
+export const mountWithGraphQL = createMount<Options, Context, true>({
+  context({graphQL = createGraphQL()}) {
+    return {graphQL};
+  },
+
+  render(element, {graphQL}) {
+    return <ApolloProvider client={graphQL.client}>{element}</ApolloProvider>;
+  },
+  async afterMount(root, {skipInitialGraphQL}) {
+    root.context.graphQL.on('pre-resolve', () => {
+      root.act(runPendingAsyncReactTasks);
+    });
+
+    if (skipInitialGraphQL) {
+      return;
+    }
+
+    await root.context.graphQL.resolveAll();
+  },
+});
+
+export function prepareAsyncReactTasks() {
+  if (!promise.isMocked()) {
+    promise.mock();
+  }
+}
+
+export function teardownAsyncReactTasks() {
+  if (promise.isMocked()) {
+    promise.restore();
+  }
+}
+
+export function runPendingAsyncReactTasks() {
+  if (!promise.isMocked()) {
+    throw new Error(
+      'You attempted to resolve pending async React tasks, but have not yet prepared to do so. Run `prepareAsyncReactTasks()` from "tests/modern" in a `beforeEach` block and try again.',
+    );
+  }
+
+  promise.runPending();
+}

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -1,0 +1,13 @@
+import ApolloClient from 'apollo-client';
+import {MutationOptions, FetchResult, OperationVariables} from 'react-apollo';
+
+export interface MutationHookOptions<
+  Data = any,
+  Variables = OperationVariables
+> extends MutationOptions<Data, Variables> {
+  client?: ApolloClient<object>;
+}
+
+export type MutationHookResult<Data, Variables> = (
+  options?: MutationOptions<Data, Variables>,
+) => Promise<FetchResult<Data>>;

--- a/packages/react-graphql/src/index.ts
+++ b/packages/react-graphql/src/index.ts
@@ -9,3 +9,5 @@ export {
   GraphQLDeepPartial,
   QueryProps,
 } from './types';
+
+export * from './hooks';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,7 +4016,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
   integrity sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w==
 
-hoist-non-react-statics@^3.0.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -5188,7 +5188,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -5781,6 +5781,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -6953,6 +6960,15 @@ prop-types@^15.5.6, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -7064,7 +7080,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-apollo@>=2.2.3 <3.0.0", react-apollo@^2.2.3:
+react-apollo@^2.2.3:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.2.tgz#6732c6af55e6adc9ebf97bf189e867a893c449d3"
   integrity sha512-lmglhG6NQ+lfAUDzx8ZgelWKUbvxBhhy1l7Z2ksgtQ8+FVqwX7i6p5O3zicAZZlIdKzdq82V0kqq5WkxEsffrA==
@@ -7074,6 +7090,18 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     lodash.isequal "^4.5.0"
     prop-types "^15.6.0"
     ts-invariant "^0.3.0"
+    tslib "^1.9.3"
+
+react-apollo@~2.5.3:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.4.tgz#4b5ad2e9e38001521d072445acdb5b3b5489b22d"
+  integrity sha512-olH9zYijOXVfj14hD7bQlZ0POBJchxg2e+mfnxEiEdqZra4+58SfIY0KPhmM9jqbeeusc6J/P4zzWIHt5DdNDg==
+  dependencies:
+    apollo-utilities "^1.2.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
+    ts-invariant "^0.3.2"
     tslib "^1.9.3"
 
 react-dom@^16.8.1:
@@ -7126,7 +7154,7 @@ react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
-react-is@^16.8.4:
+react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==


### PR DESCRIPTION
Part of #586

I have skipped the test due to `act` not supporting async operation.
https://github.com/Shopify/quilt/pull/654
show the test passing if we update to react-dom v16.9.0-alpha.0

🎩 instructions:
- get this branch & [this test branch](https://github.com/Shopify/web-proving-ground/tree/apollo-mutation-hook) on web-proving-ground locally
- run `yarn` in web-proving-ground
- in quilt, do `yarn && yarn tophat react-graphql ../web-proving-ground`
- once it complied, go to `web-proving-ground` and do `yarn dev`
- goto localhost:8081 to see the mutation working properly on customer details page