### PR TITLE
✨ include the error stack when presenting SSR errors in dev

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
-### Changed
+### Added
 
 - Added `Options` object as the second argument to `createRender()` allowing passed in values for `afterEachPass` and `betweenEachPass` [#911](https://github.com/Shopify/quilt/pull/911)
+- Now includes the full error stack when presenting SSR errors in development
 
 ## 0.2.0
 

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -95,7 +95,9 @@ export function createRender(render: RenderFunction, options: Options = {}) {
       logger.error(error);
       // eslint-disable-next-line no-process-env
       if (process.env.NODE_ENV === 'development') {
-        ctx.body = `Internal Server Error: \n\n${error.message}`;
+        ctx.body = `Internal Server Error: \n\n${error.message} \n\n ${
+          error.stack
+        }`;
       } else {
         ctx.throw(StatusCode.InternalServerError, error);
       }


### PR DESCRIPTION
## Description

Part of #894 

This PR makes it so that react-server includes the stack as well as the error message when something goes wrong in SSR. This should make it easier to debug issues. It does not change the presentation at all, so it is only part of the referenced issue.

