### PR TITLE
🎉 create @shopify/predicates

### DIFF
--- a/packages/predicates/CHANGELOG.md
+++ b/packages/predicates/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [1.0.0]
+
+### Added
+
+- `@shopify/predicates` package

--- a/packages/predicates/README.md
+++ b/packages/predicates/README.md
@@ -1,0 +1,31 @@
+# `@shopify/predicates`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fpredicates.svg)](https://badge.fury.io/js/%40shopify%2Fpredicates.svg)
+
+A set of common Javascript predicates. The functions in this library either take one input and return `true` / `false`, or return a customized function that does so.
+
+## Installation
+
+```bash
+$ yarn add @shopify/predicates
+```
+
+## API
+
+### Predicates
+
+- `isPositiveNumericString` Returns `true` when its input is a positive numeric string and `false` otherwise.
+- `isNumericString` Returns `true` when its input is a numeric string and `false` otherwise.
+- `isEmpty` Returns `true` when its input is `null`, `undefined`, or has `length` 0.
+- `isEmptyString` Returns `true` when it's input is an empty string or contains only whitespace.
+- `notEmpty` Returns `true` when its input is not `null`, `undefined` or has `length` 0.
+
+### Predicate creators
+
+- `lengthMoreThan` Given a number, returns a function that returns true when that input has length more than that number and false otherwise.
+- `lengthLessThan` Given a number, returns a function that returns true when that input has length less than that number and false otherwise.
+
+### Helpers
+
+- `not` Given a function that returns a boolean, returns a function that returns a boolean in the opposite cases.

--- a/packages/predicates/package.json
+++ b/packages/predicates/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shopify/predicates",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A set of common Javascript predicates",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/predicates/README.md",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "~3.2.1"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/predicates/src/index.ts
+++ b/packages/predicates/src/index.ts
@@ -1,0 +1,1 @@
+export * from './predicates';

--- a/packages/predicates/src/predicates.ts
+++ b/packages/predicates/src/predicates.ts
@@ -1,0 +1,35 @@
+export function lengthMoreThan(length: number) {
+  return (input: {length: number}) => input.length > length;
+}
+
+export function lengthLessThan(length: number) {
+  return (input: {length: number}) => input.length < length;
+}
+
+export function isPositiveNumericString(input: string) {
+  return input !== '' && (input.match(/[^0-9.,]/g) || []).length === 0;
+}
+
+export function isNumericString(input: string) {
+  return input !== '' && (input.match(/[^0-9.,-]/g) || []).length === 0;
+}
+
+export function isEmpty(input: any) {
+  return input === null || input === undefined || input.length === 0;
+}
+
+export function isEmptyString(input: string) {
+  return input.trim().length < 1;
+}
+
+export function notEmpty(input: any) {
+  return not(isEmpty)(input);
+}
+
+export function notEmptyString(input: string) {
+  return not(isEmptyString)(input);
+}
+
+function not<A extends any[], R>(fn: (...xs: A) => R) {
+  return (...args: A) => !fn(...args);
+}

--- a/packages/predicates/src/test/predicates.test.ts
+++ b/packages/predicates/src/test/predicates.test.ts
@@ -1,0 +1,175 @@
+import {
+  lengthMoreThan,
+  lengthLessThan,
+  isPositiveNumericString,
+  isNumericString,
+  isEmpty,
+  isEmptyString,
+  notEmpty,
+  notEmptyString,
+} from '../predicates';
+
+describe('lengthMoreThan', () => {
+  it('returns a function that returns false for inputs with length less than the given value', () => {
+    const lengthMoreThanFour = lengthMoreThan(4);
+
+    expect(lengthMoreThanFour('a')).toBe(false);
+    expect(lengthMoreThanFour({length: 1})).toBe(false);
+    expect(lengthMoreThanFour([1])).toBe(false);
+  });
+
+  it('returns a function that returns false for inputs with length equal to the given value', () => {
+    const lengthMoreThanTwo = lengthMoreThan(2);
+
+    expect(lengthMoreThanTwo('hi')).toBe(false);
+    expect(lengthMoreThanTwo({length: 2})).toBe(false);
+    expect(lengthMoreThanTwo([1, 2])).toBe(false);
+  });
+
+  it('returns a function that returns true for inputs with length more than the given value', () => {
+    const lengthMoreThanThree = lengthMoreThan(3);
+
+    expect(lengthMoreThanThree('I am so very cool')).toBe(true);
+    expect(lengthMoreThanThree({length: 10})).toBe(true);
+    expect(lengthMoreThanThree([1, 2, 3, 4])).toBe(true);
+  });
+});
+
+describe('lengthLessThan', () => {
+  it('returns a function that returns true for inputs with length less than the given value', () => {
+    const lengthLessThanFour = lengthLessThan(4);
+
+    expect(lengthLessThanFour('a')).toBe(true);
+    expect(lengthLessThanFour({length: 1})).toBe(true);
+    expect(lengthLessThanFour([1])).toBe(true);
+  });
+
+  it('returns a function that returns false for inputs with length equal to the given value', () => {
+    const lengthLessThanTwo = lengthLessThan(2);
+
+    expect(lengthLessThanTwo('hi')).toBe(false);
+    expect(lengthLessThanTwo({length: 2})).toBe(false);
+    expect(lengthLessThanTwo([1, 2])).toBe(false);
+  });
+
+  it('returns a function that returns false for inputs with length more than the given value', () => {
+    const lengthLessThanThree = lengthLessThan(3);
+
+    expect(lengthLessThanThree('I am so very cool')).toBe(false);
+    expect(lengthLessThanThree({length: 10})).toBe(false);
+    expect(lengthLessThanThree([1, 2, 3, 4])).toBe(false);
+  });
+});
+
+describe('isPositiveNumericString', () => {
+  it('returns false for numeric strings which are negative', () => {
+    expect(isPositiveNumericString('-1.00')).toBe(false);
+    expect(isPositiveNumericString('-9999')).toBe(false);
+  });
+
+  it('returns true for numeric strings which are positive', () => {
+    expect(isPositiveNumericString('254')).toBe(true);
+    expect(isPositiveNumericString('0.23')).toBe(true);
+  });
+
+  it('returns false for non-numeric strings', () => {
+    expect(isPositiveNumericString('blorp')).toBe(false);
+  });
+});
+
+describe('isNumericString', () => {
+  it('returns true for numeric strings', () => {
+    expect(isNumericString('25499')).toBe(true);
+    expect(isNumericString('-0.23')).toBe(true);
+    expect(isNumericString('-76')).toBe(true);
+    expect(isNumericString('12312312321.123')).toBe(true);
+  });
+
+  it('returns false for non-numeric strings', () => {
+    expect(isNumericString('lorem ipsum')).toBe(false);
+  });
+});
+
+describe('isEmptyString', () => {
+  it('returns true for empty strings', () => {
+    expect(isEmptyString('')).toBe(true);
+  });
+
+  it('returns true for strings with only whitespace', () => {
+    expect(isEmptyString(' ')).toBe(true);
+    expect(isEmptyString('\t')).toBe(true);
+    expect(isEmptyString('\n\n')).toBe(true);
+  });
+
+  it('returns false for strings with non-whitespace characters', () => {
+    expect(isEmptyString('foo bar baz')).toBe(false);
+  });
+});
+
+describe('notEmptyString', () => {
+  it('returns false for empty strings', () => {
+    expect(notEmptyString('')).toBe(false);
+  });
+
+  it('returns false for strings with only whitespace', () => {
+    expect(notEmptyString(' ')).toBe(false);
+    expect(notEmptyString('\t')).toBe(false);
+    expect(notEmptyString('\n\n')).toBe(false);
+  });
+
+  it('returns true for strings with non-whitespace characters', () => {
+    expect(notEmptyString('foo bar baz')).toBe(true);
+  });
+});
+
+describe('isEmpty', () => {
+  it('returns true for null', () => {
+    expect(isEmpty(null)).toBe(true);
+  });
+
+  it('returns true for undefined', () => {
+    expect(isEmpty(undefined)).toBe(true);
+  });
+
+  it('returns true for values with a `length` property of 0', () => {
+    expect(isEmpty([])).toBe(true);
+    expect(isEmpty({length: 0})).toBe(true);
+    expect(isEmpty('')).toBe(true);
+  });
+
+  it('returns false for values with a non-zero `length` property', () => {
+    expect(isEmpty([1, 2])).toBe(false);
+    expect(isEmpty({length: 1})).toBe(false);
+    expect(isEmpty('oh hi, mark')).toBe(false);
+  });
+
+  it('returns false for objects that do not have a length property', () => {
+    expect(isEmpty({foo: 'bar'})).toBe(false);
+  });
+});
+
+describe('notEmpty', () => {
+  it('returns false for null', () => {
+    expect(notEmpty(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(notEmpty(undefined)).toBe(false);
+  });
+
+  it('returns false for values with a `length` property of 0', () => {
+    expect(notEmpty([])).toBe(false);
+    expect(notEmpty({length: 0})).toBe(false);
+    expect(notEmpty('')).toBe(false);
+  });
+
+  it('returns true for values with a non-zero `length` property', () => {
+    expect(notEmpty([1, 2])).toBe(true);
+    expect(notEmpty({length: 1})).toBe(true);
+    expect(notEmpty('oh hi, mark')).toBe(true);
+  });
+
+  it('returns true for objects that do not have a length property', () => {
+    expect(notEmpty({foo: 'bar'})).toBe(true);
+  });
+});

--- a/packages/predicates/tsconfig.build.json
+++ b/packages/predicates/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
This package pulls out all the predicates from `react-form-state` into their own package, and sets it up as our one stop shop for predicate functions. Once #657 and this are merged I will go back and make both form libraries depend on this.