### PR TITLE
[@shopify/react-server] Improve logger to provide more readable splunk logs

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Improved logger to provide more readable production logs in Splunk [#978](https://github.com/Shopify/quilt/pull/978)
 
 ## [0.4.0] - 2019-09-06
 

--- a/packages/react-server/src/index.ts
+++ b/packages/react-server/src/index.ts
@@ -1,3 +1,3 @@
 export {createServer} from './server';
 export {createRender, Context} from './render';
-export {createLogger} from './logger';
+export {requestLogger} from './logger';

--- a/packages/react-server/src/logger/index.ts
+++ b/packages/react-server/src/logger/index.ts
@@ -1,8 +1,1 @@
-export {
-  createLogger,
-  Verbosity,
-  setLogger,
-  getLogger,
-  Logger,
-  noopLogger,
-} from './logger';
+export {requestLogger, Logger, noopLogger} from './logger';

--- a/packages/react-server/src/logger/index.ts
+++ b/packages/react-server/src/logger/index.ts
@@ -1,1 +1,1 @@
-export {requestLogger, Logger, noopLogger} from './logger';
+export {requestLogger, Logger, getLogger} from './logger';

--- a/packages/react-server/src/logger/logger.ts
+++ b/packages/react-server/src/logger/logger.ts
@@ -1,50 +1,87 @@
-import {Context} from 'koa';
+/* eslint-disable no-process-env */
+import {Context, Request} from 'koa';
 import chalk from 'chalk';
 import {KoaNextFunction} from '../types';
 
 export const LOGGER = Symbol('logger');
-const PREFIX = chalk`{underline sidecar} ⁓ `;
-
-interface LoggerOptions {
-  level?: Verbosity;
-}
-
-export enum Verbosity {
-  Off,
-  Debug,
-}
+const PREFIX = chalk`{underline [React Server]}  `;
 
 export class Logger {
-  private logger: Pick<Console, 'log' | 'error'> =
-    this.options.level === Verbosity.Off ? noopLogger : console;
-
-  constructor(private options: LoggerOptions = {level: Verbosity.Off}) {}
+  private buffer = '';
+  private logger = console;
 
   log(message: string) {
-    this.logger.log(`${PREFIX}${message}`);
+    if (process.env.NODE_ENV === 'development') {
+      this.logger.log(`${PREFIX}${message}`);
+    } else {
+      this.buffer = `${this.buffer}\n${message}`;
+    }
+  }
+}
+
+function initialRequestMessage(request: Request): string {
+  const requestMethod = `${request.method.toUpperCase()} "${request.url}"`;
+  return `Started ${requestMethod} for at ${new Date().toISOString()}`;
+}
+
+function endRequestMessage(ctx: Context, requestDuration: number): string {
+  const httpStatus = `${ctx.status} ${ctx.message || ''}`;
+  const duration = `${requestDuration.toFixed(0)}ms`;
+
+  return `Completed ${httpStatus} at ${new Date().toISOString()} in ${duration}`;
+}
+
+function endRequest(ctx: Context, requestDuration: number) {
+  ctx.state.logger.log(endRequestMessage(ctx, requestDuration));
+
+  if (process.env.NODE_ENV === 'development') {
+    return;
   }
 
-  error(message: string) {
-    this.logger.error(`${PREFIX}${message}`);
-  }
-}
-
-export function getLogger(ctx: Context): Logger {
-  return ctx.state[LOGGER];
-}
-
-export function setLogger(ctx: Context, logger: Logger) {
-  ctx.state[LOGGER] = logger;
-}
-
-export function createLogger(options?: LoggerOptions) {
-  const logger = new Logger(options);
-
-  return async function loggerMiddleware(ctx: Context, next: KoaNextFunction) {
-    setLogger(ctx, logger);
-
-    await next();
+  /* eslint-disable babel/camelcase */
+  const logObject: any = {
+    datetime: new Date().toISOString(),
+    http_method: ctx.method.toUpperCase(),
+    http_response: ctx.message || '',
+    http_status: ctx.status,
+    uri: ctx.originalUrl,
+    user_agent: ctx.header['User-Agent'],
+    payload: ctx.state.logger.buffer,
   };
+  /* eslint-enable babel/camelcase */
+
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify(
+      logObject,
+      undefined,
+      process.env.NODE_ENV === 'production' ? undefined : 2,
+    ),
+  );
+}
+
+function requestDuration(requestStartTime: [number, number]) {
+  const duration = process.hrtime(requestStartTime);
+  const ms = duration[0] * 1000 + duration[1] / 1e6;
+  return Math.round(ms);
+}
+
+export async function requestLogger(ctx: Context, next: KoaNextFunction) {
+  const requestStartTime = process.hrtime();
+
+  ctx.state.logger = new Logger();
+  ctx.state.logger.log(initialRequestMessage(ctx.request));
+
+  try {
+    await next();
+  } catch (error) {
+    ctx.state.logger.log('Error during server execution, see details below.');
+    ctx.state.logger.log(
+      `${error.stack || error.message || 'No stack trace was present'}`,
+    );
+  } finally {
+    endRequest(ctx, requestDuration(requestStartTime));
+  }
 }
 
 export const noopLogger = {

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -21,6 +21,7 @@ import {
 } from '@shopify/react-async';
 import {Header, StatusCode} from '@shopify/react-network';
 import {getAssets} from '@shopify/sewing-kit-koa';
+import {getLogger} from '../logger';
 
 export {Context};
 export interface RenderFunction {
@@ -38,7 +39,7 @@ type Options = Pick<
  */
 export function createRender(render: RenderFunction, options: Options = {}) {
   return async function renderFunction(ctx: Context) {
-    const logger = ctx.state.logger || console;
+    const logger = getLogger(ctx) || console;
     const assets = getAssets(ctx);
     const networkManager = new NetworkManager({
       headers: ctx.headers,
@@ -101,7 +102,8 @@ export function createRender(render: RenderFunction, options: Options = {}) {
       ctx.set(Header.ContentType, 'text/html');
       ctx.body = response;
     } catch (error) {
-      const errorMessage = `React SSR Error:\n${error.stack || error.message}`;
+      const errorMessage = `React server-side rendering error:\n${error.stack ||
+        error.message}`;
 
       logger.log(errorMessage);
       ctx.status = StatusCode.InternalServerError;

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -7,7 +7,7 @@ import compose from 'koa-compose';
 import mount from 'koa-mount';
 import {middleware as sewingKitMiddleware} from '@shopify/sewing-kit-koa';
 import {createRender, RenderFunction} from '../render';
-import {createLogger, Verbosity} from '../logger';
+import {requestLogger} from '../logger';
 import {ping} from '../ping';
 
 const logger = console;
@@ -18,7 +18,6 @@ type Options = {
   assetPrefix?: string;
   serverMiddleware?: compose.Middleware<Context>[];
   render: RenderFunction;
-  debug?: boolean;
 };
 
 /**
@@ -27,13 +26,13 @@ type Options = {
  * @returns a Server instance
  */
 export function createServer(options: Options): Server {
-  const {port, assetPrefix, render, debug, serverMiddleware, ip} = options;
+  const {port, assetPrefix, render, serverMiddleware, ip} = options;
   const app = new Koa();
   const manifestPath = getManifestPath(process.cwd());
 
   app.use(mount('/services/ping', ping));
 
-  app.use(createLogger({level: debug ? Verbosity.Debug : Verbosity.Off}));
+  app.use(requestLogger);
   app.use(sewingKitMiddleware({assetPrefix, manifestPath}));
 
   if (serverMiddleware) {


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/959



### Before (Separate logs)
* ![image](https://user-images.githubusercontent.com/6130700/64623054-4d8b6380-d3b6-11e9-8bb4-1762d40b8cc5.png)
* ![image](https://user-images.githubusercontent.com/6130700/64623076-55e39e80-d3b6-11e9-819b-a12b042d8924.png)
* ![image](https://user-images.githubusercontent.com/6130700/64623093-5f6d0680-d3b6-11e9-8460-0fd892a27a41.png)



### After (Aggregated logs)

![image](https://user-images.githubusercontent.com/6130700/64622837-eec5ea00-d3b5-11e9-9048-acf4e0472bd8.png)


This is done by adding a `buffer` property to the logger class and joining logs to it throughout the request lifecycle across middlewares. This buffer is only used in production. In development were just console logging. 

Also, since I'm already in here logging, I added a few other properties to the log object that I think would be useful in debugging: `http_method`, `http_response`

### 🎩 
- This is shipped in `@shopify/react-server@0.5.0-beta.1`. You can pull that into a Rails SSR project and poke around
- I've also pulled this into `web-rails-proving-ground` in production. You can test it out by hitting the `/debug-errors` route and verifying that those logs are readable in splunk. You can find the preconfigured splunk queries for the production machines in `CloudPortal` linked from ServicesDB.

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
