### PR TITLE
⬆️ Add 'unversioned' version to 'koa-shopify-graphql-proxy'

### DIFF
--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -8,6 +8,7 @@ export enum ApiVersion {
   April19 = '2019-04',
   July19 = '2019-07',
   Unstable = 'unstable',
+  Unversioned = 'unversioned',
 }
 
 interface DefaultProxyOptions {


### PR DESCRIPTION
Related to: https://github.com/Shopify/shopify/issues/196085

Add a new `unversioned` version in the ApiVersion enum of the `koa-shopify-graphql-proxy` package. 