### PR TITLE
[react-graphql] / Support `ssr=false` for `useQuery`

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Adds support for `ssr=false` in `useQuery` ([951](https://github.com/Shopify/quilt/pull/951))
 
 ## [5.0.9] - 2019-08-29
 

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -35,11 +35,15 @@ export default function useQuery<
     client: overrideClient,
     notifyOnNetworkStatusChange,
     context,
+    ssr = true,
   } = options;
   const client = useApolloClient(overrideClient);
 
-  if (typeof window === 'undefined' && (skip || fetchPolicy === 'no-cache')) {
-    return {...createDefaultResult(client, variables), loading: !skip};
+  if (
+    typeof window === 'undefined' &&
+    (skip || fetchPolicy === 'no-cache' || !ssr)
+  ) {
+    return createDefaultResult(client, variables);
   }
 
   const query = useGraphQLDocument(queryOrComponent);

--- a/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
@@ -30,9 +30,15 @@ const mockData = {
   ],
 };
 
-function MockQuery({fetchPolicy = 'network-only' as FetchPolicy}) {
-  const {data, loading} = useQuery(petQuery, {fetchPolicy});
-  return loading ? <div>loading</div> : <pre>{JSON.stringify(data)}</pre>;
+type QueryOptions = {
+  fetchPolicy?: FetchPolicy;
+  ssr?: boolean;
+};
+
+function MockQuery({fetchPolicy = 'network-only', ssr}: QueryOptions) {
+  const {data, loading} = useQuery(petQuery, {fetchPolicy, ssr});
+  const dataMarkup = data ? JSON.stringify(data) : 'no data';
+  return loading ? <div>loading</div> : <pre>{dataMarkup}</pre>;
 }
 
 describe('useQuery', () => {
@@ -77,6 +83,75 @@ describe('useQuery', () => {
     // no GraphQL queries to resolve.
     expect(afterEachSpy).toHaveBeenCalledTimes(1);
 
-    expect(renderToString(element)).toContain('loading');
+    // Not loading and no data
+    const markup = renderToString(element);
+    expect(markup).not.toContain('loading');
+    expect(markup).toContain('no data');
+  });
+
+  it('does not run a query when `ssr` option is set to false during SSR', async () => {
+    const graphQL = createGraphQL({PetQuery: mockData});
+    const afterEachSpy = jest.fn();
+    const element = (
+      <ApolloProvider client={graphQL.client}>
+        <MockQuery ssr={false} />
+      </ApolloProvider>
+    );
+
+    const extractPromise = extract(element, {
+      afterEachPass: afterEachSpy,
+    });
+
+    await graphQL.resolveAll();
+    await extractPromise;
+
+    // One call for the first pass, which is the only one because there are
+    // no GraphQL queries to resolve.
+    expect(afterEachSpy).toHaveBeenCalledTimes(1);
+
+    // Not loading and no data
+    const markup = renderToString(element);
+    expect(markup).not.toContain('loading');
+    expect(markup).toContain('no data');
+  });
+
+  it('runs a query when `ssr` option is set to true during SSR', async () => {
+    const graphQL = createGraphQL({PetQuery: mockData});
+    const afterEachSpy = jest.fn();
+    const element = (
+      <ApolloProvider client={graphQL.client}>
+        <MockQuery ssr />
+      </ApolloProvider>
+    );
+
+    const extractPromise = extract(element, {
+      afterEachPass: afterEachSpy,
+    });
+
+    await graphQL.resolveAll();
+    await extractPromise;
+
+    // One call for the first pass, another call after the GraphQL resolves
+    expect(afterEachSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs a query when `ssr` option is missing during SSR', async () => {
+    const graphQL = createGraphQL({PetQuery: mockData});
+    const afterEachSpy = jest.fn();
+    const element = (
+      <ApolloProvider client={graphQL.client}>
+        <MockQuery />
+      </ApolloProvider>
+    );
+
+    const extractPromise = extract(element, {
+      afterEachPass: afterEachSpy,
+    });
+
+    await graphQL.resolveAll();
+    await extractPromise;
+
+    // One call for the first pass, another call after the GraphQL resolves
+    expect(afterEachSpy).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/703

Consumers of `useQuery` can now prevent a query to resolve when rendering on the server.

```
  const {data, loading, error} = useQuery(CustomerListQuery, {
    ssr: false,
  });
```

You can 🎩 this change in a consumer project.
In quilt, `cd packages/react-graphql && yarn run build`
`yarn tophat react-graphql <relative-path-consumer-project>`

`ssr: false` in the above code snippet will prevent `CustomerListQuery` to resolve on the server. Instead, it will be resolved on the client at run-time.

<img width="581" alt="Screen Shot 2019-09-04 at 1 05 41 PM" src="https://user-images.githubusercontent.com/3925905/64275946-ba18e500-cf14-11e9-854b-ca6d5856b704.png">


## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
