### PR TITLE
Strongly type jest-dom-mocks/Storage mocks

### DIFF
--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Unreleased
+
+### Added
+
+- Accurate return types for `Storage` mocks
+
 ## [2.5.4] - 2019-04-25
 
 ### Fixed

--- a/packages/jest-dom-mocks/src/storage.ts
+++ b/packages/jest-dom-mocks/src/storage.ts
@@ -1,11 +1,11 @@
 export default class Storage {
-  getItem = jest.fn(this.unmockedGetItem);
+  getItem = jest.fn<string | null>(this.unmockedGetItem);
 
-  setItem = jest.fn(this.unmockedSetItem);
+  setItem = jest.fn<undefined>(this.unmockedSetItem);
 
-  removeItem = jest.fn(this.unmockedRemoveItem);
+  removeItem = jest.fn<undefined>(this.unmockedRemoveItem);
 
-  clear = jest.fn(this.unmockedClearItem);
+  clear = jest.fn<undefined>(this.unmockedClearItem);
 
   private store: {
     [key: string]: string;


### PR DESCRIPTION
Trying out the latest Jest types in web, tsc raises errors about `storage.getItem('foo')` returning `{}`.