### PR TITLE
💥 saner defaults for react-server-webpack-plugin and quilt_rails

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Configuration for the address of the react server now defaults to `ENV['REACT_SERVER_IP']`:`ENV['REACT_SERVER_PORT']` if they are set.
 
 ## [1.1.0] - 2019-08-15
 

--- a/gems/quilt_rails/lib/quilt_rails/configuration.rb
+++ b/gems/quilt_rails/lib/quilt_rails/configuration.rb
@@ -4,8 +4,11 @@ module Quilt
     attr_accessor :react_server_host, :react_server_protocol
 
     def initialize
-      @react_server_host = ENV['SERVICE_URL'] || 'localhost:8081'
-      @react_server_protocol = ENV['SERVICE_PROTOCOL'] || 'http'
+      ip = ENV['REACT_SERVER_IP'] || 'localhost'
+      port = ENV['REACT_SERVER_PORT'] || 8081
+
+      @react_server_host = "#{ip}:#{port}"
+      @react_server_protocol = ENV['REACT_SERVER_PROTOCOL'] || 'http'
     end
   end
 

--- a/packages/react-server-webpack-plugin/CHANGELOG.md
+++ b/packages/react-server-webpack-plugin/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.0] - 2019-08-14
 
+- The plugin now defaults the `host` of the generated code to use `process.env.REACT_SERVER_IP` and the `port` to use `process.env.REACT_SERVER_PORT` when explicit values are not supplied. [#852](https://github.com/Shopify/quilt/pull/852)
 - 💚 Increase test timeout [#849](https://github.com/Shopify/quilt/pull/849)
 
 ## [1.0.2] - 2019-08-14

--- a/packages/react-server-webpack-plugin/README.md
+++ b/packages/react-server-webpack-plugin/README.md
@@ -32,7 +32,11 @@ module.exports = function sewingKitConfig(plugins: Plugins, env: Env) {
         port,
       }),
       plugins.webpack((config: any) => {
-        config.plugins.push(new ReactServerPlugin());
+        config.plugins.push(
+          new ReactServerPlugin({
+            assetPrefix: process.env.CDN_URL || 'https://localhost:8080/webpack/assets/';
+          });
+        );
       }),
     ],
   };
@@ -46,14 +50,13 @@ In the future `@shopify/sewing-kit` will automatically configure this package fo
 First you will need to install all of the dependencies you'll need for your application
 
 ```sh
-yarn add react react-dom 
+yarn add react react-dom
 yarn add webpack @shopify/react-server @shopify/react-server-webpack-plugin @shopify/webpack-asset-metadata-plugin --dev
 ```
 
 Since `@shopify/react-server` relies on `@shopify/webpack-asset-metadata-plugin`, you will need to setup both plugins in your webpack configuration. A simple starter (not production optimized) webpack setup is as follows:
 
 ```tsx
-
 // webpack.config.js
 const {ReactServerPlugin} = require('@shopify/react-server-webpack-plugin');
 const {AssetMetadataPlugin} = require('@shopify/webpack-asset-metadata-plugin');
@@ -63,10 +66,7 @@ const universal = {
   optimization: {
     minimize: false,
   },
-  plugins: [
-    new AssetMetadataPlugin(),
-    new ReactServerPlugin(),
-  ],
+  plugins: [new AssetMetadataPlugin(), new ReactServerPlugin()],
 };
 
 const server = {
@@ -101,9 +101,7 @@ By default, this plugin expects the entrypoint to your application to be in the 
 import React from 'react';
 
 export default function App() {
-  return (
-    <div>I am an app</div>
-  )
+  return <div>I am an app</div>;
 }
 ```
 
@@ -128,14 +126,34 @@ It accepts a configuration object with the following interface:
 ```tsx
 interface Options {
   /*
-    The base-path to user for the `client.js` and `server.js` virtual entry files.
+   The base-path to use for the `client.js` and `server.js` virtual entry files,
+   this should also be where your index.tsx/jsx is.
+
+   default: '.'
   */
+
   basePath: string;
-  // The host to use when calling `createServer` from `@shopify/react-server`
+
+  /*
+   The host to use when calling `createServer` from `@shopify/react-server`,
+   this should also be where your index.tsx/jsx is.
+
+   default: process.env.REACT_SERVER_IP || "localhost"
+  */
   host: string;
-  // The port to use when calling `createServer` from `@shopify/react-server`
+
+  /*
+    The port to use when calling `createServer` from `@shopify/react-server`
+
+    default: process.env.REACT_SERVER_PORT || 8081
+  */
   port: number;
-  // The assetPrefix to use when calling `createServer` from `@shopify/react-server`
+
+  /*
+   The assetPrefix to use when calling `createServer` from `@shopify/react-server`.
+
+   default: process.env.CDN_URL || "localhost:8080/assets/webpack"
+  */
   assetPrefix: string;
 }
 ```
@@ -144,8 +162,6 @@ An example configuration for a `sewing-kit` app named `cool-app` might look like
 
 ```tsx
 new ReactServerPlugin({
-  ip: process.env.IP || 'localhost';
-  port: process.env.PORT ? parseInt(process.env.PORT, 10) : 8081;
   assetPrefix: process.env.CDN_URL || 'https://localhost:8080/webpack/assets/';
 });
 ```

--- a/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
+++ b/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
@@ -4,9 +4,9 @@ import VirtualModulesPlugin from 'webpack-virtual-modules';
 
 interface Options {
   basePath: string;
-  host: string;
-  port: number;
-  assetPrefix: string;
+  assetPrefix?: string;
+  host?: string;
+  port?: number;
 }
 
 enum Entrypoint {
@@ -23,10 +23,10 @@ export class ReactServerPlugin {
   private options: Options;
 
   constructor({
+    host,
+    port,
+    assetPrefix,
     basePath = '.',
-    host = 'localhost',
-    port = 8081,
-    assetPrefix = 'localhost:8080/assets/webpack',
   }: Partial<Options> = {}) {
     this.options = {
       basePath,
@@ -38,7 +38,7 @@ export class ReactServerPlugin {
 
   apply(compiler: Compiler) {
     const modules = this.modules(compiler);
-    const virtualModules = new VirtualModulesPlugin(modules) as Plugin;
+    const virtualModules = (new VirtualModulesPlugin(modules) as any) as Plugin;
     virtualModules.apply(compiler);
   }
 
@@ -76,9 +76,15 @@ export class ReactServerPlugin {
             });
 
           const app = createServer({
-            port: ${port},
-            ip: '${host}',
-            assetPrefix: '${assetPrefix}',
+            port: ${port ? port : 'process.env.REACT_SERVER_PORT || 8081'},
+            ip: ${
+              host ? `'${host}'` : 'process.env.REACT_SERVER_IP || "localhost"'
+            },
+            assetPrefix: '${
+              assetPrefix
+                ? assetPrefix
+                : 'process.env.CDN_URL || "localhost:8080/assets/webpack"'
+            }',
             render,
           });
           export default app;

--- a/packages/react-server-webpack-plugin/src/test/react-server-webpack-plugin.test.ts
+++ b/packages/react-server-webpack-plugin/src/test/react-server-webpack-plugin.test.ts
@@ -25,24 +25,35 @@ describe('react-server-webpack-plugin', () => {
   );
 
   it(
-    'does not use the generated client module when a bespoke file is present',
+    'uses process.env to default port and host',
     async () => {
-      const [serverResults, clientResults] = await runBuild(
-        'client-entrypoint',
-      );
+      const [serverResults] = await runBuild('no-entrypoints');
 
       const serverModule = serverResults.modules.find(
         ({name}) => name === './server.js',
       );
-      const clientModule = clientResults.modules.find(
-        ({name}) => name === './client.js',
+
+      expect(serverModule.source).toMatch('ip: process.env.REACT_SERVER_IP');
+      expect(serverModule.source).toMatch(
+        'port: process.env.REACT_SERVER_PORT',
       );
-      expect(serverModule.source).toMatch(generatedFileComment);
-      expect(clientModule.source).toMatch('I am a bespoke client entry');
-      expect(clientModule.source).not.toMatch(generatedFileComment);
     },
     BUILD_TIMEOUT,
   );
+
+  it('does not use the generated client module when a bespoke file is present', async () => {
+    const [serverResults, clientResults] = await runBuild('client-entrypoint');
+
+    const serverModule = serverResults.modules.find(
+      ({name}) => name === './server.js',
+    );
+    const clientModule = clientResults.modules.find(
+      ({name}) => name === './client.js',
+    );
+    expect(serverModule.source).toMatch(generatedFileComment);
+    expect(clientModule.source).toMatch('I am a bespoke client entry');
+    expect(clientModule.source).not.toMatch(generatedFileComment);
+  });
 
   it(
     'does not use the generated server module when a bespoke file is present',


### PR DESCRIPTION
closes #855
## Description
This PR changes the default values the webpack plugin generates into it's `react-server` server entry file. We now use generate an entrypoint that uses `process.env.REACT_SERVER_PORT` and `process.env.REACT_SERVER_IP` by default to play nicely with heroku style deployment.

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
