### PR TITLE
🔧 Split Node CI into build / lint / test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,32 @@
+shared:
+  node_container: &node_container
+    language: node_js
+    node_js:
+      - 8.10.0
+    before_install:
+      - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.17.3
+      - export PATH="$HOME/.yarn/bin:$PATH"
+    install:
+      - yarn install --production=false --frozen-lockfile
+    cache: yarn
+
 matrix:
   include:
-    - language: node_js
-      before_install:
-        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
-        - export PATH="$HOME/.yarn/bin:$PATH"
-      install:
-        - yarn install --production=false
+    - <<: *node_container
+      name: 'Node - build, type-check, and end-to-end tests'
+      script:
+        - yarn build
+        - yarn test --testPathPattern react-server-webpack-plugin
+    - <<: *node_container
+      name: 'Node - unit tests'
+      script:
+        - yarn test --testPathIgnorePatterns react-server-webpack-plugin
+        - yarn codecov
+    - <<: *node_container
+      name: 'Node - lint'
       script:
         - yarn lint
         - yarn ci:lint-docs
-        - yarn build
-        - yarn test
-        - yarn codecov
-      cache: yarn
     - language: ruby
       before_install:
         - cd gems/quilt_rails

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ type: node
 up:
   - node:
       version: v8.10.0
-      yarn: true
+      yarn: 1.17.3
 commands:
   __default__: start
   build: yarnpkg build


### PR DESCRIPTION
## Description

Split Node CI checks into separate containers (fixes #866).  This:
- Removes a few minutes from a full CI run
- Gives faster feedback for lint failures
- Gives faster feedback for unit test failures

### Before
<img width="802" alt="CI with a single Node container taking 15 minutes to complete" src="https://user-images.githubusercontent.com/673655/63230065-eb37ac80-c1d5-11e9-9b18-254dbd1707c4.png">

### After

<img width="804" alt="quilt - CI with build, lint, and test containers.  Lint finishes in less than 3 minutes, tests finish in less than 4 minutes, and build finishes in less than 12 minutes." src="https://user-images.githubusercontent.com/673655/63230099-3487fc00-c1d6-11e9-8b87-2a8b7586d13b.png">

^ this screencap contains changes from #871 and #873.