### PR TITLE
Fixup `addReleaseToChangelog()`

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## 0.0.3 - 2019-09-18
+
+- Added support for various `unreleased` heading formatting in `addReleaseToChangelog`
+
 ## 0.0.2 - 2019-09-18
 
 - Added markdown utils starting with `addReleaseToChangelog`

--- a/packages/ast-utilities/markdown.d.ts
+++ b/packages/ast-utilities/markdown.d.ts
@@ -1,1 +1,1 @@
-// export * from './dist/markdown';
+export * from './dist/markdown';

--- a/packages/ast-utilities/src/markdown/transform.ts
+++ b/packages/ast-utilities/src/markdown/transform.ts
@@ -7,7 +7,13 @@ export async function transform(initial: string, ...transforms: any[]) {
     .use(parse)
     .use({
       plugins: [...transforms],
-      settings: {bullet: '-', emphasis: '*', fences: true, position: false},
+      settings: {
+        bullet: '-',
+        emphasis: '*',
+        listItemIndent: '1',
+        fences: true,
+        position: false,
+      },
     })
     .use(stringify)
     .process(initial);

--- a/packages/ast-utilities/src/markdown/transforms/addReleaseToChangelog/tests/addReleaseToChangelog.test.ts
+++ b/packages/ast-utilities/src/markdown/transforms/addReleaseToChangelog/tests/addReleaseToChangelog.test.ts
@@ -7,21 +7,21 @@ describe('addReleaseToChangelog', () => {
     const newDate = '2019-09-16';
 
     const initial = `
-## Unreleased
+## [Unreleased]
 
 ## 0.0.1 - 2019-08-15
 
--   updated a thing
+- updated a thing
     `;
 
     const expected = `
-<!-- ## Unreleased -->
+<!-- ## [Unreleased] -->
 
 ## ${newVersion} - ${newDate}
 
 ## 0.0.1 - 2019-08-15
 
--   updated a thing
+- updated a thing
     `.trim();
 
     const result = await transform(
@@ -42,11 +42,11 @@ describe('addReleaseToChangelog', () => {
 
 ## 0.0.1 - 2019-08-15
 
--   updated a thing
+- updated a thing
     `;
 
     const expected = `
-<!-- ## Unreleased -->
+<!-- ## [Unreleased] -->
 
 ## ${version} - ${date}
 
@@ -54,7 +54,7 @@ ${notes}
 
 ## 0.0.1 - 2019-08-15
 
--   updated a thing
+- updated a thing
     `.trim();
 
     const result = await transform(
@@ -69,8 +69,8 @@ ${notes}
     const version = '0.0.2';
     const date = '2019-09-16';
     const notes = `
--   updated another thing
--   updated and a final thing
+- updated another thing
+- updated and a final thing
 		`;
 
     const initial = `
@@ -78,11 +78,11 @@ ${notes}
 
 ## 0.0.1 - 2019-08-15
 
--   updated a thing
+- updated a thing
     `;
 
     const expected = `
-<!-- ## Unreleased -->
+<!-- ## [Unreleased] -->
 
 ## ${version} - ${date}
 
@@ -90,12 +90,50 @@ ${notes}
 
 ## 0.0.1 - 2019-08-15
 
--   updated a thing
+- updated a thing
     `.trim();
 
     const result = await transform(
       initial,
       addReleaseToChangelog({version, date, notes}),
+    );
+
+    expect(result).toBeFormated(expected);
+  });
+
+  it('adds a new release to packages with no changes', async () => {
+    const newVersion = '0.0.2';
+    const newDate = '2019-09-16';
+
+    const initial = `
+<!-- ## [Unreleased] -->
+
+## 0.0.2 - 2019-08-17
+
+- test updated a package
+
+## 0.0.1 - 2019-08-15
+
+- updated a thing
+    `;
+
+    const expected = `
+<!-- ## [Unreleased] -->
+
+## ${newVersion} - ${newDate}
+
+## 0.0.2 - 2019-08-17
+
+- test updated a package
+
+## 0.0.1 - 2019-08-15
+
+- updated a thing
+    `.trim();
+
+    const result = await transform(
+      initial,
+      addReleaseToChangelog({version: newVersion, date: newDate}),
     );
 
     expect(result).toBeFormated(expected);


### PR DESCRIPTION
## Description

This PR adds some refinement around how `addReleaseToChangelog()` finds the part of the markdown file to insert the new release (previously was just putting it at the top of the children nodes) and also adds support for `LinkReference`s (which are things between square brackets). 

I also changed the bullet size and added a test for the `LinkReference` support.