### PR TITLE
✨ Add optional replacements parameter for getTranslationTree

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional replacements argument to `getTranslationTree` ([#874](https://github.com/Shopify/quilt/pull/874))
+
 ## [1.5.1] - 2019-08-07
 
 ### Fixed

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -171,9 +171,15 @@ export class I18n {
     }
   }
 
-  getTranslationTree(id: string): string | object {
+  getTranslationTree(
+    id: string,
+    replacements?:
+      | PrimitiveReplacementDictionary
+      | ComplexReplacementDictionary,
+  ): string | TranslationDictionary {
     try {
-      return getTranslationTree(id, this.translations);
+      if (!replacements) return getTranslationTree(id, this.translations);
+      return getTranslationTree(id, this.translations, replacements);
     } catch (error) {
       this.onError(error);
       return '';

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -23,8 +23,30 @@ describe('getTranslationTree()', () => {
     });
   });
 
+  it('returns the translation keys with replacements if it has nested values', () => {
+    expect(
+      getTranslationTree(
+        'foo',
+        {foo: {bar: '{replacement}'}},
+        {replacement: 'bar'},
+      ),
+    ).toMatchObject({
+      bar: 'bar',
+    });
+  });
+
   it('returns the leaf string', () => {
     expect(getTranslationTree('foo.bar', {foo: {bar: 'one'}})).toBe('one');
+  });
+
+  it('returns the leaf string with replacements', () => {
+    expect(
+      getTranslationTree(
+        'foo.bar',
+        {foo: {bar: '{replacement}'}},
+        {replacement: 'bar'},
+      ),
+    ).toBe('bar');
   });
 
   it('throws a MissingTranslationError when no translation is found', () => {


### PR DESCRIPTION
## Description

This PR adds an optional `replacements` parameter to `getTranslationTree` for strings which may have replacements in which case the current functionality does not provide a fully translated tree.

[Example use case](https://github.com/Shopify/web/pull/17070/files#diff-4287b1df531a46eaf7ccea8f4afc4c02R50) - Could replace these variables with one call to `getTranslationTree`.

## Type of change

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] react-i18n Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
