### PR TITLE
Adds missing headers

### DIFF
--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added the following headers: 'X-XSS-Protection', 'X-Frame-Options', 'X-Download-Options', 'X-Content-Type-Options', 'Strict-Transport-Security', 'Referrer-Policy' ([#752](https://github.com/Shopify/quilt/pull/752))
+
 ## [1.3.0] - 2019-06-12
 
 - Added 'Accept-Language' header ([#752](https://github.com/Shopify/quilt/pull/752))

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -78,6 +78,12 @@ export enum Header {
   AccessControlRequestMethod = 'Access-Control-Request-Method',
   CacheControl = 'Cache-Control',
   AcceptLanguage = 'Accept-Language',
+  XssProtecton = 'X-XSS-Protection',
+  FrameOptions = 'X-Frame-Options',
+  DownloadOptions = 'X-Download-Options',
+  ContentTypeOptions = 'X-Content-Type-Options',
+  StrictTransportSecurity = 'Strict-Transport-Security',
+  ReferrerPolicy = 'Referrer-Policy',
 }
 
 export enum CspDirective {


### PR DESCRIPTION
Adds the following headers: 'X-XSS-Protection', 'X-Frame-Options', 'X-Download-Options', 'X-Content-Type-Options', 'Strict-Transport-Security', 'Referrer-Policy'

Closes: https://github.com/Shopify/quilt/issues/718