### PR TITLE
Add support for body/html attributes

### DIFF
--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -244,6 +244,14 @@ Renders a `<link />` tag with the necessary props to specify a favicon. Accepts 
 
 Renders a `<link />` tag that preconnects the browser to the host specified by the `source` prop. You can read more about preconnecting on [Google’s guide to resource prioritization](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect).
 
+### `useBodyAttributes()` and `<BodyAttributes />`
+
+Applies the provided props as props on the `body` element. If multiple uses of this hook/ component are present in the application, they are flattened from first to last added.
+
+### `useHtmlAttributes()` and `<HtmlAttributes />`
+
+Applies the provided props as props on the `html` element. If multiple uses of this hook/ component are present in the application, they are flattened from first to last added.
+
 ### `<Responsive />`
 
 Renders a `<Meta />` tag that specifies additional functionality and dimensions to mobile devices. Accepts a `coverNotch` property which allows the viewport to fill the device display, and an `allowPinchToZoom` property to the allow the app to be zoomed-in. Both properties default to `true`.

--- a/packages/react-html/src/components/BodyAttributes.tsx
+++ b/packages/react-html/src/components/BodyAttributes.tsx
@@ -1,0 +1,9 @@
+import {FirstArgument} from '@shopify/useful-types';
+import {useBodyAttributes} from '../hooks';
+
+type Props = FirstArgument<typeof useBodyAttributes>;
+
+export function BodyAttributes(props: Props) {
+  useBodyAttributes(props);
+  return null;
+}

--- a/packages/react-html/src/components/HtmlAttributes.tsx
+++ b/packages/react-html/src/components/HtmlAttributes.tsx
@@ -1,0 +1,9 @@
+import {FirstArgument} from '@shopify/useful-types';
+import {useHtmlAttributes} from '../hooks';
+
+type Props = FirstArgument<typeof useHtmlAttributes>;
+
+export function HtmlAttributes(props: Props) {
+  useHtmlAttributes(props);
+  return null;
+}

--- a/packages/react-html/src/components/tests/BodyAttributes.test.tsx
+++ b/packages/react-html/src/components/tests/BodyAttributes.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import {HtmlManager} from '../../manager';
+import {BodyAttributes} from '../BodyAttributes';
+
+import {mountWithManager} from './utilities';
+
+describe('<BodyAttributes />', () => {
+  it('adds a link with the required preconnect props and the href set to source', () => {
+    const props = {lang: 'es'};
+    const manager = new HtmlManager();
+    const spy = jest.spyOn(manager, 'addBodyAttributes');
+
+    mountWithManager(<BodyAttributes {...props} />, manager);
+
+    expect(spy).toHaveBeenCalledWith(props);
+  });
+});

--- a/packages/react-html/src/components/tests/HtmlAttributes.test.tsx
+++ b/packages/react-html/src/components/tests/HtmlAttributes.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import {HtmlManager} from '../../manager';
+import {HtmlAttributes} from '../HtmlAttributes';
+
+import {mountWithManager} from './utilities';
+
+describe('<HtmlAttributes />', () => {
+  it('adds a link with the required preconnect props and the href set to source', () => {
+    const props = {lang: 'es'};
+    const manager = new HtmlManager();
+    const spy = jest.spyOn(manager, 'addHtmlAttributes');
+
+    mountWithManager(<HtmlAttributes {...props} />, manager);
+
+    expect(spy).toHaveBeenCalledWith(props);
+  });
+});

--- a/packages/react-html/src/hooks.ts
+++ b/packages/react-html/src/hooks.ts
@@ -1,5 +1,6 @@
 import {useEffect, useContext} from 'react';
 import {useServerEffect} from '@shopify/react-effect';
+import {FirstArgument} from '@shopify/useful-types';
 
 import {HtmlContext} from './context';
 import {HtmlManager} from './manager';
@@ -46,6 +47,18 @@ export function useFavicon(source: string) {
       href: source,
     }),
   );
+}
+
+export function useHtmlAttributes(
+  htmlAttributes: FirstArgument<HtmlManager['addHtmlAttributes']>,
+) {
+  useDomEffect(manager => manager.addHtmlAttributes(htmlAttributes));
+}
+
+export function useBodyAttributes(
+  bodyAttributes: FirstArgument<HtmlManager['addBodyAttributes']>,
+) {
+  useDomEffect(manager => manager.addBodyAttributes(bodyAttributes));
 }
 
 export function useClientDomEffect(

--- a/packages/react-html/src/manager.ts
+++ b/packages/react-html/src/manager.ts
@@ -64,34 +64,23 @@ export class HtmlManager {
   }
 
   addTitle(title: string) {
-    const titleObject = {title};
-    this.titles.push(titleObject);
-    this.updateSubscriptions();
-    return this.removeTitle.bind(this, titleObject);
+    return this.addDescriptor({title}, this.titles);
   }
 
   addMeta(meta: React.HTMLProps<HTMLMetaElement>) {
-    this.metas.push(meta);
-    this.updateSubscriptions();
-    return this.removeMeta.bind(this, meta);
+    return this.addDescriptor(meta, this.metas);
   }
 
   addLink(link: React.HTMLProps<HTMLLinkElement>) {
-    this.links.push(link);
-    this.updateSubscriptions();
-    return this.removeLink.bind(this, link);
+    return this.addDescriptor(link, this.links);
   }
 
   addHtmlAttributes(attributes: React.HtmlHTMLAttributes<HTMLHtmlElement>) {
-    this.htmlAttributes.push(attributes);
-    this.updateSubscriptions();
-    return this.removeHtmlAttributes.bind(this, attributes);
+    return this.addDescriptor(attributes, this.htmlAttributes);
   }
 
   addBodyAttributes(attributes: React.HTMLProps<HTMLBodyElement>) {
-    this.bodyAttributes.push(attributes);
-    this.updateSubscriptions();
-    return this.removeBodyAttributes.bind(this, attributes);
+    return this.addDescriptor(attributes, this.bodyAttributes);
   }
 
   setSerialization(id: string, data: unknown) {
@@ -112,53 +101,22 @@ export class HtmlManager {
     };
   }
 
+  private addDescriptor<T>(item: T, list: T[]) {
+    list.push(item);
+    this.updateSubscriptions();
+
+    return () => {
+      const index = list.indexOf(item);
+      if (index >= 0) {
+        list.splice(index, 1);
+        this.updateSubscriptions();
+      }
+    };
+  }
+
   private updateSubscriptions() {
     for (const subscription of this.subscriptions) {
       subscription(this.state);
-    }
-  }
-
-  private removeTitle(title: Title) {
-    const index = this.titles.indexOf(title);
-    if (index >= 0) {
-      this.titles.splice(index, 1);
-      this.updateSubscriptions();
-    }
-  }
-
-  private removeMeta(meta: React.HTMLProps<HTMLMetaElement>) {
-    const index = this.metas.indexOf(meta);
-    if (index >= 0) {
-      this.metas.splice(index, 1);
-      this.updateSubscriptions();
-    }
-  }
-
-  private removeLink(link: React.HTMLProps<HTMLLinkElement>) {
-    const index = this.links.indexOf(link);
-    if (index >= 0) {
-      this.links.splice(index, 1);
-      this.updateSubscriptions();
-    }
-  }
-
-  private removeHtmlAttributes(
-    attributes: React.HtmlHTMLAttributes<HTMLHtmlElement>,
-  ) {
-    const index = this.htmlAttributes.indexOf(attributes);
-
-    if (index >= 0) {
-      this.htmlAttributes.splice(index, 1);
-      this.updateSubscriptions();
-    }
-  }
-
-  private removeBodyAttributes(attributes: React.HTMLProps<HTMLBodyElement>) {
-    const index = this.bodyAttributes.indexOf(attributes);
-
-    if (index >= 0) {
-      this.bodyAttributes.splice(index, 1);
-      this.updateSubscriptions();
     }
   }
 }

--- a/packages/react-html/src/manager.ts
+++ b/packages/react-html/src/manager.ts
@@ -9,6 +9,8 @@ export interface State {
   title?: string;
   metas: React.HTMLProps<HTMLMetaElement>[];
   links: React.HTMLProps<HTMLLinkElement>[];
+  bodyAttributes: React.HTMLProps<HTMLBodyElement>;
+  htmlAttributes: React.HtmlHTMLAttributes<HTMLHtmlElement>;
 }
 
 interface Subscription {
@@ -27,6 +29,8 @@ export class HtmlManager {
   private titles: Title[] = [];
   private metas: React.HTMLProps<HTMLMetaElement>[] = [];
   private links: React.HTMLProps<HTMLLinkElement>[] = [];
+  private htmlAttributes: React.HtmlHTMLAttributes<HTMLHtmlElement>[] = [];
+  private bodyAttributes: React.HTMLProps<HTMLBodyElement>[] = [];
   private subscriptions = new Set<Subscription>();
 
   get state(): State {
@@ -36,6 +40,8 @@ export class HtmlManager {
       title: lastTitle && lastTitle.title,
       metas: this.metas,
       links: this.links,
+      bodyAttributes: Object.assign({}, ...this.bodyAttributes),
+      htmlAttributes: Object.assign({}, ...this.htmlAttributes),
     };
   }
 
@@ -74,6 +80,18 @@ export class HtmlManager {
     this.links.push(link);
     this.updateSubscriptions();
     return this.removeLink.bind(this, link);
+  }
+
+  addHtmlAttributes(attributes: React.HtmlHTMLAttributes<HTMLHtmlElement>) {
+    this.htmlAttributes.push(attributes);
+    this.updateSubscriptions();
+    return this.removeHtmlAttributes.bind(this, attributes);
+  }
+
+  addBodyAttributes(attributes: React.HTMLProps<HTMLBodyElement>) {
+    this.bodyAttributes.push(attributes);
+    this.updateSubscriptions();
+    return this.removeBodyAttributes.bind(this, attributes);
   }
 
   setSerialization(id: string, data: unknown) {
@@ -120,6 +138,26 @@ export class HtmlManager {
     const index = this.links.indexOf(link);
     if (index >= 0) {
       this.links.splice(index, 1);
+      this.updateSubscriptions();
+    }
+  }
+
+  private removeHtmlAttributes(
+    attributes: React.HtmlHTMLAttributes<HTMLHtmlElement>,
+  ) {
+    const index = this.htmlAttributes.indexOf(attributes);
+
+    if (index >= 0) {
+      this.htmlAttributes.splice(index, 1);
+      this.updateSubscriptions();
+    }
+  }
+
+  private removeBodyAttributes(attributes: React.HTMLProps<HTMLBodyElement>) {
+    const index = this.bodyAttributes.indexOf(attributes);
+
+    if (index >= 0) {
+      this.bodyAttributes.splice(index, 1);
       this.updateSubscriptions();
     }
   }

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -104,12 +104,20 @@ export default function Html({
     );
   });
 
-  const bodyStyles: {visibility: 'hidden'} | undefined =
-    // eslint-disable-next-line no-process-env
-    process.env.NODE_ENV === 'development' ? {visibility: 'hidden'} : undefined;
+  const htmlAttributes = extracted ? extracted.htmlAttributes : {};
+  const bodyAttributes = extracted ? extracted.bodyAttributes : {};
+
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV === 'development') {
+    if (bodyAttributes.style == null) {
+      bodyAttributes.style = {visibility: 'hidden'};
+    } else {
+      bodyAttributes.style.visibility = 'hidden';
+    }
+  }
 
   return (
-    <html lang={locale}>
+    <html lang={locale} {...htmlAttributes}>
       <head>
         {titleMarkup}
         <meta charSet="utf-8" />
@@ -124,7 +132,7 @@ export default function Html({
         {deferredScriptsMarkup}
       </head>
 
-      <body style={bodyStyles}>
+      <body {...bodyAttributes}>
         <div id="app" dangerouslySetInnerHTML={{__html: markup}} />
 
         {bodyMarkup}

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -180,7 +180,7 @@ describe('<Html />', () => {
     it('renders serializations', () => {
       const id = 'MySerialization';
       const data = {foo: 'bar'};
-      const manager = new HtmlManager({isServer: true});
+      const manager = new HtmlManager();
       manager.setSerialization(id, data);
 
       const html = mount(<Html {...mockProps} manager={manager} />);
@@ -235,6 +235,26 @@ describe('<Html />', () => {
       expect(links).toHaveLength(2);
       expect(links[0]).toHaveReactProps(linkOne);
       expect(links[1]).toHaveReactProps(linkTwo);
+    });
+
+    it('renders html attributes', () => {
+      const htmlProps = {lang: 'fr'};
+      const manager = new HtmlManager();
+      manager.addHtmlAttributes(htmlProps);
+
+      const html = mount(<Html {...mockProps} manager={manager} />);
+
+      expect(html).toContainReactComponent('html', htmlProps);
+    });
+
+    it('renders body attributes', () => {
+      const bodyProps = {className: 'beautiful'};
+      const manager = new HtmlManager();
+      manager.addBodyAttributes(bodyProps);
+
+      const html = mount(<Html {...mockProps} manager={manager} />);
+
+      expect(html).toContainReactComponent('body', bodyProps);
     });
   });
 });


### PR DESCRIPTION
This PR adds support for setting `body`/ `html` attributes from application code. It does so by augmenting the existing `HtmlManager` and adding the `useBodyAttributes`/ `<BodyAttributes />`/ `useHtmlAttributes`/ `<HtmlAttributes />` exports. Web needs this in order to properly set the HTML `lang` attribute, now that we've moved the construction of the i18n manager out of the entry points.