### PR TITLE
🐛 Remove the hostname from the proxy request path

### DIFF
--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -54,7 +54,7 @@ export default function shopifyGraphQLProxy(proxyOptions: ProxyOptions) {
         'X-Shopify-Access-Token': accessToken,
       },
       proxyReqPathResolver() {
-        return `https://${shop}${GRAPHQL_PATH_PREFIX}/${version}/graphql.json`;
+        return `${GRAPHQL_PATH_PREFIX}/${version}/graphql.json`;
       },
     })(
       ctx,

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -211,7 +211,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
     const {proxyReqPathResolver} = proxyFactory.mock.calls[0][1];
     expect(proxyReqPathResolver(ctx)).toBe(
-      `https://${shop}${GRAPHQL_PATH_PREFIX}/${version}/graphql.json`,
+      `${GRAPHQL_PATH_PREFIX}/${version}/graphql.json`,
     );
   });
 


### PR DESCRIPTION
I dug into the `koa-better-http-proxy` lib and found that we should probably not use the full path in `proxyReqPathResolver` since behind the scene they use the [`https`](https://github.com/nsimmons/koa-better-http-proxy/blob/master/lib/requestOptions.js#L47) from Node.js and set the result of `proxyReqPathResolver` as the [path](https://github.com/nsimmons/koa-better-http-proxy/blob/master/app/steps/resolveProxyReqPath.js#L15)

Probably `https` strip the hostname and the protocol for us but if some reason you try to mock the request result with nock, you will have to do something like:

```
nock(`https://example.com`)
      .post(`https://example.com/graphql-path.json`)
      .reply(200);
```

This PR will allow you to do something like this instead: 
```
nock(`https://example.com`)
      .post(`/graphql-path.json`)
      .reply(200);
```