### PR TITLE
[WIP] Preload async scripts not loaded synchronously

### DIFF
--- a/packages/react-async/README.md
+++ b/packages/react-async/README.md
@@ -240,10 +240,45 @@ await extract(<App />, {
   },
 });
 
-const moduleIds = [...asyncAssetmanager.used];
+const moduleIds = [...asyncAssetManager.used];
 ```
 
 These module IDs can be looked up in the manifest created by `@shopify/async`’s Webpack plugin. If you are using [`sewing-kit-koa`](../sewing-kit-koa), you can follow the instructions from that package to automatically collect the required JavaScript and CSS bundles.
+
+#### Preloaded assets
+
+Anytime a `Preload`, `Prefetch`, or `KeepFresh` component is rendered, this library defaults to assuming you would like to preload the scripts for that page. Additionally, rendering any async component that is not loaded on the server (for example, because its `defer` was set to `DeferTiming.Idle`) are considered to be candidates for preloading as well. You can access the modules for which preloading makes sense by calling `AsyncAssetManager#preloaded` with a `PreloadPriority`.
+
+```tsx
+import {extract} from '@shopify/react-effect/server';
+import {
+  AsyncAssetManager,
+  AsyncAssetContext,
+  PreloadPriority,
+} from '@shopify/react-async';
+
+const asyncAssetmanager = new AsyncAssetManager();
+
+await extract(<App />, {
+  decorate(app) {
+    return (
+      <AsyncAssetContext.Provider value={asyncAssetmanager}>
+        {app}
+      </AsyncAssetContext.Provider>
+    );
+  },
+});
+
+// Perfect for link rel=prefetch
+const preloadNextPage = [
+  ...asyncAssetManager.preloaded(PreloadPriority.NextPage),
+];
+
+// Perfect for link rel=preload
+const preloadNextPage = [
+  ...asyncAssetManager.preloaded(PreloadPriority.CurrentPage),
+];
+```
 
 #### `useAsyncAsset()`
 

--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -14,9 +14,11 @@ import {
 
 import {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 import {trySynchronousResolve, resolve} from './utilities';
+import {PreloadPriority} from './shared';
 
 export interface AsyncPropsRuntime {
   defer?: DeferTiming;
+  preloadPriority?: PreloadPriority;
   renderLoading?(): React.ReactNode;
 }
 
@@ -75,6 +77,7 @@ class ConnectedAsync<Value> extends React.Component<
       id,
       defer,
       manager,
+      preloadPriority = PreloadPriority.None,
       render = defaultRender,
       renderLoading = defaultRender,
     } = this.props;
@@ -85,6 +88,17 @@ class ConnectedAsync<Value> extends React.Component<
         <Effect
           kind={manager.effect}
           perform={() => manager.markAsUsed(id())}
+        />
+      ) : null;
+
+    const preloadEffect =
+      preloadPriority !== PreloadPriority.None &&
+      id != null &&
+      manager != null &&
+      resolved == null ? (
+        <Effect
+          kind={manager.effect}
+          perform={() => manager.markAsPreload(id(), preloadPriority)}
         />
       ) : null;
 
@@ -102,6 +116,7 @@ class ConnectedAsync<Value> extends React.Component<
     return (
       <>
         {effect}
+        {preloadEffect}
         {content}
         {intersectionObserver}
       </>

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -3,6 +3,7 @@ import {LoadProps, DeferTiming} from '@shopify/async';
 import {Props as ComponentProps} from '@shopify/useful-types';
 
 import {Async, AsyncPropsRuntime} from './Async';
+import {PreloadPriority} from './shared';
 
 interface ConstantProps {
   async?: AsyncPropsRuntime;
@@ -65,6 +66,7 @@ export function createAsyncComponent<
         id={id}
         defer={defer}
         renderLoading={renderLoading}
+        preloadPriority={PreloadPriority.CurrentPage}
         render={Component =>
           Component ? <Component {...componentProps} /> : null
         }
@@ -79,7 +81,12 @@ export function createAsyncComponent<
     return (
       <>
         {renderPreload(componentProps)}
-        <Async defer={DeferTiming.Idle} load={load} {...asyncProps} />
+        <Async
+          load={load}
+          defer={DeferTiming.Idle}
+          preloadPriority={PreloadPriority.NextPage}
+          {...asyncProps}
+        />
       </>
     );
   }
@@ -90,7 +97,12 @@ export function createAsyncComponent<
     return (
       <>
         {renderPrefetch(componentProps)}
-        <Async defer={DeferTiming.Mount} load={load} {...asyncProps} />
+        <Async
+          load={load}
+          defer={DeferTiming.Mount}
+          preloadPriority={PreloadPriority.NextPage}
+          {...asyncProps}
+        />
       </>
     );
   }
@@ -101,7 +113,12 @@ export function createAsyncComponent<
     return (
       <>
         {renderKeepFresh(componentProps)}
-        <Async defer={DeferTiming.Idle} load={load} {...asyncProps} />
+        <Async
+          load={load}
+          defer={DeferTiming.Idle}
+          preloadPriority={PreloadPriority.NextPage}
+          {...asyncProps}
+        />
       </>
     );
   }

--- a/packages/react-async/src/context/assets.ts
+++ b/packages/react-async/src/context/assets.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {EffectKind} from '@shopify/react-effect';
+import {PreloadPriority} from '../shared';
 
 export const EFFECT_ID = Symbol('react-async');
 
@@ -8,11 +9,33 @@ export class AsyncAssetManager {
 
   readonly effect: EffectKind = {
     id: EFFECT_ID,
-    betweenEachPass: () => this.used.clear(),
+    betweenEachPass: () => {
+      this.used.clear();
+      this.preload[PreloadPriority.CurrentPage].clear();
+      this.preload[PreloadPriority.NextPage].clear();
+    },
   };
+
+  private readonly preload = {
+    [PreloadPriority.CurrentPage]: new Set<string>(),
+    [PreloadPriority.NextPage]: new Set<string>(),
+  };
+
+  preloaded(priority: PreloadPriority) {
+    return this.preload[priority] || new Set();
+  }
 
   markAsUsed(id: string) {
     this.used.add(id);
+  }
+
+  markAsPreload(id: string, priority: PreloadPriority) {
+    if (
+      priority === PreloadPriority.CurrentPage ||
+      priority === PreloadPriority.NextPage
+    ) {
+      this.preload[priority].add(id);
+    }
   }
 }
 

--- a/packages/react-async/src/index.ts
+++ b/packages/react-async/src/index.ts
@@ -7,6 +7,7 @@ export {createAsyncComponent, AsyncComponentType} from './component';
 export {createAsyncContext, AsyncContextType} from './provider';
 export {resolve, trySynchronousResolve} from './utilities';
 export {useAsyncAsset} from './hooks';
+export {PreloadPriority} from './shared';
 
 export {AsyncAssetContext, AsyncAssetManager} from './context/assets';
 export {PrefetchContext, PrefetchManager} from './context/prefetch';

--- a/packages/react-async/src/shared.ts
+++ b/packages/react-async/src/shared.ts
@@ -3,3 +3,9 @@ export type Prefetchable<Props> =
       Prefetch: React.ComponentType<Props>;
     }
   | React.ComponentType<Props>;
+
+export enum PreloadPriority {
+  None,
+  CurrentPage,
+  NextPage,
+}

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -4,6 +4,7 @@ import {DeferTiming} from '@shopify/async';
 
 import {Async} from '../Async';
 import {createAsyncComponent} from '../component';
+import {PreloadPriority} from '../shared';
 
 jest.mock('../Async', () => ({
   Async() {
@@ -27,6 +28,7 @@ describe('createAsyncComponent()', () => {
       load,
       id,
       renderLoading,
+      preloadPriority: PreloadPriority.CurrentPage,
     });
   });
 
@@ -68,6 +70,7 @@ describe('createAsyncComponent()', () => {
       expect(preload).toContainReactComponent(Async, {
         load,
         defer: DeferTiming.Idle,
+        preloadPriority: PreloadPriority.NextPage,
       });
     });
 
@@ -80,11 +83,7 @@ describe('createAsyncComponent()', () => {
       const renderPreload = () => <Preload />;
       const AsyncComponent = createAsyncComponent({load, renderPreload});
 
-      const preload = mount(
-        <div>
-          <AsyncComponent.Preload />
-        </div>,
-      );
+      const preload = mount(<AsyncComponent.Preload />);
       expect(preload).toContainReactComponent(Preload);
     });
 
@@ -106,6 +105,7 @@ describe('createAsyncComponent()', () => {
       expect(prefetch).toContainReactComponent(Async, {
         load,
         defer: DeferTiming.Mount,
+        preloadPriority: PreloadPriority.NextPage,
       });
     });
 
@@ -118,11 +118,7 @@ describe('createAsyncComponent()', () => {
       const renderPrefetch = () => <Prefetch />;
       const AsyncComponent = createAsyncComponent({load, renderPrefetch});
 
-      const prefetch = mount(
-        <div>
-          <AsyncComponent.Prefetch />
-        </div>,
-      );
+      const prefetch = mount(<AsyncComponent.Prefetch />);
       expect(prefetch).toContainReactComponent(Prefetch);
     });
 
@@ -144,6 +140,7 @@ describe('createAsyncComponent()', () => {
       expect(keepFresh).toContainReactComponent(Async, {
         load,
         defer: DeferTiming.Idle,
+        preloadPriority: PreloadPriority.NextPage,
       });
     });
 

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -1,7 +1,5 @@
-// Enzyme doesn't know how to handle components that only return fragments.
-import * as React from 'react';
-import {mount} from 'enzyme';
-import {trigger} from '@shopify/enzyme-utilities';
+import React from 'react';
+import {mount} from '@shopify/react-testing';
 import {DeferTiming} from '@shopify/async';
 
 import {Async} from '../Async';
@@ -25,7 +23,7 @@ describe('createAsyncComponent()', () => {
 
     const AsyncComponent = createAsyncComponent({load, id, renderLoading});
     const asyncComponent = mount(<AsyncComponent />);
-    expect(asyncComponent.find(Async).props()).toMatchObject({
+    expect(asyncComponent).toContainReactComponent(Async, {
       load,
       id,
       renderLoading,
@@ -38,10 +36,10 @@ describe('createAsyncComponent()', () => {
     const AsyncComponent = createAsyncComponent({load});
     const asyncComponent = mount(<AsyncComponent {...props} />);
 
-    expect(trigger(asyncComponent.find(Async), 'render', null)).toBeNull();
+    expect(asyncComponent.find(Async)!.trigger('render', null)).toBeNull();
     expect(
-      trigger(asyncComponent.find(Async), 'render', MockComponent),
-    ).toStrictEqual(<MockComponent {...props} />);
+      asyncComponent.find(Async)!.trigger('render', MockComponent),
+    ).toMatchObject(<MockComponent {...props} />);
   });
 
   it('creates a deferred <Async /> when specified', () => {
@@ -50,16 +48,16 @@ describe('createAsyncComponent()', () => {
 
     const AsyncComponent = createAsyncComponent({load, defer});
     const asyncComponent = mount(<AsyncComponent />);
-    expect(asyncComponent.find(Async)).toHaveProp('defer', defer);
+    expect(asyncComponent).toContainReactComponent(Async, {defer});
   });
 
   it('allows passing custom async props', () => {
     const load = () => Promise.resolve(MockComponent);
-    const async = {defer: DeferTiming.Idle, renderLoading: () => <div />};
+    const asyncProps = {defer: DeferTiming.Idle, renderLoading: () => <div />};
 
     const AsyncComponent = createAsyncComponent({load});
-    const asyncComponent = mount(<AsyncComponent async={async} />);
-    expect(asyncComponent.find(Async).props()).toMatchObject(async);
+    const asyncComponent = mount(<AsyncComponent async={asyncProps} />);
+    expect(asyncComponent).toContainReactComponent(Async, asyncProps);
   });
 
   describe('<Preload />', () => {
@@ -67,9 +65,10 @@ describe('createAsyncComponent()', () => {
       const load = () => Promise.resolve(MockComponent);
       const AsyncComponent = createAsyncComponent({load});
       const preload = mount(<AsyncComponent.Preload />);
-      expect(preload).toContainReact(
-        <Async defer={DeferTiming.Idle} load={load} />,
-      );
+      expect(preload).toContainReactComponent(Async, {
+        load,
+        defer: DeferTiming.Idle,
+      });
     });
 
     it('renders the result of calling renderPreload()', () => {
@@ -86,7 +85,7 @@ describe('createAsyncComponent()', () => {
           <AsyncComponent.Preload />
         </div>,
       );
-      expect(preload).toContainReact(<Preload />);
+      expect(preload).toContainReactComponent(Preload);
     });
 
     it('allows passing custom async props', () => {
@@ -95,7 +94,7 @@ describe('createAsyncComponent()', () => {
 
       const AsyncComponent = createAsyncComponent({load});
       const preload = mount(<AsyncComponent.Preload async={async} />);
-      expect(preload.find(Async).props()).toMatchObject(async);
+      expect(preload).toContainReactComponent(Async, async);
     });
   });
 
@@ -104,9 +103,10 @@ describe('createAsyncComponent()', () => {
       const load = () => Promise.resolve(MockComponent);
       const AsyncComponent = createAsyncComponent({load});
       const prefetch = mount(<AsyncComponent.Prefetch />);
-      expect(prefetch).toContainReact(
-        <Async defer={DeferTiming.Mount} load={load} />,
-      );
+      expect(prefetch).toContainReactComponent(Async, {
+        load,
+        defer: DeferTiming.Mount,
+      });
     });
 
     it('renders the result of calling renderPrefetch()', () => {
@@ -123,16 +123,16 @@ describe('createAsyncComponent()', () => {
           <AsyncComponent.Prefetch />
         </div>,
       );
-      expect(prefetch).toContainReact(<Prefetch />);
+      expect(prefetch).toContainReactComponent(Prefetch);
     });
 
     it('allows passing custom async props', () => {
       const load = () => Promise.resolve(MockComponent);
-      const async = {defer: undefined, renderLoading: () => <div />};
+      const asyncProps = {defer: undefined, renderLoading: () => <div />};
 
       const AsyncComponent = createAsyncComponent({load});
-      const prefetch = mount(<AsyncComponent.Prefetch async={async} />);
-      expect(prefetch.find(Async).props()).toMatchObject(async);
+      const prefetch = mount(<AsyncComponent.Prefetch async={asyncProps} />);
+      expect(prefetch).toContainReactComponent(Async, asyncProps);
     });
   });
 
@@ -141,9 +141,10 @@ describe('createAsyncComponent()', () => {
       const load = () => Promise.resolve(MockComponent);
       const AsyncComponent = createAsyncComponent({load});
       const keepFresh = mount(<AsyncComponent.KeepFresh />);
-      expect(keepFresh).toContainReact(
-        <Async defer={DeferTiming.Idle} load={load} />,
-      );
+      expect(keepFresh).toContainReactComponent(Async, {
+        load,
+        defer: DeferTiming.Idle,
+      });
     });
 
     it('renders the result of calling renderKeepFresh()', () => {
@@ -155,22 +156,17 @@ describe('createAsyncComponent()', () => {
       const renderKeepFresh = () => <KeepFresh />;
       const AsyncComponent = createAsyncComponent({load, renderKeepFresh});
 
-      const keepFresh = mount(
-        // Enzyme doesn't know how to handle components that only return fragments.
-        <div>
-          <AsyncComponent.KeepFresh />
-        </div>,
-      );
-      expect(keepFresh).toContainReact(<KeepFresh />);
+      const keepFresh = mount(<AsyncComponent.KeepFresh />);
+      expect(keepFresh).toContainReactComponent(KeepFresh);
     });
 
     it('allows passing custom async props', () => {
       const load = () => Promise.resolve(MockComponent);
-      const async = {defer: undefined, renderLoading: () => <div />};
+      const asyncProps = {defer: undefined, renderLoading: () => <div />};
 
       const AsyncComponent = createAsyncComponent({load});
-      const keepFresh = mount(<AsyncComponent.KeepFresh async={async} />);
-      expect(keepFresh.find(Async).props()).toMatchObject(async);
+      const keepFresh = mount(<AsyncComponent.KeepFresh async={asyncProps} />);
+      expect(keepFresh).toContainReactComponent(Async, asyncProps);
     });
   });
 });

--- a/packages/react-graphql/src/async.tsx
+++ b/packages/react-graphql/src/async.tsx
@@ -5,6 +5,7 @@ import {LoadProps, DeferTiming} from '@shopify/async';
 import {
   Async,
   AsyncPropsRuntime,
+  PreloadPriority,
   resolve as resolver,
   trySynchronousResolve,
 } from '@shopify/react-async';
@@ -53,6 +54,7 @@ export function createAsyncQueryComponent<Data, Variables, DeepPartial>({
         id={id}
         load={load}
         defer={defer}
+        preloadPriority={PreloadPriority.CurrentPage}
         render={query =>
           query ? <Query query={query} {...componentProps as any} /> : null
         }
@@ -69,6 +71,7 @@ export function createAsyncQueryComponent<Data, Variables, DeepPartial>({
       <Async
         load={load}
         defer={DeferTiming.Mount}
+        preloadPriority={PreloadPriority.NextPage}
         render={query =>
           query ? (
             <PrefetchQuery ignoreCache query={query} variables={variables} />
@@ -82,7 +85,13 @@ export function createAsyncQueryComponent<Data, Variables, DeepPartial>({
   function Preload(props: ConstantProps) {
     const asyncProps = splitProps(props)[1];
     return (
-      <Async defer={DeferTiming.Idle} load={load} id={id} {...asyncProps} />
+      <Async
+        id={id}
+        load={load}
+        defer={DeferTiming.Idle}
+        preloadPriority={PreloadPriority.NextPage}
+        {...asyncProps}
+      />
     );
   }
 
@@ -98,6 +107,7 @@ export function createAsyncQueryComponent<Data, Variables, DeepPartial>({
       <Async
         load={load}
         defer={DeferTiming.Idle}
+        preloadPriority={PreloadPriority.NextPage}
         render={query =>
           query ? (
             <PrefetchQuery

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -169,6 +169,8 @@ The `<Html>` component serves as a top level wrapper for a React application, al
 - `styles`: descriptors for any style tags you want to include in the HEAD of the document.
 - `scripts`: descriptors for any script tags you want to include in your document. All scripts passed to this property will be deferred by appending them to the end of the document. We encourage this as a default because it improves the initial rendering performance of your page.
 - `blockingScripts`: descriptors for any script tags you want to include in the HEAD of the document. These will block HTML parsing until they are evaluated, so use them carefully.
+- `preloadCurrentPage`: descriptors for any assets you know will be loaded on thee current page. Every asset will get its own [`<link rel="preload" />`](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) tag.
+- `preloadNextPage`: descriptors for any assets you know will be loaded on the next page. Every asset will get its own [`<link rel="prefetch" />`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ) tag.
 - `headMarkup`: additional JSX to be embedded in the head of the document (after styles, but before blocking scripts).
 - `bodyMarkup`: additional JSX to be embedded in the body of the document (before serialization markup and deferred scripts).
 
@@ -180,6 +182,7 @@ const html = (
     locale="fr"
     styles={[{path: '/style.css'}]}
     scripts={[{path: '/script.js'}]}
+    preloadNextPage={[{path: '/next-page.js'}]}
   >
     <App />
   </Html>

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -20,6 +20,8 @@ export interface Props {
   styles?: Asset[];
   scripts?: Asset[];
   blockingScripts?: Asset[];
+  preloadCurrentPage?: Asset[];
+  preloadNextPage?: Asset[];
   headMarkup?: React.ReactNode;
   bodyMarkup?: React.ReactNode;
 }
@@ -29,6 +31,8 @@ export default function Html({
   children,
   locale = 'en',
   blockingScripts = [],
+  preloadCurrentPage = [],
+  preloadNextPage = [],
   scripts = [],
   styles = [],
   headMarkup = null,
@@ -69,6 +73,20 @@ export default function Html({
         <link key={index} {...managedProps} {...linkProps} />
       ))
     : null;
+
+  const linkPrefetchMarkup = preloadNextPage.map(asset => (
+    <link rel="prefetch" href={asset.path} key={asset.path} />
+  ));
+
+  const linkPreloadMarkup = preloadCurrentPage.map(asset => (
+    <link
+      key={asset.path}
+      rel="preload"
+      href={asset.path}
+      as={asForAsset(asset.path)}
+      crossOrigin="anonymous"
+    />
+  ));
 
   const stylesMarkup = styles.map(style => {
     return (
@@ -117,6 +135,8 @@ export default function Html({
         <meta name="referrer" content="never" />
         {metaMarkup}
         {linkMarkup}
+        {linkPrefetchMarkup}
+        {linkPreloadMarkup}
 
         {stylesMarkup}
         {headMarkup}
@@ -143,4 +163,13 @@ function render(app: React.ReactElement<any>, manager?: HtmlManager) {
     );
 
   return renderToString(content);
+}
+
+function asForAsset(asset: string) {
+  switch (asset.split('.').pop()) {
+    case 'js':
+      return 'script';
+    case 'css':
+      return 'style';
+  }
 }

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -98,9 +98,45 @@ describe('<Html />', () => {
     });
   });
 
+  describe('preloadCurrentPage', () => {
+    it('generates link rel=preload tags for each asset', () => {
+      const preloadCurrentPage = [{path: 'foo.js'}, {path: 'bar.js'}];
+      const html = mount(
+        <Html {...mockProps} preloadCurrentPage={preloadCurrentPage} />,
+      );
+      const head = html.find('head')!;
+
+      for (const preload of preloadCurrentPage) {
+        expect(head).toContainReactComponent('link', {
+          as: 'script',
+          rel: 'preload',
+          href: preload.path,
+          crossOrigin: 'anonymous',
+        });
+      }
+    });
+  });
+
+  describe('preloadNextPage', () => {
+    it('generates link rel=prefetch tags for each asset', () => {
+      const preloadNextPage = [{path: 'foo.css'}, {path: 'bar.css'}];
+      const html = mount(
+        <Html {...mockProps} preloadNextPage={preloadNextPage} />,
+      );
+      const head = html.find('head')!;
+
+      for (const preload of preloadNextPage) {
+        expect(head).toContainReactComponent('link', {
+          rel: 'prefetch',
+          href: preload.path,
+        });
+      }
+    });
+  });
+
   describe('styles', () => {
     it('generates a link tag in the head', () => {
-      const styles = [{path: 'foo.js'}, {path: 'bar.js'}];
+      const styles = [{path: 'foo.css'}, {path: 'bar.css'}];
       const html = mount(<Html {...mockProps} styles={styles} />);
       const head = html.find('head')!;
 
@@ -180,7 +216,7 @@ describe('<Html />', () => {
     it('renders serializations', () => {
       const id = 'MySerialization';
       const data = {foo: 'bar'};
-      const manager = new HtmlManager({isServer: true});
+      const manager = new HtmlManager();
       manager.setSerialization(id, data);
 
       const html = mount(<Html {...mockProps} manager={manager} />);

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -269,6 +269,31 @@ describe('Assets', () => {
         {path: js},
       ]);
     });
+
+    it('returns all assets for the specified identifiers', async () => {
+      const asyncCss = '/mypage.css';
+      const asyncJs = 'mypage.js';
+
+      readJson.mockImplementation(() =>
+        mockConsolidatedManifest([
+          mockManifestEntry({
+            manifest: mockManifest(
+              {},
+              {
+                mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+              },
+            ),
+          }),
+        ]),
+      );
+
+      const assets = new Assets(defaultOptions);
+
+      expect(await assets.assets(['mypage'])).toStrictEqual([
+        {path: asyncCss},
+        {path: asyncJs},
+      ]);
+    });
   });
 
   describe('asyncStyles', () => {


### PR DESCRIPTION
This PR augments `@shopify/react-async` to record the module identifiers of any async component that is not actually loaded synchronously. This includes a full set of changes to sewing-kit-koa and react-html as well, so it's easy to add link tags for these components.