### PR TITLE
♻️ move some dependencies to peer dependencies

### DIFF
--- a/packages/react-app-bridge-universal-provider/CHANGELOG.md
+++ b/packages/react-app-bridge-universal-provider/CHANGELOG.md
@@ -7,7 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.0.0] - 2019-08-28
+## 1.1.0 - 2019-??-??
+
+### Changed
+
+- Move `@shopify/app-bridge-react` to be a `peerDependencies` to ensure the same context will be use throughout the application. [#997](https://github.com/Shopify/quilt/pull/997)
+
+## 1.0.0 - 2019-08-28
 
 ### Added
 

--- a/packages/react-app-bridge-universal-provider/package.json
+++ b/packages/react-app-bridge-universal-provider/package.json
@@ -24,13 +24,14 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-app-bridge-universal-provider/README.md",
   "dependencies": {
-    "@shopify/app-bridge-react": ">=1.5.0",
     "@shopify/react-html": "^9.2.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "@shopify/app-bridge-react": "^1.5.0",
+    "react": "^16.8.0"
   },
   "devDependencies": {
+    "@shopify/app-bridge-react": "^1.5.0",
     "@shopify/react-effect": "^3.2.3",
     "@shopify/react-testing": "^1.7.8",
     "faker": "^4.1.0"

--- a/packages/react-csrf-universal-provider/CHANGELOG.md
+++ b/packages/react-csrf-universal-provider/CHANGELOG.md
@@ -7,7 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.0.0] - 2019-08-28
+## 1.1.0 - 2019-??-??
+
+### Changed
+
+- Move `@shopify/react-csrf` to be a `peerDependencies` to ensure the same context will be use throughout the application. [#997](https://github.com/Shopify/quilt/pull/997)
+
+## 1.0.0 - 2019-08-28
 
 ### Added
 

--- a/packages/react-csrf-universal-provider/package.json
+++ b/packages/react-csrf-universal-provider/package.json
@@ -24,14 +24,15 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-csrf-universal-provider/README.md",
   "dependencies": {
-    "@shopify/react-csrf": "^1.0.2",
     "@shopify/react-html": "^9.2.3",
     "@shopify/react-universal-provider": "^1.0.6"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "@shopify/react-csrf": "^1.0.2",
+    "react": "^16.8.0"
   },
   "devDependencies": {
+    "@shopify/react-csrf": "^1.0.2",
     "@shopify/react-effect": "^3.2.3",
     "@shopify/react-testing": "^1.7.8",
     "faker": "^4.1.0"

--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -7,7 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.0.0] - 2019-08-28
+## 1.1.0 - 2019-??-??
+
+### Changed
+
+- Move `@shopify/react-graphql` to be a `peerDependencies` to ensure the same context will be use throughout the application. [#997](https://github.com/Shopify/quilt/pull/997)
+
+## 1.0.0 - 2019-08-28
 
 ### Added
 

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -24,15 +24,16 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-graphql-universal-provider/README.md",
   "dependencies": {
-    "@shopify/react-graphql": "^5.1.4",
     "@shopify/react-hooks": "^1.2.3",
     "@shopify/react-html": "^9.2.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "@shopify/react-graphql": "^5.1.4",
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "@shopify/react-effect": "^3.2.3",
+    "@shopify/react-graphql": "^5.1.4",
     "@shopify/react-testing": "^1.7.8",
     "apollo-cache-inmemory": "^1.3.6",
     "apollo-client": "^2.3.8",

--- a/packages/react-i18n-universal-provider/CHANGELOG.md
+++ b/packages/react-i18n-universal-provider/CHANGELOG.md
@@ -7,7 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.0.0] - 2019-08-29
+## 1.1.0 - 2019-??-??
+
+### Changed
+
+- Move `@shopify/react-i18n` to be a `peerDependencies` to ensure the same context will be use throughout the application. [#997](https://github.com/Shopify/quilt/pull/997)
+
+## 1.0.0 - 2019-08-29
 
 ### Added
 

--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -24,13 +24,14 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-i18n-universal-provider/README.md",
   "dependencies": {
-    "@shopify/react-html": "^9.2.3",
-    "@shopify/react-i18n": "^1.9.1"
+    "@shopify/react-html": "^9.2.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "@shopify/react-i18n": "^1.9.1",
+    "react": "^16.8.0"
   },
   "devDependencies": {
+    "@shopify/react-i18n": "^1.9.1",
     "@shopify/react-effect": "^3.2.3",
     "@shopify/react-testing": "^1.7.8",
     "faker": "^4.1.0"

--- a/packages/react-universal-provider/package.json
+++ b/packages/react-universal-provider/package.json
@@ -27,7 +27,7 @@
     "@shopify/react-html": "^9.2.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "@shopify/react-testing": "^1.7.8",


### PR DESCRIPTION
## Description

Two things were done in this PR

1. "react": ">=16.8.0 <17.0.0" => "react": "^16.8.0", as ismail-syed pointed out earlier this week. This is essentially the same thing. So why not go with what npm does by default.

2. Move some (not all) of the dependencies to peerDependencies.
The two rules of thumb I am using here are
 - 1. would the consumer already had it installed. Take `react-i18n` as example, it is not reasonable that `react-i18n-universal-provider` would be consume without `react-i18n` somewhere in the application.
- 2. Do we need to make sure the `peerDependencies` is one version. As many of these are context creating. It is absolutely essential that those are one version.   


------
This is partial effort to minimize the context issue we been having. 
Unfortunately this does not invalidate the need to have those files listed in the webpack external since we can still encounter issue with `react-html`. (and `react-html` is 100% an implementation detail that the consumer would not have already installed)

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation) (for react-universal-provider)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality) (everything else)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
