### PR TITLE
Update `react-i18n` CHANGELOG.md

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
 
 ## [1.10.0] - 2019-09-17
 

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.10.0] - 2019-09-17
+
 ### Added
 
 - Added `ordinal` method to I18n class to translate ordinal numbers ([#1003](https://github.com/Shopify/quilt/pull/1003))


### PR DESCRIPTION
## Description

Backfills a missing version in the changelog for `react-i18n` from https://github.com/Shopify/quilt/commit/a38fae859161dccab46527b63a8c97a90974d3dd