### PR TITLE
Fix minor error in useMutation example for react-graphql

### DIFF
--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -320,7 +320,7 @@ If options exist in both places, they will be shallowly merge together with per-
 ```tsx
 import React from 'react';
 import {Form, TextField, Button, Banner} from '@shopify/polaris';
-import {useQuery} from '@shopify/react-graphql';
+import {useMutation} from '@shopify/react-graphql';
 
 import createCustomerMutation from './graphql/CreateCustomerMutation.graphql';
 


### PR DESCRIPTION
## Description

I caught a minor error where `useQuery` was imported in an example; it should've been `useMutation`.

## Type of change

Documentation.

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
