### PR TITLE
Memoize numberFormatter and pluralRules in translate utility

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Added `memoizedPluralRules` utility function ([#1065](https://github.com/Shopify/quilt/pull/1065)
+- Added `memoizedNumberFormatter` utility function ([#1065](https://github.com/Shopify/quilt/pull/1065)
+
+### Fixed
+
+- Removed creation of `Intl.PluralRules` object from `I18n` constructor which caused backwards incompatibility for any platforms needing a polyfill for `Intl.Plualrules` support ([#1065](https://github.com/Shopify/quilt/pull/1065)
 
 ## [2.0.2] - 2019-09-27
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -38,6 +38,8 @@ import {
   translate,
   getTranslationTree,
   TranslateOptions as RootTranslateOptions,
+  memoizedNumberFormatter,
+  memoizedPluralRules,
 } from './utilities';
 
 export interface NumberFormatOptions extends Intl.NumberFormatOptions {
@@ -64,12 +66,6 @@ const memoizedDateTimeFormatter = memoizeFn(
     `${locale}${JSON.stringify(options)}`,
 );
 
-const memoizedNumberFormatter = memoizeFn(
-  numberFormatter,
-  (locale: string, options: Intl.NumberFormatOptions = {}) =>
-    `${locale}${JSON.stringify(options)}`,
-);
-
 export class I18n {
   readonly locale: string;
   readonly pseudolocalize: boolean | string;
@@ -78,7 +74,6 @@ export class I18n {
   readonly defaultTimezone?: string;
   readonly onError: NonNullable<I18nDetails['onError']>;
   readonly loading: boolean;
-  readonly ordinalPluralRules: Intl.PluralRules;
 
   get language() {
     return languageFromLocale(this.locale);
@@ -128,7 +123,6 @@ export class I18n {
     this.pseudolocalize = pseudolocalize;
     this.onError = onError || defaultOnError;
     this.loading = loading || false;
-    this.ordinalPluralRules = new Intl.PluralRules(locale, {type: 'ordinal'});
   }
 
   translate(
@@ -319,7 +313,8 @@ export class I18n {
   }
 
   ordinal(amount: number) {
-    const group = this.ordinalPluralRules.select(amount);
+    const {locale} = this;
+    const group = memoizedPluralRules(locale, {type: 'ordinal'}).select(amount);
     return this.translate(group, {scope: 'ordinal'}, {amount});
   }
 
@@ -550,11 +545,4 @@ function dateTimeFormatter(
   options: Intl.DateTimeFormatOptions = {},
 ) {
   return new Intl.DateTimeFormat(locale, options);
-}
-
-function numberFormatter(
-  locale: string,
-  options: Intl.NumberFormatOptions = {},
-) {
-  return new Intl.NumberFormat(locale, options);
 }

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -4,6 +4,8 @@ import {
   getTranslationTree,
   PSEUDOTRANSLATE_OPTIONS,
   getCurrencySymbol,
+  memoizedNumberFormatter,
+  memoizedPluralRules,
 } from '../utilities';
 
 const {pseudotranslate} = require.requireMock('@shopify/i18n') as {
@@ -109,6 +111,69 @@ describe('getTranslationTree()', () => {
     expect(() =>
       getTranslationTree('foo.bar.baz', {foo: {bar: 'one'}}, locale),
     ).toThrow();
+  });
+});
+
+describe('memoizedNumberFormatter', () => {
+  it('returns the same object when passed the same arguments', () => {
+    const numberFormatterA = memoizedNumberFormatter(locale);
+    expect(numberFormatterA).toBeInstanceOf(Intl.NumberFormat);
+
+    const numberFormatterB = memoizedNumberFormatter(locale);
+    expect(numberFormatterB).toBeInstanceOf(Intl.NumberFormat);
+    expect(numberFormatterB).toBe(numberFormatterA);
+  });
+
+  it('returns different object when passed different arguments', () => {
+    const numberFormatterA = memoizedNumberFormatter(locale);
+    expect(numberFormatterA).toBeInstanceOf(Intl.NumberFormat);
+
+    const numberFormatterB = memoizedNumberFormatter(locale, {
+      style: 'decimal',
+    });
+    expect(numberFormatterB).toBeInstanceOf(Intl.NumberFormat);
+    expect(numberFormatterB).not.toBe(numberFormatterA);
+    expect(numberFormatterB.resolvedOptions()).toMatchObject({
+      style: 'decimal',
+    });
+  });
+
+  it('passes options to Intl.NumberFormat constructor', () => {
+    const numberFormatter = memoizedNumberFormatter(locale, {
+      style: 'decimal',
+    });
+    expect(numberFormatter).toBeInstanceOf(Intl.NumberFormat);
+    expect(numberFormatter.resolvedOptions()).toMatchObject({style: 'decimal'});
+  });
+});
+
+describe('memoizedPluralRules', () => {
+  it('returns the same object when passed the same arguments', () => {
+    const pluralRulesA = memoizedPluralRules(locale);
+    expect(pluralRulesA).toBeInstanceOf(Intl.PluralRules);
+
+    const pluralRulesB = memoizedPluralRules(locale);
+    expect(pluralRulesB).toBeInstanceOf(Intl.PluralRules);
+    expect(pluralRulesB).toBe(pluralRulesA);
+  });
+
+  it('returns different object when passed different arguments', () => {
+    const pluralRulesA = memoizedPluralRules(locale);
+    expect(pluralRulesA).toBeInstanceOf(Intl.PluralRules);
+
+    const pluralRulesB = memoizedPluralRules(locale, {
+      type: 'ordinal',
+    });
+    expect(pluralRulesB).toBeInstanceOf(Intl.PluralRules);
+    expect(pluralRulesB).not.toBe(pluralRulesA);
+  });
+
+  it('passes options to Intl.PluralRules constructor', () => {
+    const pluralRules = memoizedPluralRules(locale, {
+      type: 'ordinal',
+    });
+    expect(pluralRules).toBeInstanceOf(Intl.PluralRules);
+    expect(pluralRules.resolvedOptions()).toMatchObject({type: 'ordinal'});
   });
 });
 

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -5,6 +5,8 @@ import {
   TranslateOptions,
   translate,
   getTranslationTree,
+  memoizedNumberFormatter,
+  memoizedPluralRules,
 } from './translate';
 
 export {
@@ -14,4 +16,6 @@ export {
   translate,
   getTranslationTree,
   TranslateOptions,
+  memoizedNumberFormatter,
+  memoizedPluralRules,
 };


### PR DESCRIPTION
## Description

Memoizes some usages of `Intl.NumberFormat` and `Intl.PluralRules` to significantly reduce the number of new objects being created. 

- Created `memoizedPluralRules` in `utilities/translate.ts`
- Removed creation of `Intl.PluralRules` object from `I18n` constructor (`this.ordinalPluralRules`)
   - This object only existed for memoization purposes
   - The `ordinal` method now uses `memoizedPluralRules` instead
- Moved `memoizedNumberFormatter` from `i18n.ts` to `utilities/translate.ts` so that it can be used by other functions in that file and exported for use by `I18n`
- _Note: This has no effect for SSR because [memoization is disabled](https://github.com/Shopify/quilt/tree/master/packages/function-enhancers#memoize):_
   > Know that memoization will be skipped on server process

## Type of change

- [x] `@shopify/react-i18n` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
