### PR TITLE
Update changelog

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## 0.1.3
 
 ### Changed
 


### PR DESCRIPTION
Backfilling this changelog for the publish from https://github.com/Shopify/quilt/commit/944a1e30d8643cd0592d7f8b9cb05ec7a13d7f42. Idk why it didn't get picked up in the `yarn release` flow. 