### PR TITLE
[FormState] Extend the return type of the submt handler.

### DIFF
--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -22,7 +22,8 @@ type MaybePromise<T> = T | Promise<T>;
 interface SubmitHandler<Fields> {
   (formDetails: FormData<Fields>):
     | MaybePromise<RemoteError[]>
-    | MaybePromise<void>;
+    | MaybePromise<void>
+    | MaybePromise<RemoteError[] | void>;
 }
 
 export type Validator<T, F> = MaybeArray<ValidationFunction<T, F>>;


### PR DESCRIPTION
## The problem 
In order to be able to return both `void` and `RemoteError[]` in an
async method, the 2 types needs to be lifted within a single Promise.
This PR extends the union of the SubmitHandler return type.

## Example of use
In the render:
```
  <FormState onSubmit={this.handleSubmit} />
  ```
In the class:
  ```
private async handleSubmit() {
    const {data} = await mutation();
     if (error) { 
      return [{message: error.message}]
    }
    return;
```

Because handleSubmit being async, it would wrap all possible return type within one single promise, we need to the onSubmit prop of FormState to account for that too.