### PR TITLE
MockApolloLink propagates unmocked data errors via immediate throws

### DIFF
--- a/packages/jest-mock-apollo/CHANGELOG.md
+++ b/packages/jest-mock-apollo/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-<!-- Unreleased changes should go to UNRELEASED.md -->
+## Unreleased
+
+- Unmocked operations now fail fast with a descriptive message in Jest environments
 
 ---
 

--- a/packages/jest-mock-apollo/src/MockApolloLink.ts
+++ b/packages/jest-mock-apollo/src/MockApolloLink.ts
@@ -60,8 +60,7 @@ export default class MockApolloLink extends ApolloLink {
             ' (you provided a function that did not return a valid mock result)';
         }
 
-        const error = new Error(message);
-        result = error;
+        throw new Error(message);
       } else if (response instanceof Error) {
         result = {errors: [new GraphQLError(response.message)]};
       } else {

--- a/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
+++ b/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
@@ -27,14 +27,19 @@ describe('MockApolloLink', () => {
   it('returns error message with empty mock object', async () => {
     const mockApolloLink = new MockApolloLink({}, schema);
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
-    });
-
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({Pets: yourFixture}).'",
-    });
+    await expect(
+      new Promise((_, reject) => {
+        mockApolloLink.request(mockRequest).subscribe({
+          next() {},
+          error(err) {
+            reject(err);
+          },
+          complete() {},
+        });
+      }),
+    ).rejects.toThrow(
+      "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({Pets: yourFixture}).'",
+    );
   });
 
   it('returns error message when there are no matching mocks', async () => {
@@ -43,14 +48,19 @@ describe('MockApolloLink', () => {
       schema,
     );
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
-    });
-
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
-    });
+    await expect(
+      new Promise((_, reject) => {
+        mockApolloLink.request(mockRequest).subscribe({
+          next() {},
+          error(err) {
+            reject(err);
+          },
+          complete() {},
+        });
+      }),
+    ).rejects.toThrow(
+      "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
+    );
   });
 
   it('returns error message with empty mock function', async () => {
@@ -59,13 +69,18 @@ describe('MockApolloLink', () => {
       schema,
     );
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
-    });
-
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided a function that did not return a valid mock result)",
-    });
+    await expect(
+      new Promise((_, reject) => {
+        mockApolloLink.request(mockRequest).subscribe({
+          next() {},
+          error(err) {
+            reject(err);
+          },
+          complete() {},
+        });
+      }),
+    ).rejects.toThrow(
+      "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided a function that did not return a valid mock result)",
+    );
   });
 });


### PR DESCRIPTION
This prevents Apollo's internals from throwing unrelated errors (it tries to reach into undefined results, and throws non-descriptive results before it can propagate MockApolloLink's actional feedback).

### Before
<img width="960" alt="mock-apollo-errors-before" src="https://user-images.githubusercontent.com/673655/58763332-43400a80-8527-11e9-9d22-71aef4928cc5.png">

### After
More lines, but at least there's actionable content in here:

<img width="960" alt="mock-apollo-link-after" src="https://user-images.githubusercontent.com/673655/58763335-4f2bcc80-8527-11e9-818f-1d24a5d28909.png">
