### PR TITLE
React server add providers

### DIFF
--- a/packages/react-hydrate/README.md
+++ b/packages/react-hydrate/README.md
@@ -24,7 +24,7 @@ There are two key pieces to making this work. First, your server must render a `
 ```tsx
 import React from 'react';
 import {render} from 'react-dom';
-import {HydrationContext, HydrationManager} from '@shopify/react-hydration';
+import {HydrationContext, HydrationManager} from '@shopify/react-hydrate';
 import App from '../app';
 
 export async function middleware(ctx, next) {
@@ -44,9 +44,9 @@ Note that if you use [`@shopify/react-effect`](../react-effect), you **must** re
 
 ```tsx
 import React from 'react';
-import {render} from 'react-dom';
+import {render} from '@shopify/react-html/server';
 import {extract} from '@shopify/react-effect';
-import {HydrationContext, HydrationManager} from '@shopify/react-hydration';
+import {HydrationContext, HydrationManager} from '@shopify/react-hydrate';
 import App from '../app';
 
 export async function middleware(ctx, next) {

--- a/packages/react-network/README.md
+++ b/packages/react-network/README.md
@@ -124,7 +124,8 @@ function MyComponent() {
 To extract details from your application, render a `NetworkContext.Provider` around your app, and give it an instance of the `NetworkManager`. When using `react-effect`, this decoration can be done in the `decorate` option of `extract()`. Finally, you can use the `applyToContext` utility from this package to apply the necessary headers to the response. Your final server middleware will resemble th e example below:
 
 ```tsx
-import {renderToString} from 'react-dom/server';
+import React from 'react';
+import {render} from '@shopify/react-html/server';
 import {extract} from '@shopify/react-effect/server';
 import {
   NetworkManager,
@@ -133,7 +134,7 @@ import {
 } from '@shopify/react-network/server';
 import App from './App';
 
-export default function render(ctx: Context) {
+export default function renderApp(ctx: Context) {
   // Accepts an optional headers argument for giving access
   // to request headers.
   const networkManager = new NetworkManager({
@@ -151,7 +152,11 @@ export default function render(ctx: Context) {
   });
 
   applyToContext(ctx, networkManager);
-  ctx.body = renderToString(app);
+  ctx.body = render(
+    <NetworkContext.Provider value={networkManager}>
+      {app}
+    </NetworkContext.Provider>,
+  );
 }
 ```
 

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,16 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [0.4.0] - 2019-09-??
+
+### Fixed
+
+- Server rendering no longer fails with erroneous errors about missing AsyncAssetContext / NetworkContext values [#969](https://github.com/Shopify/quilt/pull/969)
+
+### Added
+
+- Add rendering of `HydrationContext` by default [#969](https://github.com/Shopify/quilt/pull/969)
+
 ## [0.3.1] - 2019-08-29
 
 ### Fixed

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -28,6 +28,7 @@
     "@shopify/react-async": "^3.0.6",
     "@shopify/react-effect": "^3.2.2",
     "@shopify/react-html": "^9.2.2",
+    "@shopify/react-hydrate": "^1.1.3",
     "@shopify/react-network": "^3.2.1",
     "@shopify/sewing-kit-koa": "^6.1.1",
     "chalk": "^2.4.2",


### PR DESCRIPTION
## Description

1. All the Providers need to be wrapped in both the decorate function and the stream.
We dont need `HtmlContext.Provider` because `<Html />` already [render it](https://github.com/Shopify/quilt/blob/master/packages/react-html/src/server/components/Html.tsx#L157-L182).

2. Added `@shopify/react-hydrate` because it is we are actually implicitly using it whenever we use `@shopify/react-async`, and we are already rendering `AsyncAssetManager`.

Alternatively, we can offer this as an option and automatically enable from the webpack plugin if we find `@shopify/react-async` in package.json

3. Some docs update
## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
