### PR TITLE
🐛 fix session bleeding between shops

### DIFF
--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 3.1.36 - 2019-08-30
 
 ### Fixed
 
-- Package no longer allows sessions from one shop to bleed over into another
+- Package no longer allows sessions from one shop to bleed over into another [940](https://github.com/Shopify/quilt/pull/940)
 
 ## 3.1.32 - 2019-08-15
 

--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Package no longer allows sessions from one shop to bleed over into another
 
 ## 3.1.32 - 2019-08-15
 

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -26,12 +26,14 @@
     "@shopify/network": "^1.4.1",
     "nonce": "^1.0.4",
     "safe-compare": "^1.1.2",
-    "tslib": "^1.9.3"
+    "tslib": "^1.9.3",
+    "koa-compose": ">=3.0.0 <4.0.0"
   },
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^2.7.3",
     "@shopify/jest-koa-mocks": "^2.1.4",
     "@types/koa": "^2.0.44",
+    "@types/koa-compose": "*",
     "@types/safe-compare": "^1.1.0",
     "koa": "^2.5.0",
     "typescript": "~3.2.1"

--- a/packages/koa-shopify-auth/src/verify-request/login-again-if-different-shop.ts
+++ b/packages/koa-shopify-auth/src/verify-request/login-again-if-different-shop.ts
@@ -1,0 +1,21 @@
+import {Context} from 'koa';
+import {NextFunction} from '../types';
+import {Routes} from './types';
+import {clearSession, redirectToAuth} from './utilities';
+
+export function loginAgainIfDifferentShop(routes: Routes) {
+  return async function loginAgainIfDifferentShopMiddleware(
+    ctx: Context,
+    next: NextFunction,
+  ) {
+    const {query, session} = ctx;
+
+    if (session && query.shop && session.shop !== query.shop) {
+      clearSession(ctx);
+      redirectToAuth(routes, ctx);
+      return;
+    }
+
+    await next();
+  };
+}

--- a/packages/koa-shopify-auth/src/verify-request/types.ts
+++ b/packages/koa-shopify-auth/src/verify-request/types.ts
@@ -1,0 +1,6 @@
+export interface Routes {
+  authRoute: string;
+  fallbackRoute: string;
+}
+
+export type Options = Partial<Routes>;

--- a/packages/koa-shopify-auth/src/verify-request/utilities.ts
+++ b/packages/koa-shopify-auth/src/verify-request/utilities.ts
@@ -1,0 +1,21 @@
+import {Context} from 'koa';
+import {Routes} from './types';
+
+export function redirectToAuth(
+  {fallbackRoute, authRoute}: Routes,
+  ctx: Context,
+) {
+  const {
+    query: {shop},
+  } = ctx;
+
+  const routeForRedirect =
+    shop == null ? fallbackRoute : `${authRoute}?shop=${shop}`;
+
+  ctx.redirect(routeForRedirect);
+}
+
+export function clearSession(ctx: Context) {
+  delete ctx.session.shop;
+  delete ctx.session.accessToken;
+}

--- a/packages/koa-shopify-auth/src/verify-request/verify-request.ts
+++ b/packages/koa-shopify-auth/src/verify-request/verify-request.ts
@@ -1,58 +1,14 @@
-import {Context} from 'koa';
-import {Method, Header, StatusCode} from '@shopify/network';
-import {NextFunction} from '../types';
-import {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} from '../index';
+import compose from 'koa-compose';
+import {loginAgainIfDifferentShop} from './login-again-if-different-shop';
+import {verifyToken} from './verify-token';
+import {Options, Routes} from './types';
 
-export interface Options {
-  authRoute?: string;
-  fallbackRoute?: string;
-}
-
-export default function verifyRequest({
-  authRoute = '/auth',
-  fallbackRoute = '/auth',
-}: Options = {}) {
-  return async function verifyRequestMiddleware(
-    ctx: Context,
-    next: NextFunction,
-  ) {
-    const {
-      query: {shop},
-      session,
-    } = ctx;
-    const redirect = `${authRoute}?shop=${shop}`;
-
-    if (session && session.accessToken) {
-      ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
-      // If a user has installed the store previously on their shop, the accessToken can be stored in session.
-      // we need to check if the accessToken is valid, and the only way to do this is by hitting the api.
-      const response = await fetch(
-        `https://${session.shop}/admin/metafields.json`,
-        {
-          method: Method.Post,
-          headers: {
-            [Header.ContentType]: 'application/json',
-            'X-Shopify-Access-Token': session.accessToken,
-          },
-        },
-      );
-
-      if (response.status === StatusCode.Unauthorized) {
-        ctx.redirect(redirect);
-        return;
-      }
-
-      await next();
-      return;
-    }
-
-    ctx.cookies.set(TEST_COOKIE_NAME, '1');
-
-    if (shop) {
-      ctx.redirect(redirect);
-      return;
-    }
-
-    ctx.redirect(fallbackRoute);
+export default function verifyRequest(givenOptions: Options = {}) {
+  const routes: Routes = {
+    authRoute: '/auth',
+    fallbackRoute: '/auth',
+    ...givenOptions,
   };
+
+  return compose([loginAgainIfDifferentShop(routes), verifyToken(routes)]);
 }

--- a/packages/koa-shopify-auth/src/verify-request/verify-token.ts
+++ b/packages/koa-shopify-auth/src/verify-request/verify-token.ts
@@ -1,0 +1,44 @@
+import {Context} from 'koa';
+import {Method, Header, StatusCode} from '@shopify/network';
+
+import {NextFunction} from '../types';
+import {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} from '../index';
+import {Routes} from './types';
+import {redirectToAuth} from './utilities';
+
+export function verifyToken(routes: Routes) {
+  return async function verifyTokenMiddleware(
+    ctx: Context,
+    next: NextFunction,
+  ) {
+    const {session} = ctx;
+
+    if (session && session.accessToken) {
+      ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
+      // If a user has installed the store previously on their shop, the accessToken can be stored in session.
+      // we need to check if the accessToken is valid, and the only way to do this is by hitting the api.
+      const response = await fetch(
+        `https://${session.shop}/admin/metafields.json`,
+        {
+          method: Method.Post,
+          headers: {
+            [Header.ContentType]: 'application/json',
+            'X-Shopify-Access-Token': session.accessToken,
+          },
+        },
+      );
+
+      if (response.status === StatusCode.Unauthorized) {
+        redirectToAuth(routes, ctx);
+        return;
+      }
+
+      await next();
+      return;
+    }
+
+    ctx.cookies.set(TEST_COOKIE_NAME, '1');
+
+    redirectToAuth(routes, ctx);
+  };
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/727

This PR fixes a bug where you could login to an app using `@shopify/koa-shopify-auth` on one store and then still have access to the app in context to the first shop on other stores you had open in the same browser.

## Tophat instructions
- clone the repo
- fetch/checkout this branch
- `yarn build && yarn tophat ../some-app-i-have`
- try the reproduction steps in the linked issue

## Checklist
- [x] I have added a changelog entry, prefixed by the type of change noted above

**PS:**
Check the [gem](https://github.com/Shopify/shopify_app/blob/0900ddcb2f268f6efe3e184739ee83eeab3a0020/lib/shopify_app/controller_concerns/login_protection.rb#L34) for a reference on how the same check is made there 
