### PR TITLE
Better server tests

### DIFF
--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -1,9 +1,11 @@
-import {Server} from 'http';
 import React from 'react';
-import request from 'supertest';
-import getPort from 'get-port';
-import {createServer} from '../server';
-import {mockMiddleware} from '../../test/utilities';
+import {useTitle} from '@shopify/react-html';
+import {useAcceptLanguage} from '@shopify/react-network';
+import {
+  mockMiddleware,
+  stopServers,
+  mountAppWithServer,
+} from '../../test/utilities';
 
 jest.mock('@shopify/sewing-kit-koa', () => ({
   middleware: jest.fn(() => mockMiddleware),
@@ -16,37 +18,52 @@ jest.mock('@shopify/sewing-kit-koa', () => ({
 }));
 
 describe('createServer()', () => {
-  function MockApp() {
-    return <div>markup</div>;
-  }
-
-  let server: Server;
-  let port: number;
-  const ip = 'http://localhost';
-
-  beforeEach(async () => {
-    port = await getPort();
-
-    server = await createServer({
-      port,
-      ip,
-      render: () => <MockApp />,
-    });
-  });
-
-  afterEach(() => {
-    server.close();
+  afterAll(() => {
+    stopServers();
   });
 
   it('starts a server that responds with markup', async () => {
-    const response = await request(`${ip}:${port}`)
-      .get('/')
-      .then((resp: request.Response) => {
-        return resp;
-      });
+    function MockApp() {
+      return <div>markup</div>;
+    }
+
+    const response = await mountAppWithServer(<MockApp />);
 
     expect(response.text).toBe(
       `<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="referrer" content="never"/></head><body><div id="app"><div>markup</div></div></body></html>`,
+    );
+  });
+
+  it('supports updatable meta components', async () => {
+    const myTitle = 'Shopify Mock App';
+
+    function MockApp() {
+      useTitle(myTitle);
+      return null;
+    }
+
+    const response = await mountAppWithServer(<MockApp />);
+
+    expect(response.text).toStrictEqual(
+      expect.stringContaining(
+        `<title data-react-html="true">${myTitle}</title>`,
+      ),
+    );
+  });
+
+  it('supports setting a custom locale', async () => {
+    const language = 'it';
+
+    function MockApp() {
+      const [lang] = useAcceptLanguage({code: language, quality: 1});
+      const markup = `The accept language header is ${lang.code}`;
+      return <div>{markup}</div>;
+    }
+
+    const response = await mountAppWithServer(<MockApp />);
+
+    expect(response.text).toStrictEqual(
+      expect.stringContaining(`The accept language header is ${language}`),
     );
   });
 });

--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTitle} from '@shopify/react-html';
-import {useAcceptLanguage} from '@shopify/react-network';
+
 import {
   mockMiddleware,
   stopServers,
@@ -42,28 +42,12 @@ describe('createServer()', () => {
       return null;
     }
 
-    const response = await mountAppWithServer(<MockApp />);
+    const {text} = await mountAppWithServer(<MockApp />);
 
-    expect(response.text).toStrictEqual(
+    expect(text).toStrictEqual(
       expect.stringContaining(
         `<title data-react-html="true">${myTitle}</title>`,
       ),
-    );
-  });
-
-  it('supports setting a custom locale', async () => {
-    const language = 'it';
-
-    function MockApp() {
-      const [lang] = useAcceptLanguage({code: language, quality: 1});
-      const markup = `The accept language header is ${lang.code}`;
-      return <div>{markup}</div>;
-    }
-
-    const response = await mountAppWithServer(<MockApp />);
-
-    expect(response.text).toStrictEqual(
-      expect.stringContaining(`The accept language header is ${language}`),
     );
   });
 });

--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -33,9 +33,9 @@ describe('createServer()', () => {
     const wrapper = await rack.mount(({ip, port}) =>
       createServer({port, ip, render: () => <MockApp />}),
     );
-    const {text} = await wrapper.request('/');
+    const response = await wrapper.request();
 
-    expect(text).toBe(
+    expect(await response.text()).toStrictEqual(
       `<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="referrer" content="never"/></head><body><div id="app"><div>markup</div></div></body></html>`,
     );
   });
@@ -51,9 +51,9 @@ describe('createServer()', () => {
     const wrapper = await rack.mount(({ip, port}) =>
       createServer({port, ip, render: () => <MockApp />}),
     );
-    const {text} = await wrapper.request('/');
+    const response = await wrapper.request();
 
-    expect(text).toStrictEqual(
+    expect(await response.text()).toStrictEqual(
       expect.stringContaining(
         `<title data-react-html="true">${myTitle}</title>`,
       ),

--- a/packages/react-server/src/test/utilities.ts
+++ b/packages/react-server/src/test/utilities.ts
@@ -1,5 +1,43 @@
+import {Server} from 'http';
 import {Context} from 'koa';
+import React from 'react';
+import getPort from 'get-port';
+import request from 'supertest';
 import {KoaNextFunction} from '../types';
+import {createServer} from '../server';
+
+interface Options {
+  port?: number;
+  ip?: string;
+}
+
+const servers: Server[] = [];
+
+export async function mountAppWithServer(
+  app: React.ReactElement<any>,
+  options: Options = {},
+) {
+  const {port = await getPort(), ip = 'http://localhost'} = options;
+  const url = `${ip}:${port}`;
+
+  const server = await createServer({
+    port,
+    ip,
+    render: () => app,
+  });
+
+  servers.push(server);
+
+  return request(url)
+    .get('/')
+    .then((resp: request.Response) => {
+      return resp;
+    });
+}
+
+export function stopServers() {
+  servers.forEach(server => server.close());
+}
 
 export async function mockMiddleware(_: Context, next: KoaNextFunction) {
   await next();

--- a/packages/react-server/src/test/utilities.ts
+++ b/packages/react-server/src/test/utilities.ts
@@ -1,11 +1,12 @@
 import {Server} from 'http';
 import {Context} from 'koa';
-import request from 'supertest';
 import getPort from 'get-port';
+
 import {KoaNextFunction} from '../types';
 
 export class TestRack {
   private servers: Server[] = [];
+
   unmountAll() {
     this.servers.forEach(server => server.close());
   }
@@ -18,7 +19,7 @@ export class TestRack {
     this.servers.push(server);
 
     return {
-      request: (url: string) => request(`${ip}:${port}`).get(url),
+      request: () => fetch(`${ip}:${port}`).then(response => response),
     };
   }
 }


### PR DESCRIPTION
## Description

This PR is my initial stab at https://github.com/Shopify/quilt/issues/856. The issue is a little vague so I'm just trying to hammer out a general approach.

~~The idea is that we want to test that the App component tree that users will pass into `createServer` can actually do the things we say it can. To accomplish this I've created a `mountAppWithServer` utility for mounting an App component on a random port and returning a response object that can be used in the assertions. The utility keeps track of the mounted servers in an internal array and provides a `stopServers` function to kill them all.~~

**EDIT: Sept 19th**
The idea is to have a class that does our setup (in a `mount` function) and takes in a function that will start our server. We can then call `request` and get back the returned response `text` for our assertions. The class will also expose a `unmountAll()` to kill all the servers.

In the tests themselves, I am calling some primitive hook in the App component tree that would not work if the provider did not exist in the `createServer` markup.