### PR TITLE
[WIP] [React-i18n] Handle zero count

### DIFF
--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -166,10 +166,26 @@ describe('translate()', () => {
 
         expect(
           translate('foo', {replacements: {count: 0}}, dictionary, locale),
-        ).toBe('0 foos');
+        ).toBe('no foo');
         expect(
           translate('foo', {replacements: {count: 0}}, dictionary, 'cy'),
         ).toBe('no foo');
+      });
+
+      it('handles a count of zero key when zero does not exist on dictionary', () => {
+        const dictionary = {
+          foo: {
+            one: '{count} foo',
+            other: '{count} foos',
+          },
+        };
+
+        expect(
+          translate('foo', {replacements: {count: 0}}, dictionary, locale),
+        ).toBe('0 foos');
+        expect(
+          translate('foo', {replacements: {count: 0}}, dictionary, 'cy'),
+        ).toBe('0 foos');
       });
 
       it('formats the replacement `count`', () => {

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -139,8 +139,12 @@ function translateWithDictionary(
     const count = replacements[PLURALIZATION_KEY_NAME];
 
     if (typeof count === 'number') {
-      const group = new Intl.PluralRules(locale).select(count);
-      result = result[group];
+      const group =
+        count === 0 && typeof result.zero === 'string'
+          ? 'zero'
+          : new Intl.PluralRules(locale).select(count);
+
+      result = result[group] || result.other;
 
       additionalReplacements[PLURALIZATION_KEY_NAME] = new Intl.NumberFormat(
         locale,


### PR DESCRIPTION
Fixes https://github.com/Shopify/quilt/issues/741.

If count is `0` and `zero` key exists in the dictionary, use it.