### PR TITLE
adds version to webhook package api call

### DIFF
--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## [2.0.0] - 2019-09-26
+
+*Breaking change*
+- Added API version to GraphQL endpoint.
 ## [1.1.4] - 2019-03-29
 
 - Check success via valid webhookSubscription field

--- a/packages/koa-shopify-webhooks/README.md
+++ b/packages/koa-shopify-webhooks/README.md
@@ -22,6 +22,7 @@ function registerWebhook(options: {
   format: string;
   accessToken: string;
   shop: string;
+  apiVersion: ApiVersion;
 }): {success: boolean; result: any};
 ```
 
@@ -76,6 +77,7 @@ app.use(
         topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
+        ApiVersion.Unstable
       });
 
       if (registration.success) {
@@ -141,6 +143,7 @@ app.use(
         topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
+        ApiVersion.Unstable
       });
 
       await registerWebhook({
@@ -148,6 +151,7 @@ app.use(
         topic: 'ORDERS_CREATE',
         accessToken,
         shop,
+        ApiVersion.Unstable
       });
 
       ctx.redirect('/');
@@ -185,3 +189,5 @@ In your app
 OR
 
 `require('isomorphic-fetch')`
+
+

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -1,11 +1,19 @@
 import {Method, Header} from '@shopify/network';
 import {WebhookHeader, Topic} from './types';
 
+export enum ApiVersion {
+  April19 = '2019-04',
+  July19 = '2019-07',
+  Unstable = 'unstable',
+  Unversioned = 'unversioned',
+}
+
 export interface Options {
   topic: Topic;
   address: string;
   shop: string;
   accessToken: string;
+  apiVersion: ApiVersion;
 }
 
 export async function registerWebhook({
@@ -13,15 +21,19 @@ export async function registerWebhook({
   topic,
   accessToken,
   shop,
+  apiVersion,
 }: Options) {
-  const response = await fetch(`https://${shop}/admin/api/graphql.json`, {
-    method: Method.Post,
-    body: buildQuery(topic, address),
-    headers: {
-      [WebhookHeader.AccessToken]: accessToken,
-      [Header.ContentType]: 'application/graphql',
+  const response = await fetch(
+    `https://${shop}/admin/api/${apiVersion}/graphql.json`,
+    {
+      method: Method.Post,
+      body: buildQuery(topic, address),
+      headers: {
+        [WebhookHeader.AccessToken]: accessToken,
+        [Header.ContentType]: 'application/graphql',
+      },
     },
-  });
+  );
 
   const result = await response.json();
 

--- a/packages/koa-shopify-webhooks/src/test/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/register.test.ts
@@ -1,6 +1,6 @@
 import {Header} from '@shopify/network';
 import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
-
+import {ApiVersion} from '../register';
 import {registerWebhook, Options, WebhookHeader} from '..';
 
 const successResponse = {
@@ -26,6 +26,7 @@ describe('registerWebhook', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
+      apiVersion: ApiVersion.Unstable,
     };
 
     const webhookQuery = `
@@ -47,7 +48,9 @@ describe('registerWebhook', () => {
     await registerWebhook(webhook);
 
     const [address, request] = fetchMock.lastCall();
-    expect(address).toBe(`https://${webhook.shop}/admin/api/graphql.json`);
+    expect(address).toBe(
+      `https://${webhook.shop}/admin/api/unstable/graphql.json`,
+    );
     expect(request.body).toBe(webhookQuery);
     expect(request.headers).toMatchObject({
       [WebhookHeader.AccessToken]: webhook.accessToken,


### PR DESCRIPTION
## Description
Adds the ability to pass a version of the API within webhook registration. 
@TheMallen would this be considered a breaking change?
## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->
- [x] koa-shopify-webhooks: Major change

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
