### PR TITLE
♻️ renaming Props to PropsFor

### DIFF
--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  Props as PropsForComponent,
+  PropsFor,
   Arguments,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
@@ -140,30 +140,30 @@ export class Element<Props> implements Node<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Element<PropsForComponent<Type>> {
+  ): this is Element<PropsFor<Type>> {
     return isMatchingType(this.type, type);
   }
 
   find<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Element<PropsForComponent<Type>> | null {
+    props?: Partial<PropsFor<Type>>,
+  ): Element<PropsFor<Type>> | null {
     return (this.elementDescendants.find(
       element =>
         isMatchingType(element.type, type) &&
         (props == null || equalSubset(props, element.props as object)),
-    ) || null) as Element<PropsForComponent<Type>> | null;
+    ) || null) as Element<PropsFor<Type>> | null;
   }
 
   findAll<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Element<PropsForComponent<Type>>[] {
+    props?: Partial<PropsFor<Type>>,
+  ): Element<PropsFor<Type>>[] {
     return this.elementDescendants.filter(
       element =>
         isMatchingType(element.type, type) &&
         (props == null || equalSubset(props, element.props as object)),
-    ) as Element<PropsForComponent<Type>>[];
+    ) as Element<PropsFor<Type>>[];
   }
 
   findWhere(predicate: Predicate): Element<unknown> | null {

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -5,7 +5,7 @@ import {
   EXPECTED_COLOR as expectedColor,
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
-import {Props} from '@shopify/useful-types';
+import {PropsFor} from '@shopify/useful-types';
 
 import {Node} from '../types';
 import {assertIsNode, diffs, pluralize, printType} from './utilities';
@@ -16,7 +16,7 @@ export function toContainReactComponent<
   this: jest.MatcherUtils,
   node: Node<unknown>,
   type: Type,
-  props?: Partial<Props<Type>>,
+  props?: Partial<PropsFor<Type>>,
 ) {
   assertIsNode(node, {
     expectation: 'toContainReactComponent',
@@ -74,7 +74,7 @@ export function toContainReactComponentTimes<
   node: Node<unknown>,
   type: Type,
   times: number,
-  props?: Partial<Props<Type>>,
+  props?: Partial<PropsFor<Type>>,
 ) {
   assertIsNode(node, {
     expectation: 'toContainReactComponentTimes',

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,5 +1,5 @@
 import {ComponentType, Context as ReactContext} from 'react';
-import {Props} from '@shopify/useful-types';
+import {PropsFor} from '@shopify/useful-types';
 
 import {Node} from '../types';
 import {toHaveReactProps, toHaveReactDataProps} from './props';
@@ -19,12 +19,12 @@ declare global {
       toHaveReactDataProps(data: {[key: string]: string}): void;
       toContainReactComponent<Type extends string | ComponentType<any>>(
         type: Type,
-        props?: Partial<Props<Type>>,
+        props?: Partial<PropsFor<Type>>,
       ): void;
       toContainReactComponentTimes<Type extends string | ComponentType<any>>(
         type: Type,
         times: number,
-        props?: Partial<Props<Type>>,
+        props?: Partial<PropsFor<Type>>,
       ): void;
       toProvideReactContext<Type>(
         context: ReactContext<Type>,

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -3,7 +3,7 @@ import {render, unmountComponentAtNode} from 'react-dom';
 import {act as reactAct} from 'react-dom/test-utils';
 import {
   Arguments,
-  Props as PropsForComponent,
+  PropsFor,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
 
@@ -141,7 +141,7 @@ export class Root<Props> implements Node<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Root<PropsForComponent<Type>> {
+  ): this is Root<PropsFor<Type>> {
     return this.withRoot(root => root.is(type));
   }
 
@@ -155,14 +155,14 @@ export class Root<Props> implements Node<Props> {
 
   find<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
+    props?: Partial<PropsFor<Type>>,
   ) {
     return this.withRoot(root => root.find(type, props));
   }
 
   findAll<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
+    props?: Partial<PropsFor<Type>>,
   ) {
     return this.withRoot(root => root.findAll(type, props));
   }

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
   Arguments,
   MaybeFunctionReturnType,
-  Props as PropsForComponent,
+  PropsFor,
 } from '@shopify/useful-types';
 
 export type FunctionKeys<T> = {
@@ -87,16 +87,16 @@ export interface Node<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Node<PropsForComponent<Type>>;
+  ): this is Node<PropsFor<Type>>;
 
   find<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Node<PropsForComponent<Type>> | null;
+    props?: Partial<PropsFor<Type>>,
+  ): Node<PropsFor<Type>> | null;
   findAll<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Node<PropsForComponent<Type>>[];
+    props?: Partial<PropsFor<Type>>,
+  ): Node<PropsFor<Type>>[];
   findWhere(predicate: Predicate): Node<unknown> | null;
   findAllWhere(predicate: Predicate): Node<unknown>[];
 

--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+
+- Renamed `Props<T>` to `PropsFor<T>` ([#845](https://github.com/Shopify/quilt/pull/845))
+
 ## [1.3.0]
 
 ### Added

--- a/packages/useful-types/README.md
+++ b/packages/useful-types/README.md
@@ -60,7 +60,7 @@ The following type aliases are provided by this library:
   type SelectiveObj = Omit<Obj, 'foo' | 'bar'>; // {baz: number}
   ```
 
-- `Props<T>`: Extracts the prop type from a React component. This allows you to access property types without having to manually export/ import the type.
+- `PropsFor<T>`: Extracts the prop type from a React component. This allows you to access property types without having to manually export/ import the type.
 
   ```tsx
   function MyComponent({name}: {name: string}) {
@@ -73,8 +73,8 @@ The following type aliases are provided by this library:
     }
   }
 
-  type MyComponentProps = Props<typeof MyComponent>; // {name: string}
-  type MyOtherComponentProps = Props<typeof MyOtherComponent>; // {seconds: number}
+  type MyComponentProps = PropsFor<typeof MyComponent>; // {name: string}
+  type MyOtherComponentProps = PropsFor<typeof MyOtherComponent>; // {seconds: number}
   ```
 
 - `DeepPartial<T>`: Recusively maps over all properties in a type and transforms them to be optional. Useful when you need to make optional all of the properties (and nested properties) of an existing type.

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -25,7 +25,7 @@ export type DeepPartial<T> = {
       : DeepPartial<T[P]>
 };
 
-export type Props<T> = T extends keyof JSX.IntrinsicElements
+export type PropsFor<T> = T extends keyof JSX.IntrinsicElements
   ? JSX.IntrinsicElements[T]
   : T extends string
     ? HTMLAttributes<T>


### PR DESCRIPTION
## Description

The original `Props` type often collided with pre-existing `interface Props` in components, this new `PropsFor` will not encounter the same problems.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `@shopify/useful-types` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

This is a breaking change because we are not deprecating the old `Props` and instead just renaming.

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
