### PR TITLE
[react-form] notEmptyString validator now rejects empty strings

### DIFF
--- a/packages/predicates/src/predicates.ts
+++ b/packages/predicates/src/predicates.ts
@@ -19,7 +19,7 @@ export function isEmpty(input: any) {
 }
 
 export function isEmptyString(input: string) {
-  return input.trim().length < 1;
+  return input === null || input === undefined || input.trim().length < 1;
 }
 
 export function notEmpty(input: any) {

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `notEmptyString` now rejects empty strings, similar to `notEmpty` [#759](https://github.com/Shopify/quilt/pull/759)
+
 ## [0.3.4]
 
 ### Fixed

--- a/packages/react-form/src/validation/validators.ts
+++ b/packages/react-form/src/validation/validators.ts
@@ -14,7 +14,7 @@ export function notEmpty(error: ErrorContent<string>) {
 }
 
 export function notEmptyString(error: ErrorContent<string>) {
-  return validator(predicates.notEmptyString)(error);
+  return validator(predicates.notEmptyString, {skipOnEmpty: false})(error);
 }
 
 export function positiveNumericString(error: ErrorContent<string>) {


### PR DESCRIPTION
Similar to the `notEmpty` validator, we want to disable the `skipOnEmpty` flag so that an empty string is rejected.