### PR TITLE
Fix deferred hydration assets in dev

### DIFF
--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -262,7 +262,13 @@ function getAsyncAssetsById(id: string | RegExp, {asyncAssets}: Manifest) {
 }
 
 function kindFromAssetSelector({styles = true, scripts = true}: AssetSelector) {
-  if (styles && scripts) {
+  // In development, styles are included as part of the JS bundles. Asking
+  // for only styles in that environment therefore equates to asking for
+  // both.
+  // eslint-disable-next-line no-process-env
+  const forceIncludeAll = styles && process.env.NODE_ENV === 'development';
+
+  if ((styles && scripts) || forceIncludeAll) {
     return null;
   } else if (styles) {
     return AssetKind.Styles;

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -327,6 +327,37 @@ describe('Assets', () => {
         await assets.asyncAssets([{id: /mypage/, scripts: false}]),
       ).toStrictEqual([{path: asyncCss}]);
     });
+
+    it('includes scripts even when omitted in development', async () => {
+      const css = '/style.css';
+      const asyncCss = '/mypage.css';
+      const js = '/script.js';
+      const asyncJs = 'mypage.js';
+
+      readJson.mockImplementation(() =>
+        mockConsolidatedManifest([
+          mockManifest({
+            entrypoints: {
+              custom: mockEntrypoint({
+                styles: [mockAsset(css)],
+                scripts: [mockAsset(js)],
+              }),
+            },
+            asyncAssets: {
+              mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+            },
+          }),
+        ]),
+      );
+
+      const assets = new Assets(defaultOptions);
+
+      expect(
+        await withEnv('development', () =>
+          assets.asyncAssets([{id: /mypage/, scripts: false}]),
+        ),
+      ).toStrictEqual([{path: asyncCss}, {path: asyncJs}]);
+    });
   });
 
   describe('userAgent', () => {


### PR DESCRIPTION
## Description

This PR improves the behaviour of dealing with style-only assets in dev. This is only really going to happen when an async component uses deferred hydration, because in that case we automatically include only the styles in the initial SSR. In dev, though, styles are injected by JS. This PR catches cases where only styles are requested, but the request is in dev, and reworks that to include the JS assets, too.
