### PR TITLE
⚡ prevent needless rerenders of pages using `useForm`

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- now keeps all imperative methods returned by `useForm` reference equal regardless of the `fieldBag` changing, preventing needless rerenders of `PureComponent`s
+- now keeps all imperative methods returned by `useForm` reference equal regardless of the `fieldBag` changing, preventing needless rerenders of `PureComponent`s [(716)](https://github.com/Shopify/quilt/pull/716)
 
 ## [0.2.0]
 

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.1]
+
+### Fixed
+
+- now keeps all imperative methods returned by `useForm` reference equal regardless of the `fieldBag` changing, preventing needless rerenders of `PureComponent`s
+
 ## [0.2.0]
 
 ### Changed

--- a/packages/react-form/src/hooks/reset.ts
+++ b/packages/react-form/src/hooks/reset.ts
@@ -1,6 +1,10 @@
-import {FieldBag} from '../types';
+import {FieldBag, Field} from '../types';
 import useVisitFields from './visitFields';
 
 export function useReset(fieldBag: FieldBag) {
-  return useVisitFields(fieldBag, field => field.reset());
+  return useVisitFields(fieldBag, resetField);
+}
+
+function resetField(field: Field<unknown>) {
+  field.reset();
 }

--- a/packages/react-form/src/hooks/test/form.test.tsx
+++ b/packages/react-form/src/hooks/test/form.test.tsx
@@ -261,6 +261,24 @@ describe('useForm', () => {
         error: errors[0].message,
       });
     });
+
+    it('does not create a new submit function on each render', () => {
+      const wrapper = mount(<ProductForm data={fakeProduct()} />);
+
+      const initialSubmitHandler = wrapper
+        .find('button', {type: 'submit'})!
+        .prop('onClick');
+
+      wrapper
+        .find(TextField, {label: 'title'})!
+        .trigger('onChange', 'tortoritos, the chip for turtles!');
+
+      const newSubmitHandler = wrapper
+        .find('button', {type: 'submit'})!
+        .prop('onClick');
+
+      expect(initialSubmitHandler).toBe(newSubmitHandler);
+    });
   });
 
   describe('reset', () => {
@@ -317,6 +335,24 @@ describe('useForm', () => {
       expect(wrapper).not.toContainReactComponent(TextField, {
         error: errors[0].message,
       });
+    });
+
+    it('does not create a new reset function on each render', () => {
+      const wrapper = mount(<ProductForm data={fakeProduct()} />);
+
+      const initialResetHandler = wrapper
+        .find('button', {type: 'button'})!
+        .prop('onClick');
+
+      wrapper
+        .find(TextField, {label: 'title'})!
+        .trigger('onChange', 'tortoritos, the chip for turtles!');
+
+      const newResetHandler = wrapper
+        .find('button', {type: 'button'})!
+        .prop('onClick');
+
+      expect(initialResetHandler).toBe(newResetHandler);
     });
   });
 });

--- a/packages/react-form/src/hooks/visitFields.ts
+++ b/packages/react-form/src/hooks/visitFields.ts
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useRef} from 'react';
 import {FieldDictionary, FieldOutput, Field} from '../types';
 import {isField} from '../utilities';
 
@@ -10,9 +10,12 @@ export default function useVisitFields(
   fieldBag: {[key: string]: FieldOutput<any>},
   visitor: FieldVisitor,
 ) {
+  const fieldBagRef = useRef(fieldBag);
+  fieldBagRef.current = fieldBag;
+
   return useCallback(
     () => {
-      const fields = Object.values(fieldBag);
+      const fields = Object.values(fieldBagRef.current);
 
       for (const item of fields) {
         if (isField(item)) {
@@ -29,7 +32,7 @@ export default function useVisitFields(
         visit(item);
       }
     },
-    [fieldBag, visitor],
+    [visitor],
   );
 }
 


### PR DESCRIPTION
This PR uses a cool trick thought of by @lemonmade  to keep functions returned by hooks reference equal despite the values they close over changing. It rolls this out to all of the callbacks returned by `useForm` and adds some tests to make sure we don't regress.  