### PR TITLE
Formalize `Node` type in react-testing

### DIFF
--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -4,9 +4,13 @@ import {
   Arguments,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
-import {Tag, FunctionKeys, DeepPartialArguments} from './types';
-
-export type Predicate = (element: Element<unknown>) => boolean;
+import {
+  Tag,
+  Node,
+  Predicate,
+  FunctionKeys,
+  DeepPartialArguments,
+} from './types';
 
 type Root = import('./root').Root<any>;
 
@@ -17,7 +21,7 @@ interface Tree<Props> {
   instance?: any;
 }
 
-export class Element<Props> {
+export class Element<Props> implements Node<Props> {
   get props(): Props {
     return this.tree.props;
   }
@@ -82,7 +86,7 @@ export class Element<Props> {
     ) as Element<unknown>[];
   }
 
-  data(key: string): string {
+  data(key: string): string | undefined {
     return this.props[key.startsWith('data-') ? key : `data-${key}`];
   }
 

--- a/packages/react-testing/src/index.ts
+++ b/packages/react-testing/src/index.ts
@@ -1,4 +1,5 @@
 export {Root} from './root';
 export {Element} from './element';
+export {Node} from './types';
 export * from './mount';
 export * from './destroy';

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -7,7 +7,7 @@ import {
 } from 'jest-matcher-utils';
 import {Props} from '@shopify/useful-types';
 
-import {Node} from './types';
+import {Node} from '../types';
 import {assertIsNode, diffs, pluralize, printType} from './utilities';
 
 export function toContainReactComponent<

--- a/packages/react-testing/src/matchers/context.ts
+++ b/packages/react-testing/src/matchers/context.ts
@@ -6,7 +6,7 @@ import {
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
 
-import {Node} from './types';
+import {Node} from '../types';
 import {assertIsNode, diffs, printType} from './utilities';
 
 export function toProvideReactContext<Type>(

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,6 +1,7 @@
 import {ComponentType, Context as ReactContext} from 'react';
 import {Props} from '@shopify/useful-types';
 
+import {Node} from '../types';
 import {toHaveReactProps, toHaveReactDataProps} from './props';
 import {
   toContainReactComponent,
@@ -8,7 +9,6 @@ import {
 } from './components';
 import {toProvideReactContext} from './context';
 import {toContainReactText, toContainReactHtml} from './strings';
-import {Node} from './types';
 
 type PropsFromNode<T> = T extends Node<infer U> ? U : never;
 

--- a/packages/react-testing/src/matchers/props.ts
+++ b/packages/react-testing/src/matchers/props.ts
@@ -4,7 +4,7 @@ import {
   printExpected,
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
-import {Node} from './types';
+import {Node} from '../types';
 import {assertIsNode, diffPropsForNode} from './utilities';
 
 export function toHaveReactProps<Props>(

--- a/packages/react-testing/src/matchers/strings.ts
+++ b/packages/react-testing/src/matchers/strings.ts
@@ -5,7 +5,7 @@ import {
   RECEIVED_COLOR as receivedColor,
   INVERTED_COLOR as invertedColor,
 } from 'jest-matcher-utils';
-import {Node} from './types';
+import {Node} from '../types';
 import {assertIsNode} from './utilities';
 
 export function toContainReactText<Props>(

--- a/packages/react-testing/src/matchers/types.ts
+++ b/packages/react-testing/src/matchers/types.ts
@@ -1,6 +1,0 @@
-import {Root} from '../root';
-import {Element} from '../element';
-
-export {Root, Element};
-
-export type Node<Props> = Root<Props> | Element<Props>;

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -6,7 +6,10 @@ import {
   printWithType,
   printReceived,
 } from 'jest-matcher-utils';
-import {Node, Root, Element} from './types';
+
+import {Root} from '../root';
+import {Element} from '../element';
+import {Node} from '../types';
 
 export function assertIsNode(
   node: unknown,
@@ -57,11 +60,7 @@ export function assertIsNode(
   }
 }
 
-export function diffs(
-  element: Element<any>[],
-  props: object,
-  expand?: boolean,
-) {
+export function diffs(element: Node<any>[], props: object, expand?: boolean) {
   return element.reduce<string>((diffs, element, index) => {
     const separator = index === 0 ? '' : '\n\n';
 
@@ -73,7 +72,7 @@ export function diffs(
 }
 
 function normalizedDiff(
-  element: Element<any>,
+  element: Node<any>,
   props: object,
   {expand = false, showLegend = false},
 ) {

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -141,7 +141,7 @@ export class Root<Props> implements Node<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Element<PropsForComponent<Type>> & Root<PropsForComponent<Type>> {
+  ): this is Root<PropsForComponent<Type>> {
     return this.withRoot(root => root.is(type));
   }
 

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -8,10 +8,12 @@ import {
 } from '@shopify/useful-types';
 
 import {TestWrapper} from './TestWrapper';
-import {Element, Predicate} from './element';
+import {Element} from './element';
 import {
   Tag,
   Fiber,
+  Node,
+  Predicate,
   ReactInstance,
   FunctionKeys,
   DeepPartialArguments,
@@ -37,7 +39,7 @@ export interface Options {
 
 export const connected = new Set<Root<unknown>>();
 
-export class Root<Props> {
+export class Root<Props> implements Node<Props> {
   get props() {
     return this.withRoot(root => root.props);
   }
@@ -139,12 +141,16 @@ export class Root<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Root<PropsForComponent<Type>> {
+  ): this is Element<PropsForComponent<Type>> & Root<PropsForComponent<Type>> {
     return this.withRoot(root => root.is(type));
   }
 
   prop<K extends keyof Props>(key: K) {
     return this.withRoot(root => root.prop(key));
+  }
+
+  data(key: string) {
+    return this.withRoot(root => root.data(key));
   }
 
   find<Type extends React.ComponentType<any> | string>(

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -1,4 +1,9 @@
 import * as React from 'react';
+import {
+  Arguments,
+  MaybeFunctionReturnType,
+  Props as PropsForComponent,
+} from '@shopify/useful-types';
 
 export type FunctionKeys<T> = {
   [K in keyof T]-?: NonNullable<T[K]> extends ((...args: any[]) => any)
@@ -60,4 +65,46 @@ export interface Fiber {
 
 export interface ReactInstance {
   _reactInternalFiber: Fiber;
+}
+
+export type Predicate = (element: Node<unknown>) => boolean;
+
+export interface Node<Props> {
+  readonly props: Props;
+  readonly type: string | React.ComponentType<any> | null;
+  readonly isDOM: boolean;
+  readonly instance: any;
+  readonly children: Node<unknown>[];
+  readonly descendants: Node<unknown>[];
+  readonly domNodes: HTMLElement[];
+  readonly domNode: HTMLElement | null;
+
+  data(key: string): string | undefined;
+  prop<K extends keyof Props>(key: K): Props[K];
+
+  text(): string;
+  html(): string;
+
+  is<Type extends React.ComponentType<any> | string>(
+    type: Type,
+  ): this is Node<PropsForComponent<Type>>;
+
+  find<Type extends React.ComponentType<any> | string>(
+    type: Type,
+    props?: Partial<PropsForComponent<Type>>,
+  ): Node<PropsForComponent<Type>> | null;
+  findAll<Type extends React.ComponentType<any> | string>(
+    type: Type,
+    props?: Partial<PropsForComponent<Type>>,
+  ): Node<PropsForComponent<Type>>[];
+  findWhere(predicate: Predicate): Node<unknown> | null;
+  findAllWhere(predicate: Predicate): Node<unknown>[];
+
+  trigger<K extends FunctionKeys<Props>>(
+    prop: K,
+    ...args: DeepPartialArguments<Arguments<Props[K]>>
+  ): MaybeFunctionReturnType<NonNullable<Props[K]>>;
+  triggerKeypath<T = unknown>(keypath: string, ...args: unknown[]): T;
+
+  toString(): string;
 }

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -67,7 +67,7 @@ export interface ReactInstance {
   _reactInternalFiber: Fiber;
 }
 
-export type Predicate = (element: Node<unknown>) => boolean;
+export type Predicate = (node: Node<unknown>) => boolean;
 
 export interface Node<Props> {
   readonly props: Props;


### PR DESCRIPTION
This PR formalizes the `Node` type. Previously, it was only used in the matchers to mean "the root or an element". However, it's more accurate to say that both `Root` and `Element` *are* `Node`s, and that `Node` contains the type information for all the methods/ properties they have in common. This PR does just that.

Supersedes https://github.com/Shopify/quilt/pull/789