### PR TITLE
Koa React Sidecar SSR Server

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,10 @@ const moduleNameMapper = getPackageNames().reduce(
       '<rootDir>/packages/react-effect/src/server.tsx',
     '@shopify/react-async/testing':
       '<rootDir>/packages/react-async/src/testing.tsx',
+    '@shopify/react-html/server':
+      '<rootDir>/packages/react-html/src/server/index.ts',
+    '@shopify/react-network/server':
+      '<rootDir>/packages/react-network/src/server.ts',
   },
 );
 

--- a/packages/koa-react-sidecar/CHANGELOG.md
+++ b/packages/koa-react-sidecar/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/koa-react-sidecar` package

--- a/packages/koa-react-sidecar/README.md
+++ b/packages/koa-react-sidecar/README.md
@@ -1,0 +1,14 @@
+# `@shopify/koa-react-sidecar`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-react-sidecar.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-react-sidecar.svg)
+
+Approachable React Server Side Rendering for non-node projects.
+
+## Installation
+
+```bash
+$ yarn add @shopify/koa-react-sidecar
+```
+
+## Usage

--- a/packages/koa-react-sidecar/example/index.tsx
+++ b/packages/koa-react-sidecar/example/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import {createServer} from '../dist/server';
+
+function MockApp() {
+  return <div>I am react</div>;
+}
+
+createServer({
+  port: 4444,
+  render: () => <MockApp />,
+});

--- a/packages/koa-react-sidecar/package.json
+++ b/packages/koa-react-sidecar/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@shopify/koa-react-sidecar",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Approachable React Server Side Rendering for non-node projects.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/koa-react-sidecar/README.md",
+  "dependencies": {
+    "koa": "^2.5.0",
+    "node-mocks-http": "^1.5.8",
+    "@shopify/network": "^1.4.1",
+    "@shopify/react-effect": "^3.2.0",
+    "@shopify/react-html": "8.1.3",
+    "@shopify/react-network": "3.1.2"
+  },
+  "devDependencies": {
+    "@types/koa": "^2.0.44",
+    "typescript": "~3.2.1",
+    "supertest": "^4.0.2"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/koa-react-sidecar/src/index.ts
+++ b/packages/koa-react-sidecar/src/index.ts
@@ -1,0 +1,2 @@
+export {createServer} from './server';
+export {createRender} from './render';

--- a/packages/koa-react-sidecar/src/render/index.ts
+++ b/packages/koa-react-sidecar/src/render/index.ts
@@ -1,0 +1,1 @@
+export {createRender, RenderContext} from './render';

--- a/packages/koa-react-sidecar/src/render/render.tsx
+++ b/packages/koa-react-sidecar/src/render/render.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Context} from 'koa';
+import {renderToString} from 'react-dom/server';
+import {Html, HtmlManager, HtmlContext} from '@shopify/react-html/server';
+import {
+  applyToContext,
+  NetworkContext,
+  NetworkManager,
+} from '@shopify/react-network/server';
+import {extract} from '@shopify/react-effect/server';
+import {Header} from '@shopify/react-network';
+
+export type RenderContext = Context & {};
+
+const logger = console;
+
+export function createRender(
+  renderFunction: (ctx: RenderContext) => React.ReactElement<any>,
+) {
+  return async function render(ctx: RenderContext) {
+    const app = renderFunction(ctx);
+    const networkManager = new NetworkManager();
+    const htmlManager = new HtmlManager();
+
+    try {
+      await extract(app, {
+        decorate(app) {
+          return (
+            <NetworkContext.Provider value={networkManager}>
+              <HtmlContext.Provider value={htmlManager}>
+                {app}
+              </HtmlContext.Provider>
+            </NetworkContext.Provider>
+          );
+        },
+      });
+    } catch (error) {
+      logger.error(error);
+      throw error;
+    }
+
+    applyToContext(ctx, networkManager);
+    const response = renderToString(<Html manager={htmlManager}>{app}</Html>);
+
+    ctx.set(Header.ContentType, 'text/html');
+    ctx.body = response;
+
+    return response;
+  };
+}

--- a/packages/koa-react-sidecar/src/render/test/render.test.tsx
+++ b/packages/koa-react-sidecar/src/render/test/render.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {createMockContext} from '@shopify/jest-koa-mocks';
+import {createRender, RenderContext} from '../render';
+
+describe('createRender()', () => {
+  function MockApp() {
+    return <div>markup</div>;
+  }
+
+  it('renders the return value of a given function and adds the result to the server context body', async () => {
+    const context = createRenderContext();
+    const render = createRender(() => <MockApp />);
+
+    await render(context);
+
+    expect(context.body).toMatch(/<div data-reactroot="">markup<\/div>/);
+  });
+});
+
+function createRenderContext(): RenderContext {
+  return createMockContext();
+}

--- a/packages/koa-react-sidecar/src/render/test/render.test.tsx
+++ b/packages/koa-react-sidecar/src/render/test/render.test.tsx
@@ -13,7 +13,8 @@ describe('createRender()', () => {
 
     await render(context);
 
-    expect(context.body).toMatch(/<div data-reactroot="">markup<\/div>/);
+    expect(context.body).toMatch(/<html lang="en" data-reactroot="">/);
+    expect(context.body).toMatch(/<div>markup<\/div>/);
   });
 });
 

--- a/packages/koa-react-sidecar/src/server/index.ts
+++ b/packages/koa-react-sidecar/src/server/index.ts
@@ -1,0 +1,1 @@
+export {createServer} from './server';

--- a/packages/koa-react-sidecar/src/server/server.ts
+++ b/packages/koa-react-sidecar/src/server/server.ts
@@ -1,0 +1,21 @@
+import {Server} from 'http';
+import Koa from 'koa';
+import {createRender, RenderContext} from '../render';
+
+const logger = console;
+
+interface Options {
+  port?: number;
+  render: (ctx: RenderContext) => React.ReactElement;
+}
+
+export function createServer(options: Options): Server {
+  const {port, render} = options;
+  const app = new Koa();
+
+  app.use(createRender(render));
+
+  return app.listen(port || 3000, () => {
+    logger.log(`started sidecar server on ${port}`);
+  });
+}

--- a/packages/koa-react-sidecar/src/server/test/server.test.tsx
+++ b/packages/koa-react-sidecar/src/server/test/server.test.tsx
@@ -8,7 +8,7 @@ describe('createServer()', () => {
     return <div>markup</div>;
   }
 
-  const port = 4444;
+  const port = 4443;
 
   let server: Server;
 
@@ -30,10 +30,8 @@ describe('createServer()', () => {
         return resp;
       });
 
-    expect(response).toMatchObject(
-      expect.objectContaining({
-        text: '<div data-reactroot="">markup</div>',
-      }),
+    expect(response.text).toBe(
+      `<html lang="en" data-reactroot=""><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="referrer" content="never"/></head><body><div id="app"><div>markup</div></div></body></html>`,
     );
   });
 });

--- a/packages/koa-react-sidecar/src/server/test/server.test.tsx
+++ b/packages/koa-react-sidecar/src/server/test/server.test.tsx
@@ -1,0 +1,39 @@
+import {Server} from 'http';
+import React from 'react';
+import request from 'supertest';
+import {createServer} from '../server';
+
+describe('createServer()', () => {
+  function MockApp() {
+    return <div>markup</div>;
+  }
+
+  const port = 4444;
+
+  let server: Server;
+
+  beforeEach(async () => {
+    server = await createServer({
+      port,
+      render: () => <MockApp />,
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('starts a server that responds with markup', async () => {
+    const response = await request(`http://localhost:${port}`)
+      .get('/')
+      .then((resp: request.Response) => {
+        return resp;
+      });
+
+    expect(response).toMatchObject(
+      expect.objectContaining({
+        text: '<div data-reactroot="">markup</div>',
+      }),
+    );
+  });
+});

--- a/packages/koa-react-sidecar/tsconfig.build.json
+++ b/packages/koa-react-sidecar/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,6 +1896,13 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+combined-stream@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
@@ -1923,6 +1930,11 @@ compare-versions@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
   integrity sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==
+
+component-emitter@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -2150,6 +2162,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
   integrity sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=
+
+cookiejar@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 cookies@~0.7.0:
   version "0.7.1"
@@ -3590,6 +3607,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.4.0.tgz#4902b831b051e0db5612a35e1a098376f7b13ad8"
+  integrity sha512-4FinE8RfqYnNim20xDwZZE0V2kOs/AuElIjFUbPuegQSaoZM+vUT5FnwSl10KPugH4voTg1bEQlcbCG9ka75TA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
@@ -3607,6 +3633,11 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -6110,7 +6141,7 @@ merge@^1.1.3:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
   integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
 
-methods@^1.1.2:
+methods@^1.1.1, methods@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -6165,7 +6196,7 @@ mime-types@^2.0.7, mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, m
   dependencies:
     mime-db "~1.33.0"
 
-mime@^1.3.4:
+mime@^1.3.4, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -7154,6 +7185,11 @@ q@^1.4.1, q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qs@^6.5.1:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 qs@^6.5.2:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
@@ -7437,6 +7473,19 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 realpath-native@^1.0.0:
@@ -8247,6 +8296,13 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
@@ -8317,6 +8373,30 @@ strong-log-transformer@^1.0.6:
     minimist "^0.1.0"
     moment "^2.6.0"
     through "^2.3.4"
+
+superagent@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
+
+supertest@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
+  integrity sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^3.8.3"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**This is just a pre-release version. Very WIP. Not safe for use**

This PR creates a utility function that will start a server and render a given base app in SSR.

To test it out, from the root of this repo run:

```npx ts-node packages/koa-react-sidecar/example/index.tsx ```

In another tab, check-out https://github.com/Shopify/web-rails-proving-ground/pull/4 and run:

```
dev up
dev run
```

You should see the markup from the react app, rendered server side.