### PR TITLE
Fix @shopify/react-router <Link /> component

### DIFF
--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -8,7 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Fix Redirect component
-- <Link /> add new prop for children
+- Fix <Link /> component to accept a children prop to delegate to the underlying link from `react-router`. [1073](https://github.com/Shopify/quilt/pull/1073)
 
 ## [0.0.4] - 2019-09-05
 

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -8,7 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Fix Redirect component
-- Fix <Link /> component to accept a children prop to delegate to the underlying link from `react-router`. [1073](https://github.com/Shopify/quilt/pull/1073)
+- Fix <Link /> component to explicitly accept a children prop to delegate to the underlying link from `react-router`. [1073](https://github.com/Shopify/quilt/pull/1073)
 
 ## [0.0.4] - 2019-09-05
 

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Fix Redirect component
+- <Link /> add new prop for children
 
 ## [0.0.4] - 2019-09-05
 

--- a/packages/react-router/src/components/Link/Link.tsx
+++ b/packages/react-router/src/components/Link/Link.tsx
@@ -4,9 +4,10 @@ import {Link as ReactRouterLink} from 'react-router-dom';
 export interface Props {
   external?: boolean;
   url: string;
+  children?: React.ReactNode;
 }
 
-export default function Link({url, external, ...rest}: Props) {
+export default function Link({url, external, children, ...rest}: Props) {
   let target: string | undefined;
   let rel: string | undefined;
   if (external) {
@@ -14,5 +15,9 @@ export default function Link({url, external, ...rest}: Props) {
     rel = 'noopener noreferrer';
   }
 
-  return <ReactRouterLink target={target} to={url} rel={rel} {...rest} />;
+  return (
+    <ReactRouterLink target={target} to={url} rel={rel} {...rest}>
+      {children}
+    </ReactRouterLink>
+  );
 }


### PR DESCRIPTION
## Description

This PR applies a small fix to the `<Link />` that explicitly gives it a children prop. Without this change the component would get type errors if you just tried to render it like a normal component such as `<Link url="">Some text</Link>`.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-router` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
