### PR TITLE
🔥remove Props<T> from useful-types

### DIFF
--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  Props as PropsForComponent,
   Arguments,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
@@ -10,6 +9,7 @@ import {
   Predicate,
   FunctionKeys,
   DeepPartialArguments,
+  PropsFor,
 } from './types';
 
 type Root = import('./root').Root<any>;
@@ -140,30 +140,30 @@ export class Element<Props> implements Node<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Element<PropsForComponent<Type>> {
+  ): this is Element<PropsFor<Type>> {
     return isMatchingType(this.type, type);
   }
 
   find<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Element<PropsForComponent<Type>> | null {
+    props?: Partial<PropsFor<Type>>,
+  ): Element<PropsFor<Type>> | null {
     return (this.elementDescendants.find(
       element =>
         isMatchingType(element.type, type) &&
         (props == null || equalSubset(props, element.props as object)),
-    ) || null) as Element<PropsForComponent<Type>> | null;
+    ) || null) as Element<PropsFor<Type>> | null;
   }
 
   findAll<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Element<PropsForComponent<Type>>[] {
+    props?: Partial<PropsFor<Type>>,
+  ): Element<PropsFor<Type>>[] {
     return this.elementDescendants.filter(
       element =>
         isMatchingType(element.type, type) &&
         (props == null || equalSubset(props, element.props as object)),
-    ) as Element<PropsForComponent<Type>>[];
+    ) as Element<PropsFor<Type>>[];
   }
 
   findWhere(predicate: Predicate): Element<unknown> | null {

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -5,9 +5,8 @@ import {
   EXPECTED_COLOR as expectedColor,
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
-import {Props} from '@shopify/useful-types';
 
-import {Node} from '../types';
+import {Node, PropsFor} from '../types';
 import {assertIsNode, diffs, pluralize, printType} from './utilities';
 
 export function toContainReactComponent<
@@ -16,7 +15,7 @@ export function toContainReactComponent<
   this: jest.MatcherUtils,
   node: Node<unknown>,
   type: Type,
-  props?: Partial<Props<Type>>,
+  props?: Partial<PropsFor<Type>>,
 ) {
   assertIsNode(node, {
     expectation: 'toContainReactComponent',
@@ -74,7 +73,7 @@ export function toContainReactComponentTimes<
   node: Node<unknown>,
   type: Type,
   times: number,
-  props?: Partial<Props<Type>>,
+  props?: Partial<PropsFor<Type>>,
 ) {
   assertIsNode(node, {
     expectation: 'toContainReactComponentTimes',

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,7 +1,6 @@
 import {ComponentType, Context as ReactContext} from 'react';
-import {Props} from '@shopify/useful-types';
 
-import {Node} from '../types';
+import {Node, PropsFor} from '../types';
 import {toHaveReactProps, toHaveReactDataProps} from './props';
 import {
   toContainReactComponent,
@@ -19,12 +18,12 @@ declare global {
       toHaveReactDataProps(data: {[key: string]: string}): void;
       toContainReactComponent<Type extends string | ComponentType<any>>(
         type: Type,
-        props?: Partial<Props<Type>>,
+        props?: Partial<PropsFor<Type>>,
       ): void;
       toContainReactComponentTimes<Type extends string | ComponentType<any>>(
         type: Type,
         times: number,
-        props?: Partial<Props<Type>>,
+        props?: Partial<PropsFor<Type>>,
       ): void;
       toProvideReactContext<Type>(
         context: ReactContext<Type>,

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -3,7 +3,6 @@ import {render, unmountComponentAtNode} from 'react-dom';
 import {act as reactAct} from 'react-dom/test-utils';
 import {
   Arguments,
-  Props as PropsForComponent,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
 
@@ -17,6 +16,7 @@ import {
   ReactInstance,
   FunctionKeys,
   DeepPartialArguments,
+  PropsFor,
 } from './types';
 
 // Manually casting `act()` until @types/react is updated to include
@@ -141,7 +141,7 @@ export class Root<Props> implements Node<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Root<PropsForComponent<Type>> {
+  ): this is Root<PropsFor<Type>> {
     return this.withRoot(root => root.is(type));
   }
 
@@ -155,14 +155,14 @@ export class Root<Props> implements Node<Props> {
 
   find<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
+    props?: Partial<PropsFor<Type>>,
   ) {
     return this.withRoot(root => root.find(type, props));
   }
 
   findAll<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
+    props?: Partial<PropsFor<Type>>,
   ) {
     return this.withRoot(root => root.findAll(type, props));
   }

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import {
-  Arguments,
-  MaybeFunctionReturnType,
-  Props as PropsForComponent,
-} from '@shopify/useful-types';
+import {Arguments, MaybeFunctionReturnType} from '@shopify/useful-types';
+
+export type PropsFor<
+  T extends string | React.ComponentType<any>
+> = T extends string
+  ? React.HTMLAttributes<T>
+  : T extends React.ComponentType<any>
+    ? React.ComponentPropsWithoutRef<T>
+    : never;
 
 export type FunctionKeys<T> = {
   [K in keyof T]-?: NonNullable<T[K]> extends ((...args: any[]) => any)
@@ -87,16 +91,16 @@ export interface Node<Props> {
 
   is<Type extends React.ComponentType<any> | string>(
     type: Type,
-  ): this is Node<PropsForComponent<Type>>;
+  ): this is Node<PropsFor<Type>>;
 
   find<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Node<PropsForComponent<Type>> | null;
+    props?: Partial<PropsFor<Type>>,
+  ): Node<PropsFor<Type>> | null;
   findAll<Type extends React.ComponentType<any> | string>(
     type: Type,
-    props?: Partial<PropsForComponent<Type>>,
-  ): Node<PropsForComponent<Type>>[];
+    props?: Partial<PropsFor<Type>>,
+  ): Node<PropsFor<Type>>[];
   findWhere(predicate: Predicate): Node<unknown> | null;
   findAllWhere(predicate: Predicate): Node<unknown>[];
 

--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+
+- Removed `Props<T>`, see `ComponentProps`, `ComponentPropsWithRef`, and `ComponentPropsWithoutRef` from `react` for a replacement strategy ([#846](https://github.com/Shopify/quilt/pull/846))
+
 ## [1.3.0]
 
 ### Added

--- a/packages/useful-types/README.md
+++ b/packages/useful-types/README.md
@@ -60,23 +60,6 @@ The following type aliases are provided by this library:
   type SelectiveObj = Omit<Obj, 'foo' | 'bar'>; // {baz: number}
   ```
 
-- `Props<T>`: Extracts the prop type from a React component. This allows you to access property types without having to manually export/ import the type.
-
-  ```tsx
-  function MyComponent({name}: {name: string}) {
-    return <div>Hello, {name}!</div>;
-  }
-
-  class MyOtherComponent extends React.Component<{seconds: number}> {
-    render() {
-      return <div>{this.props.seconds} seconds left!</div>;
-    }
-  }
-
-  type MyComponentProps = Props<typeof MyComponent>; // {name: string}
-  type MyOtherComponentProps = Props<typeof MyOtherComponent>; // {seconds: number}
-  ```
-
 - `DeepPartial<T>`: Recusively maps over all properties in a type and transforms them to be optional. Useful when you need to make optional all of the properties (and nested properties) of an existing type.
 
   ```ts

--- a/packages/useful-types/package.json
+++ b/packages/useful-types/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/useful-types/README.md",
   "dependencies": {
-    "@types/react": ">=16.4.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -1,5 +1,3 @@
-import {ComponentType, HTMLAttributes} from 'react';
-
 export type ThenType<T> = T extends Promise<infer U> ? U : T;
 
 export type Arguments<T> = T extends (...args: infer U) => any ? U : never;
@@ -24,12 +22,6 @@ export type DeepPartial<T> = {
       ? ReadonlyArray<DeepPartial<U>>
       : DeepPartial<T[P]>
 };
-
-export type Props<T> = T extends keyof JSX.IntrinsicElements
-  ? JSX.IntrinsicElements[T]
-  : T extends string
-    ? HTMLAttributes<T>
-    : T extends ComponentType<infer Props> ? Props : never;
 
 export type IfEmptyObject<Obj, If, Else = never> = keyof Obj extends {
   length: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,7 +639,7 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@>=16.4.0", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@^16.0.2":
   version "16.8.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
   integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==


### PR DESCRIPTION
## Description

We can now replace `Props<T>` from `@shopify/useful-types` with `ComponentProps`, `ComponentPropsWithRef`, and `ComponentPropsWithoutRef` native to the `react` types.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Typically we would be simply swapping out `Props<T>` for `ComponentPropsWithoutRef<T>` for most cases.

This also allows us to remove the `@types/react` dependency. 🎉

replaces #845 

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `useful-types` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
