### PR TITLE
Fix nested wrappers bug in `react-testing`

### DIFF
--- a/packages/react-form/src/hooks/test/form.test.tsx
+++ b/packages/react-form/src/hooks/test/form.test.tsx
@@ -160,11 +160,9 @@ describe('useForm', () => {
         .find(TextField, {label: 'title'})!
         .trigger('onChange', 'tortoritos, the chip for turtles!');
 
-      wrapper.act(() => {
-        wrapper
-          .find('button', {type: 'submit'})!
-          .trigger('onClick', clickEvent());
-      });
+      wrapper
+        .find('button', {type: 'submit'})!
+        .trigger('onClick', clickEvent());
 
       expect(wrapper).toContainReactComponent('p', {
         children: 'loading...',
@@ -181,11 +179,11 @@ describe('useForm', () => {
         .find(TextField, {label: 'title'})!
         .trigger('onChange', 'tortoritos, the chip for turtles!');
 
-      await wrapper.act(async () => {
-        wrapper
-          .find('button', {type: 'submit'})!
-          .trigger('onClick', clickEvent());
+      await wrapper
+        .find('button', {type: 'submit'})!
+        .trigger('onClick', clickEvent());
 
+      await wrapper.act(async () => {
         await promise;
       });
 
@@ -194,7 +192,7 @@ describe('useForm', () => {
       });
     });
 
-    it('validates all fields with their latest values before submitting and bails out if any fail', () => {
+    it('validates all fields with their latest values before submitting and bails out if any fail', async () => {
       const submitSpy = jest.fn(() => Promise.resolve(submitSuccess()));
       const product = {
         ...fakeProduct(),
@@ -206,11 +204,9 @@ describe('useForm', () => {
 
       wrapper.find(TextField, {label: 'title'})!.trigger('onChange', '');
 
-      wrapper.act(() => {
-        wrapper
-          .find('button', {type: 'submit'})!
-          .trigger('onClick', clickEvent());
-      });
+      await wrapper
+        .find('button', {type: 'submit'})!
+        .trigger('onClick', clickEvent());
 
       expect(submitSpy).not.toHaveBeenCalled();
       expect(wrapper).toContainReactComponent('p', {
@@ -226,11 +222,11 @@ describe('useForm', () => {
         <ProductForm data={fakeProduct()} onSubmit={() => promise} />,
       );
 
-      await wrapper.act(async () => {
-        wrapper
-          .find('button', {type: 'submit'})!
-          .trigger('onClick', clickEvent());
+      await wrapper
+        .find('button', {type: 'submit'})!
+        .trigger('onClick', clickEvent());
 
+      await wrapper.act(async () => {
         await promise;
       });
 
@@ -253,11 +249,11 @@ describe('useForm', () => {
         <ProductForm data={fakeProduct()} onSubmit={() => promise} />,
       );
 
-      await wrapper.act(async () => {
-        wrapper
-          .find('button', {type: 'submit'})!
-          .trigger('onClick', clickEvent());
+      await wrapper
+        .find('button', {type: 'submit'})!
+        .trigger('onClick', clickEvent());
 
+      await wrapper.act(async () => {
         await promise;
       });
 
@@ -310,10 +306,11 @@ describe('useForm', () => {
         .find('button', {type: 'submit'})!
         .trigger('onClick', clickEvent());
 
+      await wrapper
+        .find('button', {type: 'button'})!
+        .trigger('onClick', clickEvent());
+
       await wrapper.act(async () => {
-        wrapper
-          .find('button', {type: 'button'})!
-          .trigger('onClick', clickEvent());
         await promise;
       });
 

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,16 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Passing unresolved promises within `act()` blocks required additional nesting ([#697](https://github.com/Shopify/quilt/pull/697))
+
+## [1.5.0] - 2019-05-09
+
+### Changed
+
+- Upgraded React to versions 16.9.0-alpha.0 and added support for async `act()` calls ([#688](https://github.com/Shopify/quilt/pull/688))
+
 ## [1.4.3] - 2019-05-02
 
 ### Fixed

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -79,7 +79,9 @@ export class Root<Props> {
   }
 
   act<T>(action: () => T, {update = true} = {}): T {
+    const updateWrapper = update ? this.update.bind(this) : noop;
     let result!: T;
+
     if (this.acting) {
       return action();
     }
@@ -87,9 +89,7 @@ export class Root<Props> {
     this.acting = true;
 
     const afterResolve = () => {
-      if (update) {
-        this.update();
-      }
+      updateWrapper();
       this.acting = false;
 
       return result;
@@ -107,6 +107,8 @@ export class Root<Props> {
     });
 
     if (isPromise(result)) {
+      updateWrapper();
+
       return Promise.resolve(promise).then(afterResolve) as any;
     }
 
@@ -308,3 +310,5 @@ function isPromise<T>(promise: T | Promise<T>): promise is Promise<T> {
     promise != null && typeof promise === 'object' && 'then' in (promise as any)
   );
 }
+
+function noop() {}


### PR DESCRIPTION
This PR fixes a bug in react-testing where an unresolved promise required an additional `act()` around the state change.