### PR TITLE
Fix cache-less queries in SSR

### DIFF
--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -44,6 +44,10 @@ export default function useQuery<
 
   const query = useGraphQLDocument(queryOrComponent);
 
+  const normalizedFetchPolicy =
+    typeof window === 'undefined' && fetchPolicy === 'network-only'
+      ? 'cache-first'
+      : fetchPolicy;
   const serializedVariables = variables && JSON.stringify(variables);
   const watchQueryOptions = useMemo<WatchQueryOptions<Variables> | null>(
     () => {
@@ -55,7 +59,7 @@ export default function useQuery<
         query,
         context,
         variables,
-        fetchPolicy,
+        fetchPolicy: normalizedFetchPolicy,
         errorPolicy,
         pollInterval,
         notifyOnNetworkStatusChange,
@@ -67,7 +71,7 @@ export default function useQuery<
       // eslint-disable-next-line react-hooks/exhaustive-deps
       context && JSON.stringify(context),
       serializedVariables,
-      fetchPolicy,
+      normalizedFetchPolicy,
       errorPolicy,
       pollInterval,
       notifyOnNetworkStatusChange,

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -38,8 +38,8 @@ export default function useQuery<
   } = options;
   const client = useApolloClient(overrideClient);
 
-  if ((typeof window === 'undefined' && skip) || fetchPolicy === 'no-cache') {
-    return createDefaultResult(client, variables);
+  if (typeof window === 'undefined' && (skip || fetchPolicy === 'no-cache')) {
+    return {...createDefaultResult(client, variables), loading: !skip};
   }
 
   const query = useGraphQLDocument(queryOrComponent);

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -38,7 +38,7 @@ export default function useQuery<
   } = options;
   const client = useApolloClient(overrideClient);
 
-  if (typeof window === 'undefined' && skip) {
+  if ((typeof window === 'undefined' && skip) || fetchPolicy === 'no-cache') {
     return createDefaultResult(client, variables);
   }
 

--- a/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import {renderToString} from 'react-dom/server';
+import gql from 'graphql-tag';
+import {FetchPolicy} from 'apollo-client';
+import {createGraphQLFactory} from '@shopify/graphql-testing';
+import {extract} from '@shopify/react-effect/server';
+
+import useQuery from '../query';
+import {ApolloProvider} from '../../ApolloProvider';
+
+const petQuery = gql`
+  query PetQuery {
+    pets {
+      name
+    }
+  }
+`;
+
+const createGraphQL = createGraphQLFactory();
+const mockData = {
+  pets: [
+    {
+      __typename: 'Cat',
+      name: 'Garfield',
+    },
+  ],
+};
+
+function MockQuery({fetchPolicy = 'network-only' as FetchPolicy}) {
+  const {data, loading} = useQuery(petQuery, {fetchPolicy});
+  return loading ? <div>loading</div> : <pre>{JSON.stringify(data)}</pre>;
+}
+
+describe('useQuery', () => {
+  it('does not loop infinitely when a query has network-only during SSR', async () => {
+    const graphQL = createGraphQL({PetQuery: mockData});
+    const afterEachSpy = jest.fn();
+
+    const extractPromise = extract(
+      <ApolloProvider client={graphQL.client}>
+        <MockQuery fetchPolicy="network-only" />
+      </ApolloProvider>,
+      {
+        afterEachPass: afterEachSpy,
+      },
+    );
+
+    await graphQL.resolveAll();
+    await extractPromise;
+
+    // One call for the first pass, another call after the GraphQL
+    // resolves
+    expect(afterEachSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not run a query with the no-cache fetch policy during SSR', async () => {
+    const graphQL = createGraphQL({PetQuery: mockData});
+    const afterEachSpy = jest.fn();
+    const element = (
+      <ApolloProvider client={graphQL.client}>
+        <MockQuery fetchPolicy="no-cache" />
+      </ApolloProvider>
+    );
+
+    const extractPromise = extract(element, {
+      afterEachPass: afterEachSpy,
+    });
+
+    await graphQL.resolveAll();
+    await extractPromise;
+
+    // One call for the first pass, which is the only one because there are
+    // no GraphQL queries to resolve.
+    expect(afterEachSpy).toHaveBeenCalledTimes(1);
+
+    expect(renderToString(element)).toContain('loading');
+  });
+});


### PR DESCRIPTION
There are two types of `fetchPolicies` that ignore the cache: `network-only` and `no-cache`. We aren't currently handling either of them well: AFAICT, in both cases queries lead to infinite looping while trying to resolve during SSR, because the client will make a fresh query every time. This PR is a stab at addressing them that I *think* makes sense. In the case of `network-only`, we can transform it to be `cache-first` in SSR, so that it will save to cache and re-use for all subsequent server renders. `no-cache` has a promise about not putting stuff in the cache, so for those, I've updated the code to consider them equivalent to `skip`ped queries.

cc/ @rox163 while I was playing with this locally, it reduced the number of render loops needed for products pages to just 3 (one for the first set of queries, one for the queries rendered by the product show page, and one last one where it finds no more queries to resolve).