### PR TITLE
✨ Use url-polyfill instead of url-search-params-polyfill

### DIFF
--- a/packages/polyfills/CHANGELOG.md
+++ b/packages/polyfills/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Use `url-polyfill` instead of `url-search-params-polyfill` as it polyfills `URL` as well, including `URL.searchParams`.
+
 ## [1.0.1] - 2019-08-07
 
 - Updated `intl` polyfill featureTest from `internationalization-plural-rul` to `intl-pluralrules` as per the update in [`caniuse-lite@1.0.30000989`](https://github.com/ben-eb/caniuse-lite/commit/6966b0553f4584435a4c95a76794a93750a9004d#diff-5264ce81b24e867ed52dcca8f6a162fbR1)

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -34,7 +34,7 @@
     "mutationobserver-shim": "^0.3.3",
     "node-fetch": "^2.3.0",
     "tslib": "^1.9.3",
-    "url-search-params-polyfill": "^5.0.0",
+    "url-polyfill": "^1.1.7",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/polyfills/src/url.browser.ts
+++ b/packages/polyfills/src/url.browser.ts
@@ -1,1 +1,1 @@
-require('url-search-params-polyfill');
+require('url-polyfill');

--- a/yarn.lock
+++ b/yarn.lock
@@ -9018,10 +9018,10 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-search-params-polyfill@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-5.0.0.tgz#09b98337c89dcf6c6a6a0bfeb096f6ba83b7526b"
-  integrity sha512-+SCD22QJp4UnqPOI5UTTR0Ljuh8cHbjEf1lIiZrZ8nHTlTixqwVsVQTSfk5vrmDz7N09/Y+ka5jQr0ff35FnQQ==
+url-polyfill@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.7.tgz#402ee84360eb549bbeb585f4c7971e79a31de9e3"
+  integrity sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA==
 
 urlgrey@0.4.4:
   version "0.4.4"


### PR DESCRIPTION
## Description

This swaps the use of `url-search-params-polyfill` for `uril-polyfill`. `url-polyfill` polyfills `URL` in addition to `URLSearchParams`, including `URL.searchParams`, which the original does not.
[url-polyfill](https://www.npmjs.com/package/url-polyfill)
[url-search-params-polyfill](https://www.npmjs.com/package/url-search-params-polyfill)

url-polyfill is ~100 extra lines of code, but also polyfills more things, so a bit of a tradeoff

## Type of change

- [ ] `@shopify/polyfill` Minor: More complete polyfill

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (?)
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
