### PR TITLE
Update Manifest shape to support manifests with browser metadata

### DIFF
--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -12,6 +12,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Breaking change
 
 - Updates middleware's manifest parsing to support manifest changes made in [`@shopify/sewing-kit`](https://github.com/Shopify/sewing-kit/pull/1265) [#740](https://github.com/Shopify/quilt/pull/740)
+  - **Requires a minimum version of `@shopify/sewing-kit@0.86.0`**
 
 ## 3.3.0 - 2019-05-01
 

--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## 4.0.0 - 2019-06-05
+
+### Breaking change
+
+- Updates middleware's manifest parsing to support manifest changes made in [`@shopify/sewing-kit`](https://github.com/Shopify/sewing-kit/pull/1265) [#740](https://github.com/Shopify/quilt/pull/740)
+
 ## 3.3.0 - 2019-05-01
 
 ### Added

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -21,7 +21,7 @@ export interface AsyncAsset {
 }
 
 export interface Manifest {
-  name: string;
+  name?: string;
   browsers?: string[];
   entrypoints: {[key: string]: Entrypoint};
   asyncAssets: {[key: string]: AsyncAsset[]};
@@ -122,8 +122,8 @@ export default class Assets {
     }
 
     const consolidatedManifest = await loadConsolidatedManifest();
-
     const {userAgent} = this;
+
     const lastManifestEntry =
       consolidatedManifest[consolidatedManifest.length - 1];
 

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -21,13 +21,13 @@ export interface AsyncAsset {
 }
 
 export interface Manifest {
+  name: string;
+  browsers?: string[];
   entrypoints: {[key: string]: Entrypoint};
   asyncAssets: {[key: string]: AsyncAsset[]};
 }
 
 export interface ConsolidatedManifestEntry {
-  name: string;
-  browsers?: string[];
   manifest: Manifest;
 }
 
@@ -142,7 +142,7 @@ export default class Assets {
     } else {
       this.resolvedManifestEntry =
         consolidatedManifest.find(
-          ({browsers}) =>
+          ({manifest: {browsers}}) =>
             browsers == null ||
             matchesUA(userAgent, {
               browsers,

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -27,11 +27,7 @@ export interface Manifest {
   asyncAssets: {[key: string]: AsyncAsset[]};
 }
 
-export interface ConsolidatedManifestEntry {
-  manifest: Manifest;
-}
-
-export type ConsolidatedManifest = ConsolidatedManifestEntry[];
+export type ConsolidatedManifest = Manifest[];
 
 interface Options {
   assetPrefix: string;
@@ -55,7 +51,7 @@ enum AssetKind {
 export default class Assets {
   assetPrefix: string;
   userAgent?: string;
-  private resolvedManifestEntry?: ConsolidatedManifestEntry;
+  private resolvedManifestEntry?: Manifest;
 
   constructor({assetPrefix, userAgent}: Options) {
     this.assetPrefix = assetPrefix;
@@ -142,7 +138,7 @@ export default class Assets {
     } else {
       this.resolvedManifestEntry =
         consolidatedManifest.find(
-          ({manifest: {browsers}}) =>
+          ({browsers}) =>
             browsers == null ||
             matchesUA(userAgent, {
               browsers,
@@ -156,8 +152,9 @@ export default class Assets {
     return this.resolvedManifestEntry;
   }
 
-  private async getResolvedManifest() {
-    return (await this.getResolvedManifestEntry()).manifest;
+  private async getResolvedManifest(): Promise<Manifest> {
+    const manifest = await this.getResolvedManifestEntry();
+    return manifest;
   }
 }
 

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -61,7 +61,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(js)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -82,7 +81,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(js)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -140,7 +138,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(js)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -169,7 +166,6 @@ describe('Assets', () => {
                 styles: [mockAsset(css)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -190,7 +186,6 @@ describe('Assets', () => {
                 styles: [mockAsset(css)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -378,7 +373,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(scriptOne)],
               }),
             },
-            asyncAssets: {},
           }),
 
           mockManifest({
@@ -387,7 +381,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(scriptTwo)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -407,7 +400,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(scriptOne)],
               }),
             },
-            asyncAssets: {},
           }),
 
           mockManifest({
@@ -417,7 +409,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(scriptTwo)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -437,7 +428,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(scriptOne)],
               }),
             },
-            asyncAssets: {},
           }),
           mockManifest({
             browsers: ['chrome > 1'],
@@ -446,7 +436,6 @@ describe('Assets', () => {
                 scripts: [mockAsset(scriptTwo)],
               }),
             },
-            asyncAssets: {},
           }),
         ]),
       );
@@ -479,9 +468,9 @@ function mockEntrypoint({
 function mockManifest({
   name = 'mockedManifest',
   browsers,
-  entrypoints,
-  asyncAssets,
-}: Manifest) {
+  entrypoints = {},
+  asyncAssets = {},
+}: Partial<Manifest>): Manifest {
   return {
     name,
     browsers,

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -5,9 +5,9 @@ import Assets, {
   internalOnlyClearCache,
   Asset,
   AsyncAsset,
-  Entrypoint,
   ConsolidatedManifestEntry,
   ConsolidatedManifest,
+  Manifest,
 } from '../assets';
 
 jest.mock('fs-extra', () => ({
@@ -54,9 +54,12 @@ describe('Assets', () => {
         mockConsolidatedManifest([
           mockManifestEntry({
             manifest: mockManifest({
-              main: mockEntrypoint({
-                scripts: [mockAsset(js)],
-              }),
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(js)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -74,9 +77,12 @@ describe('Assets', () => {
         mockConsolidatedManifest([
           mockManifestEntry({
             manifest: mockManifest({
-              custom: mockEntrypoint({
-                scripts: [mockAsset(js)],
-              }),
+              entrypoints: {
+                custom: mockEntrypoint({
+                  scripts: [mockAsset(js)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -96,17 +102,17 @@ describe('Assets', () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            manifest: mockManifest(
-              {
+            manifest: mockManifest({
+              entrypoints: {
                 custom: mockEntrypoint({
                   scripts: [mockAsset(js)],
                 }),
               },
-              {
+              asyncAssets: {
                 unused: [mockAsyncAsset('/unused.js')],
                 used: [mockAsyncAsset(asyncJs), mockAsyncAsset('/used.css')],
               },
-            ),
+            }),
           }),
         ]),
       );
@@ -133,9 +139,12 @@ describe('Assets', () => {
         mockConsolidatedManifest([
           mockManifestEntry({
             manifest: mockManifest({
-              custom: mockEntrypoint({
-                scripts: [mockAsset(js)],
-              }),
+              entrypoints: {
+                custom: mockEntrypoint({
+                  scripts: [mockAsset(js)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -161,9 +170,12 @@ describe('Assets', () => {
         mockConsolidatedManifest([
           mockManifestEntry({
             manifest: mockManifest({
-              main: mockEntrypoint({
-                styles: [mockAsset(css)],
-              }),
+              entrypoints: {
+                main: mockEntrypoint({
+                  styles: [mockAsset(css)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -181,9 +193,12 @@ describe('Assets', () => {
         mockConsolidatedManifest([
           mockManifestEntry({
             manifest: mockManifest({
-              custom: mockEntrypoint({
-                styles: [mockAsset(css)],
-              }),
+              entrypoints: {
+                custom: mockEntrypoint({
+                  styles: [mockAsset(css)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -203,17 +218,17 @@ describe('Assets', () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            manifest: mockManifest(
-              {
+            manifest: mockManifest({
+              entrypoints: {
                 custom: mockEntrypoint({
                   styles: [mockAsset(css)],
                 }),
               },
-              {
+              asyncAssets: {
                 unused: [mockAsyncAsset('/unused.js')],
                 used: [mockAsyncAsset(asyncCss), mockAsyncAsset('/used.js')],
               },
-            ),
+            }),
           }),
         ]),
       );
@@ -243,17 +258,17 @@ describe('Assets', () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            manifest: mockManifest(
-              {
+            manifest: mockManifest({
+              entrypoints: {
                 custom: mockEntrypoint({
                   styles: [mockAsset(css)],
                   scripts: [mockAsset(js)],
                 }),
               },
-              {
+              asyncAssets: {
                 mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
               },
-            ),
+            }),
           }),
         ]),
       );
@@ -274,13 +289,21 @@ describe('Assets', () => {
   describe('asyncStyles', () => {
     it('returns all async styles for the specified ids', async () => {
       const asyncCss = '/mypage.css';
+      const css = '/main.css';
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            manifest: mockManifest(undefined, {
-              other: [mockAsyncAsset('/other.css')],
-              mypage: [mockAsyncAsset(asyncCss)],
+            manifest: mockManifest({
+              entrypoints: {
+                main: mockEntrypoint({
+                  styles: [mockAsset(css)],
+                }),
+              },
+              asyncAssets: {
+                other: [mockAsyncAsset('/other.css')],
+                mypage: [mockAsyncAsset(asyncCss)],
+              },
             }),
           }),
         ]),
@@ -297,13 +320,21 @@ describe('Assets', () => {
   describe('asyncScripts', () => {
     it('returns all async styles for the specified ids', async () => {
       const asyncJs = '/mypage.js';
+      const js = '/main.js';
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            manifest: mockManifest(undefined, {
-              other: [mockAsyncAsset('/other.js')],
-              mypage: [mockAsyncAsset(asyncJs)],
+            manifest: mockManifest({
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(js)],
+                }),
+              },
+              asyncAssets: {
+                other: [mockAsyncAsset('/other.js')],
+                mypage: [mockAsyncAsset(asyncJs)],
+              },
             }),
           }),
         ]),
@@ -327,17 +358,17 @@ describe('Assets', () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            manifest: mockManifest(
-              {
+            manifest: mockManifest({
+              entrypoints: {
                 custom: mockEntrypoint({
                   styles: [mockAsset(css)],
                   scripts: [mockAsset(js)],
                 }),
               },
-              {
+              asyncAssets: {
                 mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
               },
-            ),
+            }),
           }),
         ]),
       );
@@ -362,16 +393,22 @@ describe('Assets', () => {
         mockConsolidatedManifest([
           mockManifestEntry({
             manifest: mockManifest({
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptOne)],
-              }),
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(scriptOne)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
           mockManifestEntry({
             manifest: mockManifest({
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptTwo)],
-              }),
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(scriptTwo)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -386,19 +423,25 @@ describe('Assets', () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            browsers: ['firefox > 1'],
             manifest: mockManifest({
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptOne)],
-              }),
+              browsers: ['firefox > 1'],
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(scriptOne)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
           mockManifestEntry({
-            browsers: ['safari > 1'],
             manifest: mockManifest({
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptTwo)],
-              }),
+              browsers: ['safari > 1'],
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(scriptTwo)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -413,19 +456,25 @@ describe('Assets', () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
           mockManifestEntry({
-            browsers: ['chrome > 60'],
             manifest: mockManifest({
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptOne)],
-              }),
+              browsers: ['chrome > 60'],
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(scriptOne)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
           mockManifestEntry({
-            browsers: ['chrome > 1'],
             manifest: mockManifest({
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptTwo)],
-              }),
+              browsers: ['chrome > 1'],
+              entrypoints: {
+                main: mockEntrypoint({
+                  scripts: [mockAsset(scriptTwo)],
+                }),
+              },
+              asyncAssets: {},
             }),
           }),
         ]),
@@ -456,19 +505,27 @@ function mockEntrypoint({
   return {js: scripts, css: styles};
 }
 
-function mockManifest(
-  entrypoints: {[key: string]: Entrypoint} = {},
-  asyncAssets: {[key: string]: AsyncAsset[]} = {},
-) {
-  return {entrypoints, asyncAssets};
+function mockManifest({
+  name = 'mockedManifest',
+  browsers,
+  entrypoints,
+  asyncAssets,
+}: Manifest) {
+  return {
+    name,
+    browsers,
+    entrypoints,
+    asyncAssets,
+  };
 }
 
 function mockManifestEntry({
-  name = 'bundle',
-  browsers,
-  manifest = mockManifest({main: mockEntrypoint()}),
+  manifest = mockManifest({
+    entrypoints: {main: mockEntrypoint()},
+    asyncAssets: {},
+  }),
 }: Partial<ConsolidatedManifestEntry> = {}) {
-  return {name, browsers, manifest};
+  return {manifest};
 }
 
 function mockConsolidatedManifest(

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -5,7 +5,6 @@ import Assets, {
   internalOnlyClearCache,
   Asset,
   AsyncAsset,
-  ConsolidatedManifestEntry,
   ConsolidatedManifest,
   Manifest,
 } from '../assets';
@@ -22,7 +21,11 @@ describe('Assets', () => {
 
   beforeEach(() => {
     readJson.mockReset();
-    readJson.mockImplementation(() => mockConsolidatedManifest());
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        {entrypoints: {main: mockEntrypoint()}, asyncAssets: {}},
+      ]),
+    );
   });
 
   afterEach(() => {
@@ -52,15 +55,13 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(js)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -75,15 +76,13 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                custom: mockEntrypoint({
-                  scripts: [mockAsset(js)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -101,18 +100,16 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                custom: mockEntrypoint({
-                  scripts: [mockAsset(js)],
-                }),
-              },
-              asyncAssets: {
-                unused: [mockAsyncAsset('/unused.js')],
-                used: [mockAsyncAsset(asyncJs), mockAsyncAsset('/used.css')],
-              },
-            }),
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {
+              unused: [mockAsyncAsset('/unused.js')],
+              used: [mockAsyncAsset(asyncJs), mockAsyncAsset('/used.css')],
+            },
           }),
         ]),
       );
@@ -137,15 +134,13 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                custom: mockEntrypoint({
-                  scripts: [mockAsset(js)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -168,15 +163,13 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                main: mockEntrypoint({
-                  styles: [mockAsset(css)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            entrypoints: {
+              main: mockEntrypoint({
+                styles: [mockAsset(css)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -191,15 +184,13 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                custom: mockEntrypoint({
-                  styles: [mockAsset(css)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                styles: [mockAsset(css)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -217,18 +208,16 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                custom: mockEntrypoint({
-                  styles: [mockAsset(css)],
-                }),
-              },
-              asyncAssets: {
-                unused: [mockAsyncAsset('/unused.js')],
-                used: [mockAsyncAsset(asyncCss), mockAsyncAsset('/used.js')],
-              },
-            }),
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                styles: [mockAsset(css)],
+              }),
+            },
+            asyncAssets: {
+              unused: [mockAsyncAsset('/unused.js')],
+              used: [mockAsyncAsset(asyncCss), mockAsyncAsset('/used.js')],
+            },
           }),
         ]),
       );
@@ -257,18 +246,16 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                custom: mockEntrypoint({
-                  styles: [mockAsset(css)],
-                  scripts: [mockAsset(js)],
-                }),
-              },
-              asyncAssets: {
-                mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
-              },
-            }),
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                styles: [mockAsset(css)],
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {
+              mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+            },
           }),
         ]),
       );
@@ -293,18 +280,16 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                main: mockEntrypoint({
-                  styles: [mockAsset(css)],
-                }),
-              },
-              asyncAssets: {
-                other: [mockAsyncAsset('/other.css')],
-                mypage: [mockAsyncAsset(asyncCss)],
-              },
-            }),
+          mockManifest({
+            entrypoints: {
+              main: mockEntrypoint({
+                styles: [mockAsset(css)],
+              }),
+            },
+            asyncAssets: {
+              other: [mockAsyncAsset('/other.css')],
+              mypage: [mockAsyncAsset(asyncCss)],
+            },
           }),
         ]),
       );
@@ -324,18 +309,16 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(js)],
-                }),
-              },
-              asyncAssets: {
-                other: [mockAsyncAsset('/other.js')],
-                mypage: [mockAsyncAsset(asyncJs)],
-              },
-            }),
+          mockManifest({
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {
+              other: [mockAsyncAsset('/other.js')],
+              mypage: [mockAsyncAsset(asyncJs)],
+            },
           }),
         ]),
       );
@@ -357,18 +340,16 @@ describe('Assets', () => {
 
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                custom: mockEntrypoint({
-                  styles: [mockAsset(css)],
-                  scripts: [mockAsset(js)],
-                }),
-              },
-              asyncAssets: {
-                mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
-              },
-            }),
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                styles: [mockAsset(css)],
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {
+              mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+            },
           }),
         ]),
       );
@@ -391,25 +372,22 @@ describe('Assets', () => {
     it('uses the last manifest when no useragent exists', async () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(scriptOne)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptOne)],
+              }),
+            },
+            asyncAssets: {},
           }),
-          mockManifestEntry({
-            manifest: mockManifest({
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(scriptTwo)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+
+          mockManifest({
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptTwo)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -422,27 +400,24 @@ describe('Assets', () => {
     it('uses the last manifest when no manifest matches', async () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              browsers: ['firefox > 1'],
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(scriptOne)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            browsers: ['firefox > 1'],
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptOne)],
+              }),
+            },
+            asyncAssets: {},
           }),
-          mockManifestEntry({
-            manifest: mockManifest({
-              browsers: ['safari > 1'],
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(scriptTwo)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+
+          mockManifest({
+            browsers: ['safari > 1'],
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptTwo)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -455,27 +430,23 @@ describe('Assets', () => {
     it('uses the first matching manifest', async () => {
       readJson.mockImplementation(() =>
         mockConsolidatedManifest([
-          mockManifestEntry({
-            manifest: mockManifest({
-              browsers: ['chrome > 60'],
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(scriptOne)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            browsers: ['chrome > 60'],
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptOne)],
+              }),
+            },
+            asyncAssets: {},
           }),
-          mockManifestEntry({
-            manifest: mockManifest({
-              browsers: ['chrome > 1'],
-              entrypoints: {
-                main: mockEntrypoint({
-                  scripts: [mockAsset(scriptTwo)],
-                }),
-              },
-              asyncAssets: {},
-            }),
+          mockManifest({
+            browsers: ['chrome > 1'],
+            entrypoints: {
+              main: mockEntrypoint({
+                scripts: [mockAsset(scriptTwo)],
+              }),
+            },
+            asyncAssets: {},
           }),
         ]),
       );
@@ -519,17 +490,6 @@ function mockManifest({
   };
 }
 
-function mockManifestEntry({
-  manifest = mockManifest({
-    entrypoints: {main: mockEntrypoint()},
-    asyncAssets: {},
-  }),
-}: Partial<ConsolidatedManifestEntry> = {}) {
-  return {manifest};
-}
-
-function mockConsolidatedManifest(
-  manifests: ConsolidatedManifestEntry[] = [mockManifestEntry()],
-): ConsolidatedManifest {
+function mockConsolidatedManifest(manifests: Manifest[]): ConsolidatedManifest {
   return manifests;
 }


### PR DESCRIPTION
This PR updates the shape of the manifest parsed in the `@shopify/sewing-kit-koa` middleware to adhere to the changes made in https://github.com/Shopify/sewing-kit/pull/1265. 

## 🎩 

Run /web with changes in https://github.com/Shopify/web/compare/client-manifests-with-browser-metadata?expand=1. 