### PR TITLE
🔧 Suppress Travis/Slack notifications for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
 - yarn codecov
 notifications:
   slack:
+    on_pull_requests: false
     secure: 1dRk1kc3vEav6ut7FG5hj8Gowx99B/M4hEXf0b9RDHGEhaWVoDbDGZEqGUn1fdltPLNPmlGp4tM9b00ISu1MMflYkJl3l/8Czp/xGSbzD7FZYACJB2IujHms1xhIijSFkD5+EG3hcwmleWqvySjSQ42z5saaNHlM/mO5kUMIuTgaqqQV2wZC8mN0eZva85Y8HzYIeT0a5DvrTOupUiXKxk8M+y5k9HCuRYTLbgDcdjRR0u0RbGak6PVRFlSEBV4hEjdKS1aQyjXutKWfZxdgWiQbpdC0RmTNTePN0p53pt7oPFHv+BSN7eWzLkeMquIu02r2EEAb9tnYRpChuuFOphguSI5BDYtS1/zOx+VZhkXzoo4nq5iEbh8vYEXI+mj5op9Lz+v38I9j3haCjzjz/PeI7W8/DUIPHhO3t9fqKXqySm/2bx0ZSdSyW8Em63v+8LudkxEcBVLtn1ZPvOCOCfRt+FvzlwJZThzTJ92efxPuFiL5AZoeU4RQGpV/3A7W/wnHt830nNgiUAjMMXhuznF1Fnn4rsGh+Ntr8m18P0DUx+XPflp/r1EfPnkapwSM02tUwF3xunT6i++xg8tuTcVOjWLmq3CBgZ+Q/7g3Ff6Ykcfupqgm5bDgzkQ9bNZM/jAN0cDavzK9i0AELqZkqFcrQclEarL9NgAeCvsl0yk=
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1


### PR DESCRIPTION
## Description
I find #quilt to be quite noisy.  I think this should limit channel notifications to `master` builds?  [The docs](https://docs.travis-ci.com/user/notifications/#notifications-of-pr-builds-1) aren't super clear about this, but it's worth a shot.

## Type of change
Config.

## Checklist

- [ ] ~~I have added a changelog entry, prefixed by the type of change noted above~~
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
