### PR TITLE
[react-i18n] Pass loading state to I18n class

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- Added `loading` property to I18n class. This helps to determine loading states when retrieving translations async on apps that are rendered client-side.
+
 ## [1.4.0] - 2019-06-27
 
 - Added `translationKeyExists` method for checking dynamic keys ([#766](https://github.com/Shopify/quilt/pull/766))

--- a/packages/react-i18n/src/hooks.tsx
+++ b/packages/react-i18n/src/hooks.tsx
@@ -54,19 +54,23 @@ function useComplexI18n(
   }
 
   const [i18n, setI18n] = React.useState(() => {
-    const {translations} = manager.state(ids.current);
-    return new I18n(translations, manager.details);
+    const managerState = manager.state(ids.current);
+    const {translations, loading} = managerState;
+    return new I18n(translations, {...manager.details, loading});
   });
 
   const i18nRef = React.useRef(i18n);
 
   React.useEffect(
     () => {
-      return manager.subscribe(ids.current, ({translations}, details) => {
-        const newI18n = new I18n(translations, details);
-        i18nRef.current = newI18n;
-        setI18n(newI18n);
-      });
+      return manager.subscribe(
+        ids.current,
+        ({translations, loading}, details) => {
+          const newI18n = new I18n(translations, {...details, loading});
+          i18nRef.current = newI18n;
+          setI18n(newI18n);
+        },
+      );
     },
     [ids, manager],
   );

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -63,6 +63,7 @@ export class I18n {
   readonly defaultCurrency?: string;
   readonly defaultTimezone?: string;
   readonly onError: NonNullable<I18nDetails['onError']>;
+  readonly loading: boolean;
 
   get language() {
     return languageFromLocale(this.locale);
@@ -102,7 +103,8 @@ export class I18n {
       country,
       pseudolocalize = false,
       onError,
-    }: I18nDetails,
+      loading,
+    }: I18nDetails & {loading?: boolean},
   ) {
     this.locale = locale;
     this.defaultCountry = country;
@@ -110,6 +112,7 @@ export class I18n {
     this.defaultTimezone = timezone;
     this.pseudolocalize = pseudolocalize;
     this.onError = onError || defaultOnError;
+    this.loading = loading || false;
   }
 
   translate(

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -35,6 +35,20 @@ describe('I18n', () => {
     });
   });
 
+  describe('#loading', () => {
+    it('is exposed publicly', () => {
+      const locale = 'en';
+      const i18n = new I18n(defaultTranslations, {locale, loading: true});
+      expect(i18n).toHaveProperty('loading', true);
+    });
+
+    it('defaults to false', () => {
+      const locale = 'en';
+      const i18n = new I18n(defaultTranslations, {locale});
+      expect(i18n).toHaveProperty('loading', false);
+    });
+  });
+
   describe('#language', () => {
     it('is determined from the locale', () => {
       const locale = 'fr-ca';


### PR DESCRIPTION
Closes: https://github.com/Shopify/quilt/issues/728

Add the loading state to the I18n class. 

This property is already being determined by the manager.state function but isn't being read anywhere. This PR just passes it along to the I18n class and exposes it publicly.

**Note**: I made the loading prop mandatory in the I18nDetails. This lead to me having to change several tests to include this. Another option I thought of was defaulting to false in the class itself `this.loading = loading || false;`. If this is a more desirable approach I can change it. 👍

**EDIT:** I ended up going with the default approach for less code to be changed.