### PR TITLE
✨Add support for pluralization to getTranslationTree

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Added support for pluralization to `getTranslationTree` ([#988](https://github.com/Shopify/quilt/pull/988))
 
 ## [1.8.3] - 2019-09-03
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -195,8 +195,15 @@ export class I18n {
       | ComplexReplacementDictionary,
   ): string | TranslationDictionary {
     try {
-      if (!replacements) return getTranslationTree(id, this.translations);
-      return getTranslationTree(id, this.translations, replacements);
+      if (!replacements) {
+        return getTranslationTree(id, this.translations, this.locale);
+      }
+      return getTranslationTree(
+        id,
+        this.translations,
+        this.locale,
+        replacements,
+      );
     } catch (error) {
       this.onError(error);
       return '';

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -168,6 +168,7 @@ describe('I18n', () => {
       expect(getTranslationTree).toHaveBeenCalledWith(
         'hello',
         defaultTranslations,
+        i18n.locale,
       );
     });
 

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -18,40 +18,96 @@ jest.mock('@shopify/i18n', () => ({
 
 describe('getTranslationTree()', () => {
   it('returns the translation keys if it has nested values', () => {
-    expect(getTranslationTree('foo', {foo: {bar: 'one'}})).toMatchObject({
+    expect(
+      getTranslationTree('foo', {foo: {bar: 'one'}}, locale),
+    ).toMatchObject({
       bar: 'one',
     });
   });
 
   it('returns the translation keys with replacements if it has nested values', () => {
     expect(
-      getTranslationTree(
-        'foo',
-        {foo: {bar: '{replacement}'}},
-        {replacement: 'bar'},
-      ),
+      getTranslationTree('foo', {foo: {bar: '{replacement}'}}, locale, {
+        replacement: 'bar',
+      }),
     ).toMatchObject({
       bar: 'bar',
     });
   });
 
+  it('returns the singular translation keys if it has nested values', () => {
+    expect(
+      getTranslationTree(
+        'foo',
+        {foo: {bar: {one: 'one', other: 'other'}}},
+        locale,
+        {
+          count: 1,
+        },
+      ),
+    ).toMatchObject({
+      bar: 'one',
+    });
+  });
+
+  it('returns the pluralized translation keys if it has nested values', () => {
+    expect(
+      getTranslationTree(
+        'foo',
+        {foo: {bar: {one: 'one', other: 'other'}}},
+        locale,
+        {
+          count: 2,
+        },
+      ),
+    ).toMatchObject({
+      bar: 'other',
+    });
+  });
+
   it('returns the leaf string', () => {
-    expect(getTranslationTree('foo.bar', {foo: {bar: 'one'}})).toBe('one');
+    expect(getTranslationTree('foo.bar', {foo: {bar: 'one'}}, locale)).toBe(
+      'one',
+    );
   });
 
   it('returns the leaf string with replacements', () => {
     expect(
+      getTranslationTree('foo.bar', {foo: {bar: '{replacement}'}}, locale, {
+        replacement: 'bar',
+      }),
+    ).toBe('bar');
+  });
+
+  it('returns the singular leaf string', () => {
+    expect(
       getTranslationTree(
         'foo.bar',
-        {foo: {bar: '{replacement}'}},
-        {replacement: 'bar'},
+        {foo: {bar: {one: 'one', other: 'other'}}},
+        locale,
+        {
+          count: 1,
+        },
       ),
-    ).toBe('bar');
+    ).toBe('one');
+  });
+
+  it('returns the pluralized leaf string', () => {
+    expect(
+      getTranslationTree(
+        'foo.bar',
+        {foo: {bar: {one: 'one', other: 'other'}}},
+        locale,
+        {
+          count: 2,
+        },
+      ),
+    ).toBe('other');
   });
 
   it('throws a MissingTranslationError when no translation is found', () => {
     expect(() =>
-      getTranslationTree('foo.bar.baz', {foo: {bar: 'one'}}),
+      getTranslationTree('foo.bar.baz', {foo: {bar: 'one'}}, locale),
     ).toThrow();
   });
 });


### PR DESCRIPTION
## Description

When using `i18n.translate()` and passing replacements with the `count` property, we return the pluralized translated string.

This PR adds the same behaviour to `getTranslationTree`.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] react-i18n Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] react-i18n Minor: New feature (non-breaking change which adds functionality)
- [ ] react-i18n Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
