### PR TITLE
Add `i18n.ordinal()` method to `@shopify/react-i18n`

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,13 +6,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
-
-## [1.9.2] - 2019-09-17
+## [Unreleased]
 
 ### Added
 
 - Added `ordinal` method to I18n class to translate ordinal numbers ([#1003](https://github.com/Shopify/quilt/pull/1003))
+
+  Consumers will need to add the following translation keys for proper ordinal translation. _Note: values are English examples._
+
+  ```json
+  {
+    "ordinal": {
+      "one": "{number}st",
+      "two": "{number}nd",
+      "few": "{number}rd",
+      "other": "{number}th"
+    }
+  }
+  ```
+
+## [1.9.2] - 2019-09-17
 
 ### Changed
 

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [1.9.2] - 2019-09-17
 
+### Added
+
+- Added `ordinal` method to I18n class to translate ordinal numbers ([#1003](https://github.com/Shopify/quilt/pull/1003))
+
 ### Changed
 
 - Replaced `@shopify/javascript-utilities/dates` functions with those from `@shopify/dates`.

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -138,6 +138,7 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 - `formatName()`: formats a name (first name and/or last name) according to the locale. e,g
   - `formatName('John', 'Smith')` will return `John` in Germany and `Smith様` in Japan
   - `formatName('John', 'Smith', {full: true})` will return `John Smith` in Germany and `SmithJohn` in Japan
+- `ordinal()`: formats a number as an ordinal according to the locale, e.g. `1st`, `2nd`, `3rd`, `4th`
 
 Most notably, you will frequently use `i18n`’s `translate()` method. This method looks up a key in translation files that you supply based on the provided locale. This method is discussed in detail in the next section.
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -316,6 +316,14 @@ export class I18n {
     }).format(date);
   }
 
+  ordinal(amount: number) {
+    const {locale} = this;
+    const group = new Intl.PluralRules(locale, {type: 'ordinal'}).select(
+      amount,
+    );
+    return this.translate(group, {scope: 'ordinal'}, {amount});
+  }
+
   weekStartDay(argCountry?: I18n['defaultCountry']): Weekday {
     const country = argCountry || this.defaultCountry;
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -78,6 +78,7 @@ export class I18n {
   readonly defaultTimezone?: string;
   readonly onError: NonNullable<I18nDetails['onError']>;
   readonly loading: boolean;
+  readonly ordinalPluralRules: Intl.PluralRules;
 
   get language() {
     return languageFromLocale(this.locale);
@@ -127,6 +128,7 @@ export class I18n {
     this.pseudolocalize = pseudolocalize;
     this.onError = onError || defaultOnError;
     this.loading = loading || false;
+    this.ordinalPluralRules = new Intl.PluralRules(locale, {type: 'ordinal'});
   }
 
   translate(
@@ -317,10 +319,7 @@ export class I18n {
   }
 
   ordinal(amount: number) {
-    const {locale} = this;
-    const group = new Intl.PluralRules(locale, {type: 'ordinal'}).select(
-      amount,
-    );
+    const group = this.ordinalPluralRules.select(amount);
     return this.translate(group, {scope: 'ordinal'}, {amount});
   }
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -230,7 +230,7 @@ describe('I18n', () => {
   });
 
   describe('#ordinal()', () => {
-    it('calls translate() utility wth ordinal scope and replacement amount', () => {
+    it('calls translate() utility with ordinal scope and replacement amount', () => {
       const defaultTranslations = [{hello: 'Hello, {name}!'}];
       const i18n = new I18n(defaultTranslations, defaultDetails);
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -229,6 +229,61 @@ describe('I18n', () => {
     });
   });
 
+  describe('#ordinal()', () => {
+    it('calls translate() utility wth ordinal scope and replacement amount', () => {
+      const defaultTranslations = [{hello: 'Hello, {name}!'}];
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+
+      i18n.ordinal(0);
+      expect(translate).toHaveBeenCalledWith(
+        'other',
+        {scope: 'ordinal', replacements: {amount: 0}, pseudotranslate: false},
+        defaultTranslations,
+        i18n.locale,
+      );
+
+      i18n.ordinal(1);
+      expect(translate).toHaveBeenCalledWith(
+        'one',
+        {scope: 'ordinal', replacements: {amount: 1}, pseudotranslate: false},
+        defaultTranslations,
+        i18n.locale,
+      );
+
+      i18n.ordinal(2);
+      expect(translate).toHaveBeenCalledWith(
+        'two',
+        {scope: 'ordinal', replacements: {amount: 2}, pseudotranslate: false},
+        defaultTranslations,
+        i18n.locale,
+      );
+
+      i18n.ordinal(3);
+      expect(translate).toHaveBeenCalledWith(
+        'few',
+        {scope: 'ordinal', replacements: {amount: 3}, pseudotranslate: false},
+        defaultTranslations,
+        i18n.locale,
+      );
+
+      i18n.ordinal(4);
+      expect(translate).toHaveBeenCalledWith(
+        'other',
+        {scope: 'ordinal', replacements: {amount: 4}, pseudotranslate: false},
+        defaultTranslations,
+        i18n.locale,
+      );
+
+      i18n.ordinal(42);
+      expect(translate).toHaveBeenCalledWith(
+        'two',
+        {scope: 'ordinal', replacements: {amount: 42}, pseudotranslate: false},
+        defaultTranslations,
+        i18n.locale,
+      );
+    });
+  });
+
   describe('#translate()', () => {
     it('calls the translate() utility with translations, key, locale, scope, pseudotranslate, and replacements', () => {
       const mockResult = 'translated string';
@@ -1136,10 +1191,9 @@ describe('I18n', () => {
           timezone,
         });
 
-        const formatted = i18n.formatDate(lessThanOneYearAgo, {
+        i18n.formatDate(lessThanOneYearAgo, {
           style: DateStyle.Humanize,
         });
-
         expect(translate).toHaveBeenCalledWith(
           'humanize.date',
           {


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/971.

Adds `I18n#ordinal(number)` method for translating integers into ordinals, e.g., 1st, 2nd, 3rd, etc.

Uses the [`{type: 'ordinal'}` option of Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules#Using_options).

Given that ordinals are not context-specific (confirmed with #intl-services), they only need to be translated once and therefore translations are intended to be stored at the root level, e.g., `app/locales/en.json` in web, with keys of "one", "two", "few", and "other" under an "ordinal" key:

```json
{
  "ordinal": {
    "one": "{number}st",
    "two": "{number}nd",
    "few": "{number}rd",
    "other": "{number}th",
  }
}
```

### Example usage

Given the above "ordinal" translation entry and the following:

```json
{
  "myKey": "This was their {ordinal} visit."
}
```

The `ordinal` method can be combined with `translate` to include ordinal numbers in translated strings:

```js
const ordinal = i18n.ordinal(42);
// ordinal => "42nd"
const text = i18n.translate('myKey', {ordinal});
// text => "This was their 42nd visit."
```

## Type of change

- [x] `@shopify/react-i18n` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
