### PR TITLE
Update readmes to demonstrate Polaris v4 usage

### DIFF
--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -128,10 +128,11 @@ We will add a basic entrypoint using React with Polaris components.
 
 import React from 'react';
 import {AppProvider, Page, Card} from '@shopify/polaris';
+import enTranslations from '@shopify/polaris/locales/en.json';
 
 function App() {
   return (
-    <AppProvider>
+    <AppProvider i18n={enTranslations}>
       <Page title="Hello">
         <Card sectioned>Hi there</Card>
       </Page>
@@ -348,6 +349,7 @@ React-server sets up [@shopify/react-network](https://github.com/Shopify/quilt/b
 
 import React from 'react';
 import {AppProvider, Page, Card} from '@shopify/polaris';
+import enTranslations from '@shopify/polaris/locales/en.json';
 import {useRequestHeader} from '@shopify/react-network';
 
 function App() {
@@ -355,7 +357,7 @@ function App() {
   const someHeaderICareAbout = useRequestHeader('some-header');
 
   return (
-    <AppProvider>
+    <AppProvider i18n={enTranslations}>
       <Page title="Hello">
         {someHeaderICareAbout}
         <Card sectioned>Hi there</Card>
@@ -374,6 +376,7 @@ export default App;
 
 import React from 'react';
 import {AppProvider, Page, Card} from '@shopify/polaris';
+import enTranslations from '@shopify/polaris/locales/en.json';
 import {useRedirect} from '@shopify/react-network';
 
 function App() {
@@ -381,7 +384,7 @@ function App() {
   useRedirect('www.google.com');
 
   return (
-    <AppProvider>
+    <AppProvider i18n={enTranslations}>
       <Page title="Hello">
         <Card sectioned>Hi there</Card>
       </Page>

--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -650,6 +650,7 @@ import {
   Button,
   Form,
 } from '@shopify/polaris';
+import enTranslations from '@shopify/polaris/locales/en.json';
 import FormState, {
   validators,
   validateList,
@@ -684,7 +685,7 @@ interface Props {
 
 function CreateProductPage({initialValues}: Props) {
   return (
-    <AppProvider>
+    <AppProvider i18n={enTranslations}>
       <FormState
         initialValues={initialValues}
         validators={{

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -100,7 +100,6 @@ import React from 'react';
 import {useField, useForm, notEmpty, lengthMoreThan} from '@shopify/react-form';
 
 import {
-  AppProvider,
   Page,
   Layout,
   FormLayout,
@@ -205,7 +204,6 @@ import {
 } from '@shopify/react-form';
 
 import {
-  AppProvider,
   Page,
   Layout,
   FormLayout,


### PR DESCRIPTION
## Description

Related to  #1025

Polaris v4 made some breaking changes. We should reflect them in Quilt's readmes

- Adds the now-required i18n prop to AppProvider in two README examples
- Removes reference to an imported but unused AppProvider in react-form

## Type of change


- [x] quilt_rails Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] react-form-state Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] react-form Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
