### PR TITLE
Add province key to address and address-mocks

### DIFF
--- a/packages/address-mocks/src/fixtures/countries_en.ts
+++ b/packages/address-mocks/src/fixtures/countries_en.ts
@@ -26,6 +26,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Åland Islands',
@@ -52,6 +53,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Albania',
@@ -78,6 +80,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Algeria',
@@ -104,6 +107,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Andorra',
@@ -130,6 +134,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Angola',
@@ -156,6 +161,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Anguilla',
@@ -182,6 +188,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Antigua & Barbuda',
@@ -208,6 +215,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Argentina',
@@ -331,6 +339,7 @@ const data = {
             code: 'T',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Armenia',
@@ -357,6 +366,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Aruba',
@@ -383,6 +393,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Australia',
@@ -442,6 +453,7 @@ const data = {
             code: 'WA',
           },
         ],
+        provinceKey: 'STATE_AND_TERRITORY',
       },
       {
         name: 'Austria',
@@ -468,6 +480,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Azerbaijan',
@@ -494,6 +507,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bahamas',
@@ -520,6 +534,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bahrain',
@@ -546,6 +561,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bangladesh',
@@ -572,6 +588,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Barbados',
@@ -598,6 +615,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Belarus',
@@ -624,6 +642,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Belgium',
@@ -650,6 +669,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Belize',
@@ -676,6 +696,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Benin',
@@ -702,6 +723,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bermuda',
@@ -728,6 +750,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bhutan',
@@ -754,6 +777,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bolivia',
@@ -780,6 +804,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bosnia & Herzegovina',
@@ -806,6 +831,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Botswana',
@@ -832,6 +858,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bouvet Island',
@@ -858,6 +885,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Brazil',
@@ -993,6 +1021,7 @@ const data = {
             code: 'TO',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: 'British Indian Ocean Territory',
@@ -1019,6 +1048,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'British Virgin Islands',
@@ -1045,6 +1075,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Brunei',
@@ -1071,6 +1102,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Bulgaria',
@@ -1097,6 +1129,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Burkina Faso',
@@ -1123,6 +1156,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Burundi',
@@ -1149,6 +1183,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Cambodia',
@@ -1175,6 +1210,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Cameroon',
@@ -1201,6 +1237,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Canada',
@@ -1280,6 +1317,7 @@ const data = {
             code: 'YT',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Cape Verde',
@@ -1306,6 +1344,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Caribbean Netherlands',
@@ -1332,6 +1371,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Cayman Islands',
@@ -1358,6 +1398,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Central African Republic',
@@ -1384,6 +1425,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Chad',
@@ -1410,6 +1452,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Chile',
@@ -1436,6 +1479,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'STATE',
       },
       {
         name: 'China',
@@ -1587,6 +1631,7 @@ const data = {
             code: 'ZJ',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Christmas Island',
@@ -1613,6 +1658,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Cocos (Keeling) Islands',
@@ -1639,6 +1685,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Colombia',
@@ -1798,6 +1845,7 @@ const data = {
             code: 'VID',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Comoros',
@@ -1824,6 +1872,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Congo - Brazzaville',
@@ -1850,6 +1899,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Congo - Kinshasa',
@@ -1876,6 +1926,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Cook Islands',
@@ -1902,6 +1953,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Costa Rica',
@@ -1928,6 +1980,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Croatia',
@@ -1954,6 +2007,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Cuba',
@@ -1980,6 +2034,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Curaçao',
@@ -2006,6 +2061,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Cyprus',
@@ -2032,6 +2088,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Czech Republic',
@@ -2058,6 +2115,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Côte d’Ivoire',
@@ -2084,6 +2142,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Denmark',
@@ -2110,6 +2169,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Djibouti',
@@ -2136,6 +2196,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Dominica',
@@ -2162,6 +2223,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Dominican Republic',
@@ -2188,6 +2250,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Ecuador',
@@ -2214,6 +2277,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Egypt',
@@ -2357,6 +2421,7 @@ const data = {
             code: 'SUZ',
           },
         ],
+        provinceKey: 'GOVERNORATE',
       },
       {
         name: 'El Salvador',
@@ -2383,6 +2448,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Equatorial Guinea',
@@ -2409,6 +2475,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Eritrea',
@@ -2435,6 +2502,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Estonia',
@@ -2461,6 +2529,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Ethiopia',
@@ -2487,6 +2556,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Falkland Islands',
@@ -2513,6 +2583,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Faroe Islands',
@@ -2539,6 +2610,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Fiji',
@@ -2565,6 +2637,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Finland',
@@ -2591,6 +2664,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'France',
@@ -2617,6 +2691,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'French Guiana',
@@ -2643,6 +2718,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'French Polynesia',
@@ -2669,6 +2745,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'French Southern Territories',
@@ -2695,6 +2772,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Gabon',
@@ -2721,6 +2799,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Gambia',
@@ -2747,6 +2826,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Georgia',
@@ -2773,6 +2853,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Germany',
@@ -2799,6 +2880,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Ghana',
@@ -2825,6 +2907,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Gibraltar',
@@ -2851,6 +2934,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Greece',
@@ -2877,6 +2961,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Greenland',
@@ -2903,6 +2988,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Grenada',
@@ -2929,6 +3015,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Guadeloupe',
@@ -2955,6 +3042,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Guatemala',
@@ -3070,6 +3158,7 @@ const data = {
             code: 'ZAC',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'Guernsey',
@@ -3096,6 +3185,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Guinea',
@@ -3122,6 +3212,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Guinea-Bissau',
@@ -3148,6 +3239,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Guyana',
@@ -3174,6 +3266,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Haiti',
@@ -3200,6 +3293,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Heard & McDonald Islands',
@@ -3226,6 +3320,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Honduras',
@@ -3252,6 +3347,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Hong Kong SAR China',
@@ -3291,6 +3387,7 @@ const data = {
             code: 'NT',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'Hungary',
@@ -3317,6 +3414,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Iceland',
@@ -3343,6 +3441,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'India',
@@ -3514,6 +3613,7 @@ const data = {
             code: 'WB',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: 'Indonesia',
@@ -3677,6 +3777,7 @@ const data = {
             code: 'YO',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Iran',
@@ -3703,6 +3804,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Iraq',
@@ -3729,6 +3831,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Ireland',
@@ -3860,6 +3963,7 @@ const data = {
             code: 'WW',
           },
         ],
+        provinceKey: 'COUNTY',
       },
       {
         name: 'Isle of Man',
@@ -3886,6 +3990,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Israel',
@@ -3912,6 +4017,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Italy',
@@ -4379,6 +4485,7 @@ const data = {
             code: 'VT',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Jamaica',
@@ -4405,6 +4512,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Japan',
@@ -4620,6 +4728,7 @@ const data = {
             code: 'JP-47',
           },
         ],
+        provinceKey: 'PREFECTURE',
       },
       {
         name: 'Jersey',
@@ -4646,6 +4755,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Jordan',
@@ -4672,6 +4782,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Kazakhstan',
@@ -4698,6 +4809,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Kenya',
@@ -4724,6 +4836,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Kiribati',
@@ -4750,6 +4863,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Kosovo',
@@ -4776,6 +4890,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Kuwait',
@@ -4802,6 +4917,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Kyrgyzstan',
@@ -4828,6 +4944,7 @@ const data = {
             '{zip} {city}_{address2}_{address1}_{company}_{firstName} {lastName}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Laos',
@@ -4854,6 +4971,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Latvia',
@@ -4880,6 +4998,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Lebanon',
@@ -4906,6 +5025,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Lesotho',
@@ -4932,6 +5052,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Liberia',
@@ -4958,6 +5079,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Libya',
@@ -4984,6 +5106,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Liechtenstein',
@@ -5010,6 +5133,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Lithuania',
@@ -5036,6 +5160,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Luxembourg',
@@ -5062,6 +5187,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Macau SAR China',
@@ -5088,6 +5214,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Macedonia',
@@ -5114,6 +5241,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Madagascar',
@@ -5140,6 +5268,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Malawi',
@@ -5166,6 +5295,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Malaysia',
@@ -5257,6 +5387,7 @@ const data = {
             code: 'TRG',
           },
         ],
+        provinceKey: 'STATE_AND_TERRITORY',
       },
       {
         name: 'Maldives',
@@ -5283,6 +5414,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Mali',
@@ -5309,6 +5441,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Malta',
@@ -5335,6 +5468,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Martinique',
@@ -5361,6 +5495,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Mauritania',
@@ -5387,6 +5522,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Mauritius',
@@ -5413,6 +5549,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Mayotte',
@@ -5439,6 +5576,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Mexico',
@@ -5594,6 +5732,7 @@ const data = {
             code: 'ZAC',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: 'Moldova',
@@ -5620,6 +5759,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Monaco',
@@ -5646,6 +5786,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Mongolia',
@@ -5672,6 +5813,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Montenegro',
@@ -5698,6 +5840,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Montserrat',
@@ -5724,6 +5867,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Morocco',
@@ -5750,6 +5894,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Mozambique',
@@ -5776,6 +5921,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Myanmar (Burma)',
@@ -5802,6 +5948,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Namibia',
@@ -5828,6 +5975,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Nauru',
@@ -5854,6 +6002,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Nepal',
@@ -5880,6 +6029,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Netherlands',
@@ -5906,6 +6056,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Netherlands Antilles',
@@ -5932,6 +6083,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'New Caledonia',
@@ -5958,6 +6110,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'New Zealand',
@@ -6049,6 +6202,7 @@ const data = {
             code: 'WTC',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'Nicaragua',
@@ -6075,6 +6229,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Niger',
@@ -6101,6 +6256,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Nigeria',
@@ -6276,6 +6432,7 @@ const data = {
             code: 'ZA',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: 'Niue',
@@ -6302,6 +6459,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Norfolk Island',
@@ -6328,6 +6486,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'North Korea',
@@ -6354,6 +6513,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Norway',
@@ -6380,6 +6540,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Oman',
@@ -6406,6 +6567,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Pakistan',
@@ -6432,6 +6594,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Palestinian Territories',
@@ -6458,6 +6621,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Panama',
@@ -6537,6 +6701,7 @@ const data = {
             code: 'PA-9',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'Papua New Guinea',
@@ -6563,6 +6728,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Paraguay',
@@ -6589,6 +6755,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Peru',
@@ -6720,6 +6887,7 @@ const data = {
             code: 'PE-UCA',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'Philippines',
@@ -6746,6 +6914,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Pitcairn Islands',
@@ -6772,6 +6941,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Poland',
@@ -6798,6 +6968,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Portugal',
@@ -6905,6 +7076,7 @@ const data = {
             code: 'PT-18',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'Qatar',
@@ -6931,6 +7103,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Réunion',
@@ -6957,6 +7130,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Romania',
@@ -7152,6 +7326,7 @@ const data = {
             code: 'VN',
           },
         ],
+        provinceKey: 'COUNTY',
       },
       {
         name: 'Russia',
@@ -7507,6 +7682,7 @@ const data = {
             code: 'ZAB',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'Rwanda',
@@ -7533,6 +7709,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Saint Martin',
@@ -7559,6 +7736,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Samoa',
@@ -7585,6 +7763,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'San Marino',
@@ -7611,6 +7790,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'São Tomé & Príncipe',
@@ -7637,6 +7817,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Saudi Arabia',
@@ -7663,6 +7844,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Senegal',
@@ -7689,6 +7871,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Serbia',
@@ -7715,6 +7898,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Seychelles',
@@ -7741,6 +7925,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Sierra Leone',
@@ -7767,6 +7952,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Singapore',
@@ -7793,6 +7979,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Slovakia',
@@ -7819,6 +8006,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Slovenia',
@@ -7845,6 +8033,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Solomon Islands',
@@ -7871,6 +8060,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Somalia',
@@ -7897,6 +8087,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'South Africa',
@@ -7960,6 +8151,7 @@ const data = {
             code: 'WC',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'South Georgia & South Sandwich Islands',
@@ -7986,6 +8178,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'South Korea',
@@ -8081,6 +8274,7 @@ const data = {
             code: 'KR-31',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'South Sudan',
@@ -8107,6 +8301,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Spain',
@@ -8342,6 +8537,7 @@ const data = {
             code: 'Z',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Sri Lanka',
@@ -8368,6 +8564,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'St. Barthélemy',
@@ -8394,6 +8591,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'St. Helena',
@@ -8420,6 +8618,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'St. Kitts & Nevis',
@@ -8446,6 +8645,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'St. Lucia',
@@ -8472,6 +8672,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'St. Martin',
@@ -8498,6 +8699,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'St. Pierre & Miquelon',
@@ -8524,6 +8726,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'St. Vincent & Grenadines',
@@ -8550,6 +8753,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Sudan',
@@ -8576,6 +8780,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Suriname',
@@ -8602,6 +8807,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Svalbard & Jan Mayen',
@@ -8628,6 +8834,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Swaziland',
@@ -8654,6 +8861,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Sweden',
@@ -8680,6 +8888,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Switzerland',
@@ -8706,6 +8915,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Syria',
@@ -8732,6 +8942,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Taiwan',
@@ -8758,6 +8969,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Tajikistan',
@@ -8784,6 +8996,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Tanzania',
@@ -8810,6 +9023,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Thailand',
@@ -9149,6 +9363,7 @@ const data = {
             code: 'TH-35',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Timor-Leste',
@@ -9175,6 +9390,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Togo',
@@ -9201,6 +9417,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Tokelau',
@@ -9227,6 +9444,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Tonga',
@@ -9253,6 +9471,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Trinidad & Tobago',
@@ -9279,6 +9498,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Tunisia',
@@ -9305,6 +9525,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Turkey',
@@ -9331,6 +9552,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Turkmenistan',
@@ -9357,6 +9579,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Turks & Caicos Islands',
@@ -9383,6 +9606,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Tuvalu',
@@ -9409,6 +9633,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'U.S. Outlying Islands',
@@ -9435,6 +9660,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'STATE',
       },
       {
         name: 'Uganda',
@@ -9461,6 +9687,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Ukraine',
@@ -9487,6 +9714,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'United Arab Emirates',
@@ -9542,6 +9770,7 @@ const data = {
             code: 'UQ',
           },
         ],
+        provinceKey: 'EMIRATE',
       },
       {
         name: 'United Kingdom',
@@ -9568,6 +9797,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'United States',
@@ -9843,6 +10073,7 @@ const data = {
             code: 'AP',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: 'Uruguay',
@@ -9869,6 +10100,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Uzbekistan',
@@ -9895,6 +10127,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'Vanuatu',
@@ -9921,6 +10154,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Vatican City',
@@ -9947,6 +10181,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Venezuela',
@@ -9973,6 +10208,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Vietnam',
@@ -9999,6 +10235,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Wallis & Futuna',
@@ -10025,6 +10262,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Western Sahara',
@@ -10051,6 +10289,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Yemen',
@@ -10077,6 +10316,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Zambia',
@@ -10103,6 +10343,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'Zimbabwe',
@@ -10129,6 +10370,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
     ],
   },

--- a/packages/address-mocks/src/fixtures/countries_ja.ts
+++ b/packages/address-mocks/src/fixtures/countries_ja.ts
@@ -26,6 +26,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'アイルランド',
@@ -157,6 +158,7 @@ const data = {
             code: 'WW',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'アゼルバイジャン',
@@ -183,6 +185,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'COUNTY',
       },
       {
         name: 'アフガニスタン',
@@ -209,6 +212,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'アメリカ合衆国',
@@ -484,6 +488,7 @@ const data = {
             code: 'AP',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'アラブ首長国連邦',
@@ -539,6 +544,7 @@ const data = {
             code: 'UQ',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: 'アルジェリア',
@@ -565,6 +571,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'EMIRATE',
       },
       {
         name: 'アルゼンチン',
@@ -688,6 +695,7 @@ const data = {
             code: 'T',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'アルバ',
@@ -714,6 +722,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'アルバニア',
@@ -740,6 +749,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'アルメニア',
@@ -766,6 +776,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'アンギラ',
@@ -792,6 +803,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'アンゴラ',
@@ -818,6 +830,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'アンティグア・バーブーダ',
@@ -844,6 +857,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'アンドラ',
@@ -870,6 +884,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'イエメン',
@@ -896,6 +911,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'イギリス',
@@ -922,6 +938,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'イスラエル',
@@ -948,6 +965,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'イタリア',
@@ -1415,6 +1433,7 @@ const data = {
             code: 'VT',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'イラク',
@@ -1441,6 +1460,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'イラン',
@@ -1467,6 +1487,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'インド',
@@ -1638,6 +1659,7 @@ const data = {
             code: 'WB',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'インドネシア',
@@ -1801,6 +1823,7 @@ const data = {
             code: 'YO',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: 'ウォリス・フツナ',
@@ -1827,6 +1850,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'ウガンダ',
@@ -1853,6 +1877,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ウクライナ',
@@ -1879,6 +1904,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ウズベキスタン',
@@ -1905,6 +1931,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ウルグアイ',
@@ -1931,6 +1958,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'エクアドル',
@@ -1957,6 +1985,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'エジプト',
@@ -2100,6 +2129,7 @@ const data = {
             code: 'SUZ',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'エストニア',
@@ -2126,6 +2156,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'GOVERNORATE',
       },
       {
         name: 'エチオピア',
@@ -2152,6 +2183,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'エリトリア',
@@ -2178,6 +2210,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'エルサルバドル',
@@ -2204,6 +2237,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'オマーン',
@@ -2230,6 +2264,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'オランダ',
@@ -2256,6 +2291,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'オランダ領アンティル',
@@ -2282,6 +2318,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'オランダ領カリブ',
@@ -2308,6 +2345,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'オーストラリア',
@@ -2367,6 +2405,7 @@ const data = {
             code: 'WA',
           },
         ],
+        provinceKey: 'STATE_AND_TERRITORY',
       },
       {
         name: 'オーストリア',
@@ -2393,6 +2432,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'オーランド諸島',
@@ -2419,6 +2459,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'カザフスタン',
@@ -2445,6 +2486,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'カタール',
@@ -2471,6 +2513,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'カナダ',
@@ -2550,6 +2593,7 @@ const data = {
             code: 'YT',
           },
         ],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'カメルーン',
@@ -2576,6 +2620,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'カンボジア',
@@ -2602,6 +2647,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'カーボベルデ',
@@ -2628,6 +2674,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ガイアナ',
@@ -2654,6 +2701,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ガボン',
@@ -2680,6 +2728,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ガンビア',
@@ -2706,6 +2755,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ガーナ',
@@ -2732,6 +2782,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ガーンジー',
@@ -2758,6 +2809,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'キプロス',
@@ -2784,6 +2836,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'キュラソー',
@@ -2810,6 +2863,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'キューバ',
@@ -2836,6 +2890,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'キリバス',
@@ -2862,6 +2917,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'キルギス',
@@ -2888,6 +2944,7 @@ const data = {
             '{zip} {city}_{address2}_{address1}_{company}_{firstName} {lastName}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ギニア',
@@ -2914,6 +2971,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ギニアビサウ',
@@ -2940,6 +2998,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ギリシャ',
@@ -2966,6 +3025,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'クウェート',
@@ -2992,6 +3052,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'クック諸島',
@@ -3018,6 +3079,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'クリスマス島',
@@ -3044,6 +3106,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'クロアチア',
@@ -3070,6 +3133,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'グアテマラ',
@@ -3185,6 +3249,7 @@ const data = {
             code: 'ZAC',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'グアドループ',
@@ -3211,6 +3276,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'グリーンランド',
@@ -3237,6 +3303,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'グルジア',
@@ -3263,6 +3330,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'グレナダ',
@@ -3289,6 +3357,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ケイマン諸島',
@@ -3315,6 +3384,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ケニア',
@@ -3341,6 +3411,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ココス(キーリング)諸島',
@@ -3367,6 +3438,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'コスタリカ',
@@ -3393,6 +3465,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'コソボ',
@@ -3419,6 +3492,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'コモロ',
@@ -3445,6 +3519,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'コロンビア',
@@ -3604,6 +3679,7 @@ const data = {
             code: 'VID',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'コンゴ共和国(ブラザビル)',
@@ -3630,6 +3706,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'コンゴ民主共和国(キンシャサ)',
@@ -3656,6 +3733,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'コートジボワール',
@@ -3682,6 +3760,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'サウジアラビア',
@@ -3708,6 +3787,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'サモア',
@@ -3734,6 +3814,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'サントメ・プリンシペ',
@@ -3760,6 +3841,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'サンピエール島・ミクロン島',
@@ -3786,6 +3868,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'サンマリノ',
@@ -3812,6 +3895,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'サン・バルテルミー島',
@@ -3838,6 +3922,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'サン・マルタン',
@@ -3864,6 +3949,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ザンビア',
@@ -3890,6 +3976,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'シエラレオネ',
@@ -3916,6 +4003,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'シリア',
@@ -3942,6 +4030,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'シンガポール',
@@ -3968,6 +4057,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'シント・マールテン',
@@ -3994,6 +4084,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ジブチ',
@@ -4020,6 +4111,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ジブラルタル',
@@ -4046,6 +4138,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ジャマイカ',
@@ -4072,6 +4165,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ジャージー',
@@ -4098,6 +4192,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ジンバブエ',
@@ -4124,6 +4219,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スイス',
@@ -4150,6 +4246,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スウェーデン',
@@ -4176,6 +4273,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スバールバル諸島・ヤンマイエン島',
@@ -4202,6 +4300,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スペイン',
@@ -4437,6 +4536,7 @@ const data = {
             code: 'Z',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'スリナム',
@@ -4463,6 +4563,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'スリランカ',
@@ -4489,6 +4590,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スロバキア',
@@ -4515,6 +4617,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スロベニア',
@@ -4541,6 +4644,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スワジランド',
@@ -4567,6 +4671,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'スーダン',
@@ -4593,6 +4698,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'セネガル',
@@ -4619,6 +4725,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'セルビア',
@@ -4645,6 +4752,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'セントクリストファー・ネイビス',
@@ -4671,6 +4779,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'セントビンセント・グレナディーン諸島',
@@ -4697,6 +4806,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'セントヘレナ',
@@ -4723,6 +4833,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'セントルシア',
@@ -4749,6 +4860,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'セーシェル',
@@ -4775,6 +4887,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ソマリア',
@@ -4801,6 +4914,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ソロモン諸島',
@@ -4827,6 +4941,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'タイ',
@@ -5166,6 +5281,7 @@ const data = {
             code: 'TH-35',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'タジキスタン',
@@ -5192,6 +5308,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'タンザニア',
@@ -5218,6 +5335,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'タークス・カイコス諸島',
@@ -5244,6 +5362,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'チェコ共和国',
@@ -5270,6 +5389,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'チャド',
@@ -5296,6 +5416,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'チュニジア',
@@ -5322,6 +5443,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'チリ',
@@ -5348,6 +5470,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ツバル',
@@ -5374,6 +5497,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'STATE',
       },
       {
         name: 'デンマーク',
@@ -5400,6 +5524,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'トケラウ',
@@ -5426,6 +5551,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'トリニダード・トバゴ',
@@ -5452,6 +5578,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'トルクメニスタン',
@@ -5478,6 +5605,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'トルコ',
@@ -5504,6 +5632,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'トンガ',
@@ -5530,6 +5659,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'トーゴ',
@@ -5556,6 +5686,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ドイツ',
@@ -5582,6 +5713,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ドミニカ共和国',
@@ -5608,6 +5740,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ドミニカ国',
@@ -5634,6 +5767,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ナイジェリア',
@@ -5809,6 +5943,7 @@ const data = {
             code: 'ZA',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'ナウル',
@@ -5835,6 +5970,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'STATE',
       },
       {
         name: 'ナミビア',
@@ -5861,6 +5997,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ニウエ島',
@@ -5887,6 +6024,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ニカラグア',
@@ -5913,6 +6051,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ニジェール',
@@ -5939,6 +6078,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ニューカレドニア',
@@ -5965,6 +6105,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ニュージーランド',
@@ -6056,6 +6197,7 @@ const data = {
             code: 'WTC',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'ネパール',
@@ -6082,6 +6224,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ノルウェー',
@@ -6108,6 +6251,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ノーフォーク島',
@@ -6134,6 +6278,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ハイチ',
@@ -6160,6 +6305,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ハンガリー',
@@ -6186,6 +6332,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ハード島・マクドナルド諸島',
@@ -6212,6 +6359,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'バチカン市国',
@@ -6238,6 +6386,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'バヌアツ',
@@ -6264,6 +6413,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'バハマ',
@@ -6290,6 +6440,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'バミューダ',
@@ -6316,6 +6467,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'バルバドス',
@@ -6342,6 +6494,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'バングラデシュ',
@@ -6368,6 +6521,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'バーレーン',
@@ -6394,6 +6548,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'パキスタン',
@@ -6420,6 +6575,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'パナマ',
@@ -6499,6 +6655,7 @@ const data = {
             code: 'PA-9',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'パプアニューギニア',
@@ -6525,6 +6682,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'パラグアイ',
@@ -6551,6 +6709,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'パレスチナ',
@@ -6577,6 +6736,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ピトケアン諸島',
@@ -6603,6 +6763,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'フィジー',
@@ -6629,6 +6790,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'フィリピン',
@@ -6655,6 +6817,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'フィンランド',
@@ -6681,6 +6844,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'フェロー諸島',
@@ -6707,6 +6871,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'フォークランド諸島',
@@ -6733,6 +6898,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'フランス',
@@ -6759,6 +6925,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ブラジル',
@@ -6894,6 +7061,7 @@ const data = {
             code: 'TO',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'ブルガリア',
@@ -6920,6 +7088,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'STATE',
       },
       {
         name: 'ブルキナファソ',
@@ -6946,6 +7115,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ブルネイ',
@@ -6972,6 +7142,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ブルンジ',
@@ -6998,6 +7169,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ブータン',
@@ -7024,6 +7196,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ブーベ島',
@@ -7050,6 +7223,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ベトナム',
@@ -7076,6 +7250,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ベナン',
@@ -7102,6 +7277,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ベネズエラ',
@@ -7128,6 +7304,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ベラルーシ',
@@ -7154,6 +7331,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ベリーズ',
@@ -7180,6 +7358,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'ベルギー',
@@ -7206,6 +7385,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ペルー',
@@ -7337,6 +7517,7 @@ const data = {
             code: 'PE-UCA',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'ホンジュラス',
@@ -7363,6 +7544,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ボスニア・ヘルツェゴビナ',
@@ -7389,6 +7571,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ボツワナ',
@@ -7415,6 +7598,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ボリビア',
@@ -7441,6 +7625,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ポルトガル',
@@ -7548,6 +7733,7 @@ const data = {
             code: 'PT-18',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'ポーランド',
@@ -7574,6 +7760,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マケドニア',
@@ -7600,6 +7787,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マダガスカル',
@@ -7626,6 +7814,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マヨット島',
@@ -7652,6 +7841,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マラウイ',
@@ -7678,6 +7868,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マリ',
@@ -7704,6 +7895,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マルタ',
@@ -7730,6 +7922,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マルティニーク',
@@ -7756,6 +7949,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'マレーシア',
@@ -7847,6 +8041,7 @@ const data = {
             code: 'TRG',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'マン島',
@@ -7873,6 +8068,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'STATE_AND_TERRITORY',
       },
       {
         name: 'ミャンマー',
@@ -7899,6 +8095,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'メキシコ',
@@ -8054,6 +8251,7 @@ const data = {
             code: 'ZAC',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'モザンビーク',
@@ -8080,6 +8278,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'STATE',
       },
       {
         name: 'モナコ',
@@ -8106,6 +8305,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モルディブ',
@@ -8132,6 +8332,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モルドバ',
@@ -8158,6 +8359,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モロッコ',
@@ -8184,6 +8386,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モンゴル',
@@ -8210,6 +8413,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モンテネグロ',
@@ -8236,6 +8440,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モントセラト',
@@ -8262,6 +8467,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モーリシャス',
@@ -8288,6 +8494,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'モーリタニア',
@@ -8314,6 +8521,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ヨルダン',
@@ -8340,6 +8548,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ラオス',
@@ -8366,6 +8575,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ラトビア',
@@ -8392,6 +8602,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'リトアニア',
@@ -8418,6 +8629,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'リヒテンシュタイン',
@@ -8444,6 +8656,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'リビア',
@@ -8470,6 +8683,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'リベリア',
@@ -8496,6 +8710,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ルクセンブルグ',
@@ -8522,6 +8737,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ルワンダ',
@@ -8548,6 +8764,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ルーマニア',
@@ -8743,6 +8960,7 @@ const data = {
             code: 'VN',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: 'レソト',
@@ -8769,6 +8987,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'COUNTY',
       },
       {
         name: 'レバノン',
@@ -8795,6 +9014,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'レユニオン島',
@@ -8821,6 +9041,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: 'ロシア',
@@ -9176,6 +9397,7 @@ const data = {
             code: 'ZAB',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: '中国',
@@ -9327,6 +9549,7 @@ const data = {
             code: 'ZJ',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: '中央アフリカ共和国',
@@ -9353,6 +9576,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: '中華人民共和国マカオ特別行政区',
@@ -9379,6 +9603,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '中華人民共和国香港特別行政区',
@@ -9418,6 +9643,7 @@ const data = {
             code: 'NT',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: '仏領ギアナ',
@@ -9444,6 +9670,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '仏領ポリネシア',
@@ -9470,6 +9697,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '仏領極南諸島',
@@ -9496,6 +9724,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '南アフリカ',
@@ -9559,6 +9788,7 @@ const data = {
             code: 'WC',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: '南ジョージア島・南サンドイッチ諸島',
@@ -9585,6 +9815,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '南スーダン',
@@ -9611,6 +9842,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
       {
         name: '台湾',
@@ -9637,6 +9869,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '大韓民国',
@@ -9732,6 +9965,7 @@ const data = {
             code: 'KR-31',
           },
         ],
+        provinceKey: 'REGION',
       },
       {
         name: '日本',
@@ -9947,6 +10181,7 @@ const data = {
             code: 'JP-47',
           },
         ],
+        provinceKey: 'STATE',
       },
       {
         name: '朝鮮民主主義人民共和国',
@@ -9973,6 +10208,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PREFECTURE',
       },
       {
         name: '東ティモール',
@@ -9999,6 +10235,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '米領太平洋諸島',
@@ -10025,6 +10262,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '英領インド洋地域',
@@ -10051,6 +10289,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '英領ヴァージン諸島',
@@ -10077,6 +10316,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '西サハラ',
@@ -10103,6 +10343,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
       },
       {
         name: '赤道ギニア',
@@ -10129,6 +10370,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'PROVINCE',
       },
     ],
   },

--- a/packages/address-mocks/src/fixtures/country_ca_en.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_en.ts
@@ -78,6 +78,7 @@ const data = {
           code: 'YT',
         },
       ],
+      provinceKey: 'PROVINCE',
     },
   },
 };

--- a/packages/address-mocks/src/fixtures/country_ca_fr.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_fr.ts
@@ -78,6 +78,7 @@ const data = {
           code: 'YT',
         },
       ],
+      provinceKey: 'PROVINCE',
     },
   },
 };

--- a/packages/address-mocks/src/fixtures/country_ca_ja.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_ja.ts
@@ -78,6 +78,7 @@ const data = {
           code: 'YT',
         },
       ],
+      provinceKey: 'PROVINCE',
     },
   },
 };

--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
+### Added
+
+- Added `provinceKey` to `Country` interface ([#843](https://github.com/Shopify/quilt/pull/843))
+
 ## 2.5.0 - 2019-01-08
 
 - Removed `address2Key`, `zoneKey` and `zipKey`

--- a/packages/address/src/graphqlQuery.ts
+++ b/packages/address/src/graphqlQuery.ts
@@ -6,6 +6,7 @@ query countries($locale: SupportedLocale!) {
     continent
     phoneNumberPrefix
     autocompletionField
+    provinceKey
     labels {
       address1
       address2
@@ -36,6 +37,7 @@ query country($countryCode: SupportedCountry!, $locale: SupportedLocale!) {
     continent
     phoneNumberPrefix
     autocompletionField
+    provinceKey
     labels {
       address1
       address2

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -44,11 +44,11 @@ describe('getCountry()', () => {
       'code',
       'phoneNumberPrefix',
       'autocompletionField',
-      'provinceKey',
       'continent',
       'labels',
       'formatting',
       'zones',
+      'provinceKey',
     ]);
   });
 

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -44,6 +44,7 @@ describe('getCountry()', () => {
       'code',
       'phoneNumberPrefix',
       'autocompletionField',
+      'provinceKey',
       'continent',
       'labels',
       'formatting',

--- a/packages/address/src/types.ts
+++ b/packages/address/src/types.ts
@@ -11,6 +11,16 @@ export enum FieldName {
   Company = 'company',
 }
 
+export type ZoneKey =
+  | 'COUNTY'
+  | 'EMIRATE'
+  | 'GOVERNORATE'
+  | 'PREFECTURE'
+  | 'PROVINCE'
+  | 'REGION'
+  | 'STATE_AND_TERRITORY'
+  | 'STATE';
+
 export interface Address {
   company?: string;
   firstName?: string;
@@ -42,6 +52,7 @@ export interface Country {
   continent: string;
   phoneNumberPrefix: number;
   autocompletionField: string;
+  provinceKey: ZoneKey;
   labels: {
     address1: string;
     address2: string;


### PR DESCRIPTION
## Description

Fixes https://shopify.slack.com/archives/C7XKG3GLB/p1565291436258500

Adds `provinceKey` to the `Country` interface in the address package and in the address-mocks package.

## Type of change

- [x] address Minor: New feature (non-breaking change which adds functionality)
- [x] address-mocks Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
