### PR TITLE
Progressive hydration helper packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Each package has its own `README` and documentation describing usage.
 | react-graphql | [directory](packages/react-graphql) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-graphql.svg)](https://badge.fury.io/js/%40shopify%2Freact-graphql) |
 | react-hooks | [directory](packages/react-hooks) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-hooks.svg)](https://badge.fury.io/js/%40shopify%2Freact-hooks) |
 | react-html | [directory](packages/react-html) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-html.svg)](https://badge.fury.io/js/%40shopify%2Freact-html) |
+| react-hydrate | [directory](packages/react-hydrate) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-hydrate.svg)](https://badge.fury.io/js/%40shopify%2Freact-hydrate) |
 | react-i18n | [directory](packages/react-i18n) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-i18n.svg)](https://badge.fury.io/js/%40shopify%2Freact-i18n) |
 | react-import-remote | [directory](packages/react-import-remote) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-import-remote.svg)](https://badge.fury.io/js/%40shopify%2Freact-import-remote) |
 | react-intersection-observer | [directory](packages/react-intersection-observer) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg)](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer) |

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -135,6 +135,10 @@ Some of the standard mocks include additional features:
 
 Executes all queued animation callbacks.
 
+#### `RequestIdleCallback.mockAsUnsupported(): void`
+
+Removes `window.requestIdleCallback` and `window.cancelIdleCallback`, which can be useful for testing features that should work with and without idle callbacks available.
+
 #### `RequestIdleCallback.runIdleCallbacks(timeRemaining?: number, didTimeout?: boolean): void`
 
 Runs all currently-scheduled idle callbacks. If provided, `timeRemaining`/ `didTimeout` will be used to construct the argument for these callbacks. Once called, all callbacks are removed from the queue.

--- a/packages/react-hydrate/CHANGELOG.md
+++ b/packages/react-hydrate/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/react-hydrate` package

--- a/packages/react-hydrate/README.md
+++ b/packages/react-hydrate/README.md
@@ -1,0 +1,127 @@
+# `@shopify/react-hydrate`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-hydrate.svg)](https://badge.fury.io/js/%40shopify%2Freact-hydrate.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-hydrate.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-hydrate.svg)
+
+Utilities for hydrating server-rendered React apps.
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-hydrate
+```
+
+## Usage
+
+This library is intended to assist with "progressive hydration", a pattern where you fully render an application on the server, but wait to hydrate parts of it when it reaches the client. Typically, doing different work on the server and client would result in the server markup being thrown out. This library avoids that issue by rendering a wrapping `div` around the content on the server, adding an ID to that element, and setting the `dangerouslySetInnerHTML` prop on the client to the resulting server markup in order to avoid mismatches. Once you have done whatever work on the client to load the necessary components, this hardcoded markup is removed, allowing the React tree to take over.
+
+### Server
+
+There are two key pieces to making this work. First, your server must render a `HydrationContext.Provider` element around your React tree (to be clear: this is only required for the server, not on the client). This element will provide a `HydrationManager` to the three, which manages the identifiers that map server markup to client markup.
+
+```tsx
+import React from 'react';
+import {render} from 'react-dom';
+import {HydrationContext, HydrationManager} from '@shopify/react-hydration';
+import App from '../app';
+
+export async function middleware(ctx, next) {
+  const hydrationManager = new HydrationManager();
+
+  ctx.body = render(
+    <HydrationContext.Provider value={hydrationManager}>
+      <App />
+    </HydrationContext.Provider>,
+  );
+
+  await next();
+}
+```
+
+Note that if you use [`@shopify/react-effect`](../react-effect), you **must** reset the manager after each rendering pass (otherwise the identifiers will not match between client and server). You must also use a new `HydrationManager` for every request to prevent identifiers leaking between different requests.
+
+```tsx
+import React from 'react';
+import {render} from 'react-dom';
+import {extract} from '@shopify/react-effect';
+import {HydrationContext, HydrationManager} from '@shopify/react-hydration';
+import App from '../app';
+
+export async function middleware(ctx, next) {
+  const hydrationManager = new HydrationManager();
+  const app = <App />;
+
+  await extract(app, {
+    decorate(element) {
+      return (
+        <HydrationContext.Provider value={hydrationManager}>
+          {element}
+        </HydrationContext.Provider>
+      );
+    },
+    afterEachPass() {
+      hydrationManager.reset();
+    },
+  });
+
+  ctx.body = render(
+    <HydrationContext.Provider value={hydrationManager}>
+      <App />
+    </HydrationContext.Provider>,
+  );
+
+  await next();
+}
+```
+
+### Application
+
+Once the server is in place, you can start to use the `Hydrator` component. This component will do different things depending on its children:
+
+- If children are passed (the server-side case), render those children normally, but inside of a `div` with an identifier that can be matched on the client.
+- If children are not passed (the client-side case, because this is only used in cases where you will not have the code available to you on the client to render the same markup that was present on the server), render a `div` with `dangerouslySetInnerHTML` set to be the HTML of the original, server-rendered markup.
+
+> Note: you probably don’t need to know the internals of how progressive hydration works, unless you’re really interested. This package will primarily be used by other tools that manage asynchronous component loading, such as [`@shopify/react-async`](../react-async).
+
+```tsx
+import React, {useState, useEffect} from 'react';
+import {Hydrator} from '@shopify/react-hydrate';
+
+// This is a hypothetical component that knows how to load a component
+// asynchronously, but can also potentially access it synchronously on the
+// server. So, the server will immediately have access to the component and
+// can render it for the initial page load, but the client will have to wait
+// until it is loaded asynchronously. The Hydrator component stands in the middle
+// to bridge the gap and prevent the server markup from being thrown away.
+
+function MyComponent() {
+  const [ProgressivelyHydratedComponent, setComponent] = useState(() =>
+    tryToAccessModuleSynchronously(),
+  );
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      const Component = await loadModuleAsynchronously();
+      if (mounted) {
+        setComponent(Component);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return ProgressivelyHydratedComponent ? (
+    <Hydrator>
+      <ProgressivelyHydratedComponent />
+    </Hydrator>
+  ) : (
+    <Hydrator />
+  );
+}
+```
+
+You can optionally pass an `id` prop, which will be used to prefix the identifier used to match server and client markup (if the application behaves well, this should be unnecessary, but it can prevent any issues where multiple hydrated components of different types render in a different order across server and client).

--- a/packages/react-hydrate/README.md
+++ b/packages/react-hydrate/README.md
@@ -13,11 +13,13 @@ $ yarn add @shopify/react-hydrate
 
 ## Usage
 
-This library is intended to assist with "progressive hydration", a pattern where you fully render an application on the server, but wait to hydrate parts of it when it reaches the client. Typically, doing different work on the server and client would result in the server markup being thrown out. This library avoids that issue by rendering a wrapping `div` around the content on the server, adding an ID to that element, and setting the `dangerouslySetInnerHTML` prop on the client to the resulting server markup in order to avoid mismatches. Once you have done whatever work on the client to load the necessary components, this hardcoded markup is removed, allowing the React tree to take over.
+This library is intended to assist with "progressive hydration", a pattern where you fully render an application on the server, but wait to hydrate parts of it when it reaches the client. Typically, doing different work on the server and client would result in the server markup being thrown out by React’s initial reconciliation.
+
+This library avoids that issue by rendering a wrapping `div` around the content on the server, adding an ID to that element, and setting the `dangerouslySetInnerHTML` prop on the client to the resulting server markup in order to avoid mismatches. Once you have done whatever work on the client to load the necessary components, this hardcoded markup is removed, allowing the React tree to take over.
 
 ### Server
 
-There are two key pieces to making this work. First, your server must render a `HydrationContext.Provider` element around your React tree (to be clear: this is only required for the server, not on the client). This element will provide a `HydrationManager` to the three, which manages the identifiers that map server markup to client markup.
+There are two key pieces to making this work. First, your server must render a `HydrationContext.Provider` element around your React tree. This element will provide a `HydrationManager` to the tree, which manages the identifiers that map server markup to client markup.
 
 ```tsx
 import React from 'react';
@@ -38,7 +40,7 @@ export async function middleware(ctx, next) {
 }
 ```
 
-Note that if you use [`@shopify/react-effect`](../react-effect), you **must** reset the manager after each rendering pass (otherwise the identifiers will not match between client and server). You must also use a new `HydrationManager` for every request to prevent identifiers leaking between different requests.
+Note that if you use [`@shopify/react-effect`](../react-effect), you **must** reset the manager after each rendering pass. If you don’t, the identifiers will continue to increment during each pass, and will not match between client and server. You must also use a new `HydrationManager` for every request to prevent identifiers leaking between different renders.
 
 ```tsx
 import React from 'react';
@@ -124,4 +126,4 @@ function MyComponent() {
 }
 ```
 
-You can optionally pass an `id` prop, which will be used to prefix the identifier used to match server and client markup (if the application behaves well, this should be unnecessary, but it can prevent any issues where multiple hydrated components of different types render in a different order across server and client).
+You can optionally pass an `id` prop to `Hydrator`, which will be used to prefix the identifier used to match server and client markup.

--- a/packages/react-hydrate/package.json
+++ b/packages/react-hydrate/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@shopify/react-hydrate",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Utilities for hydrating server-rendered React apps",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-hydrate/README.md",
+  "dependencies": {
+    "@shopify/react-hooks": "^1.2.1"
+  },
+  "devDependencies": {
+    "typescript": "~3.2.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "files": [
+    "dist/*"
+  ]
+}

--- a/packages/react-hydrate/src/Hydrator.tsx
+++ b/packages/react-hydrate/src/Hydrator.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import {useLazyRef} from '@shopify/react-hooks';
+import {HydrationContext} from './context';
+import {HYDRATION_ATTRIBUTE} from './shared';
+
+interface Props {
+  id?: string;
+  children?: React.ReactNode;
+}
+
+export const Hydrator = React.memo(function Hydrator({children, id}: Props) {
+  const manager = React.useContext(HydrationContext);
+  const hydrationId = useLazyRef(() => manager.hydrationId(id)).current;
+  const hydrationProps = {[HYDRATION_ATTRIBUTE]: hydrationId};
+
+  return children ? (
+    <div {...hydrationProps}>{children}</div>
+  ) : (
+    <div
+      {...hydrationProps}
+      dangerouslySetInnerHTML={{
+        __html: manager.getHydration(hydrationId) || '',
+      }}
+    />
+  );
+});

--- a/packages/react-hydrate/src/context.ts
+++ b/packages/react-hydrate/src/context.ts
@@ -1,0 +1,6 @@
+import {createContext} from 'react';
+import {HydrationManager} from './manager';
+
+export const HydrationContext = createContext<HydrationManager>(
+  new HydrationManager(),
+);

--- a/packages/react-hydrate/src/index.ts
+++ b/packages/react-hydrate/src/index.ts
@@ -1,0 +1,3 @@
+export {HydrationContext} from './context';
+export {HydrationManager} from './manager';
+export {Hydrator} from './Hydrator';

--- a/packages/react-hydrate/src/manager.ts
+++ b/packages/react-hydrate/src/manager.ts
@@ -1,0 +1,37 @@
+import {HYDRATION_ATTRIBUTE} from './shared';
+
+const DEFAULT_HYDRATION_ID = Symbol('defaultId');
+const DEFAULT_HYDRATION_PREFIX = 'hydration';
+
+export class HydrationManager {
+  private readonly ids = new Map<
+    string | typeof DEFAULT_HYDRATION_ID,
+    number
+  >();
+
+  private readonly hydration = new Map<string, string>();
+
+  constructor() {
+    if (typeof document !== 'undefined') {
+      for (const element of document.querySelectorAll(
+        `[${HYDRATION_ATTRIBUTE}]`,
+      )) {
+        this.hydration.set(
+          element.getAttribute(HYDRATION_ATTRIBUTE)!,
+          element.innerHTML,
+        );
+      }
+    }
+  }
+
+  hydrationId(id?: string) {
+    const finalId = id || DEFAULT_HYDRATION_ID;
+    const current = this.ids.get(finalId) || 0;
+    this.ids.set(finalId, current + 1);
+    return `${id || DEFAULT_HYDRATION_PREFIX}${current + 1}`;
+  }
+
+  getHydration(id: string) {
+    return this.hydration.get(id);
+  }
+}

--- a/packages/react-hydrate/src/shared.ts
+++ b/packages/react-hydrate/src/shared.ts
@@ -1,0 +1,1 @@
+export const HYDRATION_ATTRIBUTE = 'data-hydration-id';

--- a/packages/react-hydrate/src/test/e2e.test.tsx
+++ b/packages/react-hydrate/src/test/e2e.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {random} from 'faker';
+import {createMount} from '@shopify/react-testing';
+
+import {Hydrator} from '../Hydrator';
+import {HydrationContext} from '../context';
+import {HydrationManager} from '../manager';
+import {HYDRATION_ATTRIBUTE} from '../shared';
+
+// We want a custom mount so that each mounted instance gets
+// its own HydrationManager, rather than using the default one
+// provided by the React context.
+const mount = createMount<
+  {manager?: HydrationManager},
+  {manager: HydrationManager}
+>({
+  context({manager = new HydrationManager()}) {
+    return {manager};
+  },
+  render(element, {manager}) {
+    return (
+      <HydrationContext.Provider value={manager}>
+        {element}
+      </HydrationContext.Provider>
+    );
+  },
+});
+
+describe('react-hydrate', () => {
+  it('renders a wrapping element with a hydration ID by no innerHTML when there are children', () => {
+    const hydrator = mount(<Hydrator>{random.words()}</Hydrator>);
+    const wrapper = hydrator.find('div')!;
+
+    expect(wrapper).toHaveReactDataProps({
+      [HYDRATION_ATTRIBUTE]: expect.any(String),
+    });
+
+    expect(wrapper).not.toHaveReactProps({
+      dangerouslySetInnerHTML: expect.anything(),
+    });
+  });
+
+  it('includes the original content when children are passed', () => {
+    const content = random.words();
+    const hydrator = mount(<Hydrator>{content}</Hydrator>);
+    expect(hydrator.find('div')).toContainReactText(content);
+  });
+
+  it('uses an explicit ID as part of the hydration attribute when provided', () => {
+    const id = random.uuid();
+    const hydrator = mount(<Hydrator id={id}>{random.words()}</Hydrator>);
+    expect(hydrator.find('div')).toHaveReactDataProps({
+      [HYDRATION_ATTRIBUTE]: expect.stringContaining(id),
+    });
+  });
+
+  it('uses different IDs for multiple hydrator components', () => {
+    const [hydratorOne, hydratorTwo] = mount(
+      // eslint-disable-next-line shopify/jsx-prefer-fragment-wrappers
+      <div>
+        <Hydrator>{random.words()}</Hydrator>
+        <Hydrator>{random.words()}</Hydrator>
+      </div>,
+    ).findAll(Hydrator);
+
+    expect(
+      hydratorOne.find('div')!.data(HYDRATION_ATTRIBUTE),
+    ).not.toStrictEqual(hydratorTwo.find('div')!.data(HYDRATION_ATTRIBUTE));
+  });
+
+  it('uses the content from a matching hydration element when mounting without children', () => {
+    const content = random.words();
+
+    // This simulates the server render
+    const serverHydrator = mount(<Hydrator>{content}</Hydrator>);
+
+    // And this simulates the client render (note that the server rendered content
+    // is still present, which allows the hydrated content to be extracted). In this
+    // scenario, the client does not have the same information as the server, hence
+    // why it has none of its original children.
+    const clientHydrator = mount(<Hydrator />);
+
+    expect(serverHydrator.find('div')!.data(HYDRATION_ATTRIBUTE)).toStrictEqual(
+      clientHydrator.find('div')!.data(HYDRATION_ATTRIBUTE),
+    );
+
+    expect(clientHydrator.find('div')).toHaveReactProps({
+      dangerouslySetInnerHTML: {__html: serverHydrator.find('div')!.html()},
+    });
+  });
+});

--- a/packages/react-hydrate/src/test/e2e.test.tsx
+++ b/packages/react-hydrate/src/test/e2e.test.tsx
@@ -27,7 +27,7 @@ const mount = createMount<
 });
 
 describe('react-hydrate', () => {
-  it('renders a wrapping element with a hydration ID by no innerHTML when there are children', () => {
+  it('renders a wrapping element with a hydration ID but no innerHTML when there are children', () => {
     const hydrator = mount(<Hydrator>{random.words()}</Hydrator>);
     const wrapper = hydrator.find('div')!;
 

--- a/packages/react-hydrate/tsconfig.build.json
+++ b/packages/react-hydrate/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/react-idle/CHANGELOG.md
+++ b/packages/react-idle/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/react-idle` package

--- a/packages/react-idle/README.md
+++ b/packages/react-idle/README.md
@@ -1,0 +1,60 @@
+# `@shopify/react-idle`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-idle.svg)](https://badge.fury.io/js/%40shopify%2Freact-idle.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-idle.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-idle.svg)
+
+Utilities for working with [idle callbacks](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) in React
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-idle
+```
+
+## Usage
+
+This library provides a hook (`useIdleCallback`) and a component (`OnIdle`) for registering a callback to run in the next idle callback.
+
+> Note: this callback is not called with any arguments, unlike direct usage of `requestIdleCallback`. This makes it more suited for use with discrete operations, rather than ones that will need to schedule themselves for subsequent idle callbacks if the work has not been completed.
+
+```tsx
+import {useCallback} from 'react';
+import {useIdleCallback, OnIdle} from '@shopify/react-idle';
+
+function MyComponent() {
+  const callback = useCallback(() => {
+    console.log('Hello from an idle callback!');
+  }, []);
+
+  useIdleCallback(callback);
+
+  // or
+
+  return <OnIdle perform={callback} />;
+}
+```
+
+If the callback ever changes, or the component unmounts, the original callback will not be run.
+
+### `UnsupportedBehavior`
+
+Because not every browser supports idle callbacks, this library allows you to specify the behavior of `perform` when `requestIdleCallback` is not present. There are currently two options (each of which can be passed as an `unsupportedBehavior` option for the hook, or an `unsupportedBehavior` prop of the component):
+
+- `UnsupportedBehavior.AnimationFrame` (default): run the callback in the next animation frame using `requestAnimationFrame`.
+- `UnsupportedBehavior.Immediate`: run the callback immediately on mount.
+
+```tsx
+import {useIdleCallback, UnsupportedBehavior} from '@shopify/react-idle';
+
+function MyComponent() {
+  useIdleCallback(doSomethingThatCanBeDeferred, {
+    unsupportedBehavior: UnsupportedBehavior.Immediate,
+  });
+
+  return null;
+}
+```
+
+### Additional types
+
+Because the typings for `requestIdleCallback` are not yet provided by the TypeScript standard library, this module also exports a number of types that are needed to interact with these globals.

--- a/packages/react-idle/package.json
+++ b/packages/react-idle/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@shopify/react-idle",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Utilities for working with idle callbacks in React",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-idle/README.md",
+  "dependencies": {
+    "@shopify/async": "^1.3.2"
+  },
+  "devDependencies": {
+    "typescript": "~3.2.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "files": [
+    "dist/*"
+  ]
+}

--- a/packages/react-idle/src/OnIdle.tsx
+++ b/packages/react-idle/src/OnIdle.tsx
@@ -1,0 +1,12 @@
+import {useIdleCallback} from './hooks';
+import {UnsupportedBehavior} from './types';
+
+interface Props {
+  perform(): void;
+  unsupportedBehavior?: UnsupportedBehavior;
+}
+
+export function OnIdle({perform, unsupportedBehavior}: Props) {
+  useIdleCallback(perform, {unsupportedBehavior});
+  return null;
+}

--- a/packages/react-idle/src/hooks.ts
+++ b/packages/react-idle/src/hooks.ts
@@ -1,0 +1,47 @@
+import {useEffect, useRef} from 'react';
+import {
+  RequestIdleCallbackHandle,
+  WindowWithRequestIdleCallback,
+  UnsupportedBehavior,
+} from './types';
+
+export function useIdleCallback(
+  callback: () => void,
+  {unsupportedBehavior = UnsupportedBehavior.AnimationFrame} = {},
+) {
+  const handle = useRef<RequestIdleCallbackHandle | null>(null);
+
+  useEffect(
+    () => {
+      if ('requestIdleCallback' in window) {
+        handle.current = (window as WindowWithRequestIdleCallback).requestIdleCallback(
+          () => callback(),
+        );
+      } else if (unsupportedBehavior === UnsupportedBehavior.AnimationFrame) {
+        handle.current = window.requestAnimationFrame(() => {
+          callback();
+        });
+      } else {
+        callback();
+      }
+
+      return () => {
+        const {current: currentHandle} = handle;
+        handle.current = null;
+
+        if (currentHandle == null) {
+          return;
+        }
+
+        if ('cancelIdleCallback' in window) {
+          (window as WindowWithRequestIdleCallback).cancelIdleCallback(
+            currentHandle,
+          );
+        } else if (unsupportedBehavior === UnsupportedBehavior.AnimationFrame) {
+          window.cancelAnimationFrame(currentHandle);
+        }
+      };
+    },
+    [callback, unsupportedBehavior],
+  );
+}

--- a/packages/react-idle/src/index.ts
+++ b/packages/react-idle/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export {useIdleCallback} from './hooks';
+export {OnIdle} from './OnIdle';

--- a/packages/react-idle/src/test/OnIdle.test.tsx
+++ b/packages/react-idle/src/test/OnIdle.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {requestIdleCallback, animationFrame} from '@shopify/jest-dom-mocks';
+
+import {OnIdle} from '../OnIdle';
+import {UnsupportedBehavior} from '../types';
+
+describe('<OnIdle />', () => {
+  describe('supported', () => {
+    beforeEach(() => {
+      requestIdleCallback.mock();
+    });
+
+    afterEach(() => {
+      requestIdleCallback.restore();
+    });
+
+    it('calls perform when the browser becomes idle', () => {
+      const spy = jest.fn();
+      const timeRemaining = 10;
+      const didTimeout = false;
+
+      mount(<OnIdle perform={spy} />);
+
+      expect(spy).not.toHaveBeenCalled();
+
+      requestIdleCallback.runIdleCallbacks(timeRemaining, didTimeout);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('cancels the idle callback when the component unmounts', () => {
+      const spy = jest.fn();
+      const onIdle = mount(<OnIdle perform={spy} />);
+
+      onIdle.unmount();
+      requestIdleCallback.runIdleCallbacks();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('cancels the idle callback when the perform prop changes', () => {
+      const spyOne = jest.fn();
+      const spyTwo = jest.fn();
+      const onIdle = mount(<OnIdle perform={spyOne} />);
+
+      onIdle.setProps({perform: spyTwo});
+      requestIdleCallback.runIdleCallbacks();
+
+      expect(spyOne).not.toHaveBeenCalled();
+      expect(spyTwo).toHaveBeenCalled();
+    });
+  });
+
+  describe('unsupported', () => {
+    beforeEach(() => {
+      requestIdleCallback.mockAsUnsupported();
+      animationFrame.mock();
+    });
+
+    afterEach(() => {
+      requestIdleCallback.restore();
+      animationFrame.restore();
+    });
+
+    it('runs perform in an animation frame when requestIdleCallback is not supported', () => {
+      const spy = jest.fn();
+      mount(<OnIdle perform={spy} />);
+
+      expect(spy).not.toHaveBeenCalled();
+
+      animationFrame.runFrame();
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('runs perform in immediately when requestIdleCallback is not supported and unsupportedBehavior is set to animation frame', () => {
+      const spy = jest.fn();
+      mount(
+        <OnIdle
+          perform={spy}
+          unsupportedBehavior={UnsupportedBehavior.AnimationFrame}
+        />,
+      );
+
+      expect(spy).not.toHaveBeenCalled();
+
+      animationFrame.runFrame();
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('runs perform in immediately when requestIdleCallback is not supported and unsupportedBehavior is set to immediate', () => {
+      const spy = jest.fn();
+      mount(
+        <OnIdle
+          perform={spy}
+          unsupportedBehavior={UnsupportedBehavior.Immediate}
+        />,
+      );
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('cancels the animation frame when the component unmounts', () => {
+      const spy = jest.fn();
+      const onIdle = mount(<OnIdle perform={spy} />);
+
+      onIdle.unmount();
+      animationFrame.runFrame();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-idle/src/test/OnIdle.test.tsx
+++ b/packages/react-idle/src/test/OnIdle.test.tsx
@@ -74,7 +74,7 @@ describe('<OnIdle />', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('runs perform in immediately when requestIdleCallback is not supported and unsupportedBehavior is set to animation frame', () => {
+    it('runs perform immediately when requestIdleCallback is not supported and unsupportedBehavior is set to animation frame', () => {
       const spy = jest.fn();
       mount(
         <OnIdle
@@ -90,7 +90,7 @@ describe('<OnIdle />', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('runs perform in immediately when requestIdleCallback is not supported and unsupportedBehavior is set to immediate', () => {
+    it('runs perform immediately when requestIdleCallback is not supported and unsupportedBehavior is set to immediate', () => {
       const spy = jest.fn();
       mount(
         <OnIdle
@@ -104,7 +104,12 @@ describe('<OnIdle />', () => {
 
     it('cancels the animation frame when the component unmounts', () => {
       const spy = jest.fn();
-      const onIdle = mount(<OnIdle perform={spy} />);
+      const onIdle = mount(
+        <OnIdle
+          perform={spy}
+          unsupportedBehavior={UnsupportedBehavior.AnimationFrame}
+        />,
+      );
 
       onIdle.unmount();
       animationFrame.runFrame();

--- a/packages/react-idle/src/types.ts
+++ b/packages/react-idle/src/types.ts
@@ -1,0 +1,12 @@
+export {
+  RequestIdleCallback,
+  RequestIdleCallbackOptions,
+  RequestIdleCallbackDeadline,
+  RequestIdleCallbackHandle,
+  WindowWithRequestIdleCallback,
+} from '@shopify/async';
+
+export enum UnsupportedBehavior {
+  Immediate,
+  AnimationFrame,
+}

--- a/packages/react-idle/tsconfig.build.json
+++ b/packages/react-idle/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -413,6 +413,18 @@ expect(myComponent.find('div')).toHaveReactProps({
 });
 ```
 
+### `.toHaveReactDataProps(data: object)`
+
+Like `.toHaveReactProps()`, but is not strictly typed. This makes it more suitable for asserting on `data-` attributes, which can’t be strongly typed.
+
+```tsx
+const myComponent = mount(<MyComponent />);
+
+expect(myComponent.find('div')).toHaveReactDataProps({
+  'data-message': 'Hello world',
+});
+```
+
 ### `.toContainReactComponent(type: string | React.ComponentType, props?: object)`
 
 Asserts that at least one component matching `type` is in the descendants of the passed node. If the second argument is passed, this expectation will further filter the matches by components whose props are equal to the passed object (again, asymmetric matchers are fully supported).

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -82,7 +82,7 @@ export class Element<Props> {
     ) as Element<unknown>[];
   }
 
-  data(key: string): unknown {
+  data(key: string): string {
     return this.props[key.startsWith('data-') ? key : `data-${key}`];
   }
 
@@ -157,7 +157,7 @@ export class Element<Props> {
   ): Element<PropsForComponent<Type>>[] {
     return this.elementDescendants.filter(
       element =>
-        element.type === type &&
+        isMatchingType(element.type, type) &&
         (props == null || equalSubset(props, element.props as object)),
     ) as Element<PropsForComponent<Type>>[];
   }

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,7 +1,7 @@
 import {ComponentType} from 'react';
 import {Props} from '@shopify/useful-types';
 
-import {toHaveReactProps} from './props';
+import {toHaveReactProps, toHaveReactDataProps} from './props';
 import {toContainReactComponent} from './components';
 import {toContainReactText, toContainReactHtml} from './strings';
 import {Node} from './types';
@@ -12,6 +12,7 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       toHaveReactProps(props: Partial<PropsFromNode<R>>): void;
+      toHaveReactDataProps(data: {[key: string]: string}): void;
       toContainReactComponent<Type extends string | ComponentType<any>>(
         type: Type,
         props?: Partial<Props<Type>>,
@@ -24,6 +25,7 @@ declare global {
 
 expect.extend({
   toHaveReactProps,
+  toHaveReactDataProps,
   toContainReactComponent,
   toContainReactText,
   toContainReactHtml,

--- a/packages/react-testing/src/matchers/props.ts
+++ b/packages/react-testing/src/matchers/props.ts
@@ -54,3 +54,11 @@ export function toHaveReactProps<Props>(
 
   return {pass, message};
 }
+
+export function toHaveReactDataProps(
+  this: jest.MatcherUtils,
+  node: Node<unknown>,
+  data: {[key: string]: string},
+) {
+  return toHaveReactProps.call(this, node, data);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,7 +576,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -598,10 +598,18 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@>=16.4.0", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.8.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
   integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@16.8.2":
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
+  integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
This PR adds two helper libraries that will be needed for progressive hydration:

- `@shopify/react-idle`, which adds some basic primitives for registering idle callbacks
- `@shopify/react-hydrate`, which provides the tools to have client and server markup differ without throwing away the server work

All of the details are in the READMEs. I also had to update our `requestIdleCallback` mock a bit more, and fix a bug in `react-testing` with `findAll` not finding `memo`-ed elements.