### PR TITLE
Add missing useLocale export

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 9.2.2 - 2019-09-06
+
+- Add missing `useLocale` export
+
 ## 9.2.0 - 2019-08-26
 
 - New `useLocale` hook for setting the `lang` attribute on HTML

--- a/packages/react-html/src/common.ts
+++ b/packages/react-html/src/common.ts
@@ -11,5 +11,6 @@ export {
   useMeta,
   useBodyAttributes,
   useHtmlAttributes,
+  useLocale,
 } from './hooks';
 export {createSerializer, useSerialized} from './serializer';


### PR DESCRIPTION
This PR back-fills a hook export that was missed in a previous release.