### PR TITLE
🐛 Return JSX.IntrinsicElements if it's a known element string

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Fixed
+
+- Fixed `find` and `findAll` not returning the correct type when being passed a string that matches `JSX.IntrinsicElements` ([#906](https://github.com/Shopify/quilt/pull/906))
+
 ## [1.7.1] - 2019-07-16
 
 ### Fixed

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -4,7 +4,9 @@ import {Arguments, MaybeFunctionReturnType} from '@shopify/useful-types';
 export type PropsFor<
   T extends string | React.ComponentType<any>
 > = T extends string
-  ? React.HTMLAttributes<T>
+  ? T extends keyof JSX.IntrinsicElements
+    ? JSX.IntrinsicElements[T]
+    : React.HTMLAttributes<T>
   : T extends React.ComponentType<any>
     ? React.ComponentPropsWithoutRef<T>
     : never;


### PR DESCRIPTION
## Description

This PR tries to fix an issue when using the `toHaveReactProps` matcher. 
Right now, if you try to find an anchor tag, for example, using the `a` string, the returned type will be `Element<React.HTMLAttributes<'a'>>`, which does not contain any anchor specific attributes.

So the matches will not accept any anchor specific attribute, such as `href`.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
