### PR TITLE
Don't call betweenEachPass on any kind of last pass

### DIFF
--- a/packages/react-effect/CHANGELOG.md
+++ b/packages/react-effect/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [3.1.1] - 2019-06-27
+## [3.2.0] - 2019-06-27
 
 ### Fixed
 

--- a/packages/react-effect/CHANGELOG.md
+++ b/packages/react-effect/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.1.1] - 2019-06-27
+
+### Fixed
+
+- Fixed an issue where `betweenEachPass` was called on the last pass before `maxPasses` was reached. In order to correct this issue, returning `false` from `betweenEachPass` no longer halts render looping (use `afterEachPass` instead). [#769](https://github.com/Shopify/quilt/pull/769)
+
 ## [3.1.0] - 2019-06-14
 
 ### Added

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -75,9 +75,9 @@ You may optionally pass an options object that contains the following keys (all 
 
 - `maxPasses`: a number that limits the number of render/ resolve cycles `extract` is allowed to perform. This option defaults to `5`.
 
-- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected). This function can return a promise, and it will be waited on before continuing. It is called with a single argument: a `Pass` object, which contains the `index`, `finished`, `renderDuration` and `resolveDuration` of the just-completed pass. Returning `false` (or a promise that resolves to `false`) from this method will bail out of subsequent passes.
-
 - `afterEachPass`: a function that is called after each pass of your tree, regardless of whether traversal is "finished". This function can return a promise, and it will be waited on before continuing. This function is called with the same argument as the `betweenEachPass` option. Returning `false` (or a promise for `false`) from this method will bail out of subsequent passes.
+
+- `betweenEachPass`: a function that is called after a pass of your tree that did not "finish" (that is, there were still promises that got collected, and we are still less than `maxPasses`). This function can return a promise, and it will be waited on before continuing. It is called with a single argument: a `Pass` object, which contains the `index`, `finished`, `cancelled` (`maxPasses` reached), `renderDuration` and `resolveDuration` of the just-completed pass. If there is another pass to perform, this method is called **after** `afterEachPass`.
 
 - `decorate`: a function that takes the root React element in your tree and returns a new tree to use. You can use this to wrap your application in context providers that only your server render requires.
 

--- a/packages/react-effect/src/manager.ts
+++ b/packages/react-effect/src/manager.ts
@@ -17,6 +17,11 @@ export class EffectManager {
     this.include = include;
   }
 
+  reset() {
+    this.effects = [];
+    this.kinds = new Set();
+  }
+
   add(effect: any, kind?: EffectKind) {
     if (kind != null) {
       this.kinds.add(kind);
@@ -34,7 +39,7 @@ export class EffectManager {
   }
 
   async betweenEachPass(pass: Pass) {
-    const results = await Promise.all(
+    await Promise.all(
       [...this.kinds].map(
         kind =>
           typeof kind.betweenEachPass === 'function'
@@ -42,8 +47,6 @@ export class EffectManager {
             : Promise.resolve(),
       ),
     );
-
-    return results.every(result => result !== false);
   }
 
   async afterEachPass(pass: Pass) {
@@ -55,9 +58,6 @@ export class EffectManager {
             : Promise.resolve(),
       ),
     );
-
-    this.effects = [];
-    this.kinds = new Set();
 
     return results.every(result => result !== false);
   }

--- a/packages/react-effect/src/types.ts
+++ b/packages/react-effect/src/types.ts
@@ -1,6 +1,7 @@
 export interface Pass {
   index: number;
   finished: boolean;
+  cancelled: boolean;
   renderDuration: number;
   resolveDuration: number;
 }

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -16,10 +16,10 @@ interface Options {
 export class NetworkManager {
   readonly effect: EffectKind = {
     id: EFFECT_ID,
-    afterEachPass() {
+    afterEachPass: () => {
       return this.redirectUrl == null;
     },
-    betweenEachPass() {
+    betweenEachPass: () => {
       this.reset();
     },
   };

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -16,13 +16,11 @@ interface Options {
 export class NetworkManager {
   readonly effect: EffectKind = {
     id: EFFECT_ID,
-    betweenEachPass: () => {
-      if (this.redirectUrl == null) {
-        this.reset();
-        return true;
-      } else {
-        return false;
-      }
+    afterEachPass() {
+      return this.redirectUrl == null;
+    },
+    betweenEachPass() {
+      this.reset();
     },
   };
 


### PR DESCRIPTION
This PR fixes some logical errors in `react-effect`’s `betweenEachPass`. We use this hook as a way to clear out any results in managers when there is another pass to perform. This prevents stale data from a previous pass ending up in a subsequent one. However, we were calling this even when we had reached the `maxPasses`. In practice, this meant that any code reaching the maximum number of passes in Web would run the `betweenEachPass` of `react-async`, which clears out the cache of used assets, so no async assets would ever be reported 😬.

cc/ @rox163 