### PR TITLE
Updated intl featureTest

### DIFF
--- a/packages/polyfills/CHANGELOG.md
+++ b/packages/polyfills/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.1] - 2019-08-07
+
+- Updated `intl` polyfill featureTest from `internationalization-plural-rul` to `intl-pluralrules` as per the update in [`caniuse-lite@1.0.30000989`](https://github.com/ben-eb/caniuse-lite/commit/6966b0553f4584435a4c95a76794a93750a9004d#diff-5264ce81b24e867ed52dcca8f6a162fbR1)
+
 ## [1.0.0] - 2019-07-17
 
 Initial release.

--- a/packages/polyfills/src/index.ts
+++ b/packages/polyfills/src/index.ts
@@ -16,7 +16,7 @@ export const polyfills: {[polyfill: string]: PolyfillDescriptor} = {
     featureTest: 'intersectionobserver',
   },
   intl: {
-    featureTest: 'internationalization-plural-rul',
+    featureTest: 'intl-pluralrules',
   },
   'mutation-observer': {
     featureTest: 'mutationobserver',


### PR DESCRIPTION
## Description

I was getting unrelated [CI test errors](https://buildkite.com/shopify/sewing-kit-gem/builds/583) in sewing-kit

```
[error] Please provide a proper feature name. Cannot find internationalization-plural-rul
```

Upon further investigation @GoodForOneFare and I discovered that `caniuse-lite` was updated [two days ago](https://github.com/ben-eb/caniuse-lite/commit/6966b0553f4584435a4c95a76794a93750a9004d#diff-5264ce81b24e867ed52dcca8f6a162fbR1)


<img width="1625" alt="Screen Shot 2019-08-07 at 1 55 30 PM" src="https://user-images.githubusercontent.com/6130700/62646036-71710a80-b91b-11e9-93b4-87a26de920da.png">


 

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above