### PR TITLE
Reinstate translation key exists method

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -241,6 +241,16 @@ i18n.translate(key, {scope: 'MyComponent.option'});
 i18n.translate(key, {scope: ['MyComponent', 'option']});
 ```
 
+It may be necessary to check dynamic keys. You can use the `translationKeyExists` method to do so:
+
+```ts
+const keyExists = i18n.translationKeyExists(key);
+
+if (keyExists) {
+  return i18n.translate(key, {scope: ['MyComponent', 'option']});
+}
+```
+
 ##### Pluralization
 
 `@shopify/react-i18n` handles pluralization similarly to [Rails’ default i18n utility](https://guides.rubyonrails.org/i18n.html#pluralization). The key is to provide the plural-dependent value as a `count` variable. `react-i18n` then looks up the plural form using [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) and, within the keypath you have specified for the translation, will look up a nested translation matching the plural form:

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -177,6 +177,15 @@ export class I18n {
     }
   }
 
+  translationKeyExists(id: string) {
+    try {
+      this.translate(id);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
   formatNumber(
     amount: number,
     {as, precision, ...options}: NumberFormatOptions = {},

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1050,4 +1050,29 @@ describe('I18n', () => {
       expect(i18n.getCurrencySymbol('eur')).toStrictEqual(mockResult);
     });
   });
+
+  describe('#translationKeyExists', () => {
+    it('returns true if the translation key exists', () => {
+      const mockResult = 'translated string';
+      translate.mockReturnValue(mockResult);
+
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      const result = i18n.translationKeyExists('hello');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false if the translation key does not exist', () => {
+      const key = 'foo';
+      const error = new MissingTranslationError(key);
+      translate.mockImplementation(() => {
+        throw error;
+      });
+
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      const result = i18n.translationKeyExists(key);
+
+      expect(result).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
[Legacy-i18n had a `translationKeyExists` method](https://github.com/Shopify/web/blob/master/packages/@shopify/legacy-i18n/src/decorators.tsx#L294). This PR adds it to the new library. Some alternatives are discussed [here](https://github.com/Shopify/web/pull/15137#discussion_r296862478).

📔will update the README if this is deemed the correct approach