### PR TITLE
 enhance: allow MockLink and MockApolloLink to return full GraphQLErrors

### DIFF
--- a/packages/graphql-testing/CHANGELOG.md
+++ b/packages/graphql-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow `MockLink` to return a full GraphQLError. ([#768](https://github.com/Shopify/quilt/pull/768))
+
 ## [3.1.0] - 2019-05-22
 
 ### Added

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -50,6 +50,10 @@ export class MockLink extends ApolloLink {
 
         const error = new Error(message);
         result = error;
+      } else if (response instanceof GraphQLError) {
+        result = {
+          errors: [response],
+        };
       } else if (response instanceof Error) {
         result = {errors: [new GraphQLError(response.message)]};
       } else {

--- a/packages/graphql-testing/src/links/tests/mocks.test.ts
+++ b/packages/graphql-testing/src/links/tests/mocks.test.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 
+import {GraphQLError} from 'graphql';
 import {MockGraphQLResponse} from '../../types';
 import {MockLink} from '../mocks';
 
@@ -69,5 +70,31 @@ describe('MockLink', () => {
         "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided a function that did not return a valid mock result)",
       ),
     );
+  });
+
+  it('returns a GraphQLError when there is a GraphQLError matching an operation', async () => {
+    const error = new GraphQLError(
+      'error message',
+      undefined,
+      undefined,
+      undefined,
+      ['path1', 'path2'],
+    );
+    const link = new MockLink({
+      Pet: error,
+    });
+    const {result} = await executeOnce(link, petQuery);
+
+    expect(result).toMatchObject({errors: [error]});
+  });
+
+  it('returns a GraphQLError with the message from an Error matching an operation', async () => {
+    const error = new Error('error message');
+    const link = new MockLink({
+      Pet: error,
+    });
+    const {result} = await executeOnce(link, petQuery);
+
+    expect(result).toMatchObject({errors: [new GraphQLError(error.message)]});
   });
 });

--- a/packages/jest-mock-apollo/CHANGELOG.md
+++ b/packages/jest-mock-apollo/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-<!-- Unreleased changes should go to UNRELEASED.md -->
-
 ---
 
-## 2.2.5 - 2019-01-09
+## [Unreleased]
 
-- Start of Changelog
+### Added
+
+- Allow `MockApolloLink` to return a full GraphQLError. ([#768](https://github.com/Shopify/quilt/pull/768))

--- a/packages/jest-mock-apollo/src/MockApolloLink.ts
+++ b/packages/jest-mock-apollo/src/MockApolloLink.ts
@@ -62,6 +62,10 @@ export default class MockApolloLink extends ApolloLink {
 
         const error = new Error(message);
         result = error;
+      } else if (response instanceof GraphQLError) {
+        result = {
+          errors: [response],
+        };
       } else if (response instanceof Error) {
         result = {errors: [new GraphQLError(response.message)]};
       } else {


### PR DESCRIPTION
Fixes https://github.com/Shopify/quilt/issues/767
Related to https://github.com/Shopify/app-bridge/issues/932