### PR TITLE
Handle invalid error path for submission errors in react-form

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- handle invalid error path for submission errors [#1007](https://github.com/Shopify/quilt/pull/1007)
+
 ## [0.3.9]
 
 ### Added

--- a/packages/react-form/src/hooks/test/form.test.tsx
+++ b/packages/react-form/src/hooks/test/form.test.tsx
@@ -262,6 +262,37 @@ describe('useForm', () => {
       });
     });
 
+    it('ignores invalid field path when propagating remote submission errors', async () => {
+      const errors = [
+        {
+          field: ['invalid'],
+          message: 'The server hates your price',
+        },
+      ];
+
+      const promise = Promise.resolve(submitFail(errors));
+
+      const wrapper = mount(
+        <ProductForm data={fakeProduct()} onSubmit={() => promise} />,
+      );
+
+      await wrapper
+        .find('button', {type: 'submit'})!
+        .trigger('onClick', clickEvent());
+
+      await wrapper.act(async () => {
+        await promise;
+      });
+
+      expect(wrapper).toContainReactComponent('p', {
+        children: errors[0].message,
+      });
+
+      expect(wrapper).not.toContainReactComponent(TextField, {
+        error: errors[0].message,
+      });
+    });
+
     it('does not create a new submit function on each render', () => {
       const wrapper = mount(<ProductForm data={fakeProduct()} />);
 

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -60,7 +60,7 @@ export function propagateErrors(
 
     const got = get(fieldBag, error.field);
 
-    if (isField(got)) {
+    if (got && isField(got)) {
       if (got.error !== error.message) {
         got.setError(error.message);
       }


### PR DESCRIPTION
## Description

Passing invalid error path on form submission was causing a JS error trace :

![image](https://user-images.githubusercontent.com/5339802/65070856-68804980-d95b-11e9-8d20-26b73208c515.png)

Issue found here: (https://github.com/Shopify/store/issues/9108)


In react-form, when propagating remote errors to its matching field,  it is possible that the return value of `get` can be `undefined` [here](https://github.com/Shopify/quilt/blob/27862acdc3b13f02dd1e0b4f2245e325955d9d6b/packages/react-form/src/utilities.ts#L61).  If an invalid field is passed, this causes `isField(undefined)` to throw an error:  

**Fix**
If `get` is undefined, we ignore the invalid field path when propagating through submission errors. Errors will still be returned to the component, but they will not be mapped to a specific field. 

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
