### PR TITLE
⚡️Fix Preconnect for Safari

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-<!-- Unreleased changes should go to UNRELEASED.md -->
-
 ---
 
 ## Unreleased
+
+### Changed
+
+- The `<Preconnect />` component now works for Safari users, at the expense of IE users. ([#776](https://github.com/Shopify/quilt/pull/776))
 
 ## 9.0.0 - 2019-07-03
 

--- a/packages/react-html/src/components/tests/Preconnect.test.tsx
+++ b/packages/react-html/src/components/tests/Preconnect.test.tsx
@@ -14,7 +14,7 @@ describe('<Preconnect />', () => {
     mountWithManager(<Preconnect source={source} />, manager);
 
     expect(spy).toHaveBeenCalledWith({
-      rel: 'dns-prefetch preconnect',
+      rel: 'preconnect',
       href: source,
     });
   });

--- a/packages/react-html/src/hooks.ts
+++ b/packages/react-html/src/hooks.ts
@@ -34,7 +34,7 @@ export function usePreconnect(source: string) {
   useDomEffect(
     manager =>
       manager.addLink({
-        rel: 'dns-prefetch preconnect',
+        rel: 'preconnect',
         href: source,
       }),
     [source],


### PR DESCRIPTION
## Description

RE: https://github.com/Shopify/marketing_assets/pull/3011
RE: https://bugs.webkit.org/show_bug.cgi?id=197010

Currently, `<Preconnect />` specifies `dns-prefetch preconnect` to support IE users and then modern browsers. Unfortunately, Safari does not support `preconnect` hints when the `rel` attribute contains multiple values and therefore Safari totally ignores the directive and won't do any preconnection.

This PR removes `dns-prefetch` and leaves `preconnect`, which essentially drops resource hints support for IE users but enables it for Safari users. I think this is a worthy trade 😅 

- [caniuse `dns-prefetch`](https://caniuse.com/#search=dns-prefetch)
- [caniuse `preconnect`](https://caniuse.com/#search=preconnect)

While I have not 🎩'd this change in the context of this package outside of the tests, I have tested the change in Marketing Assets using Safari and WebpageTest and can confirm this makes a difference.

## Type of change

- [x] `react-html` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
