### PR TITLE
✨ Allow configurable path/to/assets.json

### DIFF
--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- [Minor] Adds configurable path/to/assets.json in the middleware options ([794](https://github.com/Shopify/quilt/pull/794))
+
 ## 6.0.1 - 2019-07-10
 
 ### Fixed

--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- [Minor] Adds configurable path/to/assets.json in the middleware options ([794](https://github.com/Shopify/quilt/pull/794))
+- [Minor] Adds configurable path/to/assets.json as `manifestPath` in the middleware options ([794](https://github.com/Shopify/quilt/pull/794))
 
 ## 6.0.1 - 2019-07-10
 

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -32,7 +32,7 @@ export type ConsolidatedManifest = Manifest[];
 interface Options {
   assetPrefix: string;
   userAgent?: string;
-  assetsJsonPath?: string;
+  manifestPath?: string;
 }
 
 interface AssetSelector {
@@ -51,16 +51,18 @@ enum AssetKind {
   Scripts = 'js',
 }
 
+const DEFAULT_MANIFEST_PATH = 'build/client/assets.json';
+
 export default class Assets {
   assetPrefix: string;
   userAgent?: string;
-  assetsJsonPath?: string;
+  manifestPath: string;
   private resolvedManifestEntry?: Manifest;
 
-  constructor({assetPrefix, userAgent, assetsJsonPath}: Options) {
+  constructor({assetPrefix, userAgent, manifestPath}: Options) {
     this.assetPrefix = assetPrefix;
     this.userAgent = userAgent;
-    this.assetsJsonPath = assetsJsonPath;
+    this.manifestPath = manifestPath || DEFAULT_MANIFEST_PATH;
   }
 
   async scripts(options: AssetOptions = {}) {
@@ -106,7 +108,7 @@ export default class Assets {
     }
 
     const consolidatedManifest = await loadConsolidatedManifest(
-      this.assetsJsonPath,
+      this.manifestPath,
     );
     const {userAgent} = this;
 
@@ -151,12 +153,12 @@ export default class Assets {
 let consolidatedManifestPromise: Promise<ConsolidatedManifest> | null = null;
 let graphQLManifestPromise: Promise<Map<string, string>> | null = null;
 
-function loadConsolidatedManifest(assetsJsonPath = 'build/client/assets.json') {
+function loadConsolidatedManifest(manifestPath: string) {
   if (consolidatedManifestPromise) {
     return consolidatedManifestPromise;
   }
 
-  consolidatedManifestPromise = readJson(join(appRoot.path, assetsJsonPath));
+  consolidatedManifestPromise = readJson(join(appRoot.path, manifestPath));
 
   return consolidatedManifestPromise;
 }

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -32,6 +32,7 @@ export type ConsolidatedManifest = Manifest[];
 interface Options {
   assetPrefix: string;
   userAgent?: string;
+  assetsJsonPath?: string;
 }
 
 interface AssetSelector {
@@ -53,11 +54,13 @@ enum AssetKind {
 export default class Assets {
   assetPrefix: string;
   userAgent?: string;
+  assetsJsonPath?: string;
   private resolvedManifestEntry?: Manifest;
 
-  constructor({assetPrefix, userAgent}: Options) {
+  constructor({assetPrefix, userAgent, assetsJsonPath}: Options) {
     this.assetPrefix = assetPrefix;
     this.userAgent = userAgent;
+    this.assetsJsonPath = assetsJsonPath;
   }
 
   async scripts(options: AssetOptions = {}) {
@@ -102,7 +105,9 @@ export default class Assets {
       return this.resolvedManifestEntry;
     }
 
-    const consolidatedManifest = await loadConsolidatedManifest();
+    const consolidatedManifest = await loadConsolidatedManifest(
+      this.assetsJsonPath,
+    );
     const {userAgent} = this;
 
     const lastManifestEntry =
@@ -146,14 +151,12 @@ export default class Assets {
 let consolidatedManifestPromise: Promise<ConsolidatedManifest> | null = null;
 let graphQLManifestPromise: Promise<Map<string, string>> | null = null;
 
-function loadConsolidatedManifest() {
+function loadConsolidatedManifest(assetsJsonPath = 'build/client/assets.json') {
   if (consolidatedManifestPromise) {
     return consolidatedManifestPromise;
   }
 
-  consolidatedManifestPromise = readJson(
-    join(appRoot.path, 'build/client/assets.json'),
-  );
+  consolidatedManifestPromise = readJson(join(appRoot.path, assetsJsonPath));
 
   return consolidatedManifestPromise;
 }

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -14,6 +14,7 @@ export {Assets, Asset};
 export interface Options {
   assetPrefix?: string;
   serveAssets?: boolean;
+  assetsJsonPath?: string;
 }
 
 const ASSETS = Symbol('assets');
@@ -29,11 +30,13 @@ export function setAssets(ctx: Context, assets: Assets) {
 export default function middleware({
   serveAssets = false,
   assetPrefix = defaultAssetPrefix(serveAssets),
+  assetsJsonPath,
 }: Options = {}): Middleware {
   async function sewingKitMiddleware(ctx: Context, next: () => Promise<any>) {
     const assets = new Assets({
       assetPrefix,
       userAgent: ctx.get(Header.UserAgent),
+      assetsJsonPath,
     });
 
     setAssets(ctx, assets);

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -14,7 +14,7 @@ export {Assets, Asset};
 export interface Options {
   assetPrefix?: string;
   serveAssets?: boolean;
-  assetsJsonPath?: string;
+  manifestPath?: string;
 }
 
 const ASSETS = Symbol('assets');
@@ -30,13 +30,13 @@ export function setAssets(ctx: Context, assets: Assets) {
 export default function middleware({
   serveAssets = false,
   assetPrefix = defaultAssetPrefix(serveAssets),
-  assetsJsonPath,
+  manifestPath,
 }: Options = {}): Middleware {
   async function sewingKitMiddleware(ctx: Context, next: () => Promise<any>) {
     const assets = new Assets({
       assetPrefix,
       userAgent: ctx.get(Header.UserAgent),
-      assetsJsonPath,
+      manifestPath,
     });
 
     setAssets(ctx, assets);

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -49,6 +49,15 @@ describe('Assets', () => {
     expect(readJson).toHaveBeenCalledTimes(1);
   });
 
+  it('reads the asset cache from a custom path', async () => {
+    const manifestPath = 'path/to/manifest';
+    const assets = new Assets({...defaultOptions, manifestPath});
+
+    await assets.styles();
+
+    expect(readJson).toHaveBeenCalledWith(join(appRoot.path, manifestPath));
+  });
+
   describe('scripts', () => {
     it('returns the main scripts by default', async () => {
       const js = '/style.js';

--- a/packages/sewing-kit-koa/src/tests/middleware.test.ts
+++ b/packages/sewing-kit-koa/src/tests/middleware.test.ts
@@ -39,6 +39,22 @@ describe('middleware', () => {
     expect(getAssets(context)).toHaveProperty('userAgent', userAgent);
   });
 
+  it('defaults the manifest path to `build/client/assets.json`', async () => {
+    const context = createMockContext();
+    await middleware()(context, () => Promise.resolve());
+    expect(getAssets(context)).toHaveProperty(
+      'manifestPath',
+      'build/client/assets.json',
+    );
+  });
+
+  it('accespts a custom value for the manifest path', async () => {
+    const context = createMockContext();
+    const manifestPath = 'path/to/manifest';
+    await middleware({manifestPath})(context, () => Promise.resolve());
+    expect(getAssets(context)).toHaveProperty('manifestPath', manifestPath);
+  });
+
   it('calls the next middleware', async () => {
     const next = jest.fn(() => Promise.resolve());
     await middleware()(createMockContext(), next);


### PR DESCRIPTION
## Description

Fixes (issue #)

This PR adds the ability to specify the path/to/assets.json so that we can support rails manifest locations. I've done this by adding a third property in the options for the consumer to pass in the `assetsJsonPath` when mounting the sewing-kit-koa middleware.

## Type of change

- [x] `@shopify/sewing-kit-koa` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
