### PR TITLE
🐛 react-i18n Babel plugin no longer fails on babel-preset-typescript ASTs

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- Fixes transpilation for `babel-preset-typescript` when the last import pulls in only type definitions ([#699](https://github.com/Shopify/quilt/pull/699))
+
 ## [1.2.3] - 2019-05-09
 
 - Now exports formerly missing typings for `TranslationDictionary` ([#693](https://github.com/Shopify/quilt/pull/693))

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -25,9 +25,9 @@ describe('babel-pluin-react-i18n', () => {
       ),
     ).toBe(
       await normalize(
-        `import React from 'react';
+        `import _en from './translations/en.json';
+        import React from 'react';
         import {withI18n} from '@shopify/react-i18n';
-        import _en from './translations/en.json';
 
         function MyComponent({i18n}) {
           return i18n.translate('key');
@@ -61,9 +61,9 @@ describe('babel-pluin-react-i18n', () => {
       ),
     ).toBe(
       await normalize(
-        `import React from 'react';
+        `import _en from './translations/en.json';
+        import React from 'react';
         import {useI18n} from '@shopify/react-i18n';
-        import _en from './translations/en.json';
 
         export default function MyComponent() {
           const [i18n] = useI18n({
@@ -114,9 +114,9 @@ describe('babel-pluin-react-i18n', () => {
       ),
     ).toBe(
       await normalize(
-        `import React from 'react';
+        `import _en from './translations/en.json';
+        import React from 'react';
         import {withI18n, translate} from '@shopify/react-i18n';
-        import _en from './translations/en.json';
 
         function MyComponent({i18n}) {
           return i18n.translate('key');
@@ -184,9 +184,9 @@ describe('babel-pluin-react-i18n', () => {
       ),
     ).toBe(
       await normalize(
-        `import React from 'react';
+        `import _en from './translations/en.json';
+        import React from 'react';
         import {withI18n as foo} from '@shopify/react-i18n';
-        import _en from './translations/en.json';
 
         function MyComponent({i18n}) {
           return i18n.translate('key');
@@ -220,9 +220,9 @@ describe('babel-pluin-react-i18n', () => {
       ),
     ).toBe(
       await normalize(
-        `import React from 'react';
+        `import _en from './translations/en.json';
+        import React from 'react';
         import {useI18n as useFunI18n} from '@shopify/react-i18n';
-        import _en from './translations/en.json';
 
         export default function MyComponent() {
           const [i18n] = useFunI18n({


### PR DESCRIPTION
### The problem
When integrating react-i18n + jest@24, the i18n Babel plugin fails with messages about manipulating removed AST paths.

### The technical problem
* `babel-preset-typescript` removes all type references from the AST
* If an `import` pulls in _only_ type information, `@babel/typescript` sees it as having no purpose, and strips it out, too
* Our react-i18n/babel plugin pulls out the "last import" node at the start of processing, and stores it in state
* By the time the plugin gets to injecting a translations import, the last import state may be pointing at a removed AST path

### The solution
Figure out the last import immediately before injecting the translations import.