### PR TITLE
♻️Make release() return a promise

### DIFF
--- a/packages/semaphore/README.md
+++ b/packages/semaphore/README.md
@@ -51,6 +51,13 @@ Call the `.release()` method on a Permit instance to release it:
 permit.release();
 ```
 
+The `.release)()` method returns a promise that gets resolved when the permit is released and an earlier permit request that had been pending is resolved. Waiting on the resolution of the `.release()` is optional and could be useful in situations where you're having timing issues (e.g. in unit tests that utilize a Semaphore instance):
+
+```typescript
+await permit.release();
+```
+
+
 ## Example
 
 ```typescript

--- a/packages/semaphore/src/test/Semaphore.test.ts
+++ b/packages/semaphore/src/test/Semaphore.test.ts
@@ -1,5 +1,7 @@
 import {Semaphore, Permit} from '..';
 
+const endOfPollPhase = {then: setImmediate};
+
 describe('Semaphore', () => {
   describe('acquire()', () => {
     it('resolves with a permit when counter is > 0', async () => {
@@ -20,7 +22,7 @@ describe('Semaphore', () => {
         .then(spy)
         .catch(() => {});
 
-      await Promise.resolve();
+      await endOfPollPhase;
 
       expect(spy).not.toHaveBeenCalled();
     });
@@ -46,13 +48,11 @@ describe('Semaphore', () => {
         .then(spy)
         .catch(() => {});
 
-      await Promise.resolve();
+      await endOfPollPhase;
 
       expect(spy).not.toHaveBeenCalled();
 
-      permit.release();
-
-      await Promise.resolve();
+      await permit.release();
 
       expect(spy).toHaveBeenCalledWith(expect.any(Permit));
     });
@@ -75,21 +75,17 @@ describe('Semaphore', () => {
         .then(spy4)
         .catch(() => {});
 
-      await Promise.resolve();
+      await endOfPollPhase;
 
       expect(spy3).not.toHaveBeenCalled();
       expect(spy4).not.toHaveBeenCalled();
 
-      permit2.release();
-
-      await Promise.resolve();
+      await permit2.release();
 
       expect(spy3).toHaveBeenCalledWith(expect.any(Permit));
       expect(spy4).not.toHaveBeenCalled();
 
-      permit1.release();
-
-      await Promise.resolve();
+      await permit1.release();
 
       expect(spy4).toHaveBeenCalledWith(expect.any(Permit));
     });
@@ -115,16 +111,12 @@ describe('Permit', () => {
         .then(spy3)
         .catch(() => {});
 
-      permit.release();
-
-      await Promise.resolve();
+      await permit.release();
 
       expect(spy2).toHaveBeenCalledWith(expect.any(Permit));
       expect(spy3).not.toHaveBeenCalled();
 
-      permit.release();
-
-      await Promise.resolve();
+      await permit.release();
 
       expect(spy3).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Description

1. Make tests less flaky by waiting for the end of the poll phase instead of a `Promise.resolve()`.
2. Make the `release()` method of Permit return a promise so that things can be synchronized better (made testing a lot easier.) This was also needed for an upstream PR I'm working on to introduce a ResourcePool class.

## Type of change

A minor feature addition to an unreleased package. No need to bump versions, no need to document changes in CHANGELOG.

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
