### PR TITLE
Add `ignoreChanges` to learna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,14 +1,13 @@
 {
   "lerna": "2.9.0",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "independent",
   "commands": {
     "publish": {
-      "skipNpm": true
+      "skipNpm": true,
+      "ignoreChanges": ["**/*.md", "**/tests/**", "**/test/**"]
     }
   }
 }


### PR DESCRIPTION
## Description

Hoping this cuts down on some of the `lerna publish` noise. From the [lerna docs](https://github.com/lerna/lerna#lernajson)

>`command.publish.ignoreChanges`: an array of globs that won't be included in lerna changed/publish. Use this to prevent publishing a new version unnecessarily for changes, such as fixing a README.md typo.

- Added both `test` and `tests` because we are not consistent about this in our packages. 
- Added `.md` for Readme typos, etc...
- Anything else I have not thought of?
