### PR TITLE
Fix case sensitive header nonsense

### DIFF
--- a/packages/react-network/CHANGELOG.md
+++ b/packages/react-network/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [3.1.2] - 2019-08-21
+
+## Fixed
+
+- `useRequestHeader` is now correctly case-insensitive [#889](https://github.com/Shopify/quilt/pull/8889)
+
 ## [3.1.1] - 2019-08-20
 
 ## Fixed

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -38,7 +38,7 @@ export class NetworkManager {
   }
 
   getHeader(header: string) {
-    return this.requestHeaders && this.requestHeaders[header];
+    return this.requestHeaders && this.requestHeaders[header.toLowerCase()];
   }
 
   setHeader(header: string, value: string) {

--- a/packages/react-network/src/test/manager.test.ts
+++ b/packages/react-network/src/test/manager.test.ts
@@ -1,0 +1,23 @@
+import {NetworkManager} from '../manager';
+
+describe('NetworkManager', () => {
+  describe('getHeader', () => {
+    it('returns headers from the provided dictionary', () => {
+      const headers = {
+        foo: 'bar',
+      };
+      const manager = new NetworkManager({headers});
+
+      expect(manager.getHeader('foo')).toBe(headers.foo);
+    });
+
+    it('is case insensitive', () => {
+      const headers = {
+        foo: 'bar',
+      };
+      const manager = new NetworkManager({headers});
+
+      expect(manager.getHeader('FoO')).toBe(headers.foo);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes the hours of confusion and frustration that can result when one wonders why `useRequestHeader('Csrf-token')` does not return a value.

Koa's header objects have all keys downcased, so all we had to do was downcase the input string in `NetworkManager#getHeader`.