### PR TITLE
[react-form] adding new positiveIntegerString validator

### DIFF
--- a/packages/predicates/CHANGELOG.md
+++ b/packages/predicates/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- added the `isPositiveIntegerString` predicate, which returns `true` whent the input is a non-fractional numeric string and `false` otherwise. [#760](https://github.com/Shopify/quilt/pull/760)
+
 ## [1.1.0]
 
 ### Added

--- a/packages/predicates/src/predicates.ts
+++ b/packages/predicates/src/predicates.ts
@@ -6,6 +6,10 @@ export function lengthLessThan(length: number) {
   return (input: {length: number}) => input.length < length;
 }
 
+export function isPositiveIntegerString(input: string) {
+  return input !== '' && (input.match(/[^0-9]/g) || []).length === 0;
+}
+
 export function isPositiveNumericString(input: string) {
   return input !== '' && (input.match(/[^0-9.,]/g) || []).length === 0;
 }

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- new `positiveIntegerString` validator to validate fractionless numbers [#760](https://github.com/Shopify/quilt/pull/760)
+
 ### Fixed
 
 - `notEmptyString` now rejects empty strings, similar to `notEmpty` [#759](https://github.com/Shopify/quilt/pull/759)

--- a/packages/react-form/src/validation/validators.ts
+++ b/packages/react-form/src/validation/validators.ts
@@ -17,14 +17,14 @@ export function notEmptyString(error: ErrorContent<string>) {
   return validator(predicates.notEmptyString, {skipOnEmpty: false})(error);
 }
 
+export function positiveIntegerString(error: ErrorContent<string>) {
+  return validator(predicates.isPositiveIntegerString)(error);
+}
+
 export function positiveNumericString(error: ErrorContent<string>) {
-  return validator(input => {
-    return input !== '' && (input.match(/[^0-9.,]/g) || []).length === 0;
-  })(error);
+  return validator(predicates.isPositiveNumericString)(error);
 }
 
 export function numericString(error: ErrorContent<string>) {
-  return validator(input => {
-    return input !== '' && (input.match(/[^0-9.,-]/g) || []).length === 0;
-  })(error);
+  return validator(predicates.isNumericString)(error);
 }


### PR DESCRIPTION
This validator is similar to the `positiveNumericString` validator, except that it rejects fractional numbers. This is particularly useful for validating ID numbers (such as banking numbers).