### PR TITLE
[shopify/performance] Update README with cleanup instructions

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the README to include instructions on cleaning up listeners from `performance.on` [[#1081](https://github.com/Shopify/quilt/pull/1081)]
+
 ## [1.1.2] - 2019-03-27
 
 ### Fixed

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -44,6 +44,14 @@ performance.on('inflightNavigation', () => {});
 performance.on('lifecycleEvent', event => {});
 ```
 
+The `on` method returns a clean-up function that you can invoke when you're done listening on the event:
+
+```ts
+const cleanupNavigationListener = performance.on('navigation', navigation => {});
+
+cleanupNavigationListener();
+```
+
 You can also manage navigations using this object. Calling `performance.start()` will begin a new navigation, cancelling any that are currently inflight. `performance.event()` allows you to register custom events on the navigation. Finally, `performance.finish()` marks the navigation is complete.
 
 ```ts


### PR DESCRIPTION
## Description

There were no instructions in the README on how to cleanup the listeners that are created from `performance.on()`. 

This PR adds in a line about how to cleanup these listeners.

## Type of change

- [x] Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
