### PR TITLE
Raise a more meaningful error message when React server is booting up or down

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.3] - 2019-08-20
+
+### Fixed
+
+- Raise a more meaningful error message when React server is ready/configured properly [#870](https://github.com/Shopify/quilt/pull/870)
+
 ## [1.3.2] - 2019-08-20
 
 - Fix rails index route typo


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/837

<img width="1544" alt="Screen Shot 2019-08-20 at 4 59 35 PM" src="https://user-images.githubusercontent.com/6130700/63383985-ec9add80-c36b-11e9-9abe-7c80b025cc21.png">


## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
