### PR TITLE
🐛 add missing network dependency

### DIFF
--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## 3.1.32 - 2019-08-15
+
+### Fixed
+
+- Package no longer lists missing '@shopify/network' dependency [862](https://github.com/Shopify/quilt/pull/862)
+
 ## 3.1.31 - 2019-08-13
 
 ### Fixed

--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -11,7 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Package no longer lists missing '@shopify/network' dependency [862](https://github.com/Shopify/quilt/pull/862)
+- Package now lists missing '@shopify/network' dependency [862](https://github.com/Shopify/quilt/pull/862)
 
 ## 3.1.31 - 2019-08-13
 

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/koa-shopify-auth/README.md",
   "dependencies": {
+    "@shopify/network": "^1.4.1",
     "nonce": "^1.0.4",
     "safe-compare": "^1.1.2",
     "tslib": "^1.9.3"


### PR DESCRIPTION
## Description

In the most recent update to the koa-shopify-auth package I failed to add the network dependency to the package.json

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] koa-shopify-auth Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
