### PR TITLE
Better react-network

### DIFF
--- a/packages/react-async/src/context/assets.ts
+++ b/packages/react-async/src/context/assets.ts
@@ -8,7 +8,9 @@ export class AsyncAssetManager {
 
   readonly effect: EffectKind = {
     id: EFFECT_ID,
-    betweenEachPass: () => this.used.clear(),
+    betweenEachPass: () => {
+      this.used.clear();
+    },
   };
 
   markAsUsed(id: string) {

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -75,7 +75,7 @@ You may optionally pass an options object that contains the following keys (all 
 
 - `maxPasses`: a number that limits the number of render/ resolve cycles `extract` is allowed to perform. This option defaults to `5`.
 
-- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected). This function can return a promise, and it will be waited on before continuing. It is called with a single argument: a `Pass` object, which contains the `index`, `finished`, `renderDuration` and `resolveDuration` of the just-completed pass. Returning `false` (or a promise for `false`) from this method will bail out of subsequent passes.
+- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected). This function can return a promise, and it will be waited on before continuing. It is called with a single argument: a `Pass` object, which contains the `index`, `finished`, `renderDuration` and `resolveDuration` of the just-completed pass. Returning `false` (or a promise that resolves to `false`) from this method will bail out of subsequent passes.
 
 - `afterEachPass`: a function that is called after each pass of your tree, regardless of whether traversal is "finished". This function can return a promise, and it will be waited on before continuing. This function is called with the same argument as the `betweenEachPass` option. Returning `false` (or a promise for `false`) from this method will bail out of subsequent passes.
 

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -75,9 +75,9 @@ You may optionally pass an options object that contains the following keys (all 
 
 - `maxPasses`: a number that limits the number of render/ resolve cycles `extract` is allowed to perform. This option defaults to `5`.
 
-- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected). This function can return a promise, and it will be waited on before continuing. It is called with a single argument: a `Pass` object, which contains the `index`, `finished`, `renderDuration` and `resolveDuration` of the just-completed pass.
+- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected). This function can return a promise, and it will be waited on before continuing. It is called with a single argument: a `Pass` object, which contains the `index`, `finished`, `renderDuration` and `resolveDuration` of the just-completed pass. Returning `false` (or a promise for `false`) from this method will bail out of subsequent passes.
 
-- `afterEachPass`: a function that is called after each pass of your tree, regardless of whether traversal is "finished". This function can return a promise, and it will be waited on before continuing. This function is called with the same argument as the `betweenEachPass` option.
+- `afterEachPass`: a function that is called after each pass of your tree, regardless of whether traversal is "finished". This function can return a promise, and it will be waited on before continuing. This function is called with the same argument as the `betweenEachPass` option. Returning `false` (or a promise for `false`) from this method will bail out of subsequent passes.
 
 - `decorate`: a function that takes the root React element in your tree and returns a new tree to use. You can use this to wrap your application in context providers that only your server render requires.
 

--- a/packages/react-effect/documentation/migrating-version-1-to-2.md
+++ b/packages/react-effect/documentation/migrating-version-1-to-2.md
@@ -21,7 +21,9 @@ You might want to also attach some cleanup logic to the effect kind that will be
 class Manager {
   effect = {
     id: EFFECT_ID,
-    betweenEachPass: () => this.reset(),
+    betweenEachPass: () => {
+      this.reset();
+    },
   };
 
   reset() {}

--- a/packages/react-effect/src/manager.ts
+++ b/packages/react-effect/src/manager.ts
@@ -33,23 +33,33 @@ export class EffectManager {
     await Promise.all(this.effects);
   }
 
-  betweenEachPass(pass: Pass) {
-    for (const kind of this.kinds) {
-      if (typeof kind.betweenEachPass === 'function') {
-        kind.betweenEachPass(pass);
-      }
-    }
+  async betweenEachPass(pass: Pass) {
+    const results = await Promise.all(
+      [...this.kinds].map(
+        kind =>
+          typeof kind.betweenEachPass === 'function'
+            ? kind.betweenEachPass(pass)
+            : Promise.resolve(),
+      ),
+    );
+
+    return results.every(result => result !== false);
   }
 
-  afterEachPass(pass: Pass) {
-    for (const kind of this.kinds) {
-      if (typeof kind.afterEachPass === 'function') {
-        kind.afterEachPass(pass);
-      }
-    }
+  async afterEachPass(pass: Pass) {
+    const results = await Promise.all(
+      [...this.kinds].map(
+        kind =>
+          typeof kind.afterEachPass === 'function'
+            ? kind.afterEachPass(pass)
+            : Promise.resolve(),
+      ),
+    );
 
     this.effects = [];
     this.kinds = new Set();
+
+    return results.every(result => result !== false);
   }
 
   shouldPerform(kind: EffectKind) {

--- a/packages/react-effect/src/server.tsx
+++ b/packages/react-effect/src/server.tsx
@@ -69,39 +69,47 @@ export function extract(
       let performNextPass = true;
 
       performNextPass =
-        (await manager.betweenEachPass({
-          index,
-          finished: false,
-          renderDuration,
-          resolveDuration,
-        })) && performNextPass;
+        shouldContinue(
+          await manager.betweenEachPass({
+            index,
+            finished: false,
+            renderDuration,
+            resolveDuration,
+          }),
+        ) && performNextPass;
 
       if (betweenEachPass) {
         performNextPass =
-          (await betweenEachPass({
-            index,
-            finished: false,
-            renderDuration,
-            resolveDuration,
-          })) && performNextPass;
+          shouldContinue(
+            await betweenEachPass({
+              index,
+              finished: false,
+              renderDuration,
+              resolveDuration,
+            }),
+          ) && performNextPass;
       }
 
       performNextPass =
-        (await manager.afterEachPass({
-          index,
-          finished: false,
-          renderDuration,
-          resolveDuration,
-        })) && performNextPass;
-
-      if (afterEachPass) {
-        performNextPass =
-          (await afterEachPass({
+        shouldContinue(
+          await manager.afterEachPass({
             index,
             finished: false,
             renderDuration,
             resolveDuration,
-          })) && performNextPass;
+          }),
+        ) && performNextPass;
+
+      if (afterEachPass) {
+        performNextPass =
+          shouldContinue(
+            await afterEachPass({
+              index,
+              finished: false,
+              renderDuration,
+              resolveDuration,
+            }),
+          ) && performNextPass;
       }
 
       if (index + 1 >= maxPasses || !performNextPass) {
@@ -111,6 +119,10 @@ export function extract(
       return perform(index + 1);
     }
   })();
+}
+
+function shouldContinue(result: unknown) {
+  return result !== false;
 }
 
 function identity<T>(value: T): T {

--- a/packages/react-effect/src/server.tsx
+++ b/packages/react-effect/src/server.tsx
@@ -66,40 +66,45 @@ export function extract(
       await manager.resolve();
 
       const resolveDuration = Date.now() - resolveStart;
+      let performNextPass = true;
 
-      await manager.betweenEachPass({
-        index,
-        finished: false,
-        renderDuration,
-        resolveDuration,
-      });
+      performNextPass =
+        (await manager.betweenEachPass({
+          index,
+          finished: false,
+          renderDuration,
+          resolveDuration,
+        })) && performNextPass;
 
       if (betweenEachPass) {
-        await betweenEachPass({
+        performNextPass =
+          (await betweenEachPass({
+            index,
+            finished: false,
+            renderDuration,
+            resolveDuration,
+          })) && performNextPass;
+      }
+
+      performNextPass =
+        (await manager.afterEachPass({
           index,
           finished: false,
           renderDuration,
           resolveDuration,
-        });
-      }
-
-      await manager.afterEachPass({
-        index,
-        finished: false,
-        renderDuration,
-        resolveDuration,
-      });
+        })) && performNextPass;
 
       if (afterEachPass) {
-        await afterEachPass({
-          index,
-          finished: false,
-          renderDuration,
-          resolveDuration,
-        });
+        performNextPass =
+          (await afterEachPass({
+            index,
+            finished: false,
+            renderDuration,
+            resolveDuration,
+          })) && performNextPass;
       }
 
-      if (index + 1 >= maxPasses) {
+      if (index + 1 >= maxPasses || !performNextPass) {
         return result;
       }
 

--- a/packages/react-effect/src/test/server.test.tsx
+++ b/packages/react-effect/src/test/server.test.tsx
@@ -54,10 +54,32 @@ describe('extract()', () => {
     expect(kind.betweenEachPass).toHaveBeenCalledTimes(1);
   });
 
+  it('bails out if betweenEachPass on any kind returns false', async () => {
+    const kind = {
+      id: Symbol('id'),
+      betweenEachPass: jest.fn(() => Promise.resolve(false)),
+    };
+
+    await extract(<Effect perform={() => Promise.resolve()} kind={kind} />);
+
+    expect(kind.betweenEachPass).toHaveBeenCalledTimes(1);
+  });
+
   it('calls afterEachPass on each used kind', async () => {
     const kind = {id: Symbol('id'), afterEachPass: jest.fn()};
     await extract(<Effect perform={noop} kind={kind} />);
     expect(kind.afterEachPass).toHaveBeenCalledTimes(1);
+  });
+
+  it('bails out if afterEachPass on any kind returns false', async () => {
+    const kind = {
+      id: Symbol('id'),
+      betweenEachPass: jest.fn(() => Promise.resolve(false)),
+    };
+
+    await extract(<Effect perform={() => Promise.resolve()} kind={kind} />);
+
+    expect(kind.betweenEachPass).toHaveBeenCalledTimes(1);
   });
 
   it('does not perform effects outside of extract()', () => {
@@ -144,6 +166,14 @@ describe('extract()', () => {
         resolveDuration,
       });
     });
+
+    it('bails out if it returns false', async () => {
+      const spy = jest.fn(() => Promise.resolve(false));
+      await extract(<Effect perform={() => Promise.resolve()} />, {
+        betweenEachPass: spy,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('afterEachPass', () => {
@@ -205,6 +235,14 @@ describe('extract()', () => {
         renderDuration,
         resolveDuration: 0,
       });
+    });
+
+    it('bails out if it returns false', async () => {
+      const spy = jest.fn(() => Promise.resolve(false));
+      await extract(<Effect perform={() => Promise.resolve()} />, {
+        afterEachPass: spy,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/react-network/README.md
+++ b/packages/react-network/README.md
@@ -87,6 +87,20 @@ export default function ContentSecurityPolicy() {
 }
 ```
 
+#### `useHeader()` and `useRequestHeader()`
+
+This library allows you to read from request headers, and set response headers. To set a header, call the `useHeader()` hook, which accepts the name of a header and the desired value. `useRequestHeader()`, on the other hand, gives you access to a specified request header.
+
+```tsx
+import {useHeader, useRequestHeader} from '@shopify/react-network';
+
+function MyComponent() {
+  useHeader('X-React', 'true');
+  const acceptsLanguages = useRequestHeader('Accepts-Languages');
+  return <div>Requested languages: {acceptsLanguages}</div>;
+}
+```
+
 ### Server
 
 To extract details from your application, render a `NetworkContext.Provider` around your app, and give it an instance of the `NetworkManager`. When using `react-effect`, this decoration can be done in the `decorate` option of `extract()`. Finally, you can use the `applyToContext` utility from this package to apply the necessary headers to the response. Your final server middleware will resemble the example below:
@@ -102,8 +116,14 @@ import {
 import App from './App';
 
 export default function render(ctx: Context) {
-  const networkManager = new NetworkManager();
+  // Accepts an optional headers argument for giving access
+  // to request headers.
+  const networkManager = new NetworkManager({
+    headers: ctx.headers,
+  });
+
   const app = <App />;
+
   await extract(app, {
     decorate: element => (
       <NetworkContext.Provider value={networkManager}>

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -22,6 +22,15 @@ export function useCspDirective(
   useNetworkEffect(network => network.addCspDirective(directive, source));
 }
 
+export function useRequestHeader(header: string) {
+  const network = useContext(NetworkContext);
+  return network ? network.getHeader(header) : undefined;
+}
+
+export function useHeader(header: string, value: string) {
+  useNetworkEffect(network => network.setHeader(header, value));
+}
+
 export function useStatus(code: StatusCode) {
   useNetworkEffect(network => network.addStatusCode(code));
 }

--- a/packages/react-network/src/index.ts
+++ b/packages/react-network/src/index.ts
@@ -3,4 +3,11 @@ export * from './components';
 
 export {NetworkManager} from './manager';
 export {NetworkContext} from './context';
-export {useNetworkEffect, useStatus, useCspDirective} from './hooks';
+export {
+  useNetworkEffect,
+  useStatus,
+  useCspDirective,
+  useHeader,
+  useRequestHeader,
+  useRedirect,
+} from './hooks';

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -17,8 +17,12 @@ export class NetworkManager {
   readonly effect: EffectKind = {
     id: EFFECT_ID,
     betweenEachPass: () => {
-      this.reset();
-      return this.redirectUrl == null;
+      if (this.redirectUrl == null) {
+        this.reset();
+        return true;
+      } else {
+        return false;
+      }
     },
   };
 

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -1,24 +1,50 @@
-import {StatusCode, CspDirective} from '@shopify/network';
+import {StatusCode, CspDirective, Header} from '@shopify/network';
 import {EffectKind} from '@shopify/react-effect';
 
 export {NetworkContext} from './context';
 
 export const EFFECT_ID = Symbol('network');
 
+interface Headers {
+  get(header: string): string | undefined;
+}
+
+interface Options {
+  headers?: Headers;
+}
+
 export class NetworkManager {
   readonly effect: EffectKind = {
     id: EFFECT_ID,
-    betweenEachPass: () => this.reset(),
+    betweenEachPass: () => {
+      this.reset();
+      return this.redirectUrl == null;
+    },
   };
 
   private statusCodes: StatusCode[] = [];
-  private csp = new Map<CspDirective, string[] | boolean>();
   private redirectUrl?: string;
+  private readonly csp = new Map<CspDirective, string[] | boolean>();
+  private readonly headers = new Map<string, string>();
+  private readonly requestHeaders?: Headers;
+
+  constructor({headers}: Options = {}) {
+    this.requestHeaders = headers;
+  }
 
   reset() {
     this.statusCodes = [];
     this.csp.clear();
+    this.headers.clear();
     this.redirectUrl = undefined;
+  }
+
+  getHeader(header: string) {
+    return this.requestHeaders && this.requestHeaders.get(header);
+  }
+
+  setHeader(header: string, value: string) {
+    this.headers.set(header, value);
   }
 
   redirectTo(url: string, status = StatusCode.Found) {
@@ -45,14 +71,37 @@ export class NetworkManager {
   }
 
   extract() {
+    const csp =
+      this.csp.size === 0
+        ? undefined
+        : [...this.csp]
+            .map(([key, value]) => {
+              let printedValue: string;
+
+              if (typeof value === 'boolean') {
+                printedValue = '';
+              } else if (typeof value === 'string') {
+                printedValue = value;
+              } else {
+                printedValue = value.join(' ');
+              }
+
+              return `${key}${printedValue ? ' ' : ''}${printedValue}`;
+            })
+            .join('; ');
+
+    const headers = new Map(this.headers);
+
+    if (csp) {
+      headers.set(Header.ContentSecurityPolicy, csp);
+    }
+
     return {
       status:
         this.statusCodes.length > 0
           ? this.statusCodes.reduce((large, code) => Math.max(large, code), 0)
           : undefined,
-      csp: [...this.csp.entries()].reduce<{
-        [key: string]: string[] | string | boolean;
-      }>((csp, [directive, value]) => ({...csp, [directive]: value}), {}),
+      headers,
       redirectUrl: this.redirectUrl,
     };
   }

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -1,5 +1,4 @@
 import {Context} from 'koa';
-import {Header} from '@shopify/network';
 import {NetworkManager, EFFECT_ID} from './manager';
 
 export {NetworkContext} from './context';
@@ -9,28 +8,7 @@ export function applyToContext<T extends Context>(
   ctx: T,
   manager: NetworkManager,
 ) {
-  const {status, csp, redirectUrl} = manager.extract();
-  const cspEntries = Object.entries(csp);
-
-  if (cspEntries.length > 0) {
-    const cspHeader = cspEntries
-      .map(([key, value]) => {
-        let printedValue: string;
-
-        if (typeof value === 'boolean') {
-          printedValue = '';
-        } else if (typeof value === 'string') {
-          printedValue = value;
-        } else {
-          printedValue = value.join(' ');
-        }
-
-        return `${key}${printedValue ? ' ' : ''}${printedValue}`;
-      })
-      .join('; ');
-
-    ctx.set(Header.ContentSecurityPolicy, cspHeader);
-  }
+  const {status, redirectUrl, headers} = manager.extract();
 
   if (redirectUrl) {
     ctx.redirect(redirectUrl);
@@ -38,6 +16,10 @@ export function applyToContext<T extends Context>(
 
   if (status) {
     ctx.status = status;
+  }
+
+  for (const [header, value] of headers) {
+    ctx.set(header, value);
   }
 
   return ctx;

--- a/packages/react-network/src/test/e2e.test.tsx
+++ b/packages/react-network/src/test/e2e.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {useServerEffect} from '@shopify/react-effect';
+import {extract} from '@shopify/react-effect/server';
+
+import {
+  useStatus,
+  useCspDirective,
+  useRedirect,
+  useHeader,
+  StatusCode,
+  CspDirective,
+  Header,
+} from '..';
+
+import {NetworkContext, NetworkManager} from '../server';
+
+describe('e2e', () => {
+  it('clears network details between requests', async () => {
+    const networkManager = new NetworkManager();
+    const TwoPass = createMultiPassComponent(2);
+
+    function Network() {
+      useStatus(StatusCode.NotFound);
+      useCspDirective(CspDirective.ChildSrc, 'https://*');
+      useHeader(Header.CacheControl, 'no-cache');
+      return null;
+    }
+
+    await extract(
+      <>
+        <TwoPass />
+        <Network />
+      </>,
+      {
+        decorate: element => (
+          <NetworkContext.Provider value={networkManager}>
+            {element}
+          </NetworkContext.Provider>
+        ),
+      },
+    );
+
+    const extracted = networkManager.extract();
+    expect(extracted).toHaveProperty('headers.size', 0);
+    expect(extracted).toHaveProperty('status', undefined);
+  });
+
+  it('bails out when a redirect is set', async () => {
+    const networkManager = new NetworkManager();
+    const InfinitePass = createMultiPassComponent(Infinity);
+    const afterEachPass = jest.fn();
+
+    function Network() {
+      useRedirect('https://example.com');
+      return null;
+    }
+
+    await extract(
+      <>
+        <InfinitePass />
+        <Network />
+      </>,
+      {
+        decorate: element => (
+          <NetworkContext.Provider value={networkManager}>
+            {element}
+          </NetworkContext.Provider>
+        ),
+      },
+    );
+
+    expect(afterEachPass).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createMultiPassComponent(passes: number) {
+  let renderCount = 0;
+
+  return function TwoPass() {
+    useServerEffect(() => {
+      renderCount += 1;
+      return renderCount < passes ? Promise.resolve() : undefined;
+    });
+
+    return null;
+  };
+}

--- a/packages/react-network/src/test/server.test.ts
+++ b/packages/react-network/src/test/server.test.ts
@@ -58,6 +58,22 @@ describe('server', () => {
     });
   });
 
+  describe('headers', () => {
+    it('can set arbitrary headers', () => {
+      const manager = new NetworkManager();
+      const ctx = createMockContext();
+      const spy = jest.spyOn(ctx, 'set');
+
+      const header = 'X-Cool-Stuff';
+      const value = 'true';
+
+      manager.setHeader(header, value);
+      applyToContext(ctx, manager);
+
+      expect(spy).toHaveBeenCalledWith(header, value);
+    });
+  });
+
   describe('csp', () => {
     it('does not set a CSP header if no directives were set', () => {
       const manager = new NetworkManager();


### PR DESCRIPTION
This PR introduces two key improvements targeted towards `react-network`:

- Developers can now read request headers and set response headers using `useRequestHeader` and `useHeader`
- Added the ability for server effects to bail out of render passes during `extract`, and used this ability to bail out of subsequent passes when a redirect URL is set.