### PR TITLE
:bug: react-testing should export the Node type

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `Node` type as an export ([789](https://github.com/Shopify/quilt/pull/789))
+
 ## [1.6.0] - 2019-06-04
 
 ### Added

--- a/packages/react-testing/src/index.ts
+++ b/packages/react-testing/src/index.ts
@@ -1,4 +1,5 @@
 export {Root} from './root';
 export {Element} from './element';
+export {Node} from './node';
 export * from './mount';
 export * from './destroy';

--- a/packages/react-testing/src/matchers/types.ts
+++ b/packages/react-testing/src/matchers/types.ts
@@ -1,6 +1,5 @@
 import {Root} from '../root';
 import {Element} from '../element';
+import {Node} from '../node';
 
-export {Root, Element};
-
-export type Node<Props> = Root<Props> | Element<Props>;
+export {Root, Element, Node};

--- a/packages/react-testing/src/node.ts
+++ b/packages/react-testing/src/node.ts
@@ -1,0 +1,4 @@
+import {Root} from './root';
+import {Element} from './element';
+
+export type Node<Props> = Root<Props> | Element<Props>;


### PR DESCRIPTION
## Description

Apps that want to build their own custom matchers for react-testing nodes
will find this useful instead of having to reimplement the type.

## Type of change

- [x] react-testing Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
