### PR TITLE
export TranslationDictionary

### DIFF
--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -4,7 +4,12 @@ export {I18n} from './i18n';
 export {useI18n} from './hooks';
 export {withI18n, WithI18nProps} from './decorator';
 export {translate} from './utilities';
-export {I18nDetails, LanguageDirection, CurrencyCode} from './types';
+export {
+  I18nDetails,
+  LanguageDirection,
+  CurrencyCode,
+  TranslationDictionary,
+} from './types';
 export {
   currencyDecimalPlaces,
   DEFAULT_DECIMAL_PLACES,


### PR DESCRIPTION
This PR exports `TranslationDictionary` from `react-i18n`, so that consumers can access that type for things like mocking in tests.