### PR TITLE
:pencil2: README usePrefetch typo correction

### DIFF
--- a/packages/async/CHANGELOG.md
+++ b/packages/async/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Patch: Documentation typo fix in README.md ([842](https://github.com/Shopify/quilt/pull/842))
+
 ## 2.0.0 - 2019-07-03
 
 ### Added

--- a/packages/react-async/README.md
+++ b/packages/react-async/README.md
@@ -256,7 +256,7 @@ Consider this async component:
 ```tsx
 const ProductDetails = createAsyncComponent({
   load: () => import('./ProductDetails'),
-  renderPrefetch: ({id}: {id: string}) => <PrefetchGraphQLQuery id={id} />,
+  usePrefetch: ({id}: {id: string}) => <PrefetchGraphQLQuery id={id} />,
 });
 ```
 


### PR DESCRIPTION
## Description

Minor typo in the example of given [here](https://github.com/Shopify/quilt/tree/master/packages/react-async#prefetchroute-and-prefetcher).

Based on [this change](https://github.com/Shopify/quilt/blob/master/packages/react-async/documentation/migrations.md#renderx-options-become-usex).

It came up as a question during a PR review to what `renderPrefetch` was, which prompted this change.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
