### PR TITLE
♻️ refactor i18n errors to enforce the error message that should be t…

### DIFF
--- a/packages/react-i18n/src/errors.ts
+++ b/packages/react-i18n/src/errors.ts
@@ -1,12 +1,49 @@
-export class MissingTranslationError extends Error {}
-export class MissingReplacementError extends Error {}
-export class MissingCurrencyCodeError extends Error {}
-export class MissingCountryError extends Error {}
-export class InvalidI18nConnectionError extends Error {}
+import {Replacements} from './types';
+
+export class MissingTranslationError extends Error {
+  constructor(key: string) {
+    super(`Missing translation for key: ${key}`);
+  }
+}
+export class MissingReplacementError extends Error {
+  constructor(replacement: string, replacements: Replacements = {}) {
+    let errorMessage = '';
+    const replacementKeys = Object.keys(replacements);
+
+    if (replacementKeys.length < 1) {
+      errorMessage = `No replacement found for key '${replacement}' (and no replacements were passed in).`;
+    } else {
+      errorMessage = `No replacement found for key '${replacement}'. The following replacements were passed: ${replacementKeys
+        .map(key => `'${key}'`)
+        .join(', ')}`;
+    }
+
+    super(errorMessage);
+  }
+}
+export class MissingCurrencyCodeError extends Error {
+  constructor(additionalMessage = '') {
+    const baseErrorMessage = 'No currency code provided.';
+    super(
+      additionalMessage === ''
+        ? baseErrorMessage
+        : `${baseErrorMessage} ${additionalMessage}`,
+    );
+  }
+}
+export class MissingCountryError extends Error {
+  constructor(additionalMessage = '') {
+    const baseErrorMessage = 'No country code provided.';
+    super(
+      additionalMessage === ''
+        ? baseErrorMessage
+        : `${baseErrorMessage} ${additionalMessage}`,
+    );
+  }
+}
 
 export type I18nError =
   | MissingTranslationError
   | MissingReplacementError
   | MissingCurrencyCodeError
-  | MissingCountryError
-  | InvalidI18nConnectionError;
+  | MissingCountryError;

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -186,7 +186,7 @@ export class I18n {
     if (as === 'currency' && currency == null && options.currency == null) {
       this.onError(
         new MissingCurrencyCodeError(
-          `No currency code provided. formatNumber(amount, {as: 'currency'}) cannot be called without a currency code.`,
+          `formatNumber(amount, {as: 'currency'}) cannot be called without a currency code.`,
         ),
       );
 
@@ -282,7 +282,7 @@ export class I18n {
 
     if (!country) {
       throw new MissingCountryError(
-        `No country code provided. weekStartDay() cannot be called without a country code.`,
+        'weekStartDay() cannot be called without a country code.',
       );
     }
 
@@ -293,7 +293,7 @@ export class I18n {
     const currency = currencyCode || this.defaultCurrency;
     if (currency == null) {
       throw new MissingCurrencyCodeError(
-        `No currency code provided. formatCurrency cannot be called without a currency code.`,
+        'formatCurrency cannot be called without a currency code.',
       );
     }
     return this.getCurrencySymbolLocalized(this.locale, currency);

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -157,18 +157,33 @@ describe('I18n', () => {
     });
 
     it('rethrows a missing translation error by default', () => {
-      const error = new MissingTranslationError();
+      const key = 'hello';
+      const error = new MissingTranslationError(key);
       getTranslationTree.mockImplementation(() => {
         throw error;
       });
 
       const i18n = new I18n(defaultTranslations, defaultDetails);
-      expect(() => i18n.getTranslationTree('hello')).toThrow(error);
+      expect(() => i18n.getTranslationTree(key)).toThrow(error);
+    });
+
+    it('rethrows a missing translation error with the missing key message', () => {
+      const key = 'hello';
+      const error = new MissingTranslationError(key);
+      getTranslationTree.mockImplementation(() => {
+        throw error;
+      });
+
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      expect(() => i18n.getTranslationTree(key)).toThrow(
+        `Missing translation for key: ${key}`,
+      );
     });
 
     it('calls an onError handler', () => {
+      const key = 'hello';
       const spy = jest.fn();
-      const error = new MissingTranslationError();
+      const error = new MissingTranslationError(key);
       getTranslationTree.mockImplementation(() => {
         throw error;
       });
@@ -178,14 +193,15 @@ describe('I18n', () => {
         onError: spy,
       });
 
-      i18n.getTranslationTree('hello');
+      i18n.getTranslationTree(key);
 
       expect(spy).toHaveBeenCalledWith(error);
     });
 
     it('returns an empty string when an onError handler does not rethrow', () => {
+      const key = 'key';
       getTranslationTree.mockImplementation(() => {
-        throw new MissingTranslationError();
+        throw new MissingTranslationError(key);
       });
 
       const i18n = new I18n(defaultTranslations, {
@@ -193,7 +209,7 @@ describe('I18n', () => {
         onError: () => {},
       });
 
-      expect(i18n.getTranslationTree('hello')).toBe('');
+      expect(i18n.getTranslationTree(key)).toBe('');
     });
   });
 
@@ -286,18 +302,33 @@ describe('I18n', () => {
     });
 
     it('rethrows a missing translation error by default', () => {
-      const error = new MissingTranslationError();
+      const key = 'hello';
+      const error = new MissingTranslationError(key);
       translate.mockImplementation(() => {
         throw error;
       });
 
       const i18n = new I18n(defaultTranslations, defaultDetails);
-      expect(() => i18n.translate('hello')).toThrow(error);
+      expect(() => i18n.translate(key)).toThrow(error);
+    });
+
+    it('rethrows a missing translation error with the missing key message', () => {
+      const key = 'hello';
+      const error = new MissingTranslationError(key);
+      translate.mockImplementation(() => {
+        throw error;
+      });
+
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      expect(() => i18n.translate(key)).toThrow(
+        `Missing translation for key: ${key}`,
+      );
     });
 
     it('calls an onError handler', () => {
+      const key = 'hello';
       const spy = jest.fn();
-      const error = new MissingTranslationError();
+      const error = new MissingTranslationError(key);
       translate.mockImplementation(() => {
         throw error;
       });
@@ -307,14 +338,15 @@ describe('I18n', () => {
         onError: spy,
       });
 
-      i18n.translate('hello');
+      i18n.translate(key);
 
       expect(spy).toHaveBeenCalledWith(error);
     });
 
     it('returns an empty string when an onError handler does not rethrow', () => {
+      const key = 'hello';
       translate.mockImplementation(() => {
-        throw new MissingTranslationError();
+        throw new MissingTranslationError(key);
       });
 
       const i18n = new I18n(defaultTranslations, {
@@ -322,7 +354,7 @@ describe('I18n', () => {
         onError: () => {},
       });
 
-      expect(i18n.translate('hello')).toBe('');
+      expect(i18n.translate(key)).toBe('');
     });
   });
 

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -180,9 +180,27 @@ describe('translate()', () => {
       });
     });
 
-    it('throws a MissingReplacementError when there is a missing replacement', () => {
+    it('throws a MissingReplacementError when there is a missing replacement and no replacements', () => {
       expect(() => translate('foo', {}, {foo: 'bar: {bar}'}, locale)).toThrow(
-        'No replacement found for key',
+        "No replacement found for key 'bar' (and no replacements were passed in).",
+      );
+    });
+
+    it('throws a MissingReplacementError when there is a missing replacement', () => {
+      expect(() =>
+        translate(
+          'foo',
+          {
+            replacements: {
+              key1: 'replacements text 1',
+              key2: 123,
+            },
+          },
+          {foo: 'bar: {bar}'},
+          locale,
+        ),
+      ).toThrow(
+        "No replacement found for key 'bar'. The following replacements were passed: 'key1', 'key2'",
       );
     });
   });

--- a/packages/react-i18n/src/types.ts
+++ b/packages/react-i18n/src/types.ts
@@ -30,3 +30,7 @@ export interface ComplexReplacementDictionary {
 export type MaybePromise<T> = T | Promise<T>;
 
 export {CurrencyCode} from './currencyCode';
+
+export type Replacements =
+  | PrimitiveReplacementDictionary
+  | ComplexReplacementDictionary;

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -22,11 +22,7 @@ export const PSEUDOTRANSLATE_OPTIONS: PseudotranslateOptions = {
   append: '!!]',
 };
 
-export interface TranslateOptions<
-  Replacements extends
-    | PrimitiveReplacementDictionary
-    | ComplexReplacementDictionary = {}
-> {
+export interface TranslateOptions<Replacements = {}> {
   scope?: string | string[];
   replacements?: Replacements;
   pseudotranslate?: boolean | string;
@@ -54,7 +50,7 @@ export function getTranslationTree(
     }
   }
 
-  throw new MissingTranslationError();
+  throw new MissingTranslationError(id);
 }
 
 export function translate(
@@ -99,7 +95,7 @@ export function translate(
     }
   }
 
-  throw new MissingTranslationError();
+  throw new MissingTranslationError(id);
 }
 
 function translateWithDictionary(
@@ -195,13 +191,7 @@ function updateStringWithReplacements(
       const replacement = match.substring(1, match.length - 1);
 
       if (!replacements.hasOwnProperty(replacement)) {
-        throw new MissingReplacementError(
-          `No replacement found for key '${replacement}'. The following replacements were passed: ${Object.keys(
-            replacements,
-          )
-            .map(key => `'${key}'`)
-            .join(', ')}`,
-        );
+        throw new MissingReplacementError(replacement, replacements);
       }
 
       return replacements[replacement] as string;
@@ -226,13 +216,7 @@ function updateStringWithReplacements(
 
       if (replacement) {
         if (!replacements.hasOwnProperty(replacement)) {
-          throw new MissingReplacementError(
-            `No replacement found for key '${replacement}'. The following replacements were passed: ${Object.keys(
-              replacements,
-            )
-              .map(key => `'${key}'`)
-              .join(', ')}`,
-          );
+          throw new MissingReplacementError(replacement, replacements);
         }
 
         matchIndex += 1;


### PR DESCRIPTION
…hrow

This should fix https://github.com/Shopify/web/issues/13037 once its web is updated.

- add back the `MissingTranslationError` error message that was removed from https://github.com/Shopify/quilt/pull/547/files#diff-a1fd1ab286680c4b32b5676c4e8f4d54L77-R77
- refactor it in a way where all of the specific i18n errors will provided consistent useful message