### PR TITLE
Add DefaultProviders to webpack generated App component

### DIFF
--- a/packages/react-server-webpack-plugin/src/templates/server.ts
+++ b/packages/react-server-webpack-plugin/src/templates/server.ts
@@ -1,15 +1,20 @@
+export default app;
+
 import React from 'react';
-import {createServer} from '@shopify/react-server';
+import {createServer, DefaultProvider} from '@shopify/react-server';
 import App from 'index';
 
 const render = ctx =>
-  React.createElement(App, {
-    server: true,
-    location: ctx.request.url,
-  });
+  React.createElement(
+    DefaultProvider,
+    null,
+    React.createElement(App, {
+      server: true,
+      location: ctx.request.url,
+    }),
+  );
 
 const app = createServer({
   render,
 });
-
 export default app;

--- a/packages/react-server-webpack-plugin/src/templates/server.ts
+++ b/packages/react-server-webpack-plugin/src/templates/server.ts
@@ -1,12 +1,10 @@
-export default app;
-
 import React from 'react';
-import {createServer, DefaultProvider} from '@shopify/react-server';
+import {createServer, DefaultProviders} from '@shopify/react-server';
 import App from 'index';
 
 const render = ctx =>
   React.createElement(
-    DefaultProvider,
+    DefaultProviders,
     null,
     React.createElement(App, {
       server: true,
@@ -17,4 +15,5 @@ const render = ctx =>
 const app = createServer({
   render,
 });
+
 export default app;

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -16,6 +16,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Improved logger to provide more readable production logs in Splunk [#978](https://github.com/Shopify/quilt/pull/978)
+- App is now wrapped with a set of default providers
 
 ## [0.4.0] - 2019-09-06
 

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,18 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [0.6.1] - 2019-09-11
+
+- New Providers utlities:
+
+### `createDefaultProvider()`
+
+This function return a set of providers based on a given the of options.
+
+### `<DefaultProvider />`
+
+A single component that renders all of the providers required within a typical React application.
+
 ## [0.5.1] - 2019-09-11
 
 - Add spacing between "[React Server]" prefix and logs [#984](https://github.com/Shopify/quilt/pull/984)
@@ -16,7 +28,6 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Improved logger to provide more readable production logs in Splunk [#978](https://github.com/Shopify/quilt/pull/978)
-- App is now wrapped with a set of default providers
 
 ## [0.4.0] - 2019-09-06
 

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -44,7 +44,6 @@ If you already have an exisiting node server, you can opt in to using only the r
 
 We also provide a [webpack plugin](https://github.com/Shopify/quilt/blob/master/packages/react-server-webpack-plugin) to automatically generate the server and client entries for an application.
 
-
 ### Deployment (Shopify specific)
 
 For Shopifolk, we have a [walkthrough](https://docs.shopifycloud.com/getting_started/rails-with-node-walkthrough) for getting an app ready to deploy.
@@ -99,3 +98,11 @@ The second argument is a subset of [`@shopify/react-effect#extract`](../react-ef
 - `betweenEachPass?(pass: Pass): any` see [`@shopify/react-effect#extract`](../react-effect/README.md#extract)
 
 It returns a [Koa](https://github.com/koajs/koa/) middleware.
+
+### `createDefaultProvider()`
+
+This function return a set of providers based on a given the of options.
+
+### `<DefaultProvider />`
+
+A single component that renders all of the providers required within a typical React application.

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -31,6 +31,7 @@
     "@shopify/react-hydrate": "^1.1.4",
     "@shopify/react-network": "^3.2.2",
     "@shopify/sewing-kit-koa": "^6.1.2",
+    "@shopify/react-csrf-universal-provider": "^1.0.4",
     "chalk": "^2.4.2",
     "koa": "^2.5.0",
     "koa-compose": "^4.1.0",

--- a/packages/react-server/src/index.ts
+++ b/packages/react-server/src/index.ts
@@ -2,4 +2,3 @@ export {createServer} from './server';
 export {createRender, Context} from './render';
 export {requestLogger} from './logger';
 export {DefaultProvider, createCombinedProvider} from './providers';
-export {createLogger} from './logger';

--- a/packages/react-server/src/index.ts
+++ b/packages/react-server/src/index.ts
@@ -1,3 +1,5 @@
 export {createServer} from './server';
 export {createRender, Context} from './render';
 export {requestLogger} from './logger';
+export {DefaultProvider, createCombinedProvider} from './providers';
+export {createLogger} from './logger';

--- a/packages/react-server/src/providers/ConditionalProvider.tsx
+++ b/packages/react-server/src/providers/ConditionalProvider.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface Props<T extends React.ComponentType<any>> {
+  condition: boolean;
+  provider: T;
+  // props: React.ComponentPropsWithoutRef<T>;
+  props?: any;
+  children: any;
+}
+
+export function ConditionalProvider<T extends React.ComponentType<any>>({
+  condition,
+  provider: Provider,
+  props,
+  children,
+}: Props<T>) {
+  if (condition) {
+    return <Provider {...props}>{children}</Provider>;
+  }
+
+  return children;
+}

--- a/packages/react-server/src/providers/ConditionalProvider.tsx
+++ b/packages/react-server/src/providers/ConditionalProvider.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
 
-interface Props<T extends React.ComponentType<any>> {
+interface Props<ContextType> {
   condition: boolean;
-  provider: T;
-  // props: React.ComponentPropsWithoutRef<T>;
-  props?: any;
-  children: any;
+  provider: React.Provider<ContextType>;
+  props: React.ProviderProps<ContextType>;
+  children: React.ReactElement<ContextType>;
 }
 
-export function ConditionalProvider<T extends React.ComponentType<any>>({
+export function ConditionalProvider<ContextType>({
   condition,
   provider: Provider,
   props,
   children,
-}: Props<T>) {
+}: Props<ContextType>) {
   if (condition) {
     return <Provider {...props}>{children}</Provider>;
   }
 
-  return children;
+  return children || null;
 }

--- a/packages/react-server/src/providers/index.ts
+++ b/packages/react-server/src/providers/index.ts
@@ -1,0 +1,1 @@
+export {DefaultProvider, createCombinedProvider} from './providers';

--- a/packages/react-server/src/providers/providers.tsx
+++ b/packages/react-server/src/providers/providers.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {CookiesProvider} from 'react-cookie';
+import {useRequestHeader} from '@shopify/react-network';
+import {CsrfUniversalProvider} from '@shopify/react-csrf-universal-provider';
+import {ConditionalProvider} from './ConditionalProvider';
+
+interface Options {
+  cookies?: boolean;
+  csrf?: boolean;
+}
+
+interface Props {
+  children: any;
+}
+
+export function createCombinedProvider(options?: Options) {
+  const {cookies = true, csrf = true} = options || {};
+
+  return function CombinedProvider({children}: Props) {
+    const csrfToken = useRequestHeader('x-csrf-token');
+
+    return (
+      <ConditionalProvider provider={CookiesProvider} condition={cookies}>
+        <ConditionalProvider
+          provider={CsrfUniversalProvider}
+          condition={csrf}
+          props={{value: csrfToken}}
+        >
+          {children}
+        </ConditionalProvider>
+      </ConditionalProvider>
+    );
+  };
+}
+
+export const DefaultProvider = createCombinedProvider();

--- a/packages/react-server/src/providers/providers.tsx
+++ b/packages/react-server/src/providers/providers.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import {CookiesProvider} from 'react-cookie';
 import {useRequestHeader} from '@shopify/react-network';
 import {CsrfUniversalProvider} from '@shopify/react-csrf-universal-provider';
 import {ConditionalProvider} from './ConditionalProvider';
 
 interface Options {
-  cookies?: boolean;
   csrf?: boolean;
 }
 
@@ -14,20 +12,18 @@ interface Props {
 }
 
 export function createCombinedProvider(options?: Options) {
-  const {cookies = true, csrf = true} = options || {};
+  const {csrf = true} = options || {};
 
   return function CombinedProvider({children}: Props) {
-    const csrfToken = useRequestHeader('x-csrf-token');
+    const csrfToken = useRequestHeader('x-csrf-token') || '';
 
     return (
-      <ConditionalProvider provider={CookiesProvider} condition={cookies}>
-        <ConditionalProvider
-          provider={CsrfUniversalProvider}
-          condition={csrf}
-          props={{value: csrfToken}}
-        >
-          {children}
-        </ConditionalProvider>
+      <ConditionalProvider
+        provider={CsrfUniversalProvider}
+        condition={csrf}
+        props={{value: csrfToken}}
+      >
+        {children}
       </ConditionalProvider>
     );
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,7 +1027,7 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@shopify/app-bridge-react@>=1.5.0", "@shopify/app-bridge-react@^1.6.7":
+"@shopify/app-bridge-react@>=1.5.0":
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/@shopify/app-bridge-react/-/app-bridge-react-1.6.7.tgz#d94a5510a1f88a46b10f8e231f6f2d23e5ba0c20"
   integrity sha512-xWIikfRzJk2gB/wkBRgLVMZlC2zWvHatHpe6gkIP+kCxdK426hxtx8BEhLR4xP84mYH+Z1Ha/99voYwuzyKMCw==
@@ -1064,7 +1064,7 @@
     lodash "^4.17.4"
     lodash-decorators "^4.3.5"
 
-"@shopify/react-html@^8.0.10", "@shopify/react-html@^8.1.3":
+"@shopify/react-html@^8.0.10":
   version "8.1.3"
   resolved "https://registry.yarnpkg.com/@shopify/react-html/-/react-html-8.1.3.tgz#1cf83190ae7e3a5cb25be5ed2ed73adf36ac0a66"
   integrity sha512-uExIf1n1BnPNJm04zYRnFQAmFCjW+sOGJ0agkhGAJAN59pyHSEqknuYj4CbzXZbBb1SRS/VO/XWmRdEu697fFA==
@@ -1259,7 +1259,7 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
-"@types/faker@4.1.5", "@types/faker@^4.1.5":
+"@types/faker@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/faker/-/faker-4.1.5.tgz#8f620f9c9a67150aa0a32b4e8a407da43fca61d4"
   integrity sha512-YSDqoBEWYGdNk53xSkkb6REaUaVSlIjxIAGjj/nbLzlZOit7kUU+nA2zC2qQkIVO4MQ+3zl4Sz7aw+kbpHHHUQ==


### PR DESCRIPTION
## Description

Fixes (issue #)

This PR adds a mechanism for wrapping the App component in a set of providers using using a new function `createCombinedProviders` and a new `DefaultProviders` component. 

`createCombinedProviders` will accept a config and return a subset of providers based on that config (currently this only provides the `csrf` provider). When called with no arguments, will return all of the Providers available (the same as using `DefaultProviders`).

I also wrap the app generated by webpack with this component.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-server` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
