### PR TITLE
Replace @shopify/javascript-utilities/dates with @shopify/dates

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Replaced `@shopify/javascript-utilities/dates` functions with those from `@shopify/dates`.
+- Removed `@shopify/javascript-utilities/dates` dependency.
+
+### Fixed
+
+- Fixed translation of weekday in `humanizeDate` for dates less than one week old.
 
 ## [1.9.0] - 2019-09-12
 

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -124,15 +124,14 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 
 - `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `I18nContext.Provider` component will be used where no custom currency code is passed.
 - `formatCurrency()`: formats a number as a currency according to the locale. Its behaviour depends on the `form:` option.
-  - if `form: 'short'` is given, then a possibly-ambiguous short form is used, consisting of the bare symbol if the currency has a symbol, or the ISO 4217 code if there is no symbol for that currency.  Examples:  `CHF 1,25`, `€ 1,25 EUR`, `OMR 1.250`, `$ 1.25 USD`
+  - if `form: 'short'` is given, then a possibly-ambiguous short form is used, consisting of the bare symbol if the currency has a symbol, or the ISO 4217 code if there is no symbol for that currency. Examples: `CHF 1,25`, `€ 1,25 EUR`, `OMR 1.250`, `$ 1.25 USD`
   - if `form: 'explicit'` is given, then the result will be the same as for `short`, but will append the ISO 4217 code if it is not already present
-  - if `form:` is not given, then behaviour reverts to the legacy (deprecated) `formatCurrency()`, which is a convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`.  Note that this will resemble `form: 'short'`, but will sometimes extend the symbol with extra information depending on the browser's implementation of `Intl.NumberFormat` and the locale in use.  For example, `formatCurrency(1.25, {currency: 'CAD'})` may return `$ 1.25`, or it might return `CA$ 1.25`.
+  - if `form:` is not given, then behaviour reverts to the legacy (deprecated) `formatCurrency()`, which is a convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`. Note that this will resemble `form: 'short'`, but will sometimes extend the symbol with extra information depending on the browser's implementation of `Intl.NumberFormat` and the locale in use. For example, `formatCurrency(1.25, {currency: 'CAD'})` may return `$ 1.25`, or it might return `CA$ 1.25`.
 - `formatPercentage()`: formats a number as a percentage according to the locale. Convenience function that simply _auto-assigns_ the `as` option to `percent` and calls `formatNumber()`.
 - `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `I18nContext.Provider` component will be used when no custom `timezone` is provided. Assign the `style` option to a `DateStyle` value to use common formatting options.
   - `DateStyle.Long`: e.g., `Thursday, December 20, 2012`
   - `DateStyle.Short`: e.g., `Dec 20, 2012`
-  - `DateStyle.Humanize`: e.g., `December 20, 2012`, `Today`, or `Yesterday`
-  - `DateStyle.HumanizeWithTime`: Adheres to [Polaris guidelines for dates with times](https://polaris.shopify.com/content/grammar-and-mechanics#section-dates-numbers-and-addresses), e.g., `Just now`, `3 minutes ago`, `4 hours ago`, `10:35 am`, `Yesterday at 10:35 am`, `Friday at 10:35 am`, or `Dec 20 at 10:35 am`, or `Dec 20, 2012`
+  - `DateStyle.Humanize`: Adheres to [Polaris guidelines for dates with times](https://polaris.shopify.com/content/grammar-and-mechanics#section-dates-numbers-and-addresses), e.g., `Just now`, `3 minutes ago`, `4 hours ago`, `10:35 am`, `Yesterday at 10:35 am`, `Friday at 10:35 am`, or `Dec 20 at 10:35 am`, or `Dec 20, 2012`
   - `DateStyle.Time`: e.g., `11:00 AM`
 - `weekStartDay()`: returns start day of the week according to the country.
 - `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -38,7 +38,6 @@
     "@shopify/decorators": "^1.1.5",
     "@shopify/function-enhancers": "^1.0.5",
     "@shopify/i18n": "^0.1.6",
-    "@shopify/javascript-utilities": "^2.4.1",
     "@shopify/react-effect": "^3.2.3",
     "@shopify/react-hooks": "^1.2.3",
     "@shopify/useful-types": "^2.0.1",

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -1,5 +1,4 @@
 import {
-  getDateDiff,
   isLessThanOneHourAgo,
   isLessThanOneMinuteAgo,
   isLessThanOneWeekAgo,
@@ -7,9 +6,7 @@ import {
   isToday,
   isYesterday,
   TimeUnit,
-  Weekdays,
-} from '@shopify/javascript-utilities/dates';
-import {applyTimeZoneOffset} from '@shopify/dates';
+} from '@shopify/dates';
 import {memoize as memoizeFn} from '@shopify/function-enhancers';
 import {memoize} from '@shopify/decorators';
 import {languageFromLocale, regionFromLocale} from '@shopify/i18n';
@@ -424,16 +421,15 @@ export class I18n {
   }
 
   private humanizeDate(date: Date, options?: Intl.DateTimeFormatOptions) {
-    const {defaultTimezone} = this;
-    const timeZone =
-      options && options.timeZone ? options.timeZone : defaultTimezone;
-
     if (isLessThanOneMinuteAgo(date)) {
       return this.translate('humanize.now');
     }
 
     if (isLessThanOneHourAgo(date)) {
-      const minutes = getDateDiff(TimeUnit.Minute, date);
+      const now = new Date();
+      const minutes = Math.floor(
+        (now.getTime() - date.getTime()) / TimeUnit.Minute,
+      );
       return this.translate('humanize.minutes', {
         count: minutes,
       });
@@ -453,15 +449,12 @@ export class I18n {
     }
 
     if (isLessThanOneWeekAgo(date)) {
-      const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-      const dateInTimeZone =
-        timeZone === undefined
-          ? date
-          : applyTimeZoneOffset(date, timeZone, localTimeZone);
-
+      const weekday = this.formatDate(date, {
+        ...options,
+        weekday: 'long',
+      });
       return this.translate('humanize.weekday', {
-        day: Weekdays[dateInTimeZone.getDay()],
+        day: weekday,
         time,
       });
     }

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1114,7 +1114,7 @@ describe('I18n', () => {
           'humanize.weekday',
           {
             pseudotranslate: false,
-            replacements: {day: 'Friday', time: '11:00 a.m.'},
+            replacements: {day: 'Saturday', time: '11:00 a.m.'},
           },
           defaultTranslations,
           i18n.locale,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,16 +1054,6 @@
     lodash "^4.17.4"
     lodash-decorators "^4.3.5"
 
-"@shopify/javascript-utilities@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.4.1.tgz#99e1994381fc33a2609f7792b6812feee32362fa"
-  integrity sha512-CDp4nWHjVXTr+rYV5RMBs8aJ5PbXUdbz47jnKisBWa9GFwJktZFj2PxefXqfLd51KpIuQpFnA/NMvq4M5tdTlw==
-  dependencies:
-    "@types/lodash" "^4.14.65"
-    "@types/react" "^16.0.2"
-    lodash "^4.17.4"
-    lodash-decorators "^4.3.5"
-
 "@shopify/react-html@^8.0.10":
   version "8.1.3"
   resolved "https://registry.yarnpkg.com/@shopify/react-html/-/react-html-8.1.3.tgz#1cf83190ae7e3a5cb25be5ed2ed73adf36ac0a66"


### PR DESCRIPTION
## Description

### Changed

- Replaced `@shopify/javascript-utilities/dates` functions with those from `@shopify/dates`.
- Removed `@shopify/javascript-utilities/dates` dependency.

### Fixed

- Fixed translation of weekday in `humanizeDate` for dates less than one week old.

## Type of change

- [x] @shopify/react-i18n Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
