### PR TITLE
Support SSR in react-graphql hooks

### DIFF
--- a/packages/react-async/README.md
+++ b/packages/react-async/README.md
@@ -245,6 +245,10 @@ const moduleIds = [...asyncAssetmanager.used];
 
 These module IDs can be looked up in the manifest created by `@shopify/async`’s Webpack plugin. If you are using [`sewing-kit-koa`](../sewing-kit-koa), you can follow the instructions from that package to automatically collect the required JavaScript and CSS bundles.
 
+#### `useAsyncAsset()`
+
+Other libraries may need to register an async asset as being used. If those libraries are implemented as components and use the `Async` component from this library, this will automatically be performed when the `id` prop is passed. However, libraries implementing their feature as hooks need to explicitly register their async asset as being used. To do so, you can use the `useAsyncAsset` hook, which accepts an optional ID and registers that ID as used.
+
 ### `createAsyncContext()`
 
 Most of the time, it makes sense to split your application along component boundaries. However, you may also have a reason to split off a part of your app that is not a component. To accomplish this, `react-async` provides a `createAsyncContext()` function. This function also takes an object with a `load` property that is a promise for the value you are splitting. The returned object mimics the shape of `React.createContext()`, except that the `Provider` component does not need a value supplied:

--- a/packages/react-async/src/hooks.ts
+++ b/packages/react-async/src/hooks.ts
@@ -1,0 +1,13 @@
+import {useContext} from 'react';
+import {useServerEffect} from '@shopify/react-effect';
+import {AsyncAssetContext} from './context/assets';
+
+export function useAsyncAsset(id?: string) {
+  const assets = useContext(AsyncAssetContext);
+
+  useServerEffect(() => {
+    if (assets && id) {
+      assets.markAsUsed(id);
+    }
+  });
+}

--- a/packages/react-async/src/index.ts
+++ b/packages/react-async/src/index.ts
@@ -1,10 +1,12 @@
+export {DeferTiming} from '@shopify/async';
+
 export {Async, AsyncPropsRuntime} from './Async';
 export {Prefetcher} from './Prefetcher';
 export {PrefetchRoute} from './PrefetchRoute';
 export {createAsyncComponent, AsyncComponentType} from './component';
 export {createAsyncContext, AsyncContextType} from './provider';
-export {DeferTiming} from '@shopify/async';
 export {resolve, trySynchronousResolve} from './utilities';
+export {useAsyncAsset} from './hooks';
 
 export {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 export {PrefetchContext, PrefetchManager} from './context/prefetch';

--- a/packages/react-effect-apollo/README.md
+++ b/packages/react-effect-apollo/README.md
@@ -13,6 +13,8 @@ $ yarn add @shopify/react-effect-apollo
 
 ## Usage
 
+> **Note**: if you are only using the Apollo hooks provided by [`@shopify/react-graphql`](../react-graphql), you do not need to use this library. It is only necessary when using the `Query` component from `react-apollo` or `@shopify/react-graphql`.
+
 `react-apollo` exposes a function, `getDataFromTree`, which performs a sequence of tree traversals to resolve GraphQL data. This can be wasteful in situations where you are already traversing the tree for other purposes, like resolving translations in `@shopify/react-i18n`, or extracting network details in `@shopify/react-network`. This package provides a way of resolving Apollo’s data with just a single call of `@shopify/react-effect`’s `extract()` function, which will also extract all other server details from packages using `@shopify/react-effect`.
 
 To use this package, create a new "bridge" component from the exposed `createApolloBridge` function in your server code. Then, wrap this bridge around your application when calling `extract()`. That’s all there is to it!

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -3,7 +3,7 @@ import {OperationVariables} from 'apollo-client';
 import {DocumentNode} from 'graphql-typed';
 import {useMountedRef} from '@shopify/react-hooks';
 
-import {AsyncQueryComponentType} from '..';
+import {AsyncQueryComponentType} from '../types';
 
 export default function useGraphQLDocument<
   Data = any,
@@ -13,7 +13,7 @@ export default function useGraphQLDocument<
   documentOrComponent:
     | DocumentNode<Data, Variables>
     | AsyncQueryComponentType<Data, Variables, DeepPartial>,
-) {
+): [DocumentNode<Data, Variables> | null, string | undefined] {
   const [document, setDocument] = useState<DocumentNode<
     Data,
     Variables
@@ -52,7 +52,10 @@ export default function useGraphQLDocument<
     [document, loadDocument],
   );
 
-  return document;
+  return [
+    document,
+    isDocumentNode(documentOrComponent) ? undefined : documentOrComponent.id,
+  ];
 }
 
 function isDocumentNode(arg: any): arg is DocumentNode {

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -48,6 +48,8 @@ export interface ConstantProps {
 
 export interface AsyncQueryComponentType<Data, Variables, DeepPartial>
   extends GraphQLOperation<Data, Variables, DeepPartial> {
+  readonly id: string | undefined;
+  readonly resolved: DocumentNode<Data, Variables, DeepPartial> | null;
   (
     props: Omit<QueryProps<Data, Variables>, 'query'> & ConstantProps,
   ): React.ReactElement<{}>;
@@ -59,5 +61,4 @@ export interface AsyncQueryComponentType<Data, Variables, DeepPartial>
     props: VariableOptions<Variables> & {pollInterval?: number} & ConstantProps,
   ): React.ReactElement<{}>;
   resolve(): Promise<DocumentNode<Data, Variables, DeepPartial>>;
-  resolved: DocumentNode<Data, Variables, DeepPartial> | null;
 }


### PR DESCRIPTION
When rolling out the new stuff to `web-proving-ground`, I noticed that server rendering was broken. There were actually two separate SSR-breaking issues at play:

- When you render an `asyncQueryComponent`, it renders an `Async` component, which in turn registers the ID of that async asset as "used" for the purposes of adding the script tag. In the query hook with an async component, we manually call `resolve`, which does not have any way of registering the asset as used, so the script for the query is not in the initial payload
- When you render an `asyncQueryComponent`, it also eventually renders an Apollo `Query` component, which, through a convoluted set of steps involving old context and our `react-effect-apollo` library, eventually causes those promises to be waited on when calling `extract` from `react-effect`. No such behaviour exists when using the hook version of the query.

This PR solves the two issues by:

- Adding a new hook for registering an async asset as used, and passing through the ID of the original query document if it was an async query
- Adding a `useServerEffect` hook that waits for a query to resolve on the server (which, best of all, operates completely independently of `react-effect-apollo`!)

Here's the before showing the script tags and serialization (note that the script tag for the query is after `main`, so it wasn't part of the original payload):

![Screen Shot 2019-05-15 at 12 12 28 PM](https://user-images.githubusercontent.com/3012583/57792788-dbf41f00-770d-11e9-8a92-c72ab992de98.png)
![Screen Shot 2019-05-15 at 12 11 50 PM](https://user-images.githubusercontent.com/3012583/57792792-de567900-770d-11e9-948b-9d6001f66fc0.png)

After:

![Screen Shot 2019-05-15 at 12 11 20 PM](https://user-images.githubusercontent.com/3012583/57792800-e2829680-770d-11e9-8165-215fea03ec56.png)
![Screen Shot 2019-05-15 at 12 11 00 PM](https://user-images.githubusercontent.com/3012583/57792804-e4e4f080-770d-11e9-88f6-78cba485ba39.png)
