### PR TITLE
remove ensyme from a few packages

### DIFF
--- a/packages/react-async/src/tests/PrefetchRoute.test.tsx
+++ b/packages/react-async/src/tests/PrefetchRoute.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {mount} from '@shopify/react-testing';
 
 import {PrefetchContext} from '../context/prefetch';
 import {PrefetchRoute} from '../PrefetchRoute';

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -30,8 +30,5 @@
   "peerDependencies": {
     "react": "^16.3.2"
   },
-  "devDependencies": {
-    "@shopify/react-testing": "^1.7.3"
-  },
   "sideEffects": false
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -31,7 +31,7 @@
     "react": "^16.3.2"
   },
   "devDependencies": {
-    "@types/enzyme": "^3.1.10"
+    "@shopify/react-testing": "^1.7.3"
   },
   "sideEffects": false
 }

--- a/packages/react-compose/src/test/compose.test.tsx
+++ b/packages/react-compose/src/test/compose.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {mount} from '@shopify/react-testing';
 
 import compose from '..';
 
@@ -12,9 +12,8 @@ describe('react-compose-enhancers', () => {
       )(ClassicalComponent);
 
       const result = mount(<Component baz="baz" />);
-      const wrappedComponent = result.find(ClassicalComponent);
 
-      expect(wrappedComponent.exists()).toBe(true);
+      expect(result).toContainReactComponent(ClassicalComponent);
     });
 
     it('passes props on the wrapper down to the wrapped component', () => {
@@ -25,9 +24,10 @@ describe('react-compose-enhancers', () => {
 
       const expectedBaz = 'test';
       const result = mount(<Component baz={expectedBaz} />);
-      const actualBaz = result.find(ClassicalComponent).prop('baz');
 
-      expect(actualBaz).toBe(expectedBaz);
+      expect(result).toContainReactComponent(ClassicalComponent, {
+        baz: expectedBaz,
+      });
     });
 
     it('injects props from all enhancers passed to it to the resulting component', () => {
@@ -42,9 +42,8 @@ describe('react-compose-enhancers', () => {
         baz: 'baz',
       };
       const result = mount(<Component baz={expectedProps.baz} />);
-      const actualProps = result.find(ClassicalComponent).props();
 
-      expect(actualProps).toStrictEqual(expectedProps);
+      expect(result).toContainReactComponent(ClassicalComponent, expectedProps);
     });
 
     it('hoists static members to wrapper class', () => {
@@ -65,9 +64,8 @@ describe('react-compose-enhancers', () => {
       )(StatelessComponent);
 
       const result = mount(<Component baz="baz" />);
-      const wrappedComponent = result.find(StatelessComponent);
 
-      expect(wrappedComponent.exists()).toBe(true);
+      expect(result).toContainReactComponent(StatelessComponent);
     });
 
     it('passes props on the wrapper down to the wrapped component', () => {
@@ -78,9 +76,10 @@ describe('react-compose-enhancers', () => {
 
       const expectedBaz = 'test';
       const result = mount(<Component baz={expectedBaz} />);
-      const actualBaz = result.find(StatelessComponent).prop('baz');
 
-      expect(actualBaz).toBe(expectedBaz);
+      expect(result).toContainReactComponent(StatelessComponent, {
+        baz: expectedBaz,
+      });
     });
 
     it('injects props from all enhancers passed to it to the resulting component', () => {
@@ -95,9 +94,8 @@ describe('react-compose-enhancers', () => {
         baz: 'baz',
       };
       const result = mount(<Component baz={expectedProps.baz} />);
-      const actualProps = result.find(StatelessComponent).props();
 
-      expect(actualProps).toStrictEqual(expectedProps);
+      expect(result).toContainReactComponent(StatelessComponent, expectedProps);
     });
   });
 });

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@shopify/enzyme-utilities": "^2.1.4",
+    "@shopify/useful-types": "^1.3.0",
     "@types/enzyme": "^3.1.10",
     "faker": "^4.1.0"
   },

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@shopify/enzyme-utilities": "^2.1.4",
     "@shopify/useful-types": "^1.3.0",
-    "@types/enzyme": "^3.1.10",
     "faker": "^4.1.0"
   },
   "sideEffects": false

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import faker from 'faker';
-import {mount} from 'enzyme';
-import {trigger} from '@shopify/enzyme-utilities';
+import {mount} from '@shopify/react-testing';
 
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {Input} from '../../tests/components';
@@ -87,7 +86,7 @@ describe('<FormState.List />', () => {
     );
 
     const input = form.find(Input);
-    trigger(input, 'onChange', newTitle);
+    input.trigger('onChange', newTitle);
 
     const {fields} = lastCallArgs(renderPropSpy);
     expect(fields.products.value[0].title).toBe(newTitle);
@@ -127,11 +126,11 @@ describe('<FormState.List />', () => {
       <FormState initialValues={{products}}>{renderPropSpy}</FormState>,
     );
 
-    const titleInput = form.find(Input).first();
-    trigger(titleInput, 'onChange', newTitle);
+    const titleInput = form.find(Input);
+    titleInput.trigger('onChange', newTitle);
 
-    const priceInput = form.find(Input).at(1);
-    trigger(priceInput, 'onChange', newPrice);
+    const priceInput = form.findAll(Input)[1];
+    priceInput.trigger('onChange', newPrice);
 
     const {fields} = lastCallArgs(renderPropSpy);
     expect(fields.products.value[0].title).toBe(newTitle);

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import faker from 'faker';
-import {mount} from 'enzyme';
-import {trigger} from '@shopify/enzyme-utilities';
+import {mount} from '@shopify/react-testing';
 
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {Input} from '../../tests/components';
@@ -69,8 +68,7 @@ describe('<Nested />', () => {
       <FormState initialValues={{product}}>{renderPropSpy}</FormState>,
     );
 
-    const input = form.find(Input);
-    trigger(input, 'onChange', newTitle);
+    form.find(Input)!.trigger('onChange', newTitle);
 
     const {fields} = lastCallArgs(renderPropSpy);
     expect(fields.product.value.title).toBe(newTitle);

--- a/packages/react-form-state/src/tests/components/Input.tsx
+++ b/packages/react-form-state/src/tests/components/Input.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Omit} from '@shopify/useful-types';
 
 export interface Props {
   onChange?(value: string): void;
@@ -6,7 +7,7 @@ export interface Props {
 }
 
 export default class Input extends React.PureComponent<
-  Props & React.InputHTMLAttributes<any>,
+  Props & Omit<React.InputHTMLAttributes<any>, 'onChange'>,
   never
 > {
   render() {

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -26,6 +26,9 @@
     "serialize-javascript": "^1.5.0",
     "tslib": "^1.9.3"
   },
+  "devDependencies": {
+    "@shopify/react-testing": "^1.7.9"
+  },
   "peerDependencies": {
     "react": "^16.0.0"
   },

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -26,9 +26,6 @@
     "serialize-javascript": "^1.5.0",
     "tslib": "^1.9.3"
   },
-  "devDependencies": {
-    "@shopify/react-testing": "^1.7.9"
-  },
   "peerDependencies": {
     "react": "^16.0.0"
   },

--- a/packages/react-serialize/src/tests/Serializer.test.tsx
+++ b/packages/react-serialize/src/tests/Serializer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {shallow} from 'enzyme';
 import serialize from 'serialize-javascript';
+import {mount} from '@shopify/react-testing';
 
 import Serializer from '../Serializer';
 import {serializedID} from '../utilities';
@@ -9,15 +9,16 @@ describe('<Serializer />', () => {
   const id = 'MyData';
 
   it('generates a script tag with a JSON content type', () => {
-    const serializer = shallow(<Serializer id={id} data={{}} />);
-    expect(serializer.find('script')).toHaveLength(1);
-    expect(serializer.find('script').prop('type')).toBe('text/json');
+    const serializer = mount(<Serializer id={id} data={{}} />);
+    expect(serializer).toContainReactComponentTimes('script', 1, {
+      type: 'text/json',
+    });
   });
 
   describe('id', () => {
     it('is used as part of the ID for the script', () => {
-      const serializer = shallow(<Serializer id={id} data={{}} />);
-      expect(serializer.find('script').prop('id')).toBe(serializedID(id));
+      const serializer = mount(<Serializer id={id} data={{}} />);
+      expect(serializer.find('script')!.prop('id')).toBe(serializedID(id));
     });
   });
 
@@ -27,18 +28,18 @@ describe('<Serializer />', () => {
         foo: {bar: {baz: 'window.location = "http://dangerous.com"'}},
       };
 
-      const serializer = shallow(<Serializer id={id} data={data} />);
+      const serializer = mount(<Serializer id={id} data={data} />);
       expect(
-        serializer.find('script').prop('dangerouslySetInnerHTML'),
+        serializer.find('script')!.prop('dangerouslySetInnerHTML'),
       ).toHaveProperty('__html', serialize(data));
     });
   });
 
   describe('details', () => {
     it('does not include a data attribute with details if none are passed', () => {
-      const serializer = shallow(<Serializer id={id} data={{}} />);
+      const serializer = mount(<Serializer id={id} data={{}} />);
       expect(
-        serializer.find('script').prop('data-serialized-details'),
+        serializer.find('script')!.data('serialized-details'),
       ).toBeUndefined();
     });
 
@@ -47,10 +48,10 @@ describe('<Serializer />', () => {
         foo: {bar: {baz: 'window.location = "http://dangerous.com"'}},
       };
 
-      const serializer = shallow(
+      const serializer = mount(
         <Serializer id={id} data={{}} details={details} />,
       );
-      expect(serializer.find('script').prop('data-serialized-details')).toBe(
+      expect(serializer.find('script')!.data('serialized-details')).toBe(
         serialize(details),
       );
     });


### PR DESCRIPTION
## Description

This PR removes some lingering `enzyme` from a the following packages:

`react-async`
`react-serialize`
`react-compose`
`react-form-state`

I happened to be in here fixing some extraneous dependency violations for `enzyme` and found it easy enough to just remove it.

