### PR TITLE
Fix tophat script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "apollo-cache-inmemory": "^1.3.6",
     "apollo-client": "^2.3.8",
     "codecov": "^3.0.2",
-    "create-shopify": "0.4.25",
+    "create-shopify": "0.4.26",
     "element-closest": "^3.0.1",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,10 +2865,10 @@ create-react-class@^15.5.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-create-shopify@0.4.25:
-  version "0.4.25"
-  resolved "https://registry.yarnpkg.com/create-shopify/-/create-shopify-0.4.25.tgz#ad6a69941efe7d549b45b8314793f7a10f899109"
-  integrity sha512-lwaEkBvGN7wuIFH498eVlvoxjzmtIXMKOaxPVQYKwj5lxHsD7D7TfoRmJG80HGDArUfKnaMuBEDZC6C96M5zxg==
+create-shopify@0.4.26:
+  version "0.4.26"
+  resolved "https://registry.yarnpkg.com/create-shopify/-/create-shopify-0.4.26.tgz#f8403cc3ec6fda70908586e134806104bd0b76b7"
+  integrity sha512-PzTVtZvM3BaEjGUvu7F4zzhfRt5+1iN6tstp/WmSk/YPH3IX2vPaH4EDGwEKSw/U4fYUxnZpXfV7O7voWikk3Q==
 
 cross-fetch@2.2.2:
   version "2.2.2"


### PR DESCRIPTION
## Description
see https://github.com/Shopify/webgen/pull/235

This PR updates the `tophat` script via a `create-shopify` bump. The main issue this was fixing was caused by the presence of both the `react-router` and `@shopify/react-router` packages.