### PR TITLE
♻️ move dependencies to peerDependencies

### DIFF
--- a/packages/react-self-serializers/package.json
+++ b/packages/react-self-serializers/package.json
@@ -23,11 +23,6 @@
     "url": "https://github.com/shopify/quilt/issues"
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-self-serializers/README.md",
-  "dependencies": {
-    "@shopify/react-graphql": "^4.0.3",
-    "@shopify/react-html": "^8.1.3",
-    "@shopify/react-i18n": "^1.5.1"
-  },
   "devDependencies": {
     "@shopify/react-testing": "^1.7.3",
     "@types/faker": "4.1.5",
@@ -35,7 +30,10 @@
     "typescript": "~3.2.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@shopify/react-graphql": ">=4.0.3",
+    "@shopify/react-html": ">=2.0.0",
+    "@shopify/react-i18n": ">=1.2.3"
   },
   "files": [
     "dist/*"


### PR DESCRIPTION
I discover this while adding it to `web-proving-ground`, where the project actually have two version of `@shopify/react-html` and we run into error.

To avoid this going forward, I move all `dependencies` into `peerDependencies` and provided a greater range of support.