### PR TITLE
🐛 fix FormMapping restricting Bag type parameter 

### DIFF
--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -100,14 +100,13 @@ type FieldProp<T, K extends keyof Field<any>> = T extends Field<any>
     ? {[InnerKey in keyof T]: T[InnerKey][K]}
     : T;
 
-/*
+/**
   Represents all of the values for a given key mapped out of a mixed dictionary of Field objects,
-  nested Field objects, and arrays of nested Field objects
+  nested Field objects, and arrays of nested Field objects.
+
+  This is generally only useful if you're mapping over and transforming a nested tree of fields.
 */
-export type FormMapping<
-  Bag extends {[key: string]: FieldOutput<any>},
-  FieldKey extends keyof Field<any>
-> = {
+export type FormMapping<Bag, FieldKey extends keyof Field<any>> = {
   [Key in keyof Bag]: Bag[Key] extends any[]
     ? {[Index in keyof Bag[Key]]: FieldProp<Bag[Key][Index], FieldKey>}
     : FieldProp<Bag[Key], FieldKey>


### PR DESCRIPTION
@patsissons pointed out that the restrictions on the `Bag` type parameter were causing some problems when trying to use `FormMapping` against a predefined interface of fields. This PR fixes this by simply removing the type restriction.

before:
![image](https://user-images.githubusercontent.com/4889856/59371667-a85be300-8d13-11e9-8a4f-c0dd3cf61d59.png)

after:
![image](https://user-images.githubusercontent.com/4889856/59371741-db05db80-8d13-11e9-8044-eeaf06be7bc3.png)
![image](https://user-images.githubusercontent.com/4889856/59371759-e1945300-8d13-11e9-915f-2f4a2443a043.png)

