### PR TITLE
Fix useQuery's side effect wrapping result under 'current' key

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -7,7 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
 - `useQuery` now returns `undefined` instead of an empty object `{}` when there's no data ([#751](https://github.com/Shopify/quilt/pull/751))
+- Fix re-wrapping query result under `current` key when using `no-cache` fetch policy (as a result of leaking implementation details, exposing `ref` object intead of what it is representing)
 
 ## [3.4.0] - 2019-05-31
 

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -162,7 +162,7 @@ export default function useQuery<
         fetchPolicy === 'no-cache' &&
         Object.keys(result.data).length === 0
       ) {
-        data = previousData;
+        data = previousData.current;
       } else {
         previousData.current = result.data;
       }

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -123,9 +123,9 @@ export default function useQuery<
     [skip, queryObservable],
   );
 
-  const previousData = useRef<
-    QueryHookResult<Data, Variables>['data'] | undefined
-  >(undefined);
+  const previousData = useRef<QueryHookResult<Data, Variables>['data']>(
+    undefined,
+  );
 
   const currentResult = useMemo<QueryHookResult<Data, Variables>>(
     () => {
@@ -147,7 +147,7 @@ export default function useQuery<
       const {fetchPolicy} = queryObservable.options;
 
       const hasError = result.errors && result.errors.length > 0;
-      let data = result.data;
+      let data: QueryHookResult<Data, Variables>['data'] = result.data;
       if (result.loading) {
         data =
           previousData.current || (result && result.data)


### PR DESCRIPTION
The issue I reported in *web-foundation-tech* channel a while ago. 

<img width="1322" alt="Screen Shot 2019-06-10 at 11 29 53 AM" src="https://user-images.githubusercontent.com/354010/59207244-b0315100-8b74-11e9-9e02-6a4a2f663a60.png">

