### PR TITLE
Fix subscription updates being dropped

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,11 +8,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where async translations would sometimes not be shown on the initial mount of a component ([#824](https://github.com/Shopify/quilt/pull/824))
+
 ## [1.5.0] - 2019-07-02
+
+### Added
 
 - Added `loading` property to I18n class. This helps to determine loading states when retrieving translations async on apps that are rendered client-side.
 
 ## [1.4.0] - 2019-06-27
+
+### Added
 
 - Added `translationKeyExists` method for checking dynamic keys ([#766](https://github.com/Shopify/quilt/pull/766))
 

--- a/packages/react-i18n/src/hooks.tsx
+++ b/packages/react-i18n/src/hooks.tsx
@@ -41,6 +41,10 @@ function useComplexI18n(
   {id, fallback, translations}: Partial<RegisterOptions>,
   manager: I18nManager,
 ): Result {
+  const managerRef = React.useRef<I18nManager | null>(null);
+  const unsubscribeRef = React.useRef<ReturnType<I18nManager['subscribe']>>(
+    noop,
+  );
   const parentIds = React.useContext(I18nIdsContext);
 
   // Parent IDs can only change when a parent gets added/ removed,
@@ -49,8 +53,30 @@ function useComplexI18n(
   // reasons, it's safe to just store the IDs once and never let them change.
   const ids = useLazyRef(() => (id ? [id, ...parentIds] : parentIds));
 
-  if (id && (translations || fallback)) {
-    manager.register({id, translations, fallback});
+  // When the manager changes, we need to do the following IMMEDIATELY (i.e.,
+  // not in a useEffect callback):
+  //
+  // 1. Register the component’s translations. This ensures that the first render gets
+  //    the synchronous translations, if available.
+  // 2. Unsubscribe from changes to a previous manager.
+  // 3. Subscribe to changes from the new manager. This ensures that if the subscription
+  //    is updated between render and `useEffect`, the state update is not lost.
+  if (manager !== managerRef.current) {
+    managerRef.current = manager;
+
+    unsubscribeRef.current();
+    unsubscribeRef.current = manager.subscribe(
+      ids.current,
+      ({translations, loading}, details) => {
+        const newI18n = new I18n(translations, {...details, loading});
+        i18nRef.current = newI18n;
+        setI18n(newI18n);
+      },
+    );
+
+    if (id && (translations || fallback)) {
+      manager.register({id, translations, fallback});
+    }
   }
 
   const [i18n, setI18n] = React.useState(() => {
@@ -61,19 +87,9 @@ function useComplexI18n(
 
   const i18nRef = React.useRef(i18n);
 
-  React.useEffect(
-    () => {
-      return manager.subscribe(
-        ids.current,
-        ({translations, loading}, details) => {
-          const newI18n = new I18n(translations, {...details, loading});
-          i18nRef.current = newI18n;
-          setI18n(newI18n);
-        },
-      );
-    },
-    [ids, manager],
-  );
+  React.useEffect(() => {
+    return unsubscribeRef.current;
+  }, []);
 
   // We use refs in this component so that it never changes. If this component
   // is regenerated, it will unmount the entire tree of the previous component,
@@ -116,3 +132,5 @@ function shouldRegister({
 }: Partial<RegisterOptions> = {}) {
   return fallback != null || translations != null;
 }
+
+function noop() {}


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/713 (and hopefully a few project-specific issues, like https://github.com/Shopify/fbs/issues/5714). This PR fixes an issue where components with async translations were not always updating once the translations were loaded.

This issue was fairly intermittent on every example I had, but I finally managed to catch it in the act with a debugger. What I found was that the async translation was being loaded just fine, as evidenced by the fact that, on the second time the component loaded, its translations were present. However, in some cases, the async translation finished loading so quickly that it happened before the `useEffect` hook where the `useI18n` hook subscribes for updates to translations it cares about. So, the hook had not yet subscribed, and the manager had nothing to update. The loaded translation effectively got "lost" for the mounted component.

This PR addresses the problem by moving the subscription to be done synchronously, so it is guaranteed to be performed before the async translation is marked as loaded. This fixed the issue in FBS when I applied the changes locally.

cc/ @lsit @andrewlo @jgodson since I think you have all indicated this affected your projects.

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above