### PR TITLE
Fix a few small testing nitpicks

### DIFF
--- a/packages/react-html/src/manager.ts
+++ b/packages/react-html/src/manager.ts
@@ -23,7 +23,6 @@ export class HtmlManager {
     betweenEachPass: () => this.reset(),
   };
 
-  private isServer: boolean;
   private serializations = getSerializationsFromDocument();
   private titles: Title[] = [];
   private metas: React.HTMLProps<HTMLMetaElement>[] = [];
@@ -40,10 +39,6 @@ export class HtmlManager {
     };
   }
 
-  constructor({isServer = typeof document === 'undefined'} = {}) {
-    this.isServer = isServer;
-  }
-
   reset({includeSerializations = false} = {}) {
     this.titles = [];
     this.metas = [];
@@ -56,10 +51,6 @@ export class HtmlManager {
   }
 
   subscribe(subscription: Subscription) {
-    if (this.isServer) {
-      return () => {};
-    }
-
     this.subscriptions.add(subscription);
     return () => {
       this.subscriptions.delete(subscription);
@@ -86,9 +77,7 @@ export class HtmlManager {
   }
 
   setSerialization(id: string, data: unknown) {
-    if (this.isServer) {
-      this.serializations.set(id, data);
-    }
+    this.serializations.set(id, data);
   }
 
   getSerialization<T>(id: string): T | undefined {

--- a/packages/react-html/src/tests/serializer.test.tsx
+++ b/packages/react-html/src/tests/serializer.test.tsx
@@ -10,7 +10,7 @@ describe('useSerialized', () => {
       return <Serialize data={() => foo || Promise.resolve('foo_value')} />;
     }
 
-    const manager = new HtmlManager({isServer: true});
+    const manager = new HtmlManager();
     const app = <MockComponent />;
     await extract(app, {
       decorate: element => (

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- `Root/Element#find` now correctly find components created by `React.memo` and `React.forwardRef` ([#682](https://github.com/Shopify/quilt/pull/682))
+
 ## [1.4.0] - 2019-04-18
 
 ### Changed

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -137,7 +137,7 @@ export class Element<Props> {
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
   ): this is Element<PropsForComponent<Type>> {
-    return this.type === type;
+    return isMatchingType(this.type, type);
   }
 
   find<Type extends React.ComponentType<any> | string>(
@@ -146,7 +146,7 @@ export class Element<Props> {
   ): Element<PropsForComponent<Type>> | null {
     return (this.elementDescendants.find(
       element =>
-        element.type === type &&
+        isMatchingType(element.type, type) &&
         (props == null || equalSubset(props, element.props as object)),
     ) || null) as Element<PropsForComponent<Type>> | null;
   }
@@ -228,6 +228,18 @@ export class Element<Props> {
 
     return `<${name} />`;
   }
+}
+
+function isMatchingType(type: Tree<unknown>['type'], test: Tree<unknown>['type']) {
+  if (type === test) {
+    return true;
+  }
+
+  if (test == null) {
+    return false;
+  }
+
+  return (test as React.ExoticComponent<unknown>).type != null && isMatchingType(type, (test as React.ExoticComponent<unknown>).type);
 }
 
 function equalSubset(subset: object, full: object) {

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -230,7 +230,10 @@ export class Element<Props> {
   }
 }
 
-function isMatchingType(type: Tree<unknown>['type'], test: Tree<unknown>['type']) {
+function isMatchingType(
+  type: Tree<unknown>['type'],
+  test: Tree<unknown>['type'],
+) {
   if (type === test) {
     return true;
   }
@@ -239,7 +242,7 @@ function isMatchingType(type: Tree<unknown>['type'], test: Tree<unknown>['type']
     return false;
   }
 
-  return (test as React.ExoticComponent<unknown>).type != null && isMatchingType(type, (test as React.ExoticComponent<unknown>).type);
+  return (test as any).type != null && isMatchingType(type, (test as any).type);
 }
 
 function equalSubset(subset: object, full: object) {

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -182,4 +182,23 @@ describe('e2e', () => {
     expect(myComponent.find(Message)!.text()).toBe('Hello world');
     expect(myComponent.text()).toContain(myComponent.find(Message)!.text());
   });
+
+  it('can find exotic components', () => {
+    const Message = React.memo(
+      React.forwardRef(function Message(
+        {name}: {name: string},
+        ref: React.Ref<HTMLDivElement>,
+      ) {
+        return <div ref={ref}>Hello {name}!</div>;
+      }),
+    );
+
+    function MyComponent() {
+      return <Message name="world" />;
+    }
+
+    const myComponent = mount(<MyComponent />);
+
+    expect(myComponent.find(Message)).toHaveReactProps({name: 'world'});
+  });
 });

--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Removed the `isServer` option from the constructor for `HtmlManager` [#682](https://github.com/Shopify/quilt/pull/682)
+
 ## 3.3.0 - 2019-05-01
 
 ### Added


### PR DESCRIPTION
While writing a few tests I found two issues:

1. `HtmlManager` has a required argument that is basically useless. It was used at one point to control when subscriptions/ serializations were set, but that logic is now in the hooks themselves. Technically this will be a breaking type change, but I think I'll avoid the major version because it's so minor.
2. `@shopify/react-testing` could not find a `React.memo`/ `React.forwardRef`-ed component because they are these special exotic types.