### PR TITLE
Fixes bug with default export of sewingKitConfig

### DIFF
--- a/gems/quilt_rails/lib/generators/sewing_kit/templates/sewing-kit.config.ts
+++ b/gems/quilt_rails/lib/generators/sewing_kit/templates/sewing-kit.config.ts
@@ -1,10 +1,11 @@
+/* eslint-env node */
+
 import {Plugins} from '@shopify/sewing-kit';
 
 function sewingKitConfig() {
   return {
-    name: 'your-app-name'
+    name: 'your-app-name',
   };
 };
 
 export default sewingKitConfig;
-

--- a/gems/quilt_rails/lib/generators/sewing_kit/templates/sewing-kit.config.ts
+++ b/gems/quilt_rails/lib/generators/sewing_kit/templates/sewing-kit.config.ts
@@ -1,7 +1,10 @@
-/* eslint-env node */
+import {Plugins} from '@shopify/sewing-kit';
 
-module.exports = function sewingKitConfig() {
+function sewingKitConfig() {
   return {
-    name: 'your-app-name',
+    name: 'your-app-name'
   };
 };
+
+export default sewingKitConfig;
+


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1033

This simply changes the way the sewingKitConfig is exported in the rails generator template.

## Type of change

- [x] bugfix for quilt-rails 

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
(Not yet) ⚠️ 