### PR TITLE
remove shop and access token

### DIFF
--- a/packages/react-graphql/src/client.ts
+++ b/packages/react-graphql/src/client.ts
@@ -6,6 +6,7 @@ import {
   Observable,
   FetchResult,
 } from 'apollo-link';
+
 import {NormalizedCacheObject} from 'apollo-cache-inmemory';
 
 class SsrExtractableLink extends ApolloLink {
@@ -25,9 +26,7 @@ class SsrExtractableLink extends ApolloLink {
 
   request(operation: Operation, nextLink?: NextLink) {
     if (nextLink != null) {
-      throw new Error(
-        'Links created by createSsrExtractableLink() must be the only link in the chain.',
-      );
+      throw new Error('SsrExtractableLink must be the only link in the chain.');
     }
 
     let operationDone: Function;

--- a/packages/react-graphql/src/createClient.ts
+++ b/packages/react-graphql/src/createClient.ts
@@ -4,20 +4,16 @@ import {Header} from '@shopify/react-network';
 import {ApolloClient} from './client';
 
 export interface Options {
-  shop?: string;
   server?: boolean;
-  accessToken?: string;
   initialData?: NormalizedCacheObject;
   graphQLEndpoint?: string;
   connectToDevTools?: boolean;
 }
 
 export function createGraphQLClient({
-  shop,
   server,
   initialData,
-  accessToken,
-  graphQLEndpoint,
+  graphQLEndpoint = '/graphql',
   connectToDevTools,
 }: Options) {
   const cache = new InMemoryCache({
@@ -29,17 +25,9 @@ export function createGraphQLClient({
     [Header.ContentType.toLowerCase()]: 'application/json',
   };
 
-  if (accessToken) {
-    headers['X-Shopify-Access-Token'] = accessToken;
-  }
-
-  const uri = graphQLEndpoint
-    ? graphQLEndpoint
-    : createGraphQLEndpointForShop(shop, accessToken);
-
   const link = createHttpLink({
     credentials: 'include',
-    uri,
+    uri: graphQLEndpoint,
     headers,
   });
 
@@ -50,8 +38,4 @@ export function createGraphQLClient({
     cache: initialData ? cache.restore(initialData) : cache,
     connectToDevTools: !server && connectToDevTools,
   });
-}
-
-function createGraphQLEndpointForShop(shop?: string, accessToken?: string) {
-  return shop && accessToken ? `https://${shop}/admin/api/graphql` : '/graphql';
 }

--- a/packages/react-server/src/index.ts
+++ b/packages/react-server/src/index.ts
@@ -1,2 +1,3 @@
 export {createServer} from './server';
 export {createRender, RenderContext} from './render';
+export {createLogger} from './logger';

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -28,7 +28,7 @@ export type RenderFunction = (ctx: RenderContext) => React.ReactElement<any>;
 
 export function createRender(render: RenderFunction) {
   return async function renderFunction(ctx: RenderContext) {
-    const logger = getLogger(ctx);
+    const logger = getLogger(ctx) || console;
     const assets = getAssets(ctx);
     const networkManager = new NetworkManager();
     const htmlManager = new HtmlManager();

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import withEnv from '@shopify/with-env';
-import {createRender, RenderingContext} from '../render';
-import {Logger, noopLogger, setLogger} from '../../logger';
+import {createRender, RenderContext} from '../render';
 
 jest.mock('@shopify/sewing-kit-koa', () => ({
   getAssets() {
@@ -23,10 +22,9 @@ describe('createRender', () => {
   it('response contains "My cool app"', async () => {
     const myCoolApp = 'My cool app';
     const ctx = createMockContext();
-    setLogger(ctx, new Logger());
 
     const renderFunction = createRender(() => <>{myCoolApp}</>);
-    await renderFunction(ctx as RenderingContext);
+    await renderFunction(ctx as RenderContext);
 
     expect(ctx.body).toContain(myCoolApp);
   });
@@ -34,7 +32,6 @@ describe('createRender', () => {
   it('in development the body contains a meaningful error messages', () => {
     withEnv('development', async () => {
       const ctx = {...createMockContext(), locale: ''};
-      setLogger(ctx, new Logger());
 
       const renderFunction = createRender(() => <BrokenApp />);
       await renderFunction(ctx);
@@ -47,7 +44,6 @@ describe('createRender', () => {
     withEnv('production', async () => {
       const ctx = {...createMockContext(), locale: ''};
       const throwSpy = jest.spyOn(ctx, 'throw').mockImplementation(() => null);
-      setLogger(ctx, new Logger());
 
       const renderFunction = createRender(() => <BrokenApp />);
       await renderFunction(ctx);


### PR DESCRIPTION
## Description

Migrates some aspects over from `web-rails-proving-ground`:

- Removes the `shop` or `accesstoken` options in `createGraphQLClient`
- Exports the logger middleware from `react-server`. I was testing a few different setups with `webgen` and found that if you want to consume the `createRender` middleware directly (and roll your own koa server in a node app) you need to create the logger in a middleware as well. Right now you can't do this. Alternately, we could remove all the logging from `react-server` (just use `console`), or better, have a simple server logger middleware package that we can share. We have a logger package in this repo, but it is not very good.

