### PR TITLE
🔥de-couple quilt_rails doc from polaris

### DIFF
--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -127,16 +127,9 @@ We will add a basic entrypoint using React with Polaris components.
 // app/ui/index.tsx
 
 import React from 'react';
-import {AppProvider, Page, Card} from '@shopify/polaris';
 
 function App() {
-  return (
-    <AppProvider>
-      <Page title="Hello">
-        <Card sectioned>Hi there</Card>
-      </Page>
-    </AppProvider>
-  );
+  return <h1>My application ❤️</h1>;
 }
 
 export default App;


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1025

Polaris v4 now included a required prop `i18n`. 
Instead of fixing the doc according the new spec, I decided to decouple our documentation from polaris implementation itself.