### PR TITLE
Update readme to make default function async

### DIFF
--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -50,7 +50,7 @@ import {
   HtmlContext,
 } from '@shopify/react-html/server';
 
-export default function middleware(ctx) {
+export default async function middleware(ctx) {
   const manager = new HtmlManager();
   const app = <App />;
 


### PR DESCRIPTION
In the [example for useSerialized](https://github.com/Shopify/quilt/tree/master/packages/react-html#useserialized)
The server awaits `extract` and if the user simply copies and pastes this example they'll get an error.