### PR TITLE
fixed app install

### DIFF
--- a/packages/koa-shopify-auth/src/auth/create-enable-cookies.ts
+++ b/packages/koa-shopify-auth/src/auth/create-enable-cookies.ts
@@ -370,7 +370,7 @@ export default function createEnableCookies({apiKey}: OAuthStartOptions) {
     (function() {
       function setCookieAndRedirect() {
         document.cookie = "shopify.cookies_persist=true";
-        window.location.href = window.shopOrigin + "/admin/apps/" + window.apiKey;
+        window.location.href = "/auth?shop=${shop}"
       }
 
       function shouldDisplayPrompt() {

--- a/packages/koa-shopify-auth/src/auth/test/enable-cookies.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/enable-cookies.test.ts
@@ -25,5 +25,6 @@ describe('CreateEnableCookies', () => {
     expect(ctx.body).toContain('CookiePartitionPrompt');
     expect(ctx.body).toContain(baseConfig.apiKey);
     expect(ctx.body).toContain(shopOrigin);
+    expect(ctx.body).toContain(`window.location.href = "/auth?shop=${shop}"`);
   });
 });


### PR DESCRIPTION
## Shopify koa auth install fails when the user is trying to install the app

Fixes (issue #)

During the shopify app install, shopify-koa-auth tries to redirect user to a page that does not exist (until the application is installed) yet. This causes the installation to fail. However when the user tries it for the second time, the cookie set in the previous exchange takes it through a different workflow and the application installation succeeds.

## Type of change

There are two changes
1. After setting a cookie, instead of redirecting to the application page (`https://{SHOP}/admin/apps/{SHOP_SPI_KEY}`) in their admin console, we will redirect them to the authentication page (`https://{APPLICATION}/auth?shop={SHOP}`) of the shopify app.

Until the shopify app is installed, this link `https://{SHOP}/admin/apps/{SHOP_SPI_KEY}` doesn't exist and hence the installation always fails the first time. By redirecting to the authentication page, the shopify app just tries to authenticate and installation proceeds.

2. I also added a small test case that verifies the fix.

- [ ] shopify-koa-auth Patch
