### PR TITLE
adding validateWithFields() to support consuming fields in a validator

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- validator signatures produced by `validate()` no longer require a `fields` param. [#714](https://github.com/Shopify/quilt/pull/714)
 
 ## [0.11.1] - 2019-05-15
 

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -10,7 +10,7 @@ import {
 } from '@shopify/predicates';
 import {mapObject} from './utilities';
 
-interface Matcher<Input, Fields> {
+interface Matcher<Input, Fields = any> {
   (input: Input, fields: Fields): boolean;
 }
 
@@ -73,11 +73,26 @@ export function validateList<Input extends object, Fields>(
   };
 }
 
+export function validateWithFields<Input, Fields>(
+  matcher: Matcher<Input, Fields>,
+  errorContent: ErrorContent,
+) {
+  return validate(matcher, errorContent) as (
+    input: Input,
+    fields: Fields,
+  ) => ErrorContent | undefined | void;
+}
+
+export function validate<Input>(
+  matcher: Matcher<Input>,
+  errorContent: ErrorContent,
+): (input: Input) => ErrorContent | undefined | void;
+
 export function validate<Input, Fields>(
   matcher: Matcher<Input, Fields>,
   errorContent: ErrorContent,
 ) {
-  return (input: Input, fields: Fields): ErrorContent | undefined | void => {
+  return (input: Input, fields: Fields) => {
     const matches = matcher(input, fields);
 
     /*
@@ -101,7 +116,7 @@ export function validate<Input, Fields>(
 }
 
 export function validateRequired<Input>(
-  matcher: Matcher<Input, any>,
+  matcher: Matcher<Input>,
   errorContent: ErrorContent,
 ): (input: Input) => ErrorContent | undefined | void;
 


### PR DESCRIPTION
in #690 the `validate()` signature was updated to support consumption of `fields: Fields`, but this change also made it a required parameter of generated validator function. This PR _effectively_ reverts #690 and creates a new `validateWithFields()` wrapper that exposes the generated validator from `validate()` with a signature that supports consuming the `fields` param.