### PR TITLE
fix prop error in `@shopify/react-router`

### DIFF
--- a/packages/react-router/src/Redirect.tsx
+++ b/packages/react-router/src/Redirect.tsx
@@ -14,4 +14,4 @@ function Redirect(props: ComposedProps) {
   return <NetworkRedirect url={props.url} />;
 }
 
-export default withRouter(Redirect);
+export default withRouter<Props>(Redirect);


### PR DESCRIPTION
## Description

This PR fixes an issue with `@shopify/react-router`'s types. The Redirect component would complain that it `is missing the following properties from type 'Readonly<ComposedProps>': history, location, match`. See this build error https://buildkite.com/shopify/web-rails-proving-ground-production-builder/builds/291#a4f63244-3633-4255-8ec8-f42dc45801a0

- [x] `react-router` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
