### PR TITLE
Remove coverage report when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "lerna run build",
     "lint": "yarn eslint '**/*.{ts,tsx}'",
     "ci:lint-docs": "yarn generate docs && test -z \"$(git status --porcelain)\" || echo 'The root README has not been updated. Run `yarn generate docs` in the root of your quilt directory and try again.'",
-    "test": "jest --maxWorkers=3",
+    "test": "jest --maxWorkers=3 --coverage=false",
     "check": "lerna run check",
     "release": "lerna publish && git push --follow-tags",
     "clean": "rimraf './packages/*/dist/**/*.{js,d.ts}'",


### PR DESCRIPTION
I don't think we should display the coverage report by default. It doesn't offer much value and ends up pushing the output you care about (the test results) out of view.