### PR TITLE
adding asChoiceField utility to react-form and react-form-state

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- new `asChoiceField` utility function to support `Checkbox` and `RadioButton` [#1070](https://github.com/Shopify/quilt/pull/1070)
 
 ## [0.11.8] - 2019-08-29
 

--- a/packages/react-form-state/src/index.ts
+++ b/packages/react-form-state/src/index.ts
@@ -1,7 +1,14 @@
 import FormState from './FormState';
 
-import {push, replace, remove} from './utilities';
+import {
+  asChoiceField,
+  ChoiceFieldDescriptor,
+  push,
+  replace,
+  remove,
+} from './utilities';
 
+export {asChoiceField, ChoiceFieldDescriptor};
 export const arrayUtils = {push, replace, remove};
 
 export {default as validators} from './validators';

--- a/packages/react-form-state/src/tests/utilities.test.ts
+++ b/packages/react-form-state/src/tests/utilities.test.ts
@@ -1,4 +1,4 @@
-import {set} from '../utilities';
+import {asChoiceField, set} from '../utilities';
 
 describe('utilities', () => {
   describe('set', () => {
@@ -9,6 +9,14 @@ describe('utilities', () => {
         ab: {
           cd: 'ef',
         },
+      });
+    });
+  });
+
+  describe('asChoiceField()', () => {
+    it('replaces value with checked', () => {
+      expect(asChoiceField({value: true} as any)).toMatchObject({
+        checked: true,
       });
     });
   });

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -1,4 +1,5 @@
 import isEqual from 'fast-deep-equal';
+import {FieldDescriptor} from './types';
 
 export {isEqual};
 
@@ -61,3 +62,19 @@ export function flatMap<T>(
     [],
   );
 }
+
+/**
+ * Transforms a boolean FieldDescriptor object to work with checkboxes and radios.
+ * @param field
+ */
+export function asChoiceField({
+  value: checked,
+  ...fieldData
+}: FieldDescriptor<boolean>) {
+  return {
+    checked,
+    ...fieldData,
+  };
+}
+
+export type ChoiceFieldDescriptor = ReturnType<typeof asChoiceField>;

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- new `useChoiceField` and `asChoiceField` functions to support `Checkbox` and `RadioButton` [#1070](https://github.com/Shopify/quilt/pull/1070)
+
+### Fixed
+
 - handle invalid error path for submission errors [#1007](https://github.com/Shopify/quilt/pull/1007)
 
 ## [0.3.9]

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -14,6 +14,7 @@ Manage react forms tersely and safely-typed with no magic using React hooks. Bui
 1. [API](#api)
    1. [Hooks](#hooks)
       1. [useField](#usefield)
+      1. [useChoiceField](#usechoicefield)
       1. [useList](#uselist)
       1. [useForm](#useform)
       1. [useDirty](#usedirty)
@@ -399,6 +400,37 @@ return <TextField label="Title" {...title} />;
 **Reinitialization:** If the `value` property of the field configuration changes between calls to `useField`, the field will be reset to use it as its new default value.
 
 **Imperative methods:** The returned `Field` object contains a number of methods used to imperatively alter its state. These should only be used as escape hatches where the existing hooks and components do not make your life easy, or to build new abstractions in the same vein as `useForm`, `useSubmit` and friends.
+
+#### `useChoiceField()`
+
+An extension to `useField()` that produces a new field compatible with `<Checkbox />` and `<RadioButton />` from `@shopify/polaris`.
+
+##### Signature
+
+The signature is identical to `useField()` for `boolean` fields.
+
+```tsx
+const simple = useChoiceField(false);
+const complex = useChoiceField(config, validationDependencies);
+```
+
+##### Examples
+
+Fields produced by `useChoiceField` operate just like normal fields, except they have been converted by `asChoiceField` automatically which swaps the `value` member for `checked` to provide compatibility with `Checkbox` and `RadioButton`.
+
+```tsx
+const enabled = useChoiceField(false);
+
+return <Checkbox label="Enabled" {...enabled} />;
+```
+
+For fields that need to be compatible with choice components on the fly, the `asChoiceField` utility function can be used instead to adapt the field for a specific composition.
+
+```tsx
+const enabled = useField(false);
+
+return <Checkbox label="Enabled" {...asChoiceField(enabled)} />;
+```
 
 #### `useList()`
 

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -195,6 +195,45 @@ export function useField<Value = string>(
   return field as Field<Value>;
 }
 
+/**
+ * Converts a standard `Field<boolean>` into a `ChoiceField` that is compatible
+ * with `<Checkbox />` and `<RadioButton />` components in `@shopify/polaris`.
+ *
+ * For fields that are used by both a choice components and other components, it
+ * can be beneficial to retain the original `Field<boolean>` shape and convert
+ * the field on the fly for the choice component.
+ *
+ * ```typescript
+ * const enabled = useField(false);
+ * return (<Checkbox label="Enabled" {...asChoiceField(enabled)} />);
+ * ```
+ */
+export function asChoiceField({value: checked, ...fieldData}: Field<boolean>) {
+  return {
+    checked,
+    ...fieldData,
+  };
+}
+
+export type ChoiceField = ReturnType<typeof asChoiceField>;
+
+/**
+ * A simplification to `useField` that returns a `ChoiceField` by automatically
+ * converting the field using `asChoiceField` for direct use in choice
+ * components.
+ *
+ * ```typescript
+ * const enabled = useChoiceField(false);
+ * return (<Checkbox label="Enabled" {...enabled} />);
+ * ```
+ */
+export function useChoiceField(
+  input: FieldConfig<boolean> | boolean,
+  dependencies: unknown[] = [],
+) {
+  return asChoiceField(useField(input, dependencies));
+}
+
 function normalizeFieldConfig<Value>(
   input: FieldConfig<Value> | Value,
 ): FieldConfig<Value> {

--- a/packages/react-form/src/hooks/field/index.ts
+++ b/packages/react-form/src/hooks/field/index.ts
@@ -1,4 +1,10 @@
-export {useField, FieldConfig} from './field';
+export {
+  asChoiceField,
+  ChoiceField,
+  useChoiceField,
+  useField,
+  FieldConfig,
+} from './field';
 export {
   reduceField,
   FieldAction,

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import faker from 'faker';
 import {mount} from '@shopify/react-testing';
-import {useField, FieldConfig} from '../field';
+import {asChoiceField, useChoiceField, useField, FieldConfig} from '../field';
 
 describe('useField', () => {
   function TestField({config}: {config: string | FieldConfig<string>}) {
@@ -457,6 +457,42 @@ describe('useField', () => {
 
         expect(wrapper).not.toContainReactComponent('p');
       });
+    });
+  });
+});
+
+describe('asChoiceField', () => {
+  it('replaces value with checked', () => {
+    expect(asChoiceField({value: true} as any)).toMatchObject({checked: true});
+  });
+});
+
+describe('useChoiceField', () => {
+  it('returns a field that has been converted using asChoiceField', () => {
+    function Placeholder(_props: any) {
+      return null;
+    }
+
+    function TestField() {
+      const field = useChoiceField(true);
+
+      return <Placeholder field={field} />;
+    }
+
+    const wrapper = mount(<TestField />);
+
+    expect(wrapper.find(Placeholder)!.prop('field')).toMatchObject({
+      checked: true,
+      defaultValue: true,
+      dirty: false,
+      error: undefined,
+      newDefaultValue: expect.any(Function),
+      onBlur: expect.any(Function),
+      onChange: expect.any(Function),
+      reset: expect.any(Function),
+      runValidation: expect.any(Function),
+      setError: expect.any(Function),
+      touched: false,
     });
   });
 });

--- a/packages/react-form/src/hooks/index.ts
+++ b/packages/react-form/src/hooks/index.ts
@@ -1,4 +1,10 @@
-export {useField, FieldConfig} from './field';
+export {
+  asChoiceField,
+  ChoiceField,
+  useChoiceField,
+  useField,
+  FieldConfig,
+} from './field';
 export {useList} from './list';
 export {useForm} from './form';
 export {useSubmit, submitSuccess, submitFail} from './submit';

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -2,6 +2,9 @@ export * from './types';
 export * from './validation';
 
 export {
+  asChoiceField,
+  ChoiceField,
+  useChoiceField,
   useField,
   FieldConfig,
   useList,


### PR DESCRIPTION
## Description

Fixes #673
Related to https://github.com/Shopify/web/pull/18953

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Migrating the `asChoiceField` utility function that has been living in `web` for a while now to quilt, which simplifies spreading the field into a `Checkbox` or `RadioButton.

I have simplified these two utility functions a bit by just aliasing `value` to `checked` instead of performing a `Boolean(value)` cast (which seemed redundant).

this new utility is used by spreading its result into the `Checkbox` or `RadioButton`.

For `react-form` we also now have a simplified `useChoiceField` hook that will automatically perform the conversion which simplifies the API for consumers that only use the choice field for choice components.

```tsx
const field = useField(false);
const choiceField = useChoiceField(false);

return (
  <>
    <Checkbox label="Enabled" {...asChoiceField(field)} />
    <Checkbox label="Enabled" {...choiceField} />
  </>
);
```

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-form` and `react-form-state` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
