### PR TITLE
React renderable error in tests

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Now fails fast with an improved error message suggesting proper testing practice when used in a test, rather than giving a confusing error aimed at development flows
+
 ## [1.4.1] - 2019-08-22
 
 ### Fixed

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -7,6 +7,8 @@ module Quilt
     include ReverseProxy::Controller
 
     def render_react
+      raise DoNotIntegrationTestError if Rails.env.test?
+
       if defined? ShopifySecurityBase
         ShopifySecurityBase::HTTPHostRestriction.whitelist([Quilt.configuration.react_server_host]) do
           proxy
@@ -37,6 +39,12 @@ module Quilt
       def initialize(url)
         # rubocop:disable LineLength
         super "Errno::ECONNREFUSED: Waiting for React server to boot up. If this error presists verify that @shopify/react-server is configured on #{url}"
+      end
+    end
+
+    class DoNotIntegrationTestError < StandardError
+      def initialize
+        super "Do not try to use Rails integration tests on your quilt_rails app. Instead use Jest and @shopify/react-testing to test your React application directly."
       end
     end
   end

--- a/gems/quilt_rails/test/quilt_rails/react_renderable_test.rb
+++ b/gems/quilt_rails/test/quilt_rails/react_renderable_test.rb
@@ -4,15 +4,27 @@ module Quilt
     include Quilt::ReactRenderable
 
     def test_render_react_calls_reverse_proxy_with_server_uri_and_csrf
+      Rails.env.stubs(:test?).returns(false)
       url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
 
       assert_equal(render_react, reverse_proxy(url, headers: { 'X-CSRF-Token': form_authenticity_token }))
     end
 
+    def test_render_react_errors_in_tests
+      Rails.env.stubs(:test?).returns(true)
+      assert_raises Quilt::ReactRenderable::DoNotIntegrationTestError do
+        render_react
+      end
+    end
+
+    private
+
+    # Stubbing this method the mixin calls
     def reverse_proxy(url, headers: {})
       "called with #{url} and #{headers}"
     end
 
+    # Stubbing this method the mixin calls
     def form_authenticity_token
       'foo'
     end


### PR DESCRIPTION
closes #932 

## Problem
Currently if a user tries to use railsy integration tests on their React routes, they will see the following in their tests:

```
"Errno::ECONNREFUSED: Waiting for React server to boot up. If this error presists verify that @shopify/react-server is configured on #{url}"
```

This error is not very helpful for a few reasons:
- makes them think they have misconfigured the server somehow
- does not push them in the right direction for testing React apps (ie. our libraries / jest)

## Solution
This PR adds a special error message to `render_react` which informs the consumer they should not be using Rails integration tests, but rather use Jest and `@shopify/react-testing`

## Possible issues
If we actually *do* want to support integration / E2E tests for Rails devs, we would need a very different solution. If it becomes a common request / pain point we may want to revisit.