### PR TITLE
Upgrade react apollo to  v2.5.8

### DIFF
--- a/packages/jest-mock-apollo/CHANGELOG.md
+++ b/packages/jest-mock-apollo/CHANGELOG.md
@@ -8,10 +8,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- Updated `react-apollo` to `2.5.8` and `apollo-client` to `2.6.4`
-
 ## [3.1.0] - 2019-06-27
 
 ### Added

--- a/packages/react-effect-apollo/CHANGELOG.md
+++ b/packages/react-effect-apollo/CHANGELOG.md
@@ -7,10 +7,6 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
-
-- Updated `react-apollo` to `2.5.8` and `apollo-client` to `2.6.4`
-
 ### Added
 
 - `@shopify/react-effect-apollo` package

--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -7,10 +7,6 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
-
-- Updated `react-apollo` to `2.5.8` and `apollo-client` to `2.6.4`
-
 ## [5.0.0] - 2019-08-20
 
 ### Changed


### PR DESCRIPTION
## Description
:arrow_up: Upgrades `react-apollo` from `2.5.6` to `2.5.8` and `apollo-client` from `2.6.0` to `2.6.4`

`2.5.6` still references a beta version of `apollo-client`
https://github.com/apollographql/react-apollo/issues/3077

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [X] react-graphql graphql-testing Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have prefixed my pull request title with the corresponding emoji from [this guide](https://gitmoji.carloscuesta.me/)
