### PR TITLE
Add ArgumentAtIndex type

### DIFF
--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -3,7 +3,12 @@ import {ComponentType, HTMLAttributes} from 'react';
 export type ThenType<T> = T extends Promise<infer U> ? U : T;
 
 export type Arguments<T> = T extends (...args: infer U) => any ? U : never;
-export type FirstArgument<T> = T extends ((arg: infer U) => any) ? U : never;
+export type ArgumentAtIndex<
+  Func,
+  Index extends keyof Arguments<Func>
+> = Arguments<Func>[Index];
+export type FirstArgument<T> = ArgumentAtIndex<T, 0>;
+
 export type MaybeFunctionReturnType<T> = T extends (...args: any[]) => infer U
   ? U
   : never;


### PR DESCRIPTION
Adds an `ArgumentAtIndex` type for grabbing arbitrary argument types from a function.

![Screen Shot 2019-05-08 at 10 14 06 AM](https://user-images.githubusercontent.com/3012583/57382200-7b4b6c00-717a-11e9-92ab-494b719e4641.png)
