### PR TITLE
🐛 fix doc generation for new package

### DIFF
--- a/documentation/guides/creating-a-new-package.md
+++ b/documentation/guides/creating-a-new-package.md
@@ -11,7 +11,7 @@ Submit a [feature request](https://github.com/Shopify/quilt/issues/new?template=
 
 Once we've identified a package for adding to quilt, it's time to begin the process of creating a PR. If you haven't set up your development environment for quilt, there are instructions for getting started in our [contributing guide](../../.github/CONTRIBUTING.md).
 
-Quilt provides a generator for creating new packages. Simply run `dev generate package` and follow the prompts to set up the initial boilerplate.
+Quilt provides a generator for creating new packages. Simply run `yarn generate:package` and follow the prompts to set up the initial boilerplate.
 
 ### Naming
 
@@ -30,8 +30,6 @@ Conversely, if you have some free cycles, one great way to contribute is to pick
 ## Completing a PR
 
 Congratulations; you've taken what was once just a concept and carried it through to completion as a member of the Quilt family. Now it's time to wrap up the initial pull request and submit the package to npm.
-
-We provide a list of packages in the root `README`. To generate this documentation, run `dev generate docs` in your branch and push the changes to your PR.
 
 Now's a good time to consider the completeness of the package you've created. Every package should have:
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "check": "lerna run check",
     "release": "lerna publish",
     "clean": "rimraf './packages/*/dist/**/*.{js,d.ts}'",
-    "generate": "yarn plop"
+    "generate": "yarn plop",
+    "generate:package": "yarn plop package && yarn plop docs"
   },
   "repository": {
     "type": "git",

--- a/plopfile.js
+++ b/plopfile.js
@@ -61,27 +61,22 @@ module.exports = function(plop) {
           'packages/{{kebabCase name}}/src/test/{{properCase name}}.test.ts',
         templateFile: 'templates/test.hbs.ts',
       },
-      sharedActions.docs,
     ],
   });
 
   plop.setGenerator('docs', {
     description: 'Generate root repo documentation',
     prompts: [],
-    actions() {
-      return [sharedActions.docs];
-    },
+    actions: [
+      {
+        type: 'add',
+        path: 'README.md',
+        templateFile: 'templates/ROOT_README.hbs.md',
+        force: true,
+        data: {jsPackageNames, gemNames},
+      },
+    ],
   });
-};
-
-const sharedActions = {
-  docs: {
-    type: 'add',
-    path: 'README.md',
-    templateFile: 'templates/ROOT_README.hbs.md',
-    force: true,
-    data: {jsPackageNames, gemNames},
-  },
 };
 
 function getPackageNames(type = 'js') {


### PR DESCRIPTION
The 🐛 is because we generate doc based on existing `package.json`, and this file does not exist for new packages till the end of the `generate package` command.