### PR TITLE
React i18n babel coverage

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Fixed babel plugin incompatiblity with jest code coverage
+
 ## [2.0.0] - 2019-09-19
 
 ### Changed

--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import glob from 'glob';
 import {TemplateBuilder} from '@babel/template';
 import Types from '@babel/types';
-import {NodePath} from '@babel/traverse';
+import {Node, NodePath} from '@babel/traverse';
 import stringHash from 'string-hash';
 
 interface State {
@@ -64,8 +64,11 @@ export default function injectWithI18nArguments({
     const {referencePaths} = binding;
 
     const referencePathsToRewrite = referencePaths.filter(referencePath => {
-      const parent: NodePath = referencePath.parentPath;
-      return parent.isCallExpression() && parent.get('arguments').length === 0;
+      const parent: Node = referencePath.parent;
+      return (
+        parent.type === 'CallExpression' &&
+        (!parent.arguments || parent.arguments.length === 0)
+      );
     });
 
     if (referencePathsToRewrite.length === 0) {


### PR DESCRIPTION
## Description
Since the upgrade to jest 24 the react i18n babel plugin has not been compatible with code coverage. This PR fixes that by adjusting how referencePath parents are checked.

https://github.com/Shopify/web/pull/13887

### Why did this break?
This is the code output after the babel transforms without `--coverage`
<img width="907" alt="Screen Shot 2019-09-23 at 1 46 47 PM" src="https://user-images.githubusercontent.com/308886/65520184-34ee7380-deb5-11e9-8e59-dfa6c158892c.png">

This is the code output after the babel transforms with `--coverage`
<img width="912" alt="Screen Shot 2019-09-23 at 1 42 48 PM" src="https://user-images.githubusercontent.com/308886/65520209-3b7ceb00-deb5-11e9-8809-3e3ae18ea49a.png">

The issue is that `babel-plugin-istanbul` is running before `@shopify/react-i18n/babel` is applied.

This changes `parentPath` from `CallExpression` to `SequenceExpression` as you can see the code in the second screenshot. `parent` remains `CallExpression` and also contains the `arguments`. I adjusted this and 🎩 ed against `plus-web`.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

- [X] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
