### PR TITLE
Unmocked mutation errors now propagate to the test console

### DIFF
--- a/packages/jest-mock-apollo/CHANGELOG.md
+++ b/packages/jest-mock-apollo/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Unreleased
+
+- Unmocked mutation information now propagates to the console in Jest environments
+
 ## 2.2.5 - 2019-01-09
 
 - Start of Changelog

--- a/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
+++ b/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
@@ -6,6 +6,7 @@ import MockApolloLink from '../MockApolloLink';
 import {MockGraphQLResponse} from '../types';
 
 import petQuery from './fixtures/PetQuery.graphql';
+import haveBirthdayMutation from './fixtures/HappyPetBirthdayMutation.graphql';
 
 const schemaSrc = readFileSync(
   path.resolve(__dirname, './fixtures/schema.graphql'),
@@ -23,49 +24,120 @@ const mockRequest = {
   toKey: () => '',
 };
 
+const mockMutationRequest = {
+  query: haveBirthdayMutation,
+  operationName: 'HappyPetBirthdayMutation',
+  variables: {hadFunBirthday: true},
+  extensions: {},
+  setContext: () => ({}),
+  getContext: () => ({}),
+  toKey: () => '',
+};
+
 describe('MockApolloLink', () => {
-  it('returns error message with empty mock object', async () => {
-    const mockApolloLink = new MockApolloLink({}, schema);
+  describe('query', () => {
+    it('returns error message with empty mock object', async () => {
+      const mockApolloLink = new MockApolloLink({}, schema);
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
+      const result = await new Promise(resolve => {
+        mockApolloLink.request(mockRequest).subscribe(resolve);
+      });
+
+      expect(result).toMatchObject({
+        message:
+          "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({Pets: yourFixture}).'",
+      });
     });
 
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({Pets: yourFixture}).'",
+    it('returns error message when there are no matching mocks', async () => {
+      const mockApolloLink = new MockApolloLink(
+        {LostPets: {}, PetsForSale: {}},
+        schema,
+      );
+
+      const result = await new Promise(resolve => {
+        mockApolloLink.request(mockRequest).subscribe(resolve);
+      });
+
+      expect(result).toMatchObject({
+        message:
+          "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
+      });
+    });
+
+    it('returns error message with empty mock function', async () => {
+      const mockApolloLink = new MockApolloLink(
+        () => (null as unknown) as MockGraphQLResponse,
+        schema,
+      );
+
+      const result = await new Promise(resolve => {
+        mockApolloLink.request(mockRequest).subscribe(resolve);
+      });
+
+      expect(result).toMatchObject({
+        message:
+          "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided a function that did not return a valid mock result)",
+      });
     });
   });
 
-  it('returns error message when there are no matching mocks', async () => {
-    const mockApolloLink = new MockApolloLink(
-      {LostPets: {}, PetsForSale: {}},
-      schema,
-    );
+  describe('mutation', () => {
+    it('returns error message with empty mock object', async () => {
+      const mockApolloLink = new MockApolloLink({}, schema);
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
+      const result = await new Promise(resolve => {
+        mockApolloLink.request(mockMutationRequest).subscribe(resolve);
+      });
+
+      expect(result).toMatchObject({
+        errors: [
+          {
+            message:
+              "Can’t perform GraphQL operation 'HappyPetBirthdayMutation' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({HappyPetBirthdayMutation: yourFixture}).'",
+          },
+        ],
+      });
     });
 
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
+    it('returns error message when there are no matching mocks', async () => {
+      const mockApolloLink = new MockApolloLink(
+        {LostPets: {}, PetsForSale: {}},
+        schema,
+      );
+
+      const result = await new Promise(resolve => {
+        mockApolloLink.request(mockMutationRequest).subscribe(resolve);
+      });
+
+      expect(result).toMatchObject({
+        errors: [
+          {
+            message:
+              "Can’t perform GraphQL operation 'HappyPetBirthdayMutation' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
+          },
+        ],
+      });
     });
-  });
 
-  it('returns error message with empty mock function', async () => {
-    const mockApolloLink = new MockApolloLink(
-      () => (null as unknown) as MockGraphQLResponse,
-      schema,
-    );
+    it('returns error message with empty mock function', async () => {
+      const mockApolloLink = new MockApolloLink(
+        () => (null as unknown) as MockGraphQLResponse,
+        schema,
+      );
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
-    });
+      const result = await new Promise(resolve => {
+        mockApolloLink.request(mockMutationRequest).subscribe(resolve);
+      });
 
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided a function that did not return a valid mock result)",
+      expect(result).toMatchObject({
+        errors: [
+          {
+            message:
+              "Can’t perform GraphQL operation 'HappyPetBirthdayMutation' because no valid mocks were found (you provided a function that did not return a valid mock result)",
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/jest-mock-apollo/src/test/fixtures/HappyPetBirthdayMutation.graphql
+++ b/packages/jest-mock-apollo/src/test/fixtures/HappyPetBirthdayMutation.graphql
@@ -1,0 +1,5 @@
+mutation HappyPetBirthdayMutation {
+  haveBirthday(fun: true) {
+    hadFunBirthday
+  }
+}

--- a/packages/jest-mock-apollo/src/test/fixtures/schema.graphql
+++ b/packages/jest-mock-apollo/src/test/fixtures/schema.graphql
@@ -15,3 +15,7 @@ union Pet = Dog | Cat
 type QueryRoot {
   pets: [Pet!]!
 }
+
+type Mutation {
+  haveBirthday(wasFun: Boolean!): Pet!
+}


### PR DESCRIPTION
This is an alternative fix to https://github.com/Shopify/quilt/pull/731.  It fixes a more specific issue, and doesn't step outside of Apollo's link chain.

### What?
Better feedback for unmocked test mutations.

#### Before

<img width="949" alt="mutation-unmocked-before" src="https://user-images.githubusercontent.com/673655/58963711-a629df80-877b-11e9-9311-0f6b5343db56.png">

### After
A little more output, but there's actionable feedback in here:

<img width="956" alt="mutation-unmocked-after" src="https://user-images.githubusercontent.com/673655/58963721-aaee9380-877b-11e9-9092-f16945fa7b0f.png">

### How tho?

Previously, Apollo would try to dig into `result.errors`, find nothing, and assume that it should proceed with unpacking mutation data.  This caused Apollo to throw exceptions when trying to dig into the `undefined` result.

Now, the expected mutation result shape is used, and Apollo correctly interprets our errors as... errors :)