### PR TITLE
Fix useQuery data returned value

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- `useQuery` now returns `undefined` instead of an empty object `{}` when there's no data ([#751](https://github.com/Shopify/quilt/pull/751))
 
 ## [3.4.0] - 2019-05-31
 

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -90,7 +90,7 @@ export default function useQuery<
       return;
     }
 
-    const result = queryObservable.currentResult();
+    const result = queryObservable.getCurrentResult();
     return result.loading ? queryObservable.result() : undefined;
   });
 
@@ -143,7 +143,7 @@ export default function useQuery<
         };
       }
 
-      const result = queryObservable.currentResult();
+      const result = queryObservable.getCurrentResult();
       const {fetchPolicy} = queryObservable.options;
 
       const hasError = result.errors && result.errors.length > 0;


### PR DESCRIPTION
Fixes https://github.com/Shopify/quilt/issues/750.

So I was debugging my issue that I described in #750 and I noticed that we called `.currentResult` on the observable query and this public function is actually deprecated and will be removed in v3. And this function was actually replacing the `undefined` value with an empty object as described here:
https://github.com/apollographql/apollo-client/blob/547d9f518d6b3c5b27edbdb2365691498d9e5a8d/packages/apollo-client/src/core/ObservableQuery.ts#L154-L162

`.getCurrentResult` actually returns the data value without changing the undefined value into an empty object.