### PR TITLE
🚨add new package to prevent circular dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
       name: 'Node - build, type-check, and end-to-end tests'
       script:
         - yarn build
-        - yarn test --testPathPattern react-server-webpack-plugin
+        - yarn test --testPathPattern react-server-webpack-plugin address
     - <<: *node_container
       name: 'Node - unit tests'
       script:
-        - yarn test --testPathIgnorePatterns react-server-webpack-plugin
+        - yarn test --testPathIgnorePatterns react-server-webpack-plugin address
         - yarn codecov
     - <<: *node_container
       name: 'Node - lint'

--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/address-consts` package

--- a/packages/address-consts/README.md
+++ b/packages/address-consts/README.md
@@ -1,0 +1,8 @@
+# `@shopify/address-consts`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Faddress-consts.svg)](https://badge.fury.io/js/%40shopify%2Faddress-consts.svg)
+
+Constants and types relating to `@shopify/address`.
+
+This package is not meant for direct consumption, rather it contains dependencies that both `@shopify/address` and `@shopify/address-mocks` require.

--- a/packages/address-consts/package.json
+++ b/packages/address-consts/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shopify/address-consts",
+  "version": "0.0.1",
+  "license": "MIT",
+  "description": "Constants and types relating to @shopify/address",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/address-consts/README.md",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "~3.2.1"
+  },
+  "files": ["dist/*"]
+}

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -85,3 +85,28 @@ export interface ResponseError {
     value: any;
   }[];
 }
+
+export const GRAPHQL_ENDPOINT =
+  'https://country-service.shopifycloud.com/graphql';
+export enum GraphqlOperationName {
+  Countries = 'countries',
+  Country = 'country',
+}
+
+export const HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+};
+
+export const SUPPORTED_LOCALES = [
+  'DA',
+  'DE',
+  'EN',
+  'ES',
+  'FR',
+  'IT',
+  'JA',
+  'NL',
+  'PT',
+  'PT_BR',
+];

--- a/packages/address-consts/tsconfig.build.json
+++ b/packages/address-consts/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -29,6 +29,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@shopify/address-consts": "^0.0.1",
     "tslib": "^1.9.3"
   }
 }

--- a/packages/address-mocks/src/fixtures/index.ts
+++ b/packages/address-mocks/src/fixtures/index.ts
@@ -1,4 +1,7 @@
-import {LoadCountriesResponse, LoadCountryResponse} from '@shopify/address';
+import {
+  LoadCountriesResponse,
+  LoadCountryResponse,
+} from '@shopify/address-consts';
 
 const countryCAFr: LoadCountryResponse = require('./country_ca_fr').default;
 const countryCAEn: LoadCountryResponse = require('./country_ca_en').default;

--- a/packages/address-mocks/src/index.ts
+++ b/packages/address-mocks/src/index.ts
@@ -1,5 +1,5 @@
 import {fetch} from '@shopify/jest-dom-mocks';
-import {GRAPHQL_ENDPOINT, SUPPORTED_LOCALES} from '@shopify/address';
+import {GRAPHQL_ENDPOINT, SUPPORTED_LOCALES} from '@shopify/address-consts';
 
 import {fixtures} from './fixtures';
 

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -29,6 +29,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@shopify/address-consts": "^0.0.1",
     "tslib": "^1.9.3"
   }
 }

--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -1,4 +1,4 @@
-import {Address, FieldName, Country} from './types';
+import {Address, FieldName, Country} from '@shopify/address-consts';
 import {renderLineTemplate, FIELDS_MAPPING} from './utilities';
 import {loadCountry, loadCountries} from './loader';
 

--- a/packages/address/src/index.ts
+++ b/packages/address/src/index.ts
@@ -1,3 +1,4 @@
-export * from './types';
+export * from '@shopify/address-consts';
+
 export * from './loader';
 export {default} from './AddressFormatter';

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -3,20 +3,12 @@ import {
   LoadCountriesResponse,
   LoadCountryResponse,
   ResponseError,
-} from './types';
+  GRAPHQL_ENDPOINT,
+  SUPPORTED_LOCALES,
+  HEADERS,
+  GraphqlOperationName,
+} from '@shopify/address-consts';
 import query from './graphqlQuery';
-
-export const GRAPHQL_ENDPOINT =
-  'https://country-service.shopifycloud.com/graphql';
-export enum GraphqlOperationName {
-  Countries = 'countries',
-  Country = 'country',
-}
-
-const HEADERS = {
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
-};
 
 export const loadCountries: (
   locale: string,
@@ -80,18 +72,6 @@ class CountryLoaderError extends Error {
 }
 
 const DEFAULT_LOCALE = 'EN';
-export const SUPPORTED_LOCALES = [
-  'DA',
-  'DE',
-  'EN',
-  'ES',
-  'FR',
-  'IT',
-  'JA',
-  'NL',
-  'PT',
-  'PT_BR',
-];
 
 export function toSupportedLocale(locale: string) {
   const supportedLocale = locale.replace(/-/, '_').toUpperCase();

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -1,6 +1,6 @@
 import {fetch} from '@shopify/jest-dom-mocks';
 import {Address} from '@shopify/address-consts';
-import {mockCountryRequests} from '../../../address-mocks';
+import {mockCountryRequests} from '../../../address-mocks/src';
 import {toSupportedLocale} from '../loader';
 import AddressFormatter from '..';
 

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -1,6 +1,6 @@
 import {fetch} from '@shopify/jest-dom-mocks';
-import {mockCountryRequests} from '@shopify/address-mocks';
 import {Address} from '@shopify/address-consts';
+import {mockCountryRequests} from '../../../address-mocks';
 import {toSupportedLocale} from '../loader';
 import AddressFormatter from '..';
 
@@ -17,8 +17,8 @@ const address: Address = {
   phone: '514 xxx xxxx',
 };
 
-beforeEach(mockCountryRequests);
-afterEach(fetch.restore);
+beforeEach(() => mockCountryRequests());
+afterEach(() => fetch.restore());
 
 describe('updateLocale()', () => {
   it('returns the country information in the default locale for that country', async () => {

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -1,6 +1,6 @@
 import {fetch} from '@shopify/jest-dom-mocks';
-import {mockCountryRequests} from '../../../address-mocks/src';
-import {Address} from '../types';
+import {mockCountryRequests} from '@shopify/address-mocks';
+import {Address} from '@shopify/address-consts';
 import {toSupportedLocale} from '../loader';
 import AddressFormatter from '..';
 

--- a/packages/address/src/tests/utilities.test.ts
+++ b/packages/address/src/tests/utilities.test.ts
@@ -1,4 +1,4 @@
-import {fixtures} from '../../../address-mocks';
+import {fixtures} from '../../../address-mocks/src/fixtures';
 import {renderLineTemplate} from '../utilities';
 
 const Canada = fixtures.country.EN.data.country;

--- a/packages/address/src/tests/utilities.test.ts
+++ b/packages/address/src/tests/utilities.test.ts
@@ -1,4 +1,4 @@
-import {fixtures} from '../../../address-mocks/src/fixtures';
+import {fixtures} from '@shopify/address-mocks';
 import {renderLineTemplate} from '../utilities';
 
 const Canada = fixtures.country.EN.data.country;

--- a/packages/address/src/tests/utilities.test.ts
+++ b/packages/address/src/tests/utilities.test.ts
@@ -1,4 +1,4 @@
-import {fixtures} from '@shopify/address-mocks';
+import {fixtures} from '../../../address-mocks';
 import {renderLineTemplate} from '../utilities';
 
 const Canada = fixtures.country.EN.data.country;

--- a/packages/address/src/utilities.ts
+++ b/packages/address/src/utilities.ts
@@ -1,4 +1,4 @@
-import {Address, FieldName, Country, Zone} from './types';
+import {Address, FieldName, Country, Zone} from '@shopify/address-consts';
 
 const FIELD_REGEXP = /({\w+})/g;
 export const FIELDS_MAPPING: {


### PR DESCRIPTION
#865 

We've been getting circular dependency warnings for a while because `address` and `address-mocks` depend on eachother.

As CI pains have become a big pain-point as of late, I wanted to deal with this to rule it out as a performance problem. To do so I added a third package that `address-mocks' and `address` can both depend on instead.

Unfortunately it doesn't make much of an impact, but at least the warning is gone.