### PR TITLE
Allow extending mount

### DIFF
--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -54,7 +54,7 @@ export type CustomMountOptions<
 } & ContextOption<MountOptions, CreateContext> &
   AfterMountOption<MountOptions, Context, Async>;
 
-interface CustomMount<
+export interface CustomMount<
   MountOptions extends object,
   Context extends object,
   Async extends boolean

--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -42,7 +42,8 @@ type ContextOption<
 
 export type CustomMountOptions<
   MountOptions extends object = {},
-  Context extends object = {},
+  CreateContext extends object = {},
+  Context extends object = CreateContext,
   Async extends boolean = false
 > = {
   render(
@@ -50,24 +51,38 @@ export type CustomMountOptions<
     context: Context,
     options: MountOptions,
   ): React.ReactElement<any>;
-} & ContextOption<MountOptions, Context> &
+} & ContextOption<MountOptions, CreateContext> &
   AfterMountOption<MountOptions, Context, Async>;
 
-type CustomMount<
+interface CustomMount<
   MountOptions extends object,
   Context extends object,
   Async extends boolean
-> = IfAllOptionalKeys<
-  MountOptions,
+> {
   <Props>(
-    element: React.ReactElement<any>,
-    options?: MountOptions,
-  ) => CustomMountResult<Props, Context, Async>,
-  <Props>(
-    element: React.ReactElement<any>,
-    options: MountOptions,
-  ) => CustomMountResult<Props, Context, Async>
->;
+    ...args: IfAllOptionalKeys<
+      MountOptions,
+      [React.ReactElement<any>, MountOptions?],
+      [React.ReactElement<any>, MountOptions]
+    >
+  ): CustomMountResult<Props, Context, Async>;
+  extend<
+    AdditionalMountOptions extends object = {},
+    AdditionalContext extends object = {},
+    AdditionalAsync extends boolean = false
+  >(
+    options: CustomMountOptions<
+      MountOptions & AdditionalMountOptions,
+      AdditionalContext,
+      Context & AdditionalContext,
+      AdditionalAsync
+    >,
+  ): CustomMount<
+    MountOptions & AdditionalMountOptions,
+    Context & AdditionalContext,
+    AdditionalAsync extends true ? AdditionalAsync : Async
+  >;
+}
 
 type CustomMountResult<
   Props,
@@ -95,7 +110,7 @@ export function createMount<
   render,
   context: createContext = defaultContext,
   afterMount = defaultAfterMount,
-}: CustomMountOptions<MountOptions, Context, Async>): CustomMount<
+}: CustomMountOptions<MountOptions, Context, Context, Async>): CustomMount<
   MountOptions,
   Context,
   Async
@@ -117,6 +132,32 @@ export function createMount<
       ? afterMountResult.then(() => wrapper)
       : wrapper;
   }
+
+  Reflect.defineProperty(mount, 'extend', {
+    writable: false,
+    value: ({
+      context: createAdditionalContext = defaultContext,
+      render: additionalRender,
+      afterMount: additionalAfterMount = defaultAfterMount,
+    }: CustomMountOptions<any, any, any, any>) => {
+      return createMount<any, any, any>({
+        context: options => ({
+          ...createContext(options),
+          ...createAdditionalContext(options),
+        }),
+        render: (element, context, options) =>
+          render(additionalRender(element, context, options), context, options),
+        afterMount: (wrapper, options) => {
+          const result = additionalAfterMount(wrapper, options);
+          const finalResult = () => afterMount(wrapper, options);
+
+          return result != null && 'then' in result
+            ? result.then(finalResult)
+            : finalResult();
+        },
+      });
+    },
+  });
 
   return mount as any;
 }

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -121,4 +121,151 @@ describe('createMount()', () => {
     expect(div).toBeInstanceOf(Promise);
     await expect(div).resolves.toBeInstanceOf(Root);
   });
+
+  describe('extend', () => {
+    it('calls context with the merged options', () => {
+      const spy = jest.fn(identity);
+      const options = {foo: 'bar'};
+      const additionalOptions = {baz: 'qux'};
+
+      const customMount = createMount<typeof options, typeof options>({
+        context: identity,
+        render: identity,
+      });
+
+      const extendedMount = customMount.extend<
+        typeof additionalOptions,
+        typeof additionalOptions,
+        false
+      >({
+        render: identity,
+        context: spy,
+      });
+
+      extendedMount(<div />, {...options, ...additionalOptions});
+
+      expect(spy).toHaveBeenCalledWith({...options, ...additionalOptions});
+    });
+
+    it('stores the merged context on Root#context', () => {
+      const context = {foo: 'bar'};
+      const additionalContext = {baz: 'qux'};
+
+      const customMount = createMount<{}, typeof context>({
+        context: () => context,
+        render: identity,
+      });
+
+      const extendedMount = customMount.extend<
+        {},
+        typeof additionalContext,
+        false
+      >({
+        context: () => additionalContext,
+        render: identity,
+      });
+
+      const div = extendedMount(<div />);
+
+      expect(div).toHaveProperty('context', {...context, ...additionalContext});
+    });
+
+    it('calls the augmented render before the original render with the element, merged context, and merged options', () => {
+      const options = {foo: 'bar'};
+      const additionalOptions = {bar: 'baz'};
+      const finalOptions = {...options, ...additionalOptions};
+
+      const context = {baz: 'qux'};
+      const additionalContext = {qux: 'fuzz'};
+      const finalContext = {...context, ...additionalContext};
+
+      const element = <div />;
+
+      function InsideRender({children}: {children: React.ReactElement}) {
+        return <>{children}</>;
+      }
+
+      const renderSpy = jest.fn((element: React.ReactElement<{}>) => element);
+      const additionalRenderSpy = jest.fn((element: React.ReactElement<{}>) => (
+        <InsideRender>{element}</InsideRender>
+      ));
+
+      const customMount = createMount<typeof options, typeof context>({
+        context: () => context,
+        render: renderSpy,
+      });
+
+      const extendedMount = customMount.extend<
+        typeof additionalOptions,
+        typeof additionalContext
+      >({
+        context: () => additionalContext,
+        render: additionalRenderSpy,
+      });
+
+      extendedMount(element, finalOptions);
+
+      expect(additionalRenderSpy).toHaveBeenCalledWith(
+        element,
+        finalContext,
+        finalOptions,
+      );
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        expect.objectContaining({type: InsideRender}),
+        finalContext,
+        finalOptions,
+      );
+    });
+
+    it('calls afterMount with the wrapper and options', () => {
+      const spy = jest.fn();
+      const options = {foo: 'bar'};
+
+      const customMount = createMount({
+        render: identity,
+      });
+
+      const extendedMount = customMount.extend<typeof options>({
+        render: identity,
+        afterMount: spy,
+      });
+
+      const div = extendedMount(<div />, options);
+
+      expect(spy).toHaveBeenCalledWith(div, options);
+    });
+
+    it('waits until the extended afterMount resolves before calling the original afterMount', async () => {
+      const options = {foo: 'bar'};
+
+      const afterMountSpy = jest.fn();
+      const additionalAfterMountSpy = jest.fn(
+        () => new Promise(resolve => setTimeout(resolve, 1)),
+      );
+
+      const customMount = createMount<typeof options>({
+        render: identity,
+        afterMount: afterMountSpy,
+      });
+
+      const extendedMount = customMount.extend<{}, {}, true>({
+        render: identity,
+        afterMount: additionalAfterMountSpy,
+      });
+
+      const mountPromise = extendedMount(<div />, options);
+
+      expect(additionalAfterMountSpy).toHaveBeenCalled();
+      expect(afterMountSpy).not.toHaveBeenCalled();
+
+      const div = await mountPromise;
+
+      expect(afterMountSpy).toHaveBeenCalledWith(div, options);
+    });
+  });
 });
+
+function identity<T>(value: T) {
+  return value;
+}


### PR DESCRIPTION
## Description

This PR adds a new feature to `react-testing`: extending custom mount functions. What I've seen in Web is that many sections have additional context that are only needed for them. Implementing this is pretty annoying right now, because you can't hook into the same features as `createMount` to add new context/ accept additional options/ perform additional post-mount work. This PR adds this feature through `createMount(...).extend(...)`. Extend accepts all the same options as `createMount`, and the options are intelligently merged with the original set (see the README for details).

cc/ @patsissons because your use case made me consider this more seriously.
