### PR TITLE
✨ add the css-utilities lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Each package has its own `README` and documentation describing usage.
 | admin-graphql-api-utilities | [directory](packages/admin-graphql-api-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities) |
 | async | [directory](packages/async) | [![npm version](https://badge.fury.io/js/%40shopify%2Fasync.svg)](https://badge.fury.io/js/%40shopify%2Fasync) |
 | csrf-token-fetcher | [directory](packages/csrf-token-fetcher) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg)](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher) |
+| css-utilities | [directory](packages/css-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fcss-utilities) |
 | dates | [directory](packages/dates) | [![npm version](https://badge.fury.io/js/%40shopify%2Fdates.svg)](https://badge.fury.io/js/%40shopify%2Fdates) |
 | decorators | [directory](packages/decorators) | [![npm version](https://badge.fury.io/js/%40shopify%2Fdecorators.svg)](https://badge.fury.io/js/%40shopify%2Fdecorators) |
 | enzyme-utilities | [directory](packages/enzyme-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities) |
 | function-enhancers | [directory](packages/function-enhancers) | [![npm version](https://badge.fury.io/js/%40shopify%2Ffunction-enhancers.svg)](https://badge.fury.io/js/%40shopify%2Ffunction-enhancers) |
+| graphql-persisted | [directory](packages/graphql-persisted) | [![npm version](https://badge.fury.io/js/%40shopify%2Fgraphql-persisted.svg)](https://badge.fury.io/js/%40shopify%2Fgraphql-persisted) |
 | graphql-testing | [directory](packages/graphql-testing) | [![npm version](https://badge.fury.io/js/%40shopify%2Fgraphql-testing.svg)](https://badge.fury.io/js/%40shopify%2Fgraphql-testing) |
 | i18n | [directory](packages/i18n) | [![npm version](https://badge.fury.io/js/%40shopify%2Fi18n.svg)](https://badge.fury.io/js/%40shopify%2Fi18n) |
 | jest-dom-mocks | [directory](packages/jest-dom-mocks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks) |
@@ -43,11 +45,12 @@ Each package has its own `README` and documentation describing usage.
 | network | [directory](packages/network) | [![npm version](https://badge.fury.io/js/%40shopify%2Fnetwork.svg)](https://badge.fury.io/js/%40shopify%2Fnetwork) |
 | performance | [directory](packages/performance) | [![npm version](https://badge.fury.io/js/%40shopify%2Fperformance.svg)](https://badge.fury.io/js/%40shopify%2Fperformance) |
 | polyfills | [directory](packages/polyfills) | [![npm version](https://badge.fury.io/js/%40shopify%2Fpolyfills.svg)](https://badge.fury.io/js/%40shopify%2Fpolyfills) |
+| predicates | [directory](packages/predicates) | [![npm version](https://badge.fury.io/js/%40shopify%2Fpredicates.svg)](https://badge.fury.io/js/%40shopify%2Fpredicates) |
 | react-async | [directory](packages/react-async) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-async.svg)](https://badge.fury.io/js/%40shopify%2Freact-async) |
 | react-compose | [directory](packages/react-compose) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-compose.svg)](https://badge.fury.io/js/%40shopify%2Freact-compose) |
 | react-effect | [directory](packages/react-effect) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect) |
 | react-effect-apollo | [directory](packages/react-effect-apollo) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect-apollo.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect-apollo) |
-| react-form | [directory](packages/react-form) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form.svg)](https://badge.fury.io/js/%40shopify%2Freact-form.svg) |
+| react-form | [directory](packages/react-form) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form.svg)](https://badge.fury.io/js/%40shopify%2Freact-form) |
 | react-form-state | [directory](packages/react-form-state) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
 | react-google-analytics | [directory](packages/react-google-analytics) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg)](https://badge.fury.io/js/%40shopify%2Freact-google-analytics) |
 | react-graphql | [directory](packages/react-graphql) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-graphql.svg)](https://badge.fury.io/js/%40shopify%2Freact-graphql) |

--- a/packages/css-utilities/CHANGELOG.md
+++ b/packages/css-utilities/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/css-utilities` package which carry over `classNames` & `variationName` from `@shopify/react-utilities`

--- a/packages/css-utilities/README.md
+++ b/packages/css-utilities/README.md
@@ -1,0 +1,69 @@
+# `@shopify/css-utilities`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/css-utilities.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/css-utilities.svg)
+
+A set of css styling related utilities.
+
+## Installation
+
+```bash
+$ yarn add @shopify/css-utilities
+```
+
+Both `classNames` and `variationName` are helper functions that are use to generate class names.
+
+### `classNames`
+
+Is a straight export of [`classnames`](https://github.com/JedWatson/classnames). It returns a classNames string that are conditionally joined together.
+
+### `variationName`
+
+Is a utility that returns a camelCase string combining the name and value passed in.
+
+## Usage
+
+Given this CSS file for a `Square` React component:
+
+```scss
+.Square {
+  color: transparent;
+}
+
+.sizeSmall {
+  height: 20px
+  width: 20px
+}
+
+.sizeLarge {
+  height: 44px
+  width: 44px
+}
+
+.colorWhite {
+  background-color: white;
+}
+
+.colorBlack {
+  background-color: black;
+}
+```
+
+The following can be use to generate different class names for the component based on its props:
+
+```tsx
+interface Props {
+  size: 'small' | 'large';
+  color: 'white' | 'black';
+}
+
+function Square({size, color}: Props) {
+  const className = classNames(
+    styles.Square,
+    styles[variationName('color', color)],
+    styles[variationName('size', size)],
+  );
+
+  return <div className={className} />;
+}
+```

--- a/packages/css-utilities/package.json
+++ b/packages/css-utilities/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@shopify/css-utilities",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A set of css styling related utilities.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/css-utilities/README.md",
+  "dependencies": {
+    "classnames": "^2.2.6",
+    "@types/classnames": "^2.2.7"
+  },
+  "devDependencies": {
+    "typescript": "~3.2.1"
+  },
+  "files": [
+    "dist/*"
+  ]
+}

--- a/packages/css-utilities/src/index.ts
+++ b/packages/css-utilities/src/index.ts
@@ -1,0 +1,4 @@
+import classNames from 'classnames';
+
+export {classNames};
+export {variationName} from './variation-name';

--- a/packages/css-utilities/src/test/variation-name.test.ts
+++ b/packages/css-utilities/src/test/variation-name.test.ts
@@ -1,0 +1,17 @@
+import {variationName} from '../variation-name';
+
+describe('variationName()', () => {
+  it('returns name plus variation value with the first letter capitalized when value is string', () => {
+    const name = 'color';
+    const value = 'white';
+
+    expect(variationName(name, value)).toBe('colorWhite');
+  });
+
+  it('returns name plus variation value when value is number', () => {
+    const name = 'size';
+    const value = '123';
+
+    expect(variationName(name, value)).toBe('size123');
+  });
+});

--- a/packages/css-utilities/src/variation-name.tsx
+++ b/packages/css-utilities/src/variation-name.tsx
@@ -1,0 +1,7 @@
+export function variationName(name: string, value: string | number) {
+  const valuePortion =
+    typeof value === 'number'
+      ? String(value)
+      : `${value[0].toUpperCase()}${value.substring(1)}`;
+  return `${name}${valuePortion}`;
+}

--- a/packages/css-utilities/tsconfig.build.json
+++ b/packages/css-utilities/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,6 +278,15 @@
     lodash "^4.17.4"
     lodash-decorators "^4.3.5"
 
+"@shopify/react-import-remote@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@shopify/react-import-remote/-/react-import-remote-0.7.0.tgz#148e322c95b9224afa66c10d9d84f0e8c21860d6"
+  integrity sha512-BezBsBFJTpUwQMXvFhPoMrRwhjMmpq9hfIkytG6JYtzo0OKp4q562dfcAkkH/0GaS4UColv1WDEua+bgLFrUVQ==
+  dependencies:
+    "@shopify/react-html" "^8.0.10"
+    "@shopify/react-intersection-observer" "^2.0.3"
+    tslib "^1.9.3"
+
 "@types/accepts@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -335,6 +344,11 @@
   version "0.22.7"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.7.tgz#4a92eafedfb2b9f4437d3a4410006d81114c66ce"
   integrity sha512-+T9qBbqe/jXtTjzVddArZExahoPPmt8eq3O1ZuCKZXjBVxf/ciUYNXrIDZJEVgYvpELnv6VlPRCfLzufRxpAag==
+
+"@types/classnames@^2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.7.tgz#fb68cc9be8487e6ea5b13700e759bfbab7e0fefd"
+  integrity sha512-rzOhiQ55WzAiFgXRtitP/ZUT8iVNyllEpylJ5zHzR4vArUvMB39GTk+Zon/uAM0JxEFAWnwsxC2gH8s+tZ3Myg==
 
 "@types/connect@*":
   version "3.4.31"
@@ -1734,6 +1748,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 cli-cursor@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Close https://github.com/Shopify/react-utilities/issues/24

The plan is to release this package, and we can deprecate `@shopify/react-utilities` entirely.