### PR TITLE
react-graphql improvements

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -7,6 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.6] - 2019-05-31
+
+### Fixed
+
+- Queries are no longer waited on during server render when `skip` is `true` ([#726](https://github.com/Shopify/quilt/pull/726))
+- The result of calling `useQuery` is now referentially stable when variables stay deep-equal between calls (previously, using a different object with the same values would change the result) ([#726](https://github.com/Shopify/quilt/pull/726)).
+
 ## [3.3.5] - 2019-05-29
 
 ### Fixed

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -2,6 +2,7 @@ import {useState, useEffect, useCallback} from 'react';
 import {OperationVariables} from 'apollo-client';
 import {DocumentNode} from 'graphql-typed';
 import {useMountedRef} from '@shopify/react-hooks';
+import {useAsyncAsset} from '@shopify/react-async';
 
 import {AsyncQueryComponentType} from '../types';
 
@@ -13,7 +14,7 @@ export default function useGraphQLDocument<
   documentOrComponent:
     | DocumentNode<Data, Variables>
     | AsyncQueryComponentType<Data, Variables, DeepPartial>,
-): [DocumentNode<Data, Variables> | null, string | undefined] {
+): DocumentNode<Data, Variables> | null {
   const [document, setDocument] = useState<DocumentNode<
     Data,
     Variables
@@ -52,10 +53,11 @@ export default function useGraphQLDocument<
     [document, loadDocument],
   );
 
-  return [
-    document,
+  useAsyncAsset(
     isDocumentNode(documentOrComponent) ? undefined : documentOrComponent.id,
-  ];
+  );
+
+  return document;
 }
 
 function isDocumentNode(arg: any): arg is DocumentNode {

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -39,6 +39,7 @@ export default function useQuery<
 
   useAsyncAsset(id);
 
+  const serializedVariables = variables && JSON.stringify(variables);
   const watchQueryOptions = useMemo<WatchQueryOptions<Variables> | null>(
     () => {
       if (!query) {
@@ -60,8 +61,7 @@ export default function useQuery<
       query,
       // eslint-disable-next-line react-hooks/exhaustive-deps
       context && JSON.stringify(context),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      variables && JSON.stringify(variables),
+      serializedVariables,
       fetchPolicy,
       errorPolicy,
       pollInterval,
@@ -116,7 +116,8 @@ export default function useQuery<
         : (noop as any),
       client,
     }),
-    [queryObservable, client, variables],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [queryObservable, client, serializedVariables],
   );
 
   const [responseId, setResponseId] = useState(0);

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -1,12 +1,15 @@
+/* eslint react-hooks/rules-of-hooks: off */
+
 import {useEffect, useMemo, useState, useRef} from 'react';
 import {
+  ApolloClient,
   OperationVariables,
   ApolloError,
   WatchQueryOptions,
+  ObservableQuery,
 } from 'apollo-client';
 import {DocumentNode} from 'graphql-typed';
 import {useServerEffect} from '@shopify/react-effect';
-import {useAsyncAsset} from '@shopify/react-async';
 
 import {AsyncQueryComponentType} from '../types';
 import {QueryHookOptions, QueryHookResult} from './types';
@@ -33,11 +36,13 @@ export default function useQuery<
     notifyOnNetworkStatusChange,
     context,
   } = options;
-
   const client = useApolloClient(overrideClient);
-  const [query, id] = useGraphQLDocument(queryOrComponent);
 
-  useAsyncAsset(id);
+  if (typeof window === 'undefined' && skip) {
+    return createDefaultResult(client, variables);
+  }
+
+  const query = useGraphQLDocument(queryOrComponent);
 
   const serializedVariables = variables && JSON.stringify(variables);
   const watchQueryOptions = useMemo<WatchQueryOptions<Variables> | null>(
@@ -90,32 +95,7 @@ export default function useQuery<
   });
 
   const defaultResult = useMemo<QueryHookResult<Data, Variables>>(
-    () => ({
-      data: undefined,
-      error: undefined,
-      networkStatus: undefined,
-      loading: false,
-      variables: queryObservable ? queryObservable.variables : variables,
-      refetch: queryObservable
-        ? queryObservable.refetch.bind(queryObservable)
-        : (noop as any),
-      fetchMore: queryObservable
-        ? queryObservable.fetchMore.bind(queryObservable)
-        : (noop as any),
-      updateQuery: queryObservable
-        ? queryObservable.updateQuery.bind(queryObservable)
-        : (noop as any),
-      startPolling: queryObservable
-        ? queryObservable.startPolling.bind(queryObservable)
-        : (noop as any),
-      stopPolling: queryObservable
-        ? queryObservable.stopPolling.bind(queryObservable)
-        : (noop as any),
-      subscribeToMore: queryObservable
-        ? queryObservable.subscribeToMore.bind(queryObservable)
-        : (noop as any),
-      client,
-    }),
+    () => createDefaultResult(client, variables, queryObservable),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [queryObservable, client, serializedVariables],
   );
@@ -146,6 +126,7 @@ export default function useQuery<
   const previousData = useRef<
     QueryHookResult<Data, Variables>['data'] | undefined
   >(undefined);
+
   const currentResult = useMemo<QueryHookResult<Data, Variables>>(
     () => {
       // must of the logic below are lifted from
@@ -201,6 +182,39 @@ export default function useQuery<
   );
 
   return currentResult;
+}
+
+function createDefaultResult(
+  client: ApolloClient<unknown>,
+  variables: any,
+  queryObservable?: ObservableQuery,
+) {
+  return {
+    data: undefined,
+    error: undefined,
+    networkStatus: undefined,
+    loading: false,
+    variables: queryObservable ? queryObservable.variables : variables,
+    refetch: queryObservable
+      ? queryObservable.refetch.bind(queryObservable)
+      : noop,
+    fetchMore: queryObservable
+      ? queryObservable.fetchMore.bind(queryObservable)
+      : noop,
+    updateQuery: queryObservable
+      ? queryObservable.updateQuery.bind(queryObservable)
+      : noop,
+    startPolling: queryObservable
+      ? queryObservable.startPolling.bind(queryObservable)
+      : noop,
+    stopPolling: queryObservable
+      ? queryObservable.stopPolling.bind(queryObservable)
+      : noop,
+    subscribeToMore: queryObservable
+      ? queryObservable.subscribeToMore.bind(queryObservable)
+      : noop,
+    client,
+  };
 }
 
 function noop() {}

--- a/packages/react-graphql/src/hooks/tests/mutation.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/mutation.test.tsx
@@ -3,11 +3,7 @@ import gql from 'graphql-tag';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 
 import useMutation from '../mutation';
-import {
-  mountWithGraphQL,
-  prepareAsyncReactTasks,
-  teardownAsyncReactTasks,
-} from './utilities';
+import {mountWithGraphQL} from './utilities';
 
 const updatePetMutation = gql`
   mutation UpdatePetMutation($name: String!) {
@@ -41,14 +37,6 @@ const mockMutationData = {
 };
 
 describe('useMutation', () => {
-  beforeEach(() => {
-    prepareAsyncReactTasks();
-  });
-
-  afterEach(() => {
-    teardownAsyncReactTasks();
-  });
-
   it('returns result that contains the loaded data once the mutation finished running', async () => {
     const renderPropSpy = jest.fn(() => null);
     const graphQL = createGraphQL({UpdatePetMutation: mockMutationData});

--- a/packages/react-graphql/src/hooks/tests/utilities.tsx
+++ b/packages/react-graphql/src/hooks/tests/utilities.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {createGraphQLFactory, GraphQL} from '@shopify/graphql-testing';
 import {createMount} from '@shopify/react-testing';
-import {promise} from '@shopify/jest-dom-mocks';
 
 import {ApolloProvider} from '../../ApolloProvider';
 
@@ -36,28 +35,6 @@ export const mountWithGraphQL = createMount<Options, Context, true>({
     await graphQL.resolveAll();
   },
 });
-
-export function prepareAsyncReactTasks() {
-  if (!promise.isMocked()) {
-    promise.mock();
-  }
-}
-
-export function teardownAsyncReactTasks() {
-  if (promise.isMocked()) {
-    promise.restore();
-  }
-}
-
-export function runPendingAsyncReactTasks() {
-  if (!promise.isMocked()) {
-    throw new Error(
-      'You attempted to resolve pending async React tasks, but have not yet prepared to do so. Run `prepareAsyncReactTasks()` from "tests/modern" in a `beforeEach` block and try again.',
-    );
-  }
-
-  promise.runPending();
-}
 
 export function createResolvablePromise<T>(value: T) {
   let resolver!: () => Promise<T>;

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,16 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.4] - 2019-05-31
+
+### Fixed
+
+- When using a custom mount with `createMount`, calling `setProps` on the resulting elements will now properly set props on the JSX that was mounted, not the element returned from the `createMount` `render` option ([#726](https://github.com/Shopify/quilt/pull/726)).
+
+  > **Note**: In order to support the above, a small change was made to the `Root` class’s constructor. If you were calling this directly (which is discouraged), you will need to use the new `resolveRoot` option instead of the existing second argument. Additionally, if you were manually passing through additional props in a component you used to wrap elements in `createMount.render`, you can now remove this workaround.
+
+## [1.5.3] - 2019-05-22
+
 ### Fixed
 
 - Passing unresolved promises within `act()` blocks required additional nesting ([#697](https://github.com/Shopify/quilt/pull/697))

--- a/packages/react-testing/src/TestWrapper.tsx
+++ b/packages/react-testing/src/TestWrapper.tsx
@@ -6,6 +6,7 @@ interface State<ChildProps> {
 
 interface Props {
   children: React.ReactElement<any>;
+  render(element: React.ReactElement<any>): React.ReactElement<any>;
 }
 
 export class TestWrapper<ChildProps> extends React.Component<
@@ -21,7 +22,7 @@ export class TestWrapper<ChildProps> extends React.Component<
 
   render() {
     const {props} = this.state;
-    const {children} = this.props;
-    return props ? React.cloneElement(children, props) : children;
+    const {children, render} = this.props;
+    return render(props ? React.cloneElement(children, props) : children);
   }
 }

--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {IfAllOptionalKeys} from '@shopify/useful-types';
-import {Root} from './root';
+import {Root, Options as RootOptions} from './root';
 import {Element} from './element';
 
 export {Root, Element};
@@ -81,9 +81,9 @@ export class CustomRoot<Props, Context extends object> extends Root<Props> {
   constructor(
     tree: React.ReactElement<Props>,
     public readonly context: Context,
-    resolve: (element: Element<unknown>) => Element<unknown> | null,
+    options?: RootOptions,
   ) {
-    super(tree, resolve);
+    super(tree, options);
   }
 }
 
@@ -105,11 +105,11 @@ export function createMount<
     options: MountOptions = {} as any,
   ) {
     const context = createContext(options);
-    const rendered = render(element, context, options);
 
-    const wrapper = new CustomRoot(rendered, context, root =>
-      root.find(element.type),
-    );
+    const wrapper = new CustomRoot(element, context, {
+      render: element => render(element, context, options),
+      resolveRoot: root => root.find(element.type),
+    });
 
     const afterMountResult = afterMount(wrapper, options);
 

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -73,7 +73,7 @@ describe('createMount()', () => {
     expect(div).not.toContainReactComponent('span', {id: 'ShouldNotBeFound'});
   });
 
-  it('can props on a nested element even if it is wrapped in providers', () => {
+  it('can set props on a nested element even if it is wrapped in providers', () => {
     function TestComponent({words}: {words: string}) {
       return <div>{words}</div>;
     }

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {random} from 'faker';
 
 import {Root} from '../root';
 import {mount, createMount} from '../mount';
@@ -70,6 +71,29 @@ describe('createMount()', () => {
 
     expect(div).toHaveProperty('type', 'div');
     expect(div).not.toContainReactComponent('span', {id: 'ShouldNotBeFound'});
+  });
+
+  it('can props on a nested element even if it is wrapped in providers', () => {
+    function TestComponent({words}: {words: string}) {
+      return <div>{words}</div>;
+    }
+
+    function Wrapper({children}: {children: React.ReactElement<any>}) {
+      return children;
+    }
+
+    const customMount = createMount({
+      render: element => <Wrapper>{element}</Wrapper>,
+    });
+
+    const originalWords = random.words();
+    const updatedWords = random.words();
+    const testComponent = customMount(<TestComponent words={originalWords} />);
+
+    testComponent.setProps({words: updatedWords});
+
+    expect(testComponent).not.toContainReactText(originalWords);
+    expect(testComponent).toContainReactText(updatedWords);
   });
 
   it('calls afterMount with the wrapper and options', () => {


### PR DESCRIPTION
This PR makes a couple of small improvements to react-graphql:

1. When you pass `skip` to `useQuery` on the server, it no longer attempts to fetch anything at all (before, it would try to resolve an async GraphQL document, mark it as used, and actually run the query)
2. When variables stay deep equal, the result of `useQuery` is referentially equal (it always returned the same data, but the object itself was changed between renders, which is a bummer because it's a common one to use as an input to other `useMemo`s)

In fixing (2), I also made an improvement to `react-testing`. Previously, calling `setProps` on a custom mounted element would set props on whatever the component was wrapped in, not the component itself. The changes to `react-testing` makes it so that only the element itself is updated with new props, which removes the need for hacks like https://github.com/Shopify/web/blob/master/tests/modern/AppContext.tsx#L63-L66.