### PR TITLE
Accept ApolloClient options instead of the client iteself

### DIFF
--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## 2.0.0 - 2019-09-13
+
+- 🛑Breaking change: `GraphQLUniversalProvider` expects a `createClientOptions` prop and will create ApolloClient using the options provided [#1039](https://github.com/Shopify/quilt/pull/1039)
 
 ## 1.1.0 - 2019-09-13
 

--- a/packages/react-graphql-universal-provider/README.md
+++ b/packages/react-graphql-universal-provider/README.md
@@ -45,23 +45,23 @@ function GraphQL({
   server?: boolean;
   children?: React.ReactNode;
 }) {
-  const createClient = () => {
+  const createClientOptions = () => {
     const link = createHttpLink({
       // make sure to use absolute URL on the server
       uri: `https://your-api-end-point/api/graphql`,
     });
 
-    return new ApolloClient({
+    return {
       link,
       cache: new InMemoryCache(),
       ssrMode: server,
       ssrForceFetchDelay: 100,
       connectToDevTools: !server,
-    });
+    };
   };
 
   return (
-    <GraphQLUniversalProvider createClient={createClient}>
+    <GraphQLUniversalProvider createClientOptions={createClientOptions}>
       {children}
     </GraphQLUniversalProvider>
   );
@@ -113,7 +113,7 @@ function GraphQL({
   const cookie = useRequestHeader('cookie');
   const csrfToken = useCsrfToken();
 
-  const createClient = () => {
+  const createClientOptions = () => {
     const link = createHttpLink({
       // make sure to use absolute URL on the server
       uri: `https://your-api-end-point/api/graphql`,
@@ -123,17 +123,17 @@ function GraphQL({
       },
     });
 
-    return new ApolloClient({
+    return {
       link,
       cache: new InMemoryCache(),
       ssrMode: server,
       ssrForceFetchDelay: 100,
       connectToDevTools: !server,
-    });
+    };
   };
 
   return (
-    <GraphQLUniversalProvider createClient={createClient}>
+    <GraphQLUniversalProvider createClientOptions={createClientOptions}>
       {children}
     </GraphQLUniversalProvider>
   );

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -27,7 +27,8 @@
     "@shopify/react-effect-apollo": "^3.0.11",
     "@shopify/react-graphql": "^5.1.4",
     "@shopify/react-hooks": "^1.2.3",
-    "@shopify/react-html": "^9.2.3"
+    "@shopify/react-html": "^9.2.3",
+    "apollo-client": "^2.3.8"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0"
@@ -36,7 +37,6 @@
     "@shopify/react-effect": "^3.2.3",
     "@shopify/react-testing": "^1.7.8",
     "apollo-cache-inmemory": "^1.3.6",
-    "apollo-client": "^2.3.8",
     "apollo-link": "^1.2.3"
   },
   "files": [

--- a/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
@@ -6,7 +6,7 @@ import {ApolloLink} from 'apollo-link';
 import {extract} from '@shopify/react-effect/server';
 import {Effect} from '@shopify/react-effect';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';
-import {ApolloProvider} from '@shopify/react-graphql';
+import {ApolloProvider, SsrExtractableLink} from '@shopify/react-graphql';
 import {mount} from '@shopify/react-testing';
 
 import {GraphQLUniversalProvider} from '../GraphQLUniversalProvider';
@@ -29,12 +29,12 @@ jest.mock('@shopify/react-graphql', () => {
 
 describe('<GraphQLUniversalProvider />', () => {
   it('renders an ApolloProvider with a client created by the factory', () => {
-    const client = new ApolloClient({
+    const clientOptions = {
       cache: new InMemoryCache(),
       link: new ApolloLink(),
-    });
+    };
     const graphQL = mount(
-      <GraphQLUniversalProvider createClient={() => client} />,
+      <GraphQLUniversalProvider createClientOptions={() => clientOptions} />,
     );
 
     expect(graphQL).toContainReactComponent(ApolloProvider, {
@@ -46,10 +46,18 @@ describe('<GraphQLUniversalProvider />', () => {
     const htmlManager = new HtmlManager();
 
     const cache = new InMemoryCache();
-    const client = new ApolloClient({cache, link: new ApolloLink()});
+    const clientOptions = {cache, link: new ApolloLink()};
+
+    const graphQLProvider = (
+      <GraphQLUniversalProvider createClientOptions={() => clientOptions} />
+    );
+
+    const client = mount(graphQLProvider)
+      .find(ApolloProvider)!
+      .prop('client');
 
     // Simulated server render
-    await extract(<GraphQLUniversalProvider createClient={() => client} />, {
+    await extract(graphQLProvider, {
       decorate: (element: React.ReactNode) => (
         <HtmlContext.Provider value={htmlManager}>
           {element}
@@ -64,7 +72,7 @@ describe('<GraphQLUniversalProvider />', () => {
     // client would typically read serializations from the DOM on initialization).
     mount(
       <HtmlContext.Provider value={htmlManager}>
-        <GraphQLUniversalProvider createClient={() => client} />
+        {graphQLProvider}
       </HtmlContext.Provider>,
     );
 
@@ -72,14 +80,28 @@ describe('<GraphQLUniversalProvider />', () => {
   });
 
   it('renders an <Effect/> from ApolloBridge', () => {
-    const client = new ApolloClient({
+    const clientOptions = {
       cache: new InMemoryCache(),
       link: new ApolloLink(),
-    });
+    };
     const graphQL = mount(
-      <GraphQLUniversalProvider createClient={() => client} />,
+      <GraphQLUniversalProvider createClientOptions={() => clientOptions} />,
     );
 
     expect(graphQL).toContainReactComponent(Effect);
+  });
+
+  it('includes createSsrExtractableLink if a link is not present', () => {
+    const clientOptions = {
+      cache: new InMemoryCache(),
+    };
+
+    const client = mount(
+      <GraphQLUniversalProvider createClientOptions={() => clientOptions} />,
+    )
+      .find(ApolloProvider)!
+      .prop('client');
+
+    expect(client.link instanceof SsrExtractableLink).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

This PR updates the `GraphQLUniversalProvider` props to expect a `createClientOptions` function over a `createClient`. This prevents us from falling victim to this [issue](https://github.com/apollographql/apollo-client/issues/5347). 

This issue became apparent when working out https://github.com/Shopify/quilt/pull/1018. I've pulled it out from that PR. 

## Type of change

- [x] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
