### PR TITLE
[@shopify/react-server] Add spacing between prefix and  logs

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [0.5.1] - 2019-09-11
+
+- Add spacing between "[React Server]" prefix and logs [#984](https://github.com/Shopify/quilt/pull/984)
+
 ## [0.5.0] - 2019-09-11
 
 ### Added

--- a/packages/react-server/src/logger/logger.ts
+++ b/packages/react-server/src/logger/logger.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import {KoaNextFunction} from '../types';
 
 export const LOGGER = Symbol('logger');
-const PREFIX = chalk.underline('[React Server]');
+const PREFIX = chalk.underline('[React Server] ');
 
 export class Logger {
   buffer = '';


### PR DESCRIPTION
## Description

This PR adds spacing between the `[React Server]` prefix and the associate log

### Before

![image](https://user-images.githubusercontent.com/6130700/64710365-d45b4180-d485-11e9-94c2-3700f4ece21b.png)

### After
<img width="619" alt="Screen Shot 2019-09-11 at 11 17 23 AM" src="https://user-images.githubusercontent.com/6130700/64710351-c9081600-d485-11e9-9b54-b9bc8a828cde.png">

