### PR TITLE
[react-graphql] skip watchQuery

### DIFF
--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -71,13 +71,13 @@ export default function useQuery<
 
   const queryObservable = useMemo(
     () => {
-      if (!watchQueryOptions) {
+      if (skip || !watchQueryOptions) {
         return;
       }
 
       return client.watchQuery(watchQueryOptions);
     },
-    [client, watchQueryOptions],
+    [client, skip, watchQueryOptions],
   );
 
   useServerEffect(() => {


### PR DESCRIPTION
Fixes an issue we discovered in `web` (https://github.com/Shopify/web/issues/13938).
(Happening through `AdjacentResources` in `web`.)

The query was being run when we wanted to skip it; variables in the query may not be valid yet, so we need to wait until we don't want to skip to `watchQuery` (https://www.apollographql.com/docs/react/api/apollo-client#ApolloClient.watchQuery).
