### PR TITLE
always include csrf token for quilt rails requests

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Always include csrf token for quilt rails requests [#887](https://github.com/Shopify/quilt/pull/887)
+
 ## [1.3.3] - 2019-08-20
 
 ### Fixed

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -11,11 +11,11 @@ module Quilt
       ReactRenderable.log("[ReactRenderable] proxying to React server at #{url}")
 
       begin
-        reverse_proxy(url) do |callbacks|
+        reverse_proxy(url, headers: { 'X-CSRF-Token': form_authenticity_token }) do |callbacks|
           callbacks.on_response do |status_code, _response|
             ReactRenderable.log("[ReactRenderable] #{url} returned #{status_code}")
           end
-        end
+       end
       rescue Errno::ECONNREFUSED
         raise ReactServerNoResponseError, url
       end

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -15,7 +15,7 @@ module Quilt
           callbacks.on_response do |status_code, _response|
             ReactRenderable.log("[ReactRenderable] #{url} returned #{status_code}")
           end
-       end
+        end
       rescue Errno::ECONNREFUSED
         raise ReactServerNoResponseError, url
       end

--- a/gems/quilt_rails/test/quilt_rails/react_renderable_test.rb
+++ b/gems/quilt_rails/test/quilt_rails/react_renderable_test.rb
@@ -3,13 +3,17 @@ module Quilt
   class ReactRenderableTest < Minitest::Test
     include Quilt::ReactRenderable
 
-    def test_render_react_calls_reverse_proxy_with_server_uri
+    def test_render_react_calls_reverse_proxy_with_server_uri_and_csrf
       url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
       assert_equal(render_react, reverse_proxy(url))
     end
 
-    def reverse_proxy(url)
-      "called with #{url}"
+    def reverse_proxy(url, headers: {})
+      "called with #{url} and #{headers}"
+    end
+
+    def form_authenticity_token
+      'foo'
     end
   end
 end

--- a/gems/quilt_rails/test/quilt_rails/react_renderable_test.rb
+++ b/gems/quilt_rails/test/quilt_rails/react_renderable_test.rb
@@ -5,7 +5,8 @@ module Quilt
 
     def test_render_react_calls_reverse_proxy_with_server_uri_and_csrf
       url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
-      assert_equal(render_react, reverse_proxy(url))
+
+      assert_equal(render_react, reverse_proxy(url, headers: { 'X-CSRF-Token': form_authenticity_token }))
     end
 
     def reverse_proxy(url, headers: {})


### PR DESCRIPTION
This PR adds the X-CSRF-Token as the headers argument to `reverse_proxy`