### PR TITLE
Fix development freezes in nested controller calls

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- The Node server calling Rails controllers no longer blocks first page load [#1020](https://github.com/Shopify/quilt/pull/1020)
+- The Node server calling Rails controllers no longer blocks page loads after changing an `.rb` file [#1020](https://github.com/Shopify/quilt/pull/1020)
 
 ## [1.6.0] - 2019-09-18
 

--- a/gems/quilt_rails/lib/quilt_rails.rb
+++ b/gems/quilt_rails/lib/quilt_rails.rb
@@ -8,3 +8,4 @@ require "quilt_rails/logger"
 require "quilt_rails/configuration"
 require "quilt_rails/react_renderable"
 require "quilt_rails/trusted_ui_server_csrf_strategy"
+require "quilt_rails/monkey_patches/active_support_reloader" if Rails.env.development?

--- a/gems/quilt_rails/lib/quilt_rails/monkey_patches/active_support_reloader.rb
+++ b/gems/quilt_rails/lib/quilt_rails/monkey_patches/active_support_reloader.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'rails'
+
+# The default ActiveSupport::Reloader memoizes `@should_reload` for the
+# lifetime of each request. This is a problem for quilt_rails apps because:
+# - QuiltRails::ReactRenderable#render holds an exclusive lock until the Node
+#   server returns a result
+# - Any controller calls during Node rendering (e.g., GraphQL fetches) will
+#   hang if they try to obtain a lock
+# - Class unloading needs a lock, and so nested controller calls risk
+#   deadlocking whenever @should_reload is true
+#
+# Forcing `@should_reload` evaluation at the start of each thread prevents
+# nested controller calls from attempting class unloading.  This eliminates
+# one source of lock contention.
+#
+# The affected flow is:
+# - A developer saves a change to a Ruby file
+# - The developer refreshes their browser
+#
+# Rails processes the request:
+# - Thread0 - ActiveSupport::Reloader is called by middleware
+# - Thread0 - An exclusive class unloader lock is obtained, classes are
+#             unloaded, and the lock is released
+# - Thread0 - `Quilt::ReactRenderable#render_react` calls `reverse_proxy`,
+#             which grabs a general exclusive lock
+# - Node    - starts rendering, and calls out to a Rails controller for data
+# - Thread1 - ActiveSupport::Reloader is called by the second controller's
+#             middleware
+# - Thread1 - `@should_reload` is still true, so an attempt is made to grab an
+#              exclusive class unloader lock
+# - Thread1 - waits for Thread0 to release its lock; Thread0 never unlocks
+#             because it needs Thread1's result
+#
+module ActiveSupport
+  class Reloader
+    def self.check! # :nodoc:
+      @should_reload = check.call
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Fixes (issue #956).  Addresses a couple of problems when quilt_rails's Node server calls back to GraphQL controllers:

- On first load, prevent `ReactRenderable#render_react`'s general lock from blocking class loading in other controllers
- After an .rb change, unload classes exactly once to prevent cross-controller lock contention

## Detailed description

### Problem 1 - Nested controller calls freeze on first page load

At the beginning of every controller request:
- The [InterlockHook starts a dependency interlock](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/railties/lib/rails/application/finisher.rb#L146-L154) 
- The [Interlock starts sharing](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/dependencies/interlock.rb#L32-L34)
- This eventually [adds the controller's thread to a share lock's `@sharing` hash](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/concurrency/share_lock.rb#L127)
- While the react_renderable controller waits for a response, its thread stays in the `@sharing` hash

If the react_renderable callout causes a controller request:
- Rails will attempt to load classes for the called controller type
- This involves obtaining an exclusive `:load` lock
- [busy_for_exclusive? finds the react_renderable controller's thread inside `@sharing`](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/concurrency/share_lock.rb#L207)
- The sub-controller thread then [waits for busy_for_exclusive? to return false](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/concurrency/share_lock.rb#L83), but this can never happen due to deadlock

-----

### Proposed solution - Permit concurrent loads during react_renderable proxying

Inside react_renderable, wrap the proxy-to-Node call with `permit_concurrent_loads`.  This:
- [Calls yield_shares](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/dependencies/interlock.rb#L46-L50)
- Which [removes the react_renderable thread from the `@sharing` hash](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/concurrency/share_lock.rb#L174)

With an empty `@sharing` hash, nested controller calls are free to obtain exclusive `:load` locks

------

### Problem 2 - Nested controller calls freeze after `.rb` changes

The first solution gets the page into a loadable state, but has the unfortunate side-effect of freezing after Ruby code is updated.  This is because:
- Permitting concurrent loads just [moves the render_renderable thread into the `@waiting` hash](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/concurrency/share_lock.rb#L174-L180) with `compatibility: [:load]`
- When the nested controller call attempts to unload classes, [busy_for_sharing? now fails on a thread being found with no matching purpose](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/concurrency/share_lock.rb#L212) (`:load` vs `:unload`)
- Again, this results in both controllers deferring to each other (deadlock)

-----

### Proposed solution - avoid unnecessary unload calls

Evaluate `@should_reload` at the start of every controller call.  This allows nested controller calls to skip the unload callback that was already handled by the react_renderable controller.

Technical details:
- The `Reloader` class [sets @should_reload during controller entry, then sets it back to `false` as the request completes](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/reloader.rb#L79-L85)
- This causes problems for nested controller calls because they see that @should_reload is `true`, and try to obtain an `:unload` exclusive lock
- Evaluating @should_reload at the start of every controller call allows duplicate unload callbacks to be skipped

## Type of change

- [x] quilt_rails: Minor: New feature (non-breaking change which adds functionality)

## 🎩 

Link to these gem changes in a repo that uses `useQuery` for server-side queries and:

- Start the app
- Wait for compilation to finish
- Clear your app's cookies from the browser
- Load your app in the browser
- Verify that you see a page
- Change some .rb code (e.g. add a silly puts to graphql_controller)
- Refresh the browser
- Verify that you see a refreshed page

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
