### PR TITLE
Prefetch on touchstart

### DIFF
--- a/packages/react-async/src/Prefetcher.tsx
+++ b/packages/react-async/src/Prefetcher.tsx
@@ -41,18 +41,22 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
         <EventListener
           passive
           event="mouseover"
-          handler={this.handleMouseOver}
+          handler={this.handlePointerEnter}
         />
-        <EventListener passive event="focusin" handler={this.handleMouseOver} />
+        <EventListener
+          passive
+          event="focusin"
+          handler={this.handlePointerEnter}
+        />
         <EventListener
           passive
           event="mouseout"
-          handler={this.handleMouseLeave}
+          handler={this.handlePointerLeave}
         />
         <EventListener
           passive
           event="focusout"
-          handler={this.handleMouseLeave}
+          handler={this.handlePointerLeave}
         />
       </>
     ) : null;
@@ -62,7 +66,12 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
         <EventListener
           passive
           event="mousedown"
-          handler={this.handleMouseDown}
+          handler={this.handlePressStart}
+        />
+        <EventListener
+          passive
+          event="touchstart"
+          handler={this.handlePressStart}
         />
         {expensiveListeners}
         {preloadMarkup}
@@ -70,7 +79,7 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
     );
   }
 
-  private handleMouseDown = ({target}: MouseEvent) => {
+  private handlePressStart = ({target}: MouseEvent) => {
     this.clearTimeout();
 
     if (target == null) {
@@ -84,7 +93,7 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
     }
   };
 
-  private handleMouseLeave = ({
+  private handlePointerLeave = ({
     target,
     relatedTarget,
   }: MouseEvent | FocusEvent) => {
@@ -119,7 +128,7 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
     }
   };
 
-  private handleMouseOver = ({target}: MouseEvent | FocusEvent) => {
+  private handlePointerEnter = ({target}: MouseEvent | FocusEvent) => {
     if (target == null) {
       return;
     }

--- a/packages/react-async/src/tests/Prefetcher.test.tsx
+++ b/packages/react-async/src/tests/Prefetcher.test.tsx
@@ -103,6 +103,23 @@ describe('<Prefetch />', () => {
     expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
+  it('prefetches a component when touching an element with a matching href immediately', () => {
+    const manager = createPrefetchManager([
+      {render: () => <MockComponent />, path},
+    ]);
+    const prefetcher = mount(
+      <PrefetchContext.Provider value={manager}>
+        <Prefetcher />
+      </PrefetchContext.Provider>,
+    );
+
+    triggerListener(prefetcher, 'touchstart', {
+      target: mockElement(`<a href="${path}"></a>`),
+    });
+
+    expect(prefetcher).toContainReactComponent(MockComponent);
+  });
+
   it('does not prefetch a component when mousing over, then out, of an element with a matching href', () => {
     const manager = createPrefetchManager([
       {render: () => <MockComponent />, path},
@@ -228,6 +245,7 @@ function mockElement(markup: string) {
 
 type EventName =
   | 'mousedown'
+  | 'touchstart'
   | 'mouseover'
   | 'mouseout'
   | 'focusin'

--- a/packages/react-async/src/tests/Prefetcher.test.tsx
+++ b/packages/react-async/src/tests/Prefetcher.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import {mount, ReactWrapper} from 'enzyme';
+import {mount, Root} from '@shopify/react-testing';
 import {clock} from '@shopify/jest-dom-mocks';
-import {trigger} from '@shopify/enzyme-utilities';
 
 import {EventListener} from '../EventListener';
 import {Prefetcher, INTENTION_DELAY_MS} from '../Prefetcher';
@@ -38,7 +37,7 @@ describe('<Prefetch />', () => {
         <Prefetcher />
       </PrefetchContext.Provider>,
     );
-    expect(prefetcher).not.toContainReact(<MockComponent />);
+    expect(prefetcher).not.toContainReactComponent(MockComponent);
   });
 
   it('prefetches a component when hovering over an element with a matching href for enough time', () => {
@@ -55,12 +54,13 @@ describe('<Prefetch />', () => {
       target: mockElement(`<a href="${path}"></a>`),
     });
 
-    expect(prefetcher).not.toContainReact(<MockComponent />);
+    expect(prefetcher).not.toContainReactComponent(MockComponent);
 
-    clock.tick(INTENTION_DELAY_MS + 1);
-    prefetcher.update();
+    prefetcher.act(() => {
+      clock.tick(INTENTION_DELAY_MS + 1);
+    });
 
-    expect(prefetcher).toContainReact(<MockComponent />);
+    expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
   it('prefetches a component when focusing on an element with a matching href for enough time', () => {
@@ -77,12 +77,13 @@ describe('<Prefetch />', () => {
       target: mockElement(`<a href="${path}"></a>`),
     });
 
-    expect(prefetcher).not.toContainReact(<MockComponent />);
+    expect(prefetcher).not.toContainReactComponent(MockComponent);
 
-    clock.tick(INTENTION_DELAY_MS + 1);
-    prefetcher.update();
+    prefetcher.act(() => {
+      clock.tick(INTENTION_DELAY_MS + 1);
+    });
 
-    expect(prefetcher).toContainReact(<MockComponent />);
+    expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
   it('prefetches a component when clicking on an element with a matching href immediately', () => {
@@ -99,7 +100,7 @@ describe('<Prefetch />', () => {
       target: mockElement(`<a href="${path}"></a>`),
     });
 
-    expect(prefetcher).toContainReact(<MockComponent />);
+    expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
   it('does not prefetch a component when mousing over, then out, of an element with a matching href', () => {
@@ -120,10 +121,11 @@ describe('<Prefetch />', () => {
       target: mockElement(`<a href="${path}"></a>`),
     });
 
-    clock.tick(INTENTION_DELAY_MS + 1);
-    prefetcher.update();
+    prefetcher.act(() => {
+      clock.tick(INTENTION_DELAY_MS + 1);
+    });
 
-    expect(prefetcher).not.toContainReact(<MockComponent />);
+    expect(prefetcher).not.toContainReactComponent(MockComponent);
   });
 
   it('still prefetches a component when mousing over, then out into a child, of an element with a matching href', () => {
@@ -143,13 +145,14 @@ describe('<Prefetch />', () => {
 
     triggerListener(prefetcher, 'mouseout', {
       target: element,
-      relatedTarget: element.firstChild,
+      relatedTarget: element.firstChild!,
     });
 
-    clock.tick(INTENTION_DELAY_MS + 1);
-    prefetcher.update();
+    prefetcher.act(() => {
+      clock.tick(INTENTION_DELAY_MS + 1);
+    });
 
-    expect(prefetcher).toContainReact(<MockComponent />);
+    expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
   it('does not prefetch a component when focusing in, then out, of an element with a matching href', () => {
@@ -170,10 +173,11 @@ describe('<Prefetch />', () => {
       target: mockElement(`<a href="${path}"></a>`),
     });
 
-    clock.tick(INTENTION_DELAY_MS + 1);
-    prefetcher.update();
+    prefetcher.act(() => {
+      clock.tick(INTENTION_DELAY_MS + 1);
+    });
 
-    expect(prefetcher).not.toContainReact(<MockComponent />);
+    expect(prefetcher).not.toContainReactComponent(MockComponent);
   });
 
   it('prefetches a components with matching regex paths', () => {
@@ -190,7 +194,7 @@ describe('<Prefetch />', () => {
       target: mockElement(`<a href="${path}"></a>`),
     });
 
-    expect(prefetcher).toContainReact(<MockComponent />);
+    expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
   it('prefetches multiple matching components', () => {
@@ -212,8 +216,8 @@ describe('<Prefetch />', () => {
       target: mockElement(`<a href="${path}"></a>`),
     });
 
-    expect(prefetcher).toContainReact(<MockComponent />);
-    expect(prefetcher).toContainReact(<AnotherPrefetch />);
+    expect(prefetcher).toContainReactComponent(MockComponent);
+    expect(prefetcher).toContainReactComponent(AnotherPrefetch);
   });
 });
 
@@ -222,17 +226,21 @@ function mockElement(markup: string) {
     .firstChild as HTMLElement;
 }
 
-type Event = 'mousedown' | 'mouseover' | 'mouseout' | 'focusin' | 'focusout';
+type EventName =
+  | 'mousedown'
+  | 'mouseover'
+  | 'mouseout'
+  | 'focusin'
+  | 'focusout';
 
 function triggerListener(
-  prefetcher: ReactWrapper,
-  event: Event,
-  ...args: any[]
+  prefetcher: Root<unknown>,
+  event: EventName,
+  arg: Partial<FocusEvent>,
 ) {
-  trigger(getListener(prefetcher, event), 'handler', ...args);
-  prefetcher.update();
+  getListener(prefetcher, event)!.trigger('handler', arg);
 }
 
-function getListener(prefetcher: ReactWrapper, event: Event) {
-  return prefetcher.find(EventListener).filter({event});
+function getListener(prefetcher: Root<unknown>, event: EventName) {
+  return prefetcher.findAll(EventListener, {event})[0];
 }


### PR DESCRIPTION
Adds additional touchstart listeners that will trigger prefetching to begin immediately, like we already had for `mousedown`.