### PR TITLE
✨ add additional error message is the type passed in is null or undef…

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Both `toContainReactComponent` and `toContainReactComponentTimes` matcher will now throw a more useful error if the expected value is `null` or `undefined` ([#1047](https://github.com/Shopify/quilt/pull/1047))
+
 ## [1.7.6] - 2019-08-27
 
 ### Fixed

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -7,7 +7,13 @@ import {
 } from 'jest-matcher-utils';
 
 import {Node, PropsFor} from '../types';
-import {assertIsNode, diffs, pluralize, printType} from './utilities';
+import {
+  assertIsNode,
+  assertIsType,
+  diffs,
+  pluralize,
+  printType,
+} from './utilities';
 
 export function toContainReactComponent<
   Type extends string | ComponentType<any>
@@ -18,6 +24,11 @@ export function toContainReactComponent<
   props?: Partial<PropsFor<Type>>,
 ) {
   assertIsNode(node, {
+    expectation: 'toContainReactComponent',
+    isNot: this.isNot,
+  });
+
+  assertIsType(type, {
     expectation: 'toContainReactComponent',
     isNot: this.isNot,
   });
@@ -77,6 +88,11 @@ export function toContainReactComponentTimes<
 ) {
   assertIsNode(node, {
     expectation: 'toContainReactComponentTimes',
+    isNot: this.isNot,
+  });
+
+  assertIsType(type, {
+    expectation: 'toContainReactComponent',
     isNot: this.isNot,
   });
 

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -5,6 +5,7 @@ import {
   RECEIVED_COLOR as receivedColor,
   printWithType,
   printReceived,
+  printExpected,
 } from 'jest-matcher-utils';
 
 import {Root} from '../root';
@@ -55,6 +56,23 @@ export function assertIsNode(
           'received',
         )} value must be an @shopify/react-testing Root or Element object`,
         printWithType('Received', node, printReceived),
+      ),
+    );
+  }
+}
+
+export function assertIsType(
+  type: unknown,
+  {expectation, isNot}: {expectation: string; isNot: boolean},
+) {
+  if (type == null) {
+    throw new Error(
+      matcherErrorMessage(
+        matcherHint(`.${expectation}`, undefined, undefined, {isNot}),
+        `${receivedColor(
+          'expected',
+        )} value must be a string or a valid React component.`,
+        printWithType('Expected', type, printExpected),
       ),
     );
   }


### PR DESCRIPTION
…ined.

## Description

Fixes https://github.com/Shopify/quilt/issues/981

When `PayoutLayout` is undeifned
Before:
![64643947-90156600-d3df-11e9-8f71-605c1e82d021](https://user-images.githubusercontent.com/1610169/65639332-e2e14700-dfb5-11e9-99a1-1d943dafaf74.png)


After:
![Screen Shot 2019-09-25 at 3 35 52 PM](https://user-images.githubusercontent.com/1610169/65639335-e70d6480-dfb5-11e9-85c3-774411041b71.png)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
