### PR TITLE
Pull `react-server-webpack-plugin` files source into separate templates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ coverage
 **/node_modules/*
 **/packages/*.js
 *.d.ts
+**/templates/*

--- a/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
+++ b/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
@@ -1,6 +1,9 @@
 import {join, resolve} from 'path';
 import {Compiler} from 'webpack';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
+import {readFileSync} from 'fs-extra';
+import {transformSync} from '@shopify/ast-utilities';
+import {fillCallExpressionOptions} from './transforms';
 
 interface Options {
   basePath: string;
@@ -76,39 +79,28 @@ function serverSource(options: Options) {
     ? JSON.stringify(assetPrefix)
     : 'process.env.CDN_URL || "localhost:8080/assets/webpack"';
 
+  const initial = readFileSync(resolve(__dirname, './templates/server.ts'));
+  const source = transformSync(
+    initial.toString(),
+    fillCallExpressionOptions('createServer', {
+      port: serverPort,
+      ip: serverIp,
+      assetPrefix: serverAssetPrefix,
+    }),
+  );
+
   return `
     ${HEADER}
-    import React from 'react';
-    import {createServer} from '@shopify/react-server';
-    import App from 'index';
-
-    const render = (ctx) =>
-    React.createElement(App, {
-      server: true,
-      location: ctx.request.url,
-    });
-
-    const app = createServer({
-      port: ${serverPort},
-      ip: ${serverIp},
-      assetPrefix: ${serverAssetPrefix},
-      render,
-    });
-    export default app;
+    ${source}
   `;
 }
 
 function clientSource() {
+  const source = readFileSync(resolve(__dirname, './templates/client.ts'));
+
   return `
     ${HEADER}
-    import React from 'react';
-    import ReactDOM from 'react-dom';
-    import {showPage} from '@shopify/react-html';
-    import App from 'index';
-
-    const appContainer = document.getElementById('app');
-    ReactDOM.hydrate(React.createElement(App), appContainer);
-    showPage();
+    ${source}
   `;
 }
 

--- a/packages/react-server-webpack-plugin/src/templates/client.ts
+++ b/packages/react-server-webpack-plugin/src/templates/client.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {showPage} from '@shopify/react-html';
+import App from 'index';
+
+const appContainer = document.getElementById('app');
+ReactDOM.hydrate(React.createElement(App), appContainer);
+showPage();

--- a/packages/react-server-webpack-plugin/src/templates/server.ts
+++ b/packages/react-server-webpack-plugin/src/templates/server.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import {createServer} from '@shopify/react-server';
+import App from 'index';
+
+const render = ctx =>
+  React.createElement(App, {
+    server: true,
+    location: ctx.request.url,
+  });
+
+const app = createServer({
+  render,
+});
+
+export default app;

--- a/packages/react-server-webpack-plugin/src/test/react-server-webpack-plugin.test.ts
+++ b/packages/react-server-webpack-plugin/src/test/react-server-webpack-plugin.test.ts
@@ -24,6 +24,7 @@ describe('react-server-webpack-plugin', () => {
 
         expect(serverResults).toBeDefined();
         expect(serverModule.source).toMatch(HEADER);
+        expect(serverModule.source).toMatch('port: ');
       },
       BUILD_TIMEOUT,
     );

--- a/packages/react-server-webpack-plugin/src/transforms.ts
+++ b/packages/react-server-webpack-plugin/src/transforms.ts
@@ -1,0 +1,25 @@
+import * as t from '@babel/types';
+
+export function fillCallExpressionOptions(
+  name: string,
+  options: Record<string, string>,
+) {
+  return {
+    CallExpression(path) {
+      if (!path.node.callee || path.node.callee.name !== name) {
+        return;
+      }
+
+      const newProperties = Object.entries(options).map(
+        ([key, value]: [string, string]) => {
+          return t.objectProperty(t.identifier(key), t.identifier(`${value}`));
+        },
+      );
+
+      path.node.arguments[0] = t.objectExpression([
+        ...path.node.arguments[0].properties,
+        ...newProperties,
+      ]);
+    },
+  };
+}

--- a/packages/react-server-webpack-plugin/src/transforms.ts
+++ b/packages/react-server-webpack-plugin/src/transforms.ts
@@ -2,7 +2,7 @@ import * as t from '@babel/types';
 
 export function fillCallExpressionOptions(
   name: string,
-  options: Record<string, string>,
+  options: Record<string, string | number>,
 ) {
   return {
     CallExpression(path) {

--- a/packages/react-server-webpack-plugin/tsconfig.build.json
+++ b/packages/react-server-webpack-plugin/tsconfig.build.json
@@ -11,5 +11,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*/templates/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
       "@shopify/react-effect/server": ["packages/react-effect/src/server"],
       "@shopify/*": ["packages/*/src/index"]
     }
-  }
+  },
+  "exclude": ["**/templates/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,5 @@
       "@shopify/react-effect/server": ["packages/react-effect/src/server"],
       "@shopify/*": ["packages/*/src/index"]
     }
-  },
-  "exclude": ["**/templates/*"]
+  }
 }


### PR DESCRIPTION
## Description

This PR pulls the inline template strings used to write the "virtual" files out into templates that are parsed and transformed via babel. This allows those files to be a little more manageable and syntax-highlighted.

Fixes https://github.com/Shopify/quilt/issues/945 

~~This PR requires the `@shopify/ast-utilities` package added here https://github.com/Shopify/quilt/pull/949~~