### PR TITLE
Allow passing partial arguments to trigger

### DIFF
--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -246,7 +246,7 @@ Like `findWhere`, but returns all matches as an array.
 
 Simulates a function prop being called on your component. This is usually the key to effective tests: after you have mounted your component, you simulate a change in a subcomponent, and assert that the resulting React tree is in the expected shape. This method automatically uses [`Root#act`](#act) when calling the prop, so updates will automatically be applied to the root component.
 
-When you pass a key that is a prop on your component with a function type, this function will force you to provide additional arguments which will be passed to that function, and the return type will be whatever is returned by calling that prop.
+When you pass a key that is a prop on your component with a function type, this function will ensure that you pass arguments that are deeply partial versions of the types the prop expects. This allows you to, for example, pass an event object with only a few properties set to a `button`’s `onClick` prop. `trigger` returns whatever the result was of calling the prop.
 
 ```tsx
 function MyComponent({onClick}: {onClick(id: string): void}) {

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -4,7 +4,7 @@ import {
   Arguments,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
-import {Tag, FunctionKeys} from './types';
+import {Tag, FunctionKeys, DeepPartialArguments} from './types';
 
 export type Predicate = (element: Element<unknown>) => boolean;
 
@@ -172,7 +172,7 @@ export class Element<Props> {
 
   trigger<K extends FunctionKeys<Props>>(
     prop: K,
-    ...args: Arguments<Props[K]>
+    ...args: DeepPartialArguments<Arguments<Props[K]>>
   ): ReturnType<NonNullable<Props[K]>> {
     return this.root.act(() => {
       const propValue = this.props[prop];

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -9,7 +9,13 @@ import {
 
 import {TestWrapper} from './TestWrapper';
 import {Element, Predicate} from './element';
-import {Tag, Fiber, ReactInstance, FunctionKeys} from './types';
+import {
+  Tag,
+  Fiber,
+  ReactInstance,
+  FunctionKeys,
+  DeepPartialArguments,
+} from './types';
 import {withIgnoredReactLogs} from './errors';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -134,9 +140,9 @@ export class Root<Props> {
 
   trigger<K extends FunctionKeys<Props>>(
     prop: K,
-    ...args: Arguments<Props[K]>
+    ...args: DeepPartialArguments<Arguments<Props[K]>>
   ): ReturnType<NonNullable<Props[K]>> {
-    return this.withRoot(root => root.trigger(prop, ...args));
+    return this.withRoot(root => root.trigger(prop, ...(args as any)));
   }
 
   triggerKeypath<T = unknown>(keypath: string, ...args: unknown[]) {

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -648,6 +648,22 @@ describe('Element', () => {
 
       expect(element.trigger('onClick')).toBe(returnValue);
     });
+
+    it('allows passing a deep partial version of the props', () => {
+      const partialEvent = {altKey: true};
+      const element = new Element<React.HTMLAttributes<HTMLDivElement>>(
+        {
+          ...defaultTree,
+          type: TriggerableComponent,
+          props: {onClick: jest.fn()},
+        },
+        [],
+        [],
+        defaultRoot,
+      );
+
+      expect(() => element.trigger('onClick', partialEvent)).not.toThrow();
+    });
   });
 
   describe('#triggerKeypath()', () => {

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -6,6 +6,19 @@ export type FunctionKeys<T> = {
     : never
 }[keyof T];
 
+interface DeepPartialArray<T> extends Array<DeepPartial<T>> {}
+interface DeepPartialReadonlyArray<T> extends ReadonlyArray<DeepPartial<T>> {}
+type DeepPartialObject<T extends object> = {[K in keyof T]?: DeepPartial<T[K]>};
+
+type DeepPartial<T> = T extends (infer U)[]
+  ? DeepPartialArray<U>
+  : T extends ReadonlyArray<infer U>
+    ? DeepPartialReadonlyArray<U>
+    : T extends object ? DeepPartialObject<T> : T;
+
+export type DeepPartialArguments<T> = {[K in keyof T]?: DeepPartial<T[K]>} &
+  any[];
+
 // https://github.com/facebook/react/blob/master/packages/shared/ReactWorkTag.js
 export enum Tag {
   FunctionComponent = 0,


### PR DESCRIPTION
This PR allows you to pass partial versions of the types expected for props you are `trigger`ing. Before, if you wanted to `trigger` a prop, you needed to pass all the arguments that prop says it provides, even if your consumer only cares about a small subset. This was particularly annoying when triggering DOM props:

```tsx
const myComponent = mount(<MyComponent />);
myComponent.find('div')!.trigger('onClick', createFullClickEventOrCastAsAny());
```

Now, if you only use one of the properties, you can just pass that:

```tsx
const myComponent = mount(<MyComponent />);
myComponent.find('div')!.trigger('onClick', {key: 'a'});
```

You can also entirely omit arguments if you know they aren't used. While this is technically less type safe, I think it is a necessity in practice, because no one wants to completely fill out arguments for trigger that they don't even use.