### PR TITLE
✨ React testing / Add 'toContainReactComponentTimes' matcher 

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added a `toContainReactComponentTimes` matcher ([781](https://github.com/Shopify/quilt/pull/781))
 - Added a `toProvideReactContext` matcher ([#735](https://github.com/Shopify/quilt/pull/735))
 
 ## [1.5.4] - 2019-05-31

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -438,6 +438,18 @@ expect(myComponent).toContainReactComponent('div', {
 });
 ```
 
+### `.toContainReactComponentTimes(type: string | React.ComponentType, times: number, props?: object)`
+
+Asserts that a component matching `type` is in the descendants of the passed node a number of times. If the third argument is passed, this expectation will further filter the matches by components whose props are equal to the passed object (again, asymmetric matchers are fully supported). To assert that one component is or is not the descendant of the passed node use `.toContainReactComponent` or `.not.toContainReactComponent`.
+
+```tsx
+const myComponent = mount(<MyComponent />);
+
+expect(myComponent).toContainReactComponentTimes('div', 5, {
+  'aria-label': 'Hello world',
+});
+```
+
 ### `.toProvideReactContext<T>(context: Context<T>, value?: T)`
 
 Asserts that at least one `context.Provider` is in the descendants of the passed node. If the second argument is passed, this expectation will further filter the matches by providers whose value is equal to the passed object (again, asymmetric matchers are fully supported).

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -2,7 +2,10 @@ import {ComponentType, Context as ReactContext} from 'react';
 import {Props} from '@shopify/useful-types';
 
 import {toHaveReactProps, toHaveReactDataProps} from './props';
-import {toContainReactComponent} from './components';
+import {
+  toContainReactComponent,
+  toContainReactComponentTimes,
+} from './components';
 import {toProvideReactContext} from './context';
 import {toContainReactText, toContainReactHtml} from './strings';
 import {Node} from './types';
@@ -16,6 +19,11 @@ declare global {
       toHaveReactDataProps(data: {[key: string]: string}): void;
       toContainReactComponent<Type extends string | ComponentType<any>>(
         type: Type,
+        props?: Partial<Props<Type>>,
+      ): void;
+      toContainReactComponentTimes<Type extends string | ComponentType<any>>(
+        type: Type,
+        times: number,
         props?: Partial<Props<Type>>,
       ): void;
       toProvideReactContext<Type>(
@@ -32,6 +40,7 @@ expect.extend({
   toHaveReactProps,
   toHaveReactDataProps,
   toContainReactComponent,
+  toContainReactComponentTimes,
   toContainReactText,
   toContainReactHtml,
   toProvideReactContext,

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -141,3 +141,7 @@ function getObjectSubset(object: any, subset: any): any {
 
   return object;
 }
+
+export function pluralize(word: string, count: number) {
+  return count === 1 ? word : `${word}s`;
+}


### PR DESCRIPTION
## Description

This PR adds a new Jest matcher `toContainReactComponentTimes` to `react-testing`.

```
.toContainReactComponentTimes(type: string | React.ComponentType, times: number, props?: object)
```

It asserts that a component matching `type` is in the descendants of the passed node a number of times.

A similar matcher `toContainComponentTimes` is available in Shopify Web and is widely used. Adding it here so other developers could benefit from it.

Screenshots of errors messages when assertions are failing:

<img width="641" alt="Screen Shot 2019-07-08 at 11 48 36 AM" src="https://user-images.githubusercontent.com/3925905/60823798-5cffed80-a176-11e9-915f-e76a91bb26bc.png">
<img width="686" alt="Screen Shot 2019-07-08 at 11 47 48 AM" src="https://user-images.githubusercontent.com/3925905/60823799-5cffed80-a176-11e9-8873-a7e4fc4d6eff.png">

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->
- [x] React-testing - Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
