### PR TITLE
🐛 fix auth issue with invalid accesstoken

### DIFF
--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## 3.1.31 - 2019-08-13
+
+### Fixed
+
+- Installation no longer fails if accessToken is invalid [#844](https://github.com/Shopify/quilt/pull/844)
+
 ## 3.1.14 - 2019-02-05
 
 ### Fixed

--- a/packages/koa-shopify-auth/src/verify-request/verify-request.ts
+++ b/packages/koa-shopify-auth/src/verify-request/verify-request.ts
@@ -1,5 +1,5 @@
 import {Context} from 'koa';
-
+import {Method, Header, StatusCode} from '@shopify/network';
 import {NextFunction} from '../types';
 import {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} from '../index';
 
@@ -20,9 +20,28 @@ export default function verifyRequest({
       query: {shop},
       session,
     } = ctx;
+    const redirect = `${authRoute}?shop=${shop}`;
 
     if (session && session.accessToken) {
       ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
+      // If a user has installed the store previously on their shop, the accessToken can be stored in session.
+      // we need to check if the accessToken is valid, and the only way to do this is by hitting the api.
+      const response = await fetch(
+        `https://${session.shop}/admin/metafields.json`,
+        {
+          method: Method.Post,
+          headers: {
+            [Header.ContentType]: 'application/json',
+            'X-Shopify-Access-Token': session.accessToken,
+          },
+        },
+      );
+
+      if (response.status === StatusCode.Unauthorized) {
+        ctx.redirect(redirect);
+        return;
+      }
+
       await next();
       return;
     }
@@ -30,7 +49,7 @@ export default function verifyRequest({
     ctx.cookies.set(TEST_COOKIE_NAME, '1');
 
     if (shop) {
-      ctx.redirect(`${authRoute}?shop=${shop}`);
+      ctx.redirect(redirect);
       return;
     }
 


### PR DESCRIPTION
## Description

Fixes #727 

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change
In the koa-shopify-auth package, users were having issues reinstalling their apps via the partner dashboard. This PR adds a call to the admin API (I tried to find the 'cheapest' call) to check the validity of the access token. This solve the issue of users not being able to reinstall the app on their stores. 

I'm looking for feedback on this. If anyone knows a better way of checking if an access token is valid please let me know! 

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] koa-shopify-auth Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
