### PR TITLE
Log errors on `uncaughtException` `unhandledRejection` events

### DIFF
--- a/packages/react-server-webpack-plugin/CHANGELOG.md
+++ b/packages/react-server-webpack-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## [2.2.0] - 2019-09-26
+
+- Log errors on `uncaughtException` `unhandledRejection` events [#1006](https://github.com/Shopify/quilt/pull/1006)
+
 ## [2.1.1] - 2019-09-17
 
 - Fixes an error regrding missing templates [#1006](https://github.com/Shopify/quilt/pull/1006)

--- a/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
+++ b/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
@@ -81,6 +81,13 @@ function serverSource(options: Options) {
     import React from 'react';
     import {createServer} from '@shopify/react-server';
     import App from 'index';
+    process.on('uncaughtException', logError);
+    process.on('unhandledRejection', logError);
+    function logError(error) {
+      const errorLog = \`\${error.stack || error.message || 'No stack trace was present'}\`;
+      console.log(\`React Server failed to start.\n\${errorLog}\`);
+      process.exit(1);
+    }
     const render = (ctx) =>
     React.createElement(App, {
       server: true,


### PR DESCRIPTION
## Description
See title

Fixes https://github.com/Shopify/quilt/issues/958

- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

I did a 🎩 in [`web-rails-proving-ground`](https://github.com/Shopify/web-rails-proving-ground/pull/164) with this change along with a change to generate a [exception](https://github.com/Shopify/quilt/pull/react-server-uncaught-server-exceptions-test-release).

Shipit deploy [logs](https://shipit.shopify.io/shopify/web-rails-proving-ground/production/deploys/849980) contain more meaningful logs on why the node server failed on startup.

```
[FATAL][2019-09-26 14:07:54 +0000]	      $ node build/server/main.js
[FATAL][2019-09-26 14:07:54 +0000]	      React Server failed to start.
[FATAL][2019-09-26 14:07:54 +0000]	      Error: Test error. I am an uncaught exception thrown in the server that shows in shipit logs
[FATAL][2019-09-26 14:07:54 +0000]	      at breakThings (/app/build/server/webpack:/app/ui/server.js:18:15)
[FATAL][2019-09-26 14:07:54 +0000]	      at Module.breakThings (/app/build/server/webpack:/app/ui/server.js:34:5)
```  


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
