### PR TITLE
🐛 fix breakages in production when used with ShopifySecurityBase

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2019-08-22
+
+### Fixed
+
+- No longer breaks when used with `ShopifySecurityBase`
+
 ## [1.4.0] - 2019-08-21
 
 ### Added

--- a/gems/quilt_rails/lib/quilt_rails.rb
+++ b/gems/quilt_rails/lib/quilt_rails.rb
@@ -2,7 +2,8 @@
 module Quilt
 end
 
-require "quilt_rails/engine"
 require "quilt_rails/version"
+require "quilt_rails/engine"
+require "quilt_rails/logger"
 require "quilt_rails/configuration"
 require "quilt_rails/react_renderable"

--- a/gems/quilt_rails/lib/quilt_rails/logger.rb
+++ b/gems/quilt_rails/lib/quilt_rails/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Quilt
   module Logger
     def self.log(string)

--- a/gems/quilt_rails/lib/quilt_rails/logger.rb
+++ b/gems/quilt_rails/lib/quilt_rails/logger.rb
@@ -1,0 +1,11 @@
+module Quilt
+  module Logger
+    def self.log(string)
+      if defined? Rails && Rails.logger.nil?
+        puts string
+      else
+        Rails.logger.info(string)
+      end
+    end
+  end
+end

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -17,6 +17,7 @@ module Quilt
     end
 
     private
+
     def proxy
       url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
       Quilt::Logger.log("[ReactRenderable] proxying to React server at #{url}")

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -7,25 +7,28 @@ module Quilt
     include ReverseProxy::Controller
 
     def render_react
+      if defined? ShopifySecurityBase
+        ShopifySecurityBase::HTTPHostRestriction.whitelist([Quilt.configuration.react_server_host]) do
+          proxy
+        end
+      else
+        proxy
+      end
+    end
+
+    private
+    def proxy
       url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
-      ReactRenderable.log("[ReactRenderable] proxying to React server at #{url}")
+      Quilt::Logger.log("[ReactRenderable] proxying to React server at #{url}")
 
       begin
         reverse_proxy(url, headers: { 'X-CSRF-Token': form_authenticity_token }) do |callbacks|
           callbacks.on_response do |status_code, _response|
-            ReactRenderable.log("[ReactRenderable] #{url} returned #{status_code}")
+            Quilt::Logger.log("[ReactRenderable] #{url} returned #{status_code}")
           end
         end
       rescue Errno::ECONNREFUSED
         raise ReactServerNoResponseError, url
-      end
-    end
-
-    def self.log(string)
-      if Rails.logger.nil?
-        puts string
-      else
-        Rails.logger.info(string)
       end
     end
 


### PR DESCRIPTION
## Summary
This adds an explicit check for `ShopifySecurityBase ` and if it is defined wraps our call to `reverse_proxy` with a call to `ShopifySecurityBase::HTTPHostRestriction.whitelist`. This should fix the issues we've been having with using the two gems together causing SSR to break.

## Tophatting🎩

I'm not really sure how to tophat this locally to be honest. I wanted to get feedback from security folks quick regardless.