### PR TITLE
fix setState no-op warnings and add missing dependency

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+
+### Fixed
+
+- now correctly depends on `fast-deep-equal` [#680](https://github.com/Shopify/quilt/pull/680)
+- no longer triggers set-state warnings when the component calling `useSubmit` is unmounted during submission [#680](https://github.com/Shopify/quilt/pull/680)
+
 ## [0.1.0]
 
 ### Changed

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -37,6 +37,8 @@
   ],
   "dependencies": {
     "@shopify/predicates": "^1.1.0",
+    "@shopify/react-hooks": "^1.2.1",
+    "fast-deep-equal": "^2.0.1",
     "get-value": "^3.0.1"
   }
 }

--- a/packages/react-form/src/hooks/submit.ts
+++ b/packages/react-form/src/hooks/submit.ts
@@ -1,5 +1,5 @@
-import {useMountedRef} from '@shopify/react-hooks';
 import {useState} from 'react';
+import {useMountedRef} from '@shopify/react-hooks';
 import {
   FormMapping,
   SubmitHandler,

--- a/packages/react-form/src/hooks/submit.ts
+++ b/packages/react-form/src/hooks/submit.ts
@@ -1,3 +1,4 @@
+import {useMountedRef} from '@shopify/react-hooks';
 import {useState} from 'react';
 import {
   FormMapping,
@@ -13,6 +14,7 @@ export function useSubmit<T extends FieldBag>(
   onSubmit: SubmitHandler<FormMapping<T, 'value'>> = noopSubmission,
   fieldBag: T,
 ) {
+  const mounted = useMountedRef();
   const [submitting, setSubmitting] = useState(false);
   const [remoteErrors, setRemoteErrors] = useState([] as FormError[]);
 
@@ -23,6 +25,11 @@ export function useSubmit<T extends FieldBag>(
 
     setSubmitting(true);
     const result = await onSubmit(getValues(fieldBag));
+
+    if (mounted.current === false) {
+      return;
+    }
+
     setSubmitting(false);
 
     if (result.status === 'fail') {


### PR DESCRIPTION
This PR fixes a couple small mistakes in `react-form`. Specifically, it adds mount tracking to the generated submit handler and adds missing dependencies.