### PR TITLE
Fail i18n Babel plugin when multiple i18n references found

### DIFF
--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -49,6 +49,14 @@ export default function injectWithI18nArguments({
   }) {
     let _hasTranslations: boolean | undefined;
 
+    if (binding.referencePaths.length > 1) {
+      throw new Error(
+        `You attempted to use ${bindingName} ${
+          binding.referencePaths.length
+        } times in a single file. This is not supported by the Babel plugin that automatically inserts translations.`,
+      );
+    }
+
     for (const refPath of binding.referencePaths) {
       const callExpression: NodePath = refPath.parentPath;
 

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -271,6 +271,29 @@ describe('babel-pluin-react-i18n', () => {
       code,
     );
   });
+
+  it('throws when multiple components in a single file request translations', async () => {
+    const code = await normalize(`
+      import React from 'react';
+      import {useI18n} from '@shopify/react-i18n';
+
+      function MyOtherComponent() {
+        const [i18n] = useI18n();
+      }
+
+      export default function MyComponent() {
+        const [i18n] = useI18n();
+        return i18n.translate('key');
+      }
+    `);
+
+    await expect(
+      transform(code, optionsForFile('MyComponent.tsx', true)),
+    ).rejects.toMatchObject({
+      message:
+        'You attempted to use useI18n 2 times in a single file. This is not supported by the Babel plugin that automatically inserts translations.',
+    });
+  });
 });
 
 async function normalize(code: string) {


### PR DESCRIPTION
This should fail the cases that broke Web's build this morning.