### PR TITLE
`quilt:install` should fully bootstrap TypeScript / React

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Quilt generator now adds `typescript`, `react`, `react-dom`, and types as project dependencies [#1038](https://github.com/Shopify/quilt/pull/1038)
+- Quilt generator now adds a `tsconfig.json` [#1038](https://github.com/Shopify/quilt/pull/1038)
+- Quilt generator now avoids warnings about `--isolated-modules` by using ES export syntax [#1038](https://github.com/Shopify/quilt/pull/1038)
+- Quilt generated apps no longer start up with exceptions about `app/ui/App.tsx` being uncompilable [#1038](https://github.com/Shopify/quilt/pull/1038)
 
 ## [1.7.0] - 2019-09-23
 

--- a/gems/quilt_rails/lib/generators/quilt/install_generator.rb
+++ b/gems/quilt_rails/lib/generators/quilt/install_generator.rb
@@ -8,7 +8,24 @@ module Quilt
 
     def install_js_dependencies
       say "Installing @shopify/react-server and @shopify/sewing-kit dependencies"
-      system("yarn add @shopify/sewing-kit @shopify/react-server") unless Rails.env.test?
+      system("yarn add "\
+        "@shopify/sewing-kit "\
+        "@shopify/react-server "\
+        "typescript "\
+        "react "\
+        "react-dom "\
+        "@types/react "\
+        "@types/react-dom") unless Rails.env.test?
+    end
+
+    def create_tsconfig
+      tsconfig_path = "tsconfig.json"
+
+      unless File.exist?(tsconfig_path)
+        copy_file "tsconfig.json", tsconfig_path
+
+        log(tsconfig_path, 'wrote')
+      end
     end
 
     def create_app_file

--- a/gems/quilt_rails/lib/generators/quilt/templates/tsconfig.json
+++ b/gems/quilt_rails/lib/generators/quilt/templates/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shopify/typescript-configs/application.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "."
+  },
+  "include": ["app/ui"]
+}

--- a/gems/quilt_rails/lib/generators/sewing_kit/templates/sewing-kit.config.ts
+++ b/gems/quilt_rails/lib/generators/sewing_kit/templates/sewing-kit.config.ts
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
-module.exports = function sewingKitConfig() {
-  return {
-    name: 'your-app-name',
-  };
-};
+import {Env, Plugins} from '@shopify/sewing-kit';
+
+export default function sewingKitConfig(_plugins: Plugins, _env: Env) {
+  return {};
+}

--- a/gems/quilt_rails/test/generators/quilt/install_generator_test.rb
+++ b/gems/quilt_rails/test/generators/quilt/install_generator_test.rb
@@ -13,6 +13,13 @@ class QuiltInstallGeneratorTest < Rails::Generators::TestCase
     provide_existing_routes_file
   end
 
+  test "creates tsconfig.json" do
+    run_generator
+    assert_file "tsconfig.json" do |tsconfig|
+      assert_match '"extends": "@shopify/typescript-configs/application.json"', tsconfig
+    end
+  end
+
   test "creates the main React app" do
     run_generator
     assert_file "app/ui/index.tsx" do |app|

--- a/gems/quilt_rails/test/generators/sewing_kit/install_generator_test.rb
+++ b/gems/quilt_rails/test/generators/sewing_kit/install_generator_test.rb
@@ -15,7 +15,7 @@ class SewingKitInstallGeneratorTest < Rails::Generators::TestCase
   test "creates a sewing-kit file" do
     run_generator
     assert_file "config/sewing-kit.config.ts" do |config|
-      assert_match "name: 'your-app-name'", config
+      assert_match "export default function sewingKitConfig(_plugins: Plugins, _env: Env)", config
     end
   end
 end

--- a/packages/sewing-kit-koa/README.md
+++ b/packages/sewing-kit-koa/README.md
@@ -47,8 +47,9 @@ By default, the styles and scripts of the main bundle will be returned to you. T
 
 ```ts
 // In your sewing-kit.config.ts...
+import {Plugins} from '@shopify/sewing-kit';
 
-module.exports = function sewingKitConfig(plugins) {
+export default function sewingKitConfig(plugins: Plugins) {
   return {
     plugins: [
       plugins.entry({
@@ -57,7 +58,7 @@ module.exports = function sewingKitConfig(plugins) {
       }),
     ],
   };
-};
+}
 ```
 
 ```ts
@@ -119,11 +120,13 @@ The middleware accepts some optional parameters that you can use to customize ho
   // In this example, we want our application to serve assets only when we pass an
   // environment variable that indicates we are performing an end-to-end test.
 
-  module.exports = function sewingKitConfig(plugins) {
+  import {Plugins} from '@shopify/sewing-kit';
+
+  export default function sewingKitConfig(plugins: Plugins) {
     const plugins = process.env.E2E ? [plugins.cdn('/e2e-assets/')] : [];
 
     return {plugins};
-  };
+  }
   ```
 
   ```ts


### PR DESCRIPTION
## Description

Fixes (issue #1033)

- Adds typescript as a dependency to stop compilation throwing exceptions about `App.tsx`
- Generates a `tsconfig.json` to stop sewing-kit complaining about `cannot build a typescript project without tsconfig.json`
- Use `export default` in `sewing-kit.config.ts` to compile without depending on CommonJS
  - This addresses the warnings about `--isolated-modules` in #1033 
- Add `react`, et al. as dependencies because `react-server` crashes hard without them

## Type of change

- [x] quilt_rails - Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
