### PR TITLE
🐛[react-testing] explicitly typing findWhere and findAllWhere

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- explicitly defining return type for `findWhere` and `findAllWhere` operators ([#795](https://github.com/Shopify/quilt/pull/795))
+
 ## [1.7.0] - 2019-07-15
 
 ### Added

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -166,11 +166,11 @@ export class Element<Props> implements Node<Props> {
     ) as Element<PropsForComponent<Type>>[];
   }
 
-  findWhere(predicate: Predicate) {
+  findWhere(predicate: Predicate): Element<unknown> | null {
     return this.elementDescendants.find(element => predicate(element)) || null;
   }
 
-  findAllWhere(predicate: Predicate) {
+  findAllWhere(predicate: Predicate): Element<unknown>[] {
     return this.elementDescendants.filter(element => predicate(element));
   }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

the `findWhere()` and `findAllWhere()` operators are currently untyped due to re-entrancy issues.

```tsx
    findWhere(predicate: Predicate): any;
    findAllWhere(predicate: Predicate): any;
```

This PR is explicitly typing these operators to deal with the issue.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-testing` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
