### PR TITLE
➕Fix Node dependencies for faster yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/faker": "^4.1.5",
     "@types/jest": "^23.3.5",
-    "@types/react": "16.8.2",
+    "@types/react": "16.8.10",
     "@types/react-dom": "^16.8.3",
     "@types/react-helmet": "^5.0.6",
     "apollo-cache-inmemory": "^1.3.6",
@@ -61,7 +61,7 @@
     "react-dom": "16.9.0-alpha.0",
     "react-helmet": "^5.2.0",
     "rimraf": "^2.6.2",
-    "tslib": "^1.9.3",	
+    "tslib": "^1.9.3",
     "typescript": "~3.2.1",
     "ts-jest": "^23.10.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,14 @@
     "@shopify/react-intersection-observer" "^2.0.3"
     tslib "^1.9.3"
 
+"@shopify/useful-types@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@shopify/useful-types/-/useful-types-1.3.0.tgz#79cfb6722d2cc192c05f14e55789bcfe2b40a6de"
+  integrity sha512-BQw5KFuDm7aAH1bPECxnC1bPyaLSmZP0ecs0XwzKtgltBHWGvgu8dpqNXvY+sDfG5tnF+79EjiytRCOsTElyIg==
+  dependencies:
+    "@types/react" ">=16.4.0"
+    tslib "^1.9.3"
+
 "@types/accepts@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -639,7 +647,7 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.10", "@types/react@16.8.2", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.8.10", "@types/react@>=16.4.0", "@types/react@^16.0.2":
   version "16.8.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
   integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==


### PR DESCRIPTION
## Description

Speed up warm `yarn install` in CI by ~40 seconds by:
* Adding a missing `@shopify/useful-types` dependency
* Consistency between the `@types/react` version and its resolution

## 🎩 
Locally, run:
```
yarn
yarn
yarn
```

The second and third installs should take <1 second.