### PR TITLE
updating return signature for validate function

### DIFF
--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -73,16 +73,11 @@ export function validateList<Input extends object, Fields>(
   };
 }
 
-export function validate<Input>(
-  matcher: Matcher<Input, any>,
-  errorContent: ErrorContent,
-): (input: Input) => ErrorContent | undefined | void;
-
 export function validate<Input, Fields>(
   matcher: Matcher<Input, Fields>,
   errorContent: ErrorContent,
 ) {
-  return (input: Input, fields: Fields) => {
+  return (input: Input, fields: Fields): ErrorContent | undefined | void => {
     const matches = matcher(input, fields);
 
     /*


### PR DESCRIPTION
The signature for `validate` was being redefined without any generic typing for `Fields` and without the ability to call the validator directly with fields. This PR removes the redefinition and defines the result function's return type so that the `validate` function can organically return the correct typing information.

```tsx
  const foo = validate((arg: string, {field}: FieldDescriptors<any>) => {
    return Boolean(arg && field.value);
  }, 'bar');

  foo('', {field: {value: ''}} as any);
```