### PR TITLE
Add toProvideReactContext matcher

### DIFF
--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -438,6 +438,19 @@ expect(myComponent).toContainReactComponent('div', {
 });
 ```
 
+### `.toProvideReactContext<T>(context: Context<T>, value?: T)`
+
+Asserts that at least one `context.Provider` is in the descendants of the passed node. If the second argument is passed, this expectation will further filter the matches by providers whose value is equal to the passed object (again, asymmetric matchers are fully supported).
+
+```tsx
+const MyContext = React.createContext({hello: 'world'});
+const myComponent = mount(<MyComponent />);
+
+expect(myComponent).toProvideReactContext(MyContext, {
+  hello: expect.any(String),
+});
+```
+
 ### `.toContainReactText(text: string)`
 
 Asserts that the rendered output of the component contains the passed string as text content (that is, the text is included in what you would get by calling `textContent` on all root DOM nodes rendered by the component).

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -7,9 +7,8 @@ import {
 } from 'jest-matcher-utils';
 import {Props} from '@shopify/useful-types';
 
-import {Element} from '../element';
 import {Node} from './types';
-import {assertIsNode, diffPropsForNode} from './utilities';
+import {assertIsNode, diffs, printType} from './utilities';
 
 export function toContainReactComponent<
   Type extends string | ComponentType<any>
@@ -66,34 +65,4 @@ export function toContainReactComponent<
         }`;
 
   return {pass, message};
-}
-
-function diffs(element: Element<any>[], props: object, expand?: boolean) {
-  return element.reduce<string>(
-    (diffs, element, index) =>
-      `${diffs}${index === 0 ? '' : '\n\n'}${normalizedDiff(element, props, {
-        expand,
-        showLegend: index === 0,
-      })}`,
-    '',
-  );
-}
-
-function normalizedDiff(
-  element: Element<any>,
-  props: object,
-  {expand = false, showLegend = false},
-) {
-  const result =
-    diffPropsForNode(element, props, {
-      expand,
-    }) || '';
-
-  return showLegend ? result : result.split('\n\n')[1];
-}
-
-function printType(type: string | React.ComponentType<any>) {
-  return `<${
-    typeof type === 'string' ? type : type.displayName || type.name
-  } />`;
 }

--- a/packages/react-testing/src/matchers/context.ts
+++ b/packages/react-testing/src/matchers/context.ts
@@ -1,0 +1,67 @@
+import {Context} from 'react';
+import {
+  matcherHint,
+  printExpected,
+  EXPECTED_COLOR as expectedColor,
+  RECEIVED_COLOR as receivedColor,
+} from 'jest-matcher-utils';
+
+import {Node} from './types';
+import {assertIsNode, diffs, printType} from './utilities';
+
+export function toProvideReactContext<Type>(
+  this: jest.MatcherUtils,
+  node: Node<unknown>,
+  Context: Context<Type>,
+  value?: Type,
+) {
+  assertIsNode(node, {
+    expectation: 'toProvideReactContext',
+    isNot: this.isNot,
+  });
+
+  const foundByType = node.findAll(Context.Provider);
+  const foundByValue =
+    value == null
+      ? foundByType
+      : foundByType.filter(element =>
+          this.equals(value, element.prop('value')),
+        );
+
+  const pass = foundByValue.length > 0;
+
+  const message = pass
+    ? () =>
+        `${matcherHint('.not.toProvideReactContext')}\n\n` +
+        `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+        `Not to contain context provider:\n  ${expectedColor(
+          printType(Context.Provider),
+        )}\n${
+          value ? `With value matching:\n  ${printExpected(value)}\n` : ''
+        }` +
+        `But ${foundByValue.length} matching ${printType(Context.Provider)}${
+          foundByValue.length === 1 ? 's were' : ' was'
+        } found.\n`
+    : () =>
+        `${`${matcherHint('.toProvideReactContext')}\n\n` +
+          `Expected the React element:\n  ${receivedColor(node.toString())}\n` +
+          `To contain context provider:\n  ${expectedColor(
+            printType(Context.Provider),
+          )}\n${
+            value ? `With value matching:\n  ${printExpected(value)}\n` : ''
+          }`}${
+          foundByType.length === 0
+            ? `But no matching ${printType(Context.Provider)}s were found.\n`
+            : `But the ${
+                foundByType.length === 1
+                  ? 'found provider has'
+                  : 'found provider have'
+              } had different values:\n\n${diffs(
+                foundByType,
+                {value},
+                this.expand,
+              )}`
+        }`;
+
+  return {pass, message};
+}

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,8 +1,9 @@
-import {ComponentType} from 'react';
+import {ComponentType, Context as ReactContext} from 'react';
 import {Props} from '@shopify/useful-types';
 
 import {toHaveReactProps, toHaveReactDataProps} from './props';
 import {toContainReactComponent} from './components';
+import {toProvideReactContext} from './context';
 import {toContainReactText, toContainReactHtml} from './strings';
 import {Node} from './types';
 
@@ -17,6 +18,10 @@ declare global {
         type: Type,
         props?: Partial<Props<Type>>,
       ): void;
+      toProvideReactContext<Type>(
+        context: ReactContext<Type>,
+        value?: Type,
+      ): void;
       toContainReactText(text: string): void;
       toContainReactHtml(text: string): void;
     }
@@ -29,4 +34,5 @@ expect.extend({
   toContainReactComponent,
   toContainReactText,
   toContainReactHtml,
+  toProvideReactContext,
 });

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -62,14 +62,14 @@ export function diffs(
   props: object,
   expand?: boolean,
 ) {
-  return element.reduce<string>(
-    (diffs, element, index) =>
-      `${diffs}${index === 0 ? '' : '\n\n'}${normalizedDiff(element, props, {
-        expand,
-        showLegend: index === 0,
-      })}`,
-    '',
-  );
+  return element.reduce<string>((diffs, element, index) => {
+    const separator = index === 0 ? '' : '\n\n';
+
+    return `${diffs}${separator}${normalizedDiff(element, props, {
+      expand,
+      showLegend: index === 0,
+    })}`;
+  }, '');
 }
 
 function normalizedDiff(
@@ -93,11 +93,12 @@ export function printType(type: string | React.ComponentType<any>) {
     return `<${displayName}.${componentName} />`;
   }
 
-  return `<${
+  const displayName =
     typeof type === 'string'
       ? type
-      : type.displayName || type.name || 'Component'
-  } />`;
+      : type.displayName || type.name || 'Component';
+
+  return `<${displayName} />`;
 }
 
 export function diffPropsForNode(

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -57,11 +57,50 @@ export function assertIsNode(
   }
 }
 
-export function diffPropsForNode(
-  node: Node<any>,
+export function diffs(
+  element: Element<any>[],
   props: object,
-  {expand = false},
+  expand?: boolean,
 ) {
+  return element.reduce<string>(
+    (diffs, element, index) =>
+      `${diffs}${index === 0 ? '' : '\n\n'}${normalizedDiff(element, props, {
+        expand,
+        showLegend: index === 0,
+      })}`,
+    '',
+  );
+}
+
+function normalizedDiff(
+  element: Element<any>,
+  props: object,
+  {expand = false, showLegend = false},
+) {
+  const result =
+    diffPropsForNode(element, props, {
+      expand,
+    }) || '';
+
+  return showLegend ? result : result.split('\n\n')[1];
+}
+
+export function printType(type: string | React.ComponentType<any>) {
+  if (typeof type === 'object' && '_context' in type) {
+    const context = (type as any)._context;
+    const componentName = type === context.Provider ? 'Provider' : 'Consumer';
+    const displayName = context.displayName || 'Context';
+    return `<${displayName}.${componentName} />`;
+  }
+
+  return `<${
+    typeof type === 'string'
+      ? type
+      : type.displayName || type.name || 'Component'
+  } />`;
+}
+
+function diffPropsForNode(node: Node<any>, props: object, {expand = false}) {
   return diff(props, getObjectSubset(node.props, props), {
     expand,
   });

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -100,7 +100,11 @@ export function printType(type: string | React.ComponentType<any>) {
   } />`;
 }
 
-function diffPropsForNode(node: Node<any>, props: object, {expand = false}) {
+export function diffPropsForNode(
+  node: Node<any>,
+  props: object,
+  {expand = false},
+) {
   return diff(props, getObjectSubset(node.props, props), {
     expand,
   });

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -201,4 +201,21 @@ describe('e2e', () => {
 
     expect(myComponent.find(Message)).toHaveReactProps({name: 'world'});
   });
+
+  it('can find context providers', () => {
+    const Context = React.createContext({hello: 'world'});
+    const value = {hello: 'goodbye'};
+
+    function MyComponent() {
+      return (
+        <Context.Provider value={value}>
+          <div />
+        </Context.Provider>
+      );
+    }
+
+    const myComponent = mount(<MyComponent />);
+
+    expect(myComponent).toProvideReactContext(Context, value);
+  });
 });


### PR DESCRIPTION
Adds a new matcher to make it easier to assert on context. While I was here, I also improved the printing of context providers and consumers.

![Screen Shot 2019-06-04 at 11 53 27 AM](https://user-images.githubusercontent.com/3012583/58895307-98b01f00-86c1-11e9-9484-a9253093a3f2.png)
