### PR TITLE
 ✨ Add ability to format names based on locale

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Added `formatName` method to I18n class to format a first name and/or last name based on the locale used. ([#834](https://github.com/Shopify/quilt/pull/834))
+
 ## [1.6.0] - 2019-08-23
 
 ### Added

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -123,8 +123,8 @@ export default withI18n()(NotFound);
 The provided `i18n` object exposes many useful methods for internationalizing your apps. You can see the full details in the [`i18n` source file](https://github.com/Shopify/quilt/blob/master/packages/react-i18n/src/i18n.ts), but you will commonly need the following:
 
 - `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `I18nContext.Provider` component will be used where no custom currency code is passed.
-- `formatCurrency()`: formats a number as a currency according ot the locale. Convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`.
-- `formatPercentage()`: formats a number as a percentage according ot the locale. Convenience function that simply _auto-assigns_ the `as` option to `percent` and calls `formatNumber()`.
+- `formatCurrency()`: formats a number as a currency according to the locale. Convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`.
+- `formatPercentage()`: formats a number as a percentage according to the locale. Convenience function that simply _auto-assigns_ the `as` option to `percent` and calls `formatNumber()`.
 - `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `I18nContext.Provider` component will be used when no custom `timezone` is provided. Assign the `style` option to a `DateStyle` value to use common formatting options.
   - `DateStyle.Long`: e.g., `Thursday, December 20, 2012`
   - `DateStyle.Short`: e.g., `Dec 20, 2012`
@@ -132,6 +132,9 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
   - `DateStyle.Time`: e.g., `11:00 AM`
 - `weekStartDay()`: returns start day of the week according to the country.
 - `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.
+- `formatName()`: formats a name (first name and/or last name) according to the locale. e,g
+  - `formatName('John', 'Smith')` will return `John` in Germany and `Smith様` in Japan
+  - `formatName('John', 'Smith', {full: true})` will return `John Smith` in Germany and `SmithJohn` in Japan
 
 Most notably, you will frequently use `i18n`’s `translate()` method. This method looks up a key in translation files that you supply based on the provided locale. This method is discussed in detail in the next section.
 

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -180,3 +180,21 @@ export {
   default as currencyDecimalPlaces,
   DEFAULT_DECIMAL_PLACES,
 } from './currency-decimal-places';
+
+export const CUSTOM_NAME_FORMATTERS = new Map([
+  [
+    'ja',
+    (firstName: string, lastName: string, full: boolean) =>
+      full ? `${lastName}${firstName}` : `${lastName}様`,
+  ],
+  [
+    'zh-CN',
+    (firstName: string, lastName: string, full: boolean) =>
+      full ? `${lastName}${firstName}` : lastName,
+  ],
+  [
+    'zh-TW',
+    (firstName: string, lastName: string, full: boolean) =>
+      full ? `${lastName}${firstName}` : lastName,
+  ],
+]);

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -17,6 +17,7 @@ import {
   Weekday,
   currencyDecimalPlaces,
   DEFAULT_DECIMAL_PLACES,
+  CUSTOM_NAME_FORMATTERS,
 } from './constants';
 import {
   MissingCurrencyCodeError,
@@ -312,6 +313,29 @@ export class I18n {
   @memoize((currency: string, locale: string) => `${locale}${currency}`)
   getCurrencySymbolLocalized(locale: string, currency: string) {
     return getCurrencySymbol(locale, {currency});
+  }
+
+  formatName(firstName: string, lastName?: string, options?: {full?: boolean}) {
+    if (!firstName) {
+      return lastName || '';
+    }
+    if (!lastName) {
+      return firstName;
+    }
+
+    const isFullName = Boolean(options && options.full);
+
+    const customNameFormatter =
+      CUSTOM_NAME_FORMATTERS.get(this.locale) ||
+      CUSTOM_NAME_FORMATTERS.get(this.language);
+
+    if (customNameFormatter) {
+      return customNameFormatter(firstName, lastName, isFullName);
+    }
+    if (isFullName) {
+      return `${firstName} ${lastName}`;
+    }
+    return firstName;
   }
 
   private humanizeDate(date: Date, options?: Intl.DateTimeFormatOptions) {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -8,6 +8,7 @@ import {DateStyle, Weekday} from '../constants';
 import {MissingTranslationError} from '../errors';
 
 jest.mock('../utilities', () => ({
+  ...require.requireActual('../utilities'),
   translate: jest.fn(),
   getTranslationTree: jest.fn(),
   getCurrencySymbol: jest.fn(),
@@ -1062,6 +1063,126 @@ describe('I18n', () => {
       const i18n = new I18n(defaultTranslations, {locale: 'en'});
 
       expect(i18n.getCurrencySymbol('eur')).toStrictEqual(mockResult);
+    });
+  });
+
+  describe('#formatName()', () => {
+    it('returns only the firstName when lastName is missing', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.formatName('first')).toStrictEqual('first');
+      expect(i18n.formatName('first', '')).toStrictEqual('first');
+    });
+
+    it('returns only the lastName when firstName is missing', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.formatName('', 'last')).toStrictEqual('last');
+    });
+
+    it('defaults to firstName for unknown locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'unknown'});
+
+      expect(i18n.formatName('first', 'last')).toStrictEqual('first');
+    });
+
+    it('uses fallback locale value for locale without custom formatter', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'fr-CA'});
+
+      expect(i18n.formatName('first', 'last')).toStrictEqual('first');
+    });
+
+    it('returns firstName for English', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.formatName('first', 'last')).toStrictEqual('first');
+    });
+
+    it('returns custom name for Japanese', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'ja'});
+
+      expect(i18n.formatName('first', 'last')).toStrictEqual('last様');
+    });
+
+    it('returns lastName only, for zh-CN', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'zh-CN'});
+
+      expect(i18n.formatName('first', 'last')).toStrictEqual('last');
+    });
+
+    it('returns lastName only, for zh-TW', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'zh-TW'});
+
+      expect(i18n.formatName('first', 'last')).toStrictEqual('last');
+    });
+
+    it('returns only the firstName when lastName is missing using full', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.formatName('first', '', {full: true})).toStrictEqual('first');
+      expect(i18n.formatName('first', undefined, {full: true})).toStrictEqual(
+        'first',
+      );
+    });
+
+    it('returns only the lastName when firstName is missing using full', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.formatName('', 'last', {full: true})).toStrictEqual('last');
+    });
+
+    it('returns a string when firstName and lastName are missing using full', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.formatName('', undefined, {full: true})).toStrictEqual('');
+    });
+
+    it('defaults to firstName lastName for unknown locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'unknown'});
+
+      expect(i18n.formatName('first', 'last', {full: true})).toStrictEqual(
+        'first last',
+      );
+    });
+
+    it('uses fallback locale value for locale without custom formatter using full', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'fr-CA'});
+
+      expect(i18n.formatName('first', 'last', {full: true})).toStrictEqual(
+        'first last',
+      );
+    });
+
+    it('returns firstName first for English', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.formatName('first', 'last', {full: true})).toStrictEqual(
+        'first last',
+      );
+    });
+
+    it('returns lastName first and no space for Japanese', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'ja'});
+
+      expect(i18n.formatName('first', 'last', {full: true})).toStrictEqual(
+        'lastfirst',
+      );
+    });
+
+    it('returns lastName first and no space for zh-CN', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'zh-CN'});
+
+      expect(i18n.formatName('first', 'last', {full: true})).toStrictEqual(
+        'lastfirst',
+      );
+    });
+
+    it('returns lastName first and no space for zh-TW', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'zh-TW'});
+
+      expect(i18n.formatName('first', 'last', {full: true})).toStrictEqual(
+        'lastfirst',
+      );
     });
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/787

Gives the ability to format a person's name properly based on their locale.

In country like 🇯🇵 for example, it's offensive to display first_name before last_name. We provide the following method to solve this problem:

- Add `formatName(firstName, lastName, {full: true})` in the react-i18n package


## Notes

The locales using the most frequent usage (`firstName lastName`) are not listed in the constant file on purpose: reduce the amount of unnecessary data and reduce the run time of going through the Map.

## Type of change

- [X] `react-i18n` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
