### PR TITLE
Don’t load translations if they don't exist

### DIFF
--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -29,6 +29,7 @@
     "@types/babel__core": "^7.0.4",
     "@types/babel__template": "^7.0.1",
     "@types/babel__traverse": "^7.0.5",
+    "@types/glob": "^7.1.1",
     "intl-pluralrules": "^0.2.1",
     "typescript": "~3.2.1"
   },
@@ -38,6 +39,7 @@
     "@shopify/react-hooks": "^1.2.1",
     "@shopify/useful-types": "^1.3.0",
     "@types/hoist-non-react-statics": "^3.0.1",
+    "glob": "^7.1.4",
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.6.2",
     "string-hash": "^1.1.3",

--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import glob from 'glob';
 import {TemplateBuilder} from '@babel/template';
 import * as Types from '@babel/types';
 import {NodePath} from '@babel/traverse';
@@ -22,14 +23,28 @@ export default function injectWithI18nArguments({
     })() as Types.ImportDeclaration;
   }
 
-  function i18nCallExpression({id, fallbackID, bindingName}) {
+  function i18nCallExpression({id, fallbackID, bindingName, translations}) {
     return template(
       `${bindingName}({
         id: '${id}',
         fallback: ${fallbackID},
-        async translations(locale) {
-          const dictionary = await import(/* webpackChunkName: "${id}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-          return dictionary && dictionary.default;
+        translations(locale) {
+          const translations = [${translations
+            .filter(locale => !locale.endsWith('en.json'))
+            .map(locale =>
+              JSON.stringify(path.basename(locale, path.extname(locale))),
+            )
+            .sort()
+            .join(', ')}];
+
+          if (translations.indexOf(locale) < 0) {
+            return;
+          }
+
+          return (async () => {
+            const dictionary = await import(/* webpackChunkName: "${id}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            return dictionary && dictionary.default;
+          })();
         },
       })`,
       {
@@ -66,7 +81,9 @@ export default function injectWithI18nArguments({
       );
     }
 
-    if (!hasTranslations(filename)) {
+    const translations = getTranslations(filename);
+
+    if (translations.length === 0) {
       return;
     }
 
@@ -77,6 +94,7 @@ export default function injectWithI18nArguments({
         id: generateID(filename),
         fallbackID,
         bindingName,
+        translations,
       }),
     );
   }
@@ -129,13 +147,13 @@ export default function injectWithI18nArguments({
   };
 }
 
-function hasTranslations(filename) {
-  const enJSONPath = path.resolve(
-    path.dirname(filename),
-    'translations',
-    'en.json',
+function getTranslations(filename: string): string[] {
+  return glob.sync(
+    path.resolve(path.dirname(filename), 'translations', '*.json'),
+    {
+      nodir: true,
+    },
   );
-  return fs.existsSync(enJSONPath);
 }
 
 // based on postcss-modules implementation

--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import fs from 'fs';
 import glob from 'glob';
 import {TemplateBuilder} from '@babel/template';
 import * as Types from '@babel/types';

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -6,9 +6,23 @@ jest.mock('string-hash', () => () => {
   return Number.MAX_SAFE_INTEGER;
 });
 
-describe('babel-pluin-react-i18n', () => {
-  const defaultHash = Number.MAX_SAFE_INTEGER.toString(36).substr(0, 5);
+const defaultHash = Number.MAX_SAFE_INTEGER.toString(36).substr(0, 5);
+const expectedTranslationsOption = `
+  translations(locale) {
+    const translations = ["de", "fr"];
 
+    if (translations.indexOf(locale) < 0) {
+      return;
+    }
+
+    return (async () => {
+      const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+      return dictionary && dictionary.default;
+    })();
+  }
+`;
+
+describe('babel-pluin-react-i18n', () => {
   it('injects arguments into withI18n when adjacent translations exist', async () => {
     expect(
       await transform(
@@ -36,10 +50,7 @@ describe('babel-pluin-react-i18n', () => {
         export default withI18n({
           id: 'MyComponent_${defaultHash}',
           fallback: _en,
-          async translations(locale) {
-            const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return dictionary && dictionary.default;
-          },
+          ${expectedTranslationsOption}
         })(MyComponent);
         `,
       ),
@@ -69,10 +80,7 @@ describe('babel-pluin-react-i18n', () => {
           const [i18n] = useI18n({
             id: 'MyComponent_${defaultHash}',
             fallback: _en,
-            async translations(locale) {
-              const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-              return dictionary && dictionary.default;
-            },
+            ${expectedTranslationsOption}
           });
           return i18n.translate('key');
         }
@@ -98,43 +106,21 @@ describe('babel-pluin-react-i18n', () => {
   });
 
   it('does not transform other react-i18n imports', async () => {
+    const content = `
+      import React from 'react';
+      import {withFoo} from '@shopify/react-i18n';
+
+      function MyComponent({i18n}) {
+        return i18n.translate('key');
+      }
+      export const key = translate('key');
+
+      export default withFoo()(MyComponent);
+    `;
+
     expect(
-      await transform(
-        `import React from 'react';
-        import {withI18n, translate} from '@shopify/react-i18n';
-
-        function MyComponent({i18n}) {
-          return i18n.translate('key');
-        }
-        export const key = translate('key');
-
-        export default withI18n()(MyComponent);
-        `,
-        optionsForFile('MyComponent.tsx', true),
-      ),
-    ).toBe(
-      await normalize(
-        `import _en from './translations/en.json';
-        import React from 'react';
-        import {withI18n, translate} from '@shopify/react-i18n';
-
-        function MyComponent({i18n}) {
-          return i18n.translate('key');
-        }
-
-        export const key = translate('key');
-
-        export default withI18n({
-          id: 'MyComponent_${defaultHash}',
-          fallback: _en,
-          async translations(locale) {
-            const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return dictionary && dictionary.default;
-          },
-        })(MyComponent);
-        `,
-      ),
-    );
+      await transform(content, optionsForFile('MyComponent.tsx', true)),
+    ).toBe(await normalize(content));
   });
 
   it('does not transform withI18n imports from other libraries', async () => {
@@ -195,10 +181,7 @@ describe('babel-pluin-react-i18n', () => {
         export default foo({
           id: 'MyComponent_${defaultHash}',
           fallback: _en,
-          async translations(locale) {
-            const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-            return dictionary && dictionary.default;
-          },
+          ${expectedTranslationsOption}
         })(MyComponent);
         `,
       ),
@@ -228,10 +211,7 @@ describe('babel-pluin-react-i18n', () => {
           const [i18n] = useFunI18n({
             id: 'MyComponent_${defaultHash}',
             fallback: _en,
-            async translations(locale) {
-              const dictionary = await import(/* webpackChunkName: "MyComponent_${defaultHash}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
-              return dictionary && dictionary.default;
-            },
+            ${expectedTranslationsOption}
           });
           return i18n.translate('key');
         }

--- a/packages/react-i18n/src/test/fixtures/adjacentTranslations/translations/de.json
+++ b/packages/react-i18n/src/test/fixtures/adjacentTranslations/translations/de.json
@@ -1,0 +1,3 @@
+{
+  "key": "etwas Text"
+}

--- a/packages/react-i18n/src/test/fixtures/adjacentTranslations/translations/fr.json
+++ b/packages/react-i18n/src/test/fixtures/adjacentTranslations/translations/fr.json
@@ -1,0 +1,3 @@
+{
+  "key": "du texte"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,7 +590,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -612,18 +612,10 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.4.0", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.8.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
   integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@16.8.2":
-  version "16.8.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
-  integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -429,6 +429,15 @@
   dependencies:
     "@types/node" "*"
 
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graphql@^14.0.0":
   version "14.0.7"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.7.tgz#daa09397220a68ce1cbb3f76a315ff3cd92312f6"
@@ -566,6 +575,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
   integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+
 "@types/node@*", "@types/node@^12.0.2":
   version "12.0.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.4.tgz#46832183115c904410c275e34cf9403992999c32"
@@ -576,7 +590,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -598,10 +612,18 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@>=16.4.0", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.8.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
   integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@16.8.2":
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
+  integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -3826,6 +3848,18 @@ glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"


### PR DESCRIPTION
Our current Babel transform attempts to return the result of importing `import('./translations/${locale}')`. This works fine, but means that for any locale other than the fallback, we always try to load that file. This is useless for locales like `en-CA`, where we do not provide explicit translations and instead just use an `en.json`. For those, it's just wasted bandwidth.

This PR fixes this issue by reading the translations that are available for a component, and bailing immediately if the requested locale is not one of those.