### PR TITLE
Universal Cookies

### DIFF
--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -29,7 +29,8 @@
     "@types/accept-language-parser": "1.5.0",
     "@types/koa": "^2.0.46",
     "accept-language-parser": "1.5.0",
-    "tslib": "^1.9.3"
+     "tslib": "^1.9.3",
+    "cookies": "0.7.3"
   },
   "files": [
     "dist/*",

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -27,10 +27,11 @@
     "@shopify/network": "^1.4.2",
     "@shopify/react-effect": "^3.2.3",
     "@types/accept-language-parser": "1.5.0",
-    "@types/koa": "^2.0.46",
     "accept-language-parser": "1.5.0",
-     "tslib": "^1.9.3",
-    "cookies": "0.7.3"
+    "@types/cookie": "^0.3.3",
+    "@types/koa": "^2.0.46",
+    "cookie": "^0.4.0",
+    "tslib": "^1.9.3"
   },
   "files": [
     "dist/*",

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -48,3 +48,18 @@ export function useAcceptLanguage(
 
   return locales;
 }
+
+export function useCookie(cookie: string) {
+  const network = useContext(NetworkContext);
+  const initialValue = network ? network.getCookie(cookie) : undefined;
+
+  const set = value => {
+    if (!network) {
+      return;
+    }
+
+    network.setCookie(cookie, value);
+  };
+
+  return [initialValue, set];
+}

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -1,7 +1,7 @@
-import {useContext} from 'react';
 import {parse, Language} from 'accept-language-parser';
+import {useContext, useState} from 'react';
+import {CookieSerializeOptions} from 'cookie';
 import {CspDirective, StatusCode, Header} from '@shopify/network';
-import Cookies from 'cookies';
 import {useServerEffect} from '@shopify/react-effect';
 
 import {NetworkContext} from './context';
@@ -51,18 +51,24 @@ export function useAcceptLanguage(
 }
 
 export function useCookie(
-  cookie: string,
-): [string | undefined, (value: string, options?: Cookies.SetOption) => void] {
+  key: string,
+): [
+  string | undefined,
+  (value: string, options?: CookieSerializeOptions) => void
+] {
   const network = useContext(NetworkContext);
-  const initialValue = network ? network.getCookie(cookie) : undefined;
+  const [cookie, setCookieValue] = useState(() => {
+    return network ? network.getCookie(key) : undefined;
+  });
 
-  const setCookie = (value: string, options?: Cookies.SetOption) => {
+  const setCookie = (value: string, options?: CookieSerializeOptions) => {
     if (!network) {
       return;
     }
 
-    network.setCookie(cookie, value, options);
+    setCookieValue(value);
+    network.setCookie(key, value, options);
   };
 
-  return [initialValue, setCookie];
+  return [cookie, setCookie];
 }

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -1,11 +1,11 @@
 import {parse, Language} from 'accept-language-parser';
-import {useContext, useState} from 'react';
+import {useContext, useState, useEffect} from 'react';
 import {CookieSerializeOptions} from 'cookie';
 import {CspDirective, StatusCode, Header} from '@shopify/network';
 import {useServerEffect} from '@shopify/react-effect';
 
 import {NetworkContext} from './context';
-import {NetworkManager} from './manager';
+import {NetworkManager, setBrowserCookie} from './manager';
 
 export function useNetworkEffect(perform: (network: NetworkManager) => void) {
   const network = useContext(NetworkContext);
@@ -50,6 +50,16 @@ export function useAcceptLanguage(
   return locales;
 }
 
+export function useServerCookie(key: string) {
+  console.log('using server cookie', key);
+  useNetworkEffect(network => {
+    console.log(network);
+    const cookie = network.getCookie(key);
+    console.log(cookie, key);
+    return cookie;
+  });
+}
+
 export function useCookie(
   key: string,
 ): [
@@ -58,15 +68,25 @@ export function useCookie(
 ] {
   const network = useContext(NetworkContext);
   const [cookie, setCookieValue] = useState(() => {
+    console.log('the network is', network);
     return network ? network.getCookie(key) : undefined;
   });
 
+  useEffect(
+    () => {
+      console.log('the network is', network);
+    },
+    [network],
+  );
+
   const setCookie = (value: string, options?: CookieSerializeOptions) => {
+    setCookieValue(value);
+
     if (!network) {
+      setBrowserCookie(key, value, options);
       return;
     }
 
-    setCookieValue(value);
     network.setCookie(key, value, options);
   };
 

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -1,6 +1,7 @@
 import {useContext} from 'react';
 import {parse, Language} from 'accept-language-parser';
 import {CspDirective, StatusCode, Header} from '@shopify/network';
+import Cookies from 'cookies';
 import {useServerEffect} from '@shopify/react-effect';
 
 import {NetworkContext} from './context';
@@ -49,17 +50,19 @@ export function useAcceptLanguage(
   return locales;
 }
 
-export function useCookie(cookie: string) {
+export function useCookie(
+  cookie: string,
+): [string | undefined, (value: string, options?: Cookies.SetOption) => void] {
   const network = useContext(NetworkContext);
   const initialValue = network ? network.getCookie(cookie) : undefined;
 
-  const set = value => {
+  const setCookie = (value: string, options?: Cookies.SetOption) => {
     if (!network) {
       return;
     }
 
-    network.setCookie(cookie, value);
+    network.setCookie(cookie, value, options);
   };
 
-  return [initialValue, set];
+  return [initialValue, setCookie];
 }

--- a/packages/react-network/src/index.ts
+++ b/packages/react-network/src/index.ts
@@ -11,4 +11,5 @@ export {
   useRequestHeader,
   useRedirect,
   useAcceptLanguage,
+  useCookie,
 } from './hooks';

--- a/packages/react-network/src/index.ts
+++ b/packages/react-network/src/index.ts
@@ -12,4 +12,5 @@ export {
   useRedirect,
   useAcceptLanguage,
   useCookie,
+  useServerCookie,
 } from './hooks';

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -34,24 +34,6 @@ export class NetworkManager {
     } & CookieSerializeOptions
   >();
 
-  private get browser() {
-    return Boolean(
-      typeof document === 'object' && typeof document.cookie === 'string',
-    );
-  }
-
-  private setBrowserCookie(
-    name: string,
-    value: string,
-    options?: CookieSerializeOptions,
-  ) {
-    if (!this.browser) {
-      return;
-    }
-
-    document.cookie = cookie.serialize(name, value, options);
-  }
-
   constructor({headers, cookies}: Options = {}) {
     this.requestHeaders = lowercaseEntries(headers);
 
@@ -161,6 +143,24 @@ export class NetworkManager {
       cookies,
       redirectUrl: this.redirectUrl,
     };
+  }
+
+  private get browser() {
+    return Boolean(
+      typeof document === 'object' && typeof document.cookie === 'string',
+    );
+  }
+
+  private setBrowserCookie(
+    name: string,
+    value: string,
+    options?: CookieSerializeOptions,
+  ) {
+    if (!this.browser) {
+      return;
+    }
+
+    document.cookie = cookie.serialize(name, value, options);
   }
 }
 

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -1,3 +1,4 @@
+import Cookies from 'cookies';
 import {StatusCode, CspDirective, Header} from '@shopify/network';
 import {EffectKind} from '@shopify/react-effect';
 
@@ -25,7 +26,12 @@ export class NetworkManager {
   private readonly csp = new Map<CspDirective, string[] | boolean>();
   private readonly headers = new Map<string, string>();
   private readonly requestHeaders: Record<string, string>;
-  private readonly cookies = new Map<string, string>();
+  private readonly cookies = new Map<
+    string,
+    {
+      value: string;
+    } & Cookies.SetOption
+  >();
 
   constructor({headers}: Options = {}) {
     this.requestHeaders = lowercaseEntries(headers);
@@ -48,11 +54,12 @@ export class NetworkManager {
   }
 
   getCookie(cookie: string) {
-    return this.cookies[cookie.toLowerCase()];
+    const value = this.cookies.get(cookie.toLowerCase());
+    return value && value.value;
   }
 
-  setCookie(cookie: string, value: string) {
-    this.cookies.set(cookie, value);
+  setCookie(cookie: string, value: string, options: Cookies.SetOption = {}) {
+    this.cookies.set(cookie, {value, ...options});
   }
 
   redirectTo(url: string, status = StatusCode.Found) {

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -22,9 +22,9 @@ export function applyToContext<T extends Context>(
     ctx.set(header, value);
   }
 
-  for (const [cookie, value] of cookies) {
-    console.log(cookie, value);
-    ctx.cookies.set(cookie, value);
+  for (const [cookie, options] of cookies) {
+    const {value, ...rest} = options;
+    ctx.cookies.set(cookie, value, rest);
   }
 
   return ctx;

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -24,7 +24,7 @@ export function applyToContext<T extends Context>(
 
   for (const [cookie, options] of cookies) {
     const {value, ...rest} = options;
-    ctx.cookies.set(cookie, value, rest);
+    ctx.cookies.set(cookie, value, rest as any);
   }
 
   // eslint-disable-next-line no-warning-comments

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -8,7 +8,7 @@ export function applyToContext<T extends Context>(
   ctx: T,
   manager: NetworkManager,
 ) {
-  const {status, redirectUrl, headers} = manager.extract();
+  const {status, redirectUrl, headers, cookies} = manager.extract();
 
   if (redirectUrl) {
     ctx.redirect(redirectUrl);
@@ -20,6 +20,11 @@ export function applyToContext<T extends Context>(
 
   for (const [header, value] of headers) {
     ctx.set(header, value);
+  }
+
+  for (const [cookie, value] of cookies) {
+    console.log(cookie, value);
+    ctx.cookies.set(cookie, value);
   }
 
   return ctx;

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -24,6 +24,7 @@ export function applyToContext<T extends Context>(
 
   for (const [cookie, options] of cookies) {
     const {value, ...rest} = options;
+    console.log('setting server ', cookie, value);
     ctx.cookies.set(cookie, value, rest as any);
   }
 

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -24,7 +24,7 @@ export function applyToContext<T extends Context>(
 
   for (const [cookie, options] of cookies) {
     const {value, ...rest} = options;
-    ctx.cookies.set(cookie, value, rest);
+    ctx.cookies.set(cookie, value, rest as any);
   }
 
   return ctx;

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -24,8 +24,12 @@ export function applyToContext<T extends Context>(
 
   for (const [cookie, options] of cookies) {
     const {value, ...rest} = options;
-    ctx.cookies.set(cookie, value, rest as any);
+    ctx.cookies.set(cookie, value, rest);
   }
+
+  // eslint-disable-next-line no-warning-comments
+  // TODO: Add a watcher function that reapplies the cookies
+  // to context when they change
 
   return ctx;
 }

--- a/packages/react-network/src/test/e2e.test.tsx
+++ b/packages/react-network/src/test/e2e.test.tsx
@@ -8,6 +8,7 @@ import {
   useCspDirective,
   useRedirect,
   useHeader,
+  useCookie,
   StatusCode,
   CspDirective,
   Header,
@@ -23,10 +24,12 @@ describe('e2e', () => {
       if (pass > 0) {
         return;
       }
+      const [, setFooCookie] = useCookie('foo');
 
       useStatus(StatusCode.NotFound);
       useCspDirective(CspDirective.ChildSrc, 'https://*');
       useHeader(Header.CacheControl, 'no-cache');
+      setFooCookie('bar');
     });
 
     await extract(<TwoPass />, {
@@ -40,6 +43,7 @@ describe('e2e', () => {
     const extracted = networkManager.extract();
     expect(extracted).toHaveProperty('headers.size', 0);
     expect(extracted).toHaveProperty('status', undefined);
+    expect(extracted).toHaveProperty('cookies.size', 0);
   });
 
   it('bails out when a redirect is set', async () => {

--- a/packages/react-network/src/test/hooks.test.tsx
+++ b/packages/react-network/src/test/hooks.test.tsx
@@ -4,7 +4,7 @@ import {Header} from '@shopify/network';
 import {FirstArgument} from '@shopify/useful-types';
 import {NetworkManager} from '../manager';
 import {NetworkContext} from '../context';
-import {useCookie, useAcceptLanguage} from '../hooks';
+import {useAcceptLanguage} from '../hooks';
 
 describe('hooks', () => {
   describe('useAcceptLanguage()', () => {
@@ -46,50 +46,6 @@ describe('hooks', () => {
       const wrapper = await mount(<MockComponent />);
 
       expect(wrapper).toContainReactText('en');
-    });
-  });
-
-  describe('useCookie', () => {
-    function MockComponent({cookie}: {cookie: string}) {
-      const [value, setCookie] = useCookie(cookie);
-
-      return (
-        <>
-          <button type="button" onClick={() => setCookie('baz')}>
-            Set Cookie
-          </button>
-          {value}
-        </>
-      );
-    }
-
-    it('gets a cookie', async () => {
-      const key = 'foo';
-      const value = 'bar';
-      const cookies = {[key]: value};
-
-      const wrapper = await mount(<MockComponent cookie={key} />, {
-        manager: new NetworkManager({cookies}),
-      });
-
-      expect(wrapper).toContainReactText(value);
-    });
-
-    it('sets a cookie', async () => {
-      const key = 'foo';
-      const value = 'bar';
-      const cookies = {[key]: value};
-
-      const wrapper = await mount(<MockComponent cookie={key} />, {
-        manager: new NetworkManager({cookies}),
-      });
-
-      wrapper
-        .find(MockComponent)!
-        .find('button')!
-        .trigger('onClick');
-
-      expect(wrapper).toContainReactText(`baz`);
     });
   });
 });

--- a/packages/react-network/src/test/hooks.test.tsx
+++ b/packages/react-network/src/test/hooks.test.tsx
@@ -66,32 +66,30 @@ describe('hooks', () => {
     it('gets a cookie', async () => {
       const key = 'foo';
       const value = 'bar';
-      const cookie = {[key]: value};
+      const cookies = {[key]: value};
 
-      const wrapper = await mountWithCookies(
-        <MockComponent cookie={key} />,
-        cookie,
-      );
+      const wrapper = await mount(<MockComponent cookie={key} />, {
+        manager: new NetworkManager({cookies}),
+      });
 
-      expect(wrapper.find(MockComponent)).toContainReactText(value);
+      expect(wrapper).toContainReactText(value);
     });
 
     it('sets a cookie', async () => {
       const key = 'foo';
       const value = 'bar';
-      const cookie = {[key]: value};
+      const cookies = {[key]: value};
 
-      const wrapper = await mountWithCookies(
-        <MockComponent cookie={key} />,
-        cookie,
-      );
+      const wrapper = await mount(<MockComponent cookie={key} />, {
+        manager: new NetworkManager({cookies}),
+      });
 
       wrapper
         .find(MockComponent)!
         .find('button')!
         .trigger('onClick');
 
-      expect(wrapper.find(MockComponent)).toContainReactText(`baz`);
+      expect(wrapper).toContainReactText(`baz`);
     });
   });
 });
@@ -113,16 +111,3 @@ const mount = createMount<{language?: string}>({
     );
   },
 });
-
-function mountWithCookies(
-  component: React.ReactElement,
-  cookies: Record<string, string>,
-) {
-  const manager = new NetworkManager({cookies});
-
-  return mount(
-    <NetworkContext.Provider value={manager}>
-      {component}
-    </NetworkContext.Provider>,
-  );
-}

--- a/packages/react-network/src/test/manager.test.ts
+++ b/packages/react-network/src/test/manager.test.ts
@@ -43,12 +43,34 @@ describe('NetworkManager', () => {
       expect(manager.getCookie('foo')).toBeUndefined();
     });
 
+    it('sets initial cookies when coming the request as a string', () => {
+      const manager = new NetworkManager({cookies: 'foo=bar'});
+
+      expect(manager.getCookie('foo')).toBe('bar');
+    });
+
+    it('sets initial cookies when manually set as an object', () => {
+      const manager = new NetworkManager({cookies: {foo: 'bar'}});
+
+      expect(manager.getCookie('foo')).toBe('bar');
+    });
+
     it('returns cookies after they are set', () => {
       const manager = new NetworkManager();
 
       manager.setCookie('foo', 'bar');
 
       expect(manager.getCookie('foo')).toBe('bar');
+    });
+
+    it('removes cookies after they are set', () => {
+      const manager = new NetworkManager({cookies: {foo: 'bar'}});
+
+      expect(manager.getCookie('foo')).toBe('bar');
+
+      manager.removeCookie('foo');
+
+      expect(manager.getCookie('foo')).toBeUndefined();
     });
   });
 });

--- a/packages/react-network/src/test/manager.test.ts
+++ b/packages/react-network/src/test/manager.test.ts
@@ -35,4 +35,20 @@ describe('NetworkManager', () => {
       expect(manager.getHeader('FoO')).toBe(headers.Foo);
     });
   });
+
+  describe('cookies', () => {
+    it('returns undefined when getting a cookie that does not exist', () => {
+      const manager = new NetworkManager();
+
+      expect(manager.getCookie('foo')).toBeUndefined();
+    });
+
+    it('returns cookies after they are set', () => {
+      const manager = new NetworkManager();
+
+      manager.setCookie('foo', 'bar');
+
+      expect(manager.getCookie('foo')).toBe('bar');
+    });
+  });
 });

--- a/packages/react-network/src/test/manager.test.ts
+++ b/packages/react-network/src/test/manager.test.ts
@@ -43,7 +43,7 @@ describe('NetworkManager', () => {
       expect(manager.getCookie('foo')).toBeUndefined();
     });
 
-    it('sets initial cookies when coming the request as a string', () => {
+    it('sets initial cookies when set as a string', () => {
       const manager = new NetworkManager({cookies: 'foo=bar'});
 
       expect(manager.getCookie('foo')).toBe('bar');

--- a/packages/react-network/src/test/server.test.ts
+++ b/packages/react-network/src/test/server.test.ts
@@ -74,6 +74,23 @@ describe('server', () => {
     });
   });
 
+  describe('cookies', () => {
+    it('can set cookies', () => {
+      const manager = new NetworkManager();
+      const ctx = createMockContext();
+      const spy = jest.spyOn(ctx.cookies, 'set');
+
+      const cookie = 'Cooookie';
+      const value = 'Crisp';
+      const options = {maxAge: 123456789};
+
+      manager.setCookie(cookie, value, options);
+      applyToContext(ctx, manager);
+
+      expect(spy).toHaveBeenCalledWith(cookie, value, options);
+    });
+  });
+
   describe('csp', () => {
     it('does not set a CSP header if no directives were set', () => {
       const manager = new NetworkManager();

--- a/packages/react-network/src/test/server.test.ts
+++ b/packages/react-network/src/test/server.test.ts
@@ -80,8 +80,8 @@ describe('server', () => {
       const ctx = createMockContext();
       const spy = jest.spyOn(ctx.cookies, 'set');
 
-      const cookie = 'Cooookie';
-      const value = 'Crisp';
+      const cookie = 'foo';
+      const value = 'bar';
       const options = {maxAge: 123456789};
 
       manager.setCookie(cookie, value, options);

--- a/packages/react-network/src/test/useCookie.test.tsx
+++ b/packages/react-network/src/test/useCookie.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {createMount} from '@shopify/react-testing';
+import {NetworkManager} from '../manager';
+import {NetworkContext} from '../context';
+import {useCookie} from '../hooks';
+
+describe('hooks', () => {
+  describe('useCookie', () => {
+    function MockComponent({cookie}: {cookie: string}) {
+      const [value, setCookie] = useCookie(cookie);
+
+      return (
+        <>
+          <button type="button" onClick={() => setCookie('baz')}>
+            Set Cookie
+          </button>
+          {value}
+        </>
+      );
+    }
+
+    it('gets a cookie', async () => {
+      const key = 'foo';
+      const value = 'bar';
+      const cookies = {[key]: value};
+
+      const wrapper = await mount(<MockComponent cookie={key} />, {
+        manager: new NetworkManager({cookies}),
+      });
+
+      expect(wrapper).toContainReactText(value);
+    });
+
+    it('sets a cookie', async () => {
+      const key = 'foo';
+      const value = 'bar';
+      const cookies = {[key]: value};
+
+      const wrapper = await mount(<MockComponent cookie={key} />, {
+        manager: new NetworkManager({cookies}),
+      });
+
+      wrapper
+        .find(MockComponent)!
+        .find('button')!
+        .trigger('onClick');
+
+      expect(wrapper).toContainReactText(`baz`);
+    });
+  });
+});
+
+const mount = createMount<{manager?: NetworkManager}>({
+  render: (element, _, {manager = new NetworkManager()}) => {
+    return (
+      <NetworkContext.Provider value={manager}>
+        {element}
+      </NetworkContext.Provider>
+    );
+  },
+});

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -41,9 +41,7 @@ export function createRender(render: RenderFunction, options: Options = {}) {
   return async function renderFunction(ctx: Context) {
     const logger = getLogger(ctx) || console;
     const assets = getAssets(ctx);
-    const networkManager = new NetworkManager({
-      headers: ctx.headers,
-    });
+    const networkManager = new NetworkManager(ctx);
     const htmlManager = new HtmlManager();
     const asyncAssetManager = new AsyncAssetManager();
     const hydrationManager = new HydrationManager();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,7 +1486,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,14 @@ cookiejar@^2.1.0:
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
+cookies@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.3.tgz#7912ce21fbf2e8c2da70cf1c3f351aecf59dadfa"
+  integrity sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==
+  dependencies:
+    depd "~1.1.2"
+    keygrip "~1.0.3"
+
 cookies@~0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.1.tgz#7c8a615f5481c61ab9f16c833731bcb8f663b99b"
@@ -7204,6 +7212,11 @@ keygrip@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.2.tgz#ad3297c557069dea8bcfe7a4fa491b75c5ddeb91"
   integrity sha1-rTKXxVcGneqLz+ek+kkbdcXd65E=
+
+keygrip@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
+  integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.1.0, kind-of@^3.2.0:
   version "3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,6 +1199,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/cookiejar@*":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
@@ -1481,7 +1486,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
-"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -3505,18 +3510,15 @@ convert-source-map@^1.4.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
   integrity sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=
 
+cookie@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
+  integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
 cookiejar@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
-
-cookies@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.3.tgz#7912ce21fbf2e8c2da70cf1c3f351aecf59dadfa"
-  integrity sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==
-  dependencies:
-    depd "~1.1.2"
-    keygrip "~1.0.3"
 
 cookies@~0.7.0:
   version "0.7.1"
@@ -7212,11 +7214,6 @@ keygrip@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.2.tgz#ad3297c557069dea8bcfe7a4fa491b75c5ddeb91"
   integrity sha1-rTKXxVcGneqLz+ek+kkbdcXd65E=
-
-keygrip@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
-  integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.1.0, kind-of@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
## Description

This PR adds logic around setting and getting cookies to `react-network`.

Question: Should we have a separate package for this (`@shopify/universal-cookies`)? At first I felt like cookies fell into the "network" side of things, but on the other hand, they also live in the browser.

I also need to figure out a way to keep the cookie headers on the server in sync with changes (see comment [here](https://github.com/Shopify/quilt/pull/935/files#diff-30b2790b68e33e0fdcd0c1ad0932a5faR30). One way I was thinking would be that there is a way to attach a change watcher on the cookies during the `applyToContext` step. The cookies setter would then call the watcher every time cookies change. This pushes me further in the direction of this being outside of the `react-network` package.

## Type of change

- [x] `react-network` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
