### PR TITLE
Store assets in `sewing-kit-koa` as a Symbol

### DIFF
--- a/packages/graphql-persisted/src/koa-middleware.ts
+++ b/packages/graphql-persisted/src/koa-middleware.ts
@@ -1,7 +1,7 @@
 import {Context} from 'koa';
 import compose from 'koa-compose';
 import bodyparser from 'koa-bodyparser';
-import {State} from '@shopify/sewing-kit-koa';
+import {getAssets} from '@shopify/sewing-kit-koa';
 
 import {CacheMissBehavior} from './shared';
 
@@ -63,7 +63,8 @@ function createOperationAssociationMiddleware({
       return;
     }
 
-    const {assets} = ctx.state as State;
+    const assets = getAssets(ctx);
+
     const operationFromManifest =
       assets != null && assets.graphQLSource != null
         ? await assets.graphQLSource(id)

--- a/packages/graphql-persisted/src/tests/koa-middleware.test.ts
+++ b/packages/graphql-persisted/src/tests/koa-middleware.test.ts
@@ -1,6 +1,7 @@
 import faker from 'faker';
 import {Header} from '@shopify/network';
 import {createMockContext} from '@shopify/jest-koa-mocks';
+import {setAssets} from '@shopify/sewing-kit-koa';
 import {
   Cache,
   CacheMissBehavior,
@@ -63,7 +64,7 @@ describe('persistedGraphQLMiddleware', () => {
     const id = faker.random.uuid();
     const query = createQuery();
     const ctx = createContext({id, persisted: true});
-    ctx.state.assets = {graphQLSource: () => Promise.resolve(query)};
+    setAssets(ctx, {graphQLSource: () => Promise.resolve(query)});
 
     const spy = jest.fn();
     const persistedGraphQLMiddleware = createPersistedGraphQLMiddleware();
@@ -78,7 +79,7 @@ describe('persistedGraphQLMiddleware', () => {
     const id = faker.random.uuid();
     const query = createQuery();
     const ctx = createContext({id, persisted: true});
-    ctx.state.assets = {graphQLSource: () => Promise.resolve(query)};
+    setAssets(ctx, {graphQLSource: () => Promise.resolve(query)});
 
     const cache = createCache();
     const persistedGraphQLMiddleware = createPersistedGraphQLMiddleware({

--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- **Breaking Change:** The `assets` property is now only accessible via a new function, `getAssets(ctx: Context)`, and set via `setAssets(ctx: Context, assets: Assets)`. [#743](https://github.com/Shopify/quilt/pull/743)
+
 ## 4.0.0 - 2019-06-05
 
 ### Breaking change

--- a/packages/sewing-kit-koa/src/index.ts
+++ b/packages/sewing-kit-koa/src/index.ts
@@ -1,2 +1,2 @@
 export {default as Assets} from './assets';
-export {default as middleware, State} from './middleware';
+export {default as middleware, getAssets, setAssets} from './middleware';

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -11,13 +11,19 @@ import Assets, {Asset} from './assets';
 
 export {Assets, Asset};
 
-export interface State {
-  assets: Assets;
-}
-
 export interface Options {
   assetPrefix?: string;
   serveAssets?: boolean;
+}
+
+const ASSETS = Symbol('assets');
+
+export function getAssets(ctx: Context): Assets {
+  return ctx.state[ASSETS];
+}
+
+export function setAssets(ctx: Context, assets: Assets) {
+  ctx.state[ASSETS] = assets;
 }
 
 export default function middleware({
@@ -29,7 +35,9 @@ export default function middleware({
       assetPrefix,
       userAgent: ctx.get(Header.UserAgent),
     });
-    ctx.state.assets = assets;
+
+    setAssets(ctx, assets);
+
     await next();
   }
 

--- a/packages/sewing-kit-koa/src/tests/middleware.test.ts
+++ b/packages/sewing-kit-koa/src/tests/middleware.test.ts
@@ -1,6 +1,6 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {Header} from '@shopify/network';
-import middleware from '../middleware';
+import middleware, {getAssets} from '../middleware';
 import Assets from '../assets';
 
 describe('middleware', () => {
@@ -9,15 +9,14 @@ describe('middleware', () => {
     const context = createMockContext();
     await middleware({assetPrefix})(context, () => Promise.resolve());
 
-    expect(context.state).toHaveProperty('assets');
-    expect(context.state.assets).toBeInstanceOf(Assets);
-    expect(context.state.assets).toHaveProperty('assetPrefix', assetPrefix);
+    expect(getAssets(context)).toBeInstanceOf(Assets);
+    expect(getAssets(context)).toHaveProperty('assetPrefix', assetPrefix);
   });
 
   it('defaults the asset host to Sewing Kit’s dev server', async () => {
     const context = createMockContext();
     await middleware()(context, () => Promise.resolve());
-    expect(context.state.assets).toHaveProperty(
+    expect(getAssets(context)).toHaveProperty(
       'assetPrefix',
       'http://localhost:8080/webpack/assets/',
     );
@@ -26,7 +25,7 @@ describe('middleware', () => {
   it('defaults the asset host to /assets/ when serveAssets is true', async () => {
     const context = createMockContext();
     await middleware({serveAssets: true})(context, () => Promise.resolve());
-    expect(context.state.assets).toHaveProperty('assetPrefix', '/assets/');
+    expect(getAssets(context)).toHaveProperty('assetPrefix', '/assets/');
   });
 
   it('passes the userAgent to the asset', async () => {
@@ -37,7 +36,7 @@ describe('middleware', () => {
     });
 
     await middleware({serveAssets: true})(context, () => Promise.resolve());
-    expect(context.state.assets).toHaveProperty('userAgent', userAgent);
+    expect(getAssets(context)).toHaveProperty('userAgent', userAgent);
   });
 
   it('calls the next middleware', async () => {


### PR DESCRIPTION
We are moving away from storing properties directly on State. This PR hides the `assets` property in `sewing-kit-koa` under a new `getAssets()` function.