### PR TITLE
[react-i18n] Adding `unformatNumber`

### DIFF
--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -511,6 +511,61 @@ describe('I18n', () => {
     });
   });
 
+  describe('#unformatNumber()', () => {
+    let formatNumber: jest.SpyInstance;
+    let i18n: I18n;
+
+    beforeAll(() => {
+      formatNumber = jest.spyOn(I18n.prototype, 'formatNumber');
+    });
+
+    beforeEach(() => {
+      i18n = new I18n(defaultTranslations, defaultDetails);
+    });
+
+    afterEach(() => {
+      formatNumber.mockClear();
+    });
+
+    afterAll(() => {
+      formatNumber.mockRestore();
+    });
+
+    const input = 123456.7891;
+
+    it('handles number with period decimal symbol', () => {
+      formatNumber.mockImplementationOnce(() => '1.1');
+
+      const formatted = '123,456.7891';
+
+      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+    });
+
+    it('handles number with comma decimal symbol', () => {
+      formatNumber.mockImplementationOnce(() => '1,1');
+
+      const formatted = '123.456,7891';
+
+      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+    });
+
+    it('handles number with unusual comma separators and period decimal symbol', () => {
+      formatNumber.mockImplementationOnce(() => '1.1');
+
+      const formatted = '1,23,456.7891';
+
+      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+    });
+
+    it('handles invalid value', () => {
+      formatNumber.mockImplementationOnce(() => '1.1');
+
+      const formatted = 'foobar';
+
+      expect(i18n.unformatNumber(formatted)).toBe('');
+    });
+  });
+
   describe('#formatCurrency()', () => {
     const currency = 'USD';
 


### PR DESCRIPTION
This PR adds a function to convert locale formatted number to a plain javascript number number in a string form.

*Example*

`"1,23,456.789"` in `en-IN` locale will be unformatted to `"123456.789"`

Very similar to `unformatCurrency` just without the currency stuff.

This utility will be used to unformat decimal number in https://github.com/Shopify/web/issues/14837

