### PR TITLE
[react-i18n] Modify translation keys used by I18n#humanizeDate

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
 
-## [1.10.0] - 2019-09-17
+### Changed
+
+- Modified translation keys used by `I18n#humanizeDate` method ([#1011](https://github.com/Shopify/quilt/pull/1011))
+
+## [1.10.0] - 2019-09-18
 
 ### Added
 
@@ -26,10 +30,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     }
   }
   ```
-
-### Changed
-
-- Modified translation keys used by `I18n#humanizeDate` method ([#1011](https://github.com/Shopify/quilt/pull/1011))
 
 ## [1.9.2] - 2019-09-17
 

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   }
   ```
 
+### Changed
+
+- Modified translation keys used by `I18n#humanizeDate` method ([#1011](https://github.com/Shopify/quilt/pull/1011))
+
 ## [1.9.2] - 2019-09-17
 
 ### Changed

--- a/packages/react-i18n/migration-guide.md
+++ b/packages/react-i18n/migration-guide.md
@@ -1,0 +1,83 @@
+# Migration guide
+
+This is a concise summary of changes and recommendations around updating `@shopify/react-i18n` in consuming projects. For a more detailed list of changes, see [the changelog](./CHANGELOG.md).
+
+## Unreleased
+
+🛑Breaking change - The translation keys for dates formatted with `DateStyle.Humanize` have changed. Consumers will need to modify the translation keys as outlined below.
+
+1. The top-level "humanize" key is now nested under a "date" key.
+
+   **Before**
+
+   ```json
+   {
+     "humanize": {
+       ...
+     }
+   }
+   ```
+
+   **After**
+
+   ```json
+   {
+     "date": {
+       "humanize": {
+         ...
+       }
+     }
+   }
+   ```
+
+2. The `day` replacement parameter for the `lessThanOneWeekAgo` (formerly `weekday`) string has been renamed to `weekday`.
+
+   **Before**
+
+   ```json
+   "weekday": "{day} at {time}",
+   ```
+
+   **After**
+
+   ```json
+   "lessThanOneWeekAgo": "{weekday} at {time}"
+   ```
+
+3. The individual date string keys have been renamed as shown in the following table.
+
+   | Original Key | New Key                |
+   | ------------ | ---------------------- |
+   | `now`        | `lessThanOneMinuteAgo` |
+   | `minutes`    | `lessThanOneHourAgo`   |
+   | `yesterday`  | `yesterday`            |
+   | `weekday`    | `lessThanOneWeekAgo`   |
+   | `date`       | `lessThanOneYearAgo`   |
+
+   **Example before**
+
+   ```json
+   {
+     "humanize": {
+       "date": "{date} at {time}",
+       "minutes": "{count} minutes ago",
+       "now": "Just now",
+       "weekday": "{day} at {time}",
+       "yesterday": "Yesterday at {time}"
+     }
+   }
+   ```
+
+   **Example after**
+
+   ```json
+   "date": {
+     "humanize": {
+       "lessThanOneMinuteAgo": "Just now",
+       "lessThanOneHourAgo": "{count} minutes ago",
+       "yesterday": "Yesterday at {time}",
+       "lessThanOneWeekAgo": "{weekday} at {time}",
+       "lessThanOneYearAgo": "{date} at {time}"
+     }
+   },
+   ```

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -429,7 +429,7 @@ export class I18n {
 
   private humanizeDate(date: Date, options?: Intl.DateTimeFormatOptions) {
     if (isLessThanOneMinuteAgo(date)) {
-      return this.translate('humanize.now');
+      return this.translate('date.humanize.lessThanOneMinuteAgo');
     }
 
     if (isLessThanOneHourAgo(date)) {
@@ -437,7 +437,7 @@ export class I18n {
       const minutes = Math.floor(
         (now.getTime() - date.getTime()) / TimeUnit.Minute,
       );
-      return this.translate('humanize.minutes', {
+      return this.translate('date.humanize.lessThanOneHourAgo', {
         count: minutes,
       });
     }
@@ -452,7 +452,7 @@ export class I18n {
     }
 
     if (isYesterday(date)) {
-      return this.translate('humanize.yesterday', {time});
+      return this.translate('date.humanize.yesterday', {time});
     }
 
     if (isLessThanOneWeekAgo(date)) {
@@ -460,8 +460,8 @@ export class I18n {
         ...options,
         weekday: 'long',
       });
-      return this.translate('humanize.weekday', {
-        day: weekday,
+      return this.translate('date.humanize.lessThanOneWeekAgo', {
+        weekday,
         time,
       });
     }
@@ -472,7 +472,7 @@ export class I18n {
         month: 'short',
         day: 'numeric',
       });
-      return this.translate('humanize.date', {
+      return this.translate('date.humanize.lessThanOneYearAgo', {
         date: monthDay,
         time,
       });

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1087,7 +1087,7 @@ describe('I18n', () => {
           style: DateStyle.Humanize,
         });
         expect(translate).toHaveBeenCalledWith(
-          'humanize.now',
+          'date.humanize.lessThanOneMinuteAgo',
           {pseudotranslate: false},
           defaultTranslations,
           i18n.locale,
@@ -1109,7 +1109,7 @@ describe('I18n', () => {
           style: DateStyle.Humanize,
         });
         expect(translate).toHaveBeenCalledWith(
-          'humanize.minutes',
+          'date.humanize.lessThanOneHourAgo',
           {pseudotranslate: false, replacements: {count: minutesAgo}},
           defaultTranslations,
           i18n.locale,
@@ -1143,7 +1143,7 @@ describe('I18n', () => {
 
         i18n.formatDate(yesterday, {style: DateStyle.Humanize});
         expect(translate).toHaveBeenCalledWith(
-          'humanize.yesterday',
+          'date.humanize.yesterday',
           {pseudotranslate: false, replacements: {time: '11:00 a.m.'}},
           defaultTranslations,
           i18n.locale,
@@ -1166,10 +1166,10 @@ describe('I18n', () => {
           style: DateStyle.Humanize,
         });
         expect(translate).toHaveBeenCalledWith(
-          'humanize.weekday',
+          'date.humanize.lessThanOneWeekAgo',
           {
             pseudotranslate: false,
-            replacements: {day: 'Saturday', time: '11:00 a.m.'},
+            replacements: {weekday: 'Saturday', time: '11:00 a.m.'},
           },
           defaultTranslations,
           i18n.locale,
@@ -1195,7 +1195,7 @@ describe('I18n', () => {
           style: DateStyle.Humanize,
         });
         expect(translate).toHaveBeenCalledWith(
-          'humanize.date',
+          'date.humanize.lessThanOneYearAgo',
           {
             pseudotranslate: false,
             replacements: {date: 'Jul. 20', time: '10:00 a.m.'},


### PR DESCRIPTION
## Description

Modifies the translation keys used by the `I18n#humanizeDate` method to more accurately reflect the conditions rather than the (expected) English values.

### Before

```json
  "humanize": {
    "date": "{date} at {time}",
    "minutes": "{count} minutes ago",
    "now": "Just now",
    "weekday": "{day} at {time}",
    "yesterday": "Yesterday at {time}"
  },
```

### After

```json
  "date": {
    "humanize": {
      "lessThanOneMinuteAgo": "Just now",
      "lessThanOneHourAgo": "{count} minutes ago",
      "yesterday": "Yesterday at {time}",
      "lessThanOneWeekAgo": "{weekday} at {time}",
      "lessThanOneYearAgo": "{date} at {time}"
    }
  },
```

## Type of change

- [x] `@shopify/react-i18n` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
