### PR TITLE
react-i18n perf optimizations

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -7,7 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.0.1] - 2019-04-17
+## [1.1.0] - 2019-04-17
+
+### Added
+
+- Added a `useLazyRef` hook ([#659](https://github.com/Shopify/quilt/pull/659))
+
+## [1.0.0] - 2019-04-12
 
 ### Added
 

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -40,3 +40,19 @@ function MyComponent() {
   return <div>{foo}</div>;
 }
 ```
+
+### `useLazyRef()`
+
+This hook creates a ref object like React’s `useRef`, but instead of providing it the value directly, you provide a function that returns the value. The first time the hook is run, it will call the function and use the returned value as the initial `ref.current` value. Afterwards, the function is never invoked. You can use this for creating refs to values that are expensive to initialize.
+
+```tsx
+function MyComponent() {
+  const ref = useLazyRef(() => someExpensiveOperation());
+
+  React.useEffect(() => {
+    console.log('Initialized expensive ref', ref.current);
+  });
+
+  return null;
+}
+```

--- a/packages/react-hooks/src/hooks/index.ts
+++ b/packages/react-hooks/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export {useLazyRef} from './lazy-ref';
 export {default as useTimeout} from './timeout';
 export {default as useOnValueChange} from './on-value-change';

--- a/packages/react-hooks/src/hooks/lazy-ref.ts
+++ b/packages/react-hooks/src/hooks/lazy-ref.ts
@@ -1,0 +1,13 @@
+import {useRef, MutableRefObject} from 'react';
+
+const UNSET = Symbol('unset');
+
+export function useLazyRef<T>(getValue: () => T): MutableRefObject<T> {
+  const ref = useRef<T | typeof UNSET>(UNSET);
+
+  if (ref.current === UNSET) {
+    ref.current = getValue();
+  }
+
+  return ref as MutableRefObject<T>;
+}

--- a/packages/react-hooks/src/hooks/tests/lazy-ref.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/lazy-ref.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {useLazyRef} from '../lazy-ref';
+
+describe('useLazyRef()', () => {
+  it('calls the passed function and returns the ref for it', () => {
+    const content = 'Hello world';
+    const spy = jest.fn(() => content);
+
+    function MockComponent() {
+      const value = useLazyRef(spy);
+      return <div>{value.current}</div>;
+    }
+
+    const mockComponent = mount(<MockComponent />);
+
+    expect(spy).toHaveBeenCalled();
+    expect(mockComponent).toContainReactText(content);
+  });
+
+  it('does not call the passed function on subsequent renders', () => {
+    function MockComponent({spy}: {spy: () => any}) {
+      const value = useLazyRef(spy);
+      return <div>{value.current}</div>;
+    }
+
+    const mockComponent = mount(<MockComponent spy={() => 'Hello'} />);
+
+    const newContent = 'Goodbye';
+    const spy = jest.fn(() => newContent);
+    mockComponent.setProps({spy});
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(mockComponent).not.toContainReactText(newContent);
+  });
+});

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2019-04-12
+
 ### Changed
 
 - `Weekdays` renamed to `Weekday` as part of `shopify/typescript/prefer-singular-enums` eslint rule ([#648](https://github.com/Shopify/quilt/pull/648))

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a number of performance issues with resolving asynchronous translations ([#659](https://github.com/Shopify/quilt/pull/659))
+
 ## [1.1.1] - 2019-04-12
 
 ### Changed

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -120,26 +120,6 @@ class NotFound extends React.Component<ComposedProps> {
 export default withI18n()(NotFound);
 ```
 
-If you only need access to parent translations and/ or the various formatting utilities found on the `I18n` object, you can instead use the `useSimpleI18n` hook. This hook does not support providing any internationalization details for the component itself, but is a very performant way to access i18n utilities that are tied to the global locale.
-
-```tsx
-import * as React from 'react';
-import {EmptyState} from '@shopify/polaris';
-import {useSimpleI18n} from '@shopify/react-i18n';
-
-export default function NotFound() {
-  const i18n = useSimpleI18n();
-  return (
-    <EmptyState
-      heading={i18n.translate('NotFound.heading')}
-      action={{content: i18n.translate('Common.back'), url: '/'}}
-    >
-      <p>{i18n.translate('NotFound.content')}</p>
-    </EmptyState>
-  );
-}
-```
-
 #### `i18n`
 
 The provided `i18n` object exposes many useful methods for internationalizing your apps. You can see the full details in the [`i18n` source file](https://github.com/Shopify/quilt/blob/master/packages/react-i18n/src/i18n.ts), but you will commonly need the following:

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -69,6 +69,8 @@ export default function NotFound() {
 
 The hook also returns a `ShareTranslations` component. You can wrap this around a part of the subtree that should have access to this component’s translations.
 
+> **Note:** `ShareTranslations` is not guaranteed to re-render when your i18n object changes. If you render `ShareTranslations` inside of a component that might block changes to children, you will likely run into issues. To prevent this, we recommend that `ShareTranslations` should be rendered as a top-level child of the component that uses `useI18n`.
+
 ```tsx
 import * as React from 'react';
 import {Page} from '@shopify/polaris';
@@ -81,13 +83,9 @@ interface Props {
 export default function ProductDetails({children}: Props) {
   const [i18n, ShareTranslations] = useI18n();
   return (
-    <Page
-      title={i18n.translate('ProductDetails.title')}
-    >
-      <ShareTranslations>
-        {children}
-      </ShareTranslations>
-    </EmptyState>
+    <ShareTranslations>
+      <Page title={i18n.translate('ProductDetails.title')}>{children}</Page>
+    </ShareTranslations>
   );
 }
 ```

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@shopify/i18n": "^0.1.3",
     "@shopify/react-effect": "^3.0.1",
+    "@shopify/react-hooks": "^1.0.0",
     "@types/hoist-non-react-statics": "^3.0.1",
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.6.2",

--- a/packages/react-i18n/src/context.ts
+++ b/packages/react-i18n/src/context.ts
@@ -3,4 +3,5 @@ import {I18nManager} from './manager';
 import {I18n} from './i18n';
 
 export const I18nContext = React.createContext<I18nManager | null>(null);
-export const I18nParentsContext = React.createContext<I18n | null>(null);
+export const I18nIdsContext = React.createContext<string[]>([]);
+export const I18nParentContext = React.createContext<I18n | null>(null);

--- a/packages/react-i18n/src/hooks.tsx
+++ b/packages/react-i18n/src/hooks.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 
+import {useLazyRef} from '@shopify/react-hooks';
+
 import {I18n} from './i18n';
 import {I18nManager, RegisterOptions} from './manager';
 import {I18nContext, I18nIdsContext, I18nParentContext} from './context';
 
-export function useI18n(options?: Partial<RegisterOptions>): [
-  I18n,
-  React.ComponentType<{children: React.ReactNode}>
-] {
+type Result = [I18n, React.ComponentType<{children: React.ReactNode}>];
+
+export function useI18n(options?: Partial<RegisterOptions>): Result {
   const manager = React.useContext(I18nContext);
 
   if (manager == null) {
@@ -19,7 +20,9 @@ export function useI18n(options?: Partial<RegisterOptions>): [
   const registerOptions = React.useRef(options);
 
   if (shouldRegister(registerOptions.current) !== shouldRegister(options)) {
-    throw new Error('You switched between providing registration options and not providing them, which is not supported.');
+    throw new Error(
+      'You switched between providing registration options and not providing them, which is not supported.',
+    );
   }
 
   if (options == null) {
@@ -29,56 +32,66 @@ export function useI18n(options?: Partial<RegisterOptions>): [
   }
 }
 
-function useComplexI18n({
-  id,
-  fallback,
-  translations,
-}: Partial<RegisterOptions>, manager: I18nManager) {
+function useComplexI18n(
+  {id, fallback, translations}: Partial<RegisterOptions>,
+  manager: I18nManager,
+): Result {
   const parentIds = React.useContext(I18nIdsContext);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const ids = React.useMemo(() => (id ? [id, ...parentIds] : parentIds), [
-    id,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    ...parentIds,
-  ]);
+  // Parent IDs can only change when a parent gets added/ removed,
+  // which would cause the component using `useI18n` to unmount.
+  // We also don't support the `id` changing between renders. For these
+  // reasons, it's safe to just store the IDs once and never let them change.
+  const ids = useLazyRef(() => (id ? [id, ...parentIds] : parentIds));
 
   if (id && (translations || fallback)) {
     manager.register({id, translations, fallback});
   }
 
   const [i18n, setI18n] = React.useState(() => {
-    const {translations} = manager.state(ids);
-    return new I18n(translations, manager.details, ids);
+    const {translations} = manager.state(ids.current);
+    return new I18n(translations, manager.details, ids.current);
   });
+
+  const i18nRef = React.useRef(i18n);
 
   React.useEffect(
     () => {
-      return manager.subscribe(ids, ({translations}, details) => {
-        setI18n(new I18n(translations, details, ids));
+      return manager.subscribe(ids.current, ({translations}, details) => {
+        const newI18n = new I18n(translations, details, ids.current);
+        i18nRef.current = newI18n;
+        setI18n(newI18n);
       });
     },
-    [ids, manager],
+    [manager],
   );
 
+  // We use refs in this component so that it never changes. If this component
+  // is regenerated, it will unmount the entire tree of the previous component,
+  // which is usually not desirable. Technically, this does leave surface area
+  // for a bug to sneak in: if the component that renders this does so inside
+  // a component that blocks the update from passing down, nothing will force
+  // this component to re-render, so no descendants will get the new ids/ i18n
+  // value. Because we don't actually have any such cases, we're OK with this
+  // for now.
   const ShareTranslations = React.useMemo(
     () =>
       function ShareTranslations({children}: {children: React.ReactNode}) {
         return (
-          <I18nIdsContext.Provider value={ids}>
-            <I18nParentContext.Provider value={i18n}>
+          <I18nIdsContext.Provider value={ids.current}>
+            <I18nParentContext.Provider value={i18nRef.current}>
               {children}
             </I18nParentContext.Provider>
           </I18nIdsContext.Provider>
         );
       },
-    [i18n, ids],
+    [i18nRef, ids],
   );
 
   return [i18n, ShareTranslations];
 }
 
-function useSimpleI18n(manager: I18nManager) {
+function useSimpleI18n(manager: I18nManager): Result {
   const i18n =
     React.useContext(I18nParentContext) || new I18n([], manager.details);
 
@@ -86,9 +99,12 @@ function useSimpleI18n(manager: I18nManager) {
 }
 
 function IdentityComponent({children}: {children: React.ReactNode}) {
-  return children;
+  return <>{children}</>;
 }
 
-function shouldRegister({fallback, translations}: Partial<RegisterOptions> = {}) {
+function shouldRegister({
+  fallback,
+  translations,
+}: Partial<RegisterOptions> = {}) {
   return fallback != null || translations != null;
 }

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -102,7 +102,6 @@ export class I18n {
       pseudolocalize = false,
       onError,
     }: I18nDetails,
-    public readonly ids?: string[],
   ) {
     this.locale = locale;
     this.defaultCountry = country;

--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -1,7 +1,7 @@
 export {I18nManager, ExtractedTranslations} from './manager';
 export {I18nContext} from './context';
 export {I18n} from './i18n';
-export {useI18n, useSimpleI18n} from './hooks';
+export {useI18n} from './hooks';
 export {withI18n, WithI18nProps} from './decorator';
 export {translate} from './utilities';
 export {I18nDetails, LanguageDirection, CurrencyCode} from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,7 +550,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -572,10 +572,18 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@>=16.4.0", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.8.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
   integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@16.8.2":
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
+  integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,7 +550,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -572,18 +572,10 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.4.0", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.8.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
   integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@16.8.2":
-  version "16.8.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
-  integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -7088,6 +7080,18 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+"react-apollo@>=2.2.3 <3.0.0":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.4.tgz#4b5ad2e9e38001521d072445acdb5b3b5489b22d"
+  integrity sha512-olH9zYijOXVfj14hD7bQlZ0POBJchxg2e+mfnxEiEdqZra4+58SfIY0KPhmM9jqbeeusc6J/P4zzWIHt5DdNDg==
+  dependencies:
+    apollo-utilities "^1.2.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
+    ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+
 react-apollo@^2.2.3:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.2.tgz#6732c6af55e6adc9ebf97bf189e867a893c449d3"
@@ -7098,18 +7102,6 @@ react-apollo@^2.2.3:
     lodash.isequal "^4.5.0"
     prop-types "^15.6.0"
     ts-invariant "^0.3.0"
-    tslib "^1.9.3"
-
-react-apollo@~2.5.3:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.4.tgz#4b5ad2e9e38001521d072445acdb5b3b5489b22d"
-  integrity sha512-olH9zYijOXVfj14hD7bQlZ0POBJchxg2e+mfnxEiEdqZra4+58SfIY0KPhmM9jqbeeusc6J/P4zzWIHt5DdNDg==
-  dependencies:
-    apollo-utilities "^1.2.1"
-    hoist-non-react-statics "^3.3.0"
-    lodash.isequal "^4.5.0"
-    prop-types "^15.7.2"
-    ts-invariant "^0.3.2"
     tslib "^1.9.3"
 
 react-dom@^16.8.1:


### PR DESCRIPTION
This PR addresses a few performance concerns, one of which was the cause of the issue we had in Web when we tried to roll these out:

1. Calling subscriptions when async translations are resolved now queues subscriptions to run in a single animation frame
2. When async translations are resolved to `undefined`, we no longer call the subscription (this is technically a bit dangerous because the `loading` property can get out of date, but we don't currently use this anywhere anyways, and this basically only happens for more detailed locales (e.g., `fr-CA`), where the consumer will get an update on the `fr` part resolving just fine
3. I removed a hacky `useSimpleI18n` hook and, instead, made `useI18n` bail out early when there are no options passed. This violates the rules of hooks, but we get around that by throwing an error if they try to switch between the two modes
4. I split apart the context for i18n objects and the one for the nested IDs in the parent. By having `useI18n` hooks linked up to the `I18nContext`, any update to one `i18n` object higher in the tree would cause all descendants' hooks to run again, which would be useless, because the IDs in question are still the same.
5. Made it so that the `ShareTranslations` component that gets returned is always the same function. This was the main cause of the incident we had: when the "highest" i18n-connected component had some translations that resolved async (even for locales like `en-CA`, which would do an async lookup for the `-CA` languages), its `ShareTranslations` would change. When that happened, the entire subtree below it got unmounted (this is how React's reconciliation works), then remounted. For a component like our `AdminNextFallback`, which sometimes makes non-idempotent get requests on mount, this could cause issues (like multiple GETs eventually causing full-page auth redirects).

With these in place, the performance of i18n on load is much better. Here's the before/ after for a shop in `en-CA`:

![Screen Shot 2019-04-17 at 10 46 14 AM](https://user-images.githubusercontent.com/3012583/56300277-a0ad0300-6103-11e9-86c3-20a661d4cdb9.png)

![Screen Shot 2019-04-17 at 10 52 15 AM](https://user-images.githubusercontent.com/3012583/56300285-a60a4d80-6103-11e9-84f0-58cccaa970a8.png)

The `hydrate` bit is about the same length in both, So this basically shaves off 500–600ms.