### PR TITLE
✨ React performance

### DIFF
--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## Added
+
+- Added the `Connection` class for to allow mocking `navigator.connection` in tests
+
 ## [2.7.1] - 2019-07-03
 
 ### Fixed

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -95,6 +95,7 @@ The following standard mocks are available:
 - `promise`
 - `intersectionObserver`
 - `dimension`
+- `connection`
 
 Each of the standard mocks can be installed, for a given test, using `standardMock.mock()`, and must be restored before the end of the test using `standardMock.restore()`.
 

--- a/packages/jest-dom-mocks/src/connection.ts
+++ b/packages/jest-dom-mocks/src/connection.ts
@@ -1,0 +1,55 @@
+import {set} from './utilities';
+
+export interface NavigatorWithConnection extends Navigator {
+  connection: {
+    downlink: number;
+    effectiveType: string;
+    onchange: null | Function;
+    rtt: number;
+    saveData: boolean;
+  };
+}
+
+export class Connection {
+  private isUsingMockConnection = false;
+  private originalConnection?: NavigatorWithConnection['connection'];
+
+  mock(timing: Partial<NavigatorWithConnection['connection']> = {}) {
+    const globalNavigator = navigator as NavigatorWithConnection;
+    if (this.isUsingMockConnection) {
+      throw new Error(
+        'You tried to mock navigator.connection when it was already mocked.',
+      );
+    }
+
+    this.originalConnection = globalNavigator.connection;
+
+    const mockConnection: NavigatorWithConnection['connection'] = {
+      downlink: 0,
+      effectiveType: '3g',
+      onchange: null,
+      rtt: 100,
+      saveData: false,
+      ...timing,
+    };
+
+    set(globalNavigator, 'connection', mockConnection);
+    this.isUsingMockConnection = true;
+  }
+
+  restore() {
+    const globalNavigator = navigator as NavigatorWithConnection;
+    if (!this.isUsingMockConnection) {
+      throw new Error(
+        'You tried to restore navigator.connection when it was already restored.',
+      );
+    }
+
+    set(globalNavigator, 'connection', this.originalConnection);
+    this.isUsingMockConnection = false;
+  }
+
+  isMocked() {
+    return this.isUsingMockConnection;
+  }
+}

--- a/packages/jest-dom-mocks/src/index.ts
+++ b/packages/jest-dom-mocks/src/index.ts
@@ -10,6 +10,9 @@ import UserTiming from './user-timing';
 import IntersectionObserver from './intersection-observer';
 import Promise from './promise';
 import Dimension from './dimension';
+import {Connection} from './connection';
+
+export const connection = new Connection();
 
 export const animationFrame = new AnimationFrame();
 export const requestIdleCallback = new RequestIdleCallback();
@@ -56,6 +59,7 @@ const mocksToEnsureReset = {
   matchMedia,
   userTiming,
   intersectionObserver,
+  connection,
 };
 
 export function ensureMocksReset() {

--- a/packages/jest-dom-mocks/src/test/connection.test.ts
+++ b/packages/jest-dom-mocks/src/test/connection.test.ts
@@ -1,0 +1,53 @@
+import {Connection, NavigatorWithConnection} from '../connection';
+
+describe('Connection', () => {
+  describe('mock', () => {
+    it('sets isMocked()', () => {
+      const connection = new Connection();
+      connection.mock();
+
+      expect(connection.isMocked()).toBe(true);
+    });
+
+    it('throws if it is already mocked', () => {
+      const connection = new Connection();
+      connection.mock();
+
+      expect(() => {
+        connection.mock();
+      }).toThrow();
+    });
+
+    it('delegates stubbed options to navigator.connection', () => {
+      const connection = new Connection();
+      const mockValues = {
+        effectiveType: '4g',
+        rtt: 32,
+      };
+
+      connection.mock(mockValues);
+
+      expect((navigator as NavigatorWithConnection).connection).toMatchObject(
+        mockValues,
+      );
+    });
+  });
+
+  describe('restore', () => {
+    it('sets isMocked', () => {
+      const connection = new Connection();
+      connection.mock();
+      connection.restore();
+
+      expect(connection.isMocked()).toBe(false);
+    });
+
+    it('throws if it has not yet been mocked', () => {
+      const connection = new Connection();
+
+      expect(() => {
+        connection.restore();
+      }).toThrow();
+    });
+  });
+});

--- a/packages/jest-dom-mocks/src/user-timing.ts
+++ b/packages/jest-dom-mocks/src/user-timing.ts
@@ -1,4 +1,4 @@
-import set from 'lodash/set';
+import {set} from './utilities';
 
 type UserTimingMock = typeof window.performance.timing;
 

--- a/packages/jest-dom-mocks/src/utilities.ts
+++ b/packages/jest-dom-mocks/src/utilities.ts
@@ -1,0 +1,3 @@
+export function set(object: any, key: string, value: any) {
+  object[key] = value;
+}

--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -11,6 +11,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Updated the README to include instructions on cleaning up listeners from `performance.on` [[#1081](https://github.com/Shopify/quilt/pull/1081)]
 
+## Added
+
+- Added a new API `mark` to the `Performance` class. This encapsulates both checking for `supportsMarks` and calling `window.performance.mark` into one call.
+
 ## [1.1.2] - 2019-03-27
 
 ### Fixed

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -171,6 +171,12 @@ export class Performance {
     }
   }
 
+  mark(stage: string, id: string) {
+    if (this.supportsMarks) {
+      window.performance.mark(`${id}::${stage}`);
+    }
+  }
+
   on<T extends keyof EventMap>(event: T, handler: EventMap[T]) {
     const handlers = this.eventHandlers[event] as Set<any>;
     handlers.add(handler);

--- a/packages/react-performance/CHANGELOG.md
+++ b/packages/react-performance/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/react-performance` package

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -1,0 +1,261 @@
+# `@shopify/react-performance`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-performance.svg)](https://badge.fury.io/js/%40shopify%2Freact-performance.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-performance.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-performance.svg)
+
+Primitives to measure your React application's performance using `@shopify/performance`
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-performance
+```
+
+## Quick-start
+
+### Basic
+
+The most basic way to use the tools in this package is to record information and display it locally to the user. In practice you usually only want to do this in development so that developers can easily see performance information.
+
+#### Add the context provider
+
+Before we can use any of the components or hooks in the package we must wrap our app tree with the `PerformanceContext.Provider` component.
+
+```tsx
+// App.tsx
+import React from 'react';
+import {Performance, PerformanceContext} from '@shopify/react-performance';
+
+// in a Server-Side-Rendering enabled app you will likely only want to instantiate this if `document` is defined.
+const performance = new Performance();
+
+function App() {
+  return (
+    <PerformanceContext.Provider value={performance}>
+      {/* The rest of your app */}
+    </PerformanceContext.Provider>
+  );
+}
+```
+
+#### Display data using NavigationListener
+
+Now that we have access to `PerformanceContext` we can use the other components and hooks offered by `@shopify/react-performance` anywhere in our tree. To demonstrate, we'll create a component called `LastNavigationDetails` and use it to display some basic data about our app's performance.
+
+```tsx
+// LastNavigationDetails.tsx
+import React, {useState} from 'react';
+import {useNavigationListener, Navigation} from '@shopify/react-performance';
+
+export function LastNavigationDetails() {
+  const [lastNavigation, setLastNavigation] = useState<Navigation | null>(null);
+
+  useNavigationListener(navigation => {
+    setLastNavigation(navigation);
+  });
+
+  if (lastNavigation == null) {
+    return <p>no data</p>;
+  }
+
+  const {duration, isFullPageNavigation, target};
+  const navigationType = isFullPageNavigation
+    ? 'full page navigation'
+    : 'single-page-app style navigation';
+  return (
+    <p>
+      The last navigation was to {target}. It was a {navigationType} navigation
+      which took {duration / 1000} seconds to complete.
+    </p>
+  );
+}
+```
+
+We can render this component anywhere in our tree, but lets do so in our App component from earlier.
+
+```tsx
+// App.tsx
+import React from 'react';
+import {Performance, PerformanceContext} from '@shopify/react-performance';
+import {LastNavigationDetails} from './LastNavigationDetails';
+
+// in a Server-Side-Rendering enabled app you will likely only want to instantiate this if `document` is defined.
+const performance = new Performance();
+
+function App() {
+  return (
+    <PerformanceContext.Provider value={performance}>
+      {/* The rest of your app */}
+      <LastNavigationDetails />
+    </PerformanceContext.Provider>
+  );
+}
+```
+
+Now our developers will have access to up-to-date information about how long initial page-loads and incremental navigations take to complete without needing to open their devtools or dig into DOM APIs manually.
+
+### Reporting data to the server
+
+Performance metrics data is most useful when it can be aggregated and used to make smart optimization decisions or warn you when your app is beginning to become slow. To aggregate such data you'll need to be able to send it to a server. `@shopify/react-performance` provides the `PerformanceReport` component to facilitate this.
+
+> This section is a work in progress. It will be filled out as helper libraries for marshalling data on the server are added to Quilt.
+
+## API
+
+Most APIs provided by this package are available as both hooks (ie. `useNavigationListener`), as well as components (ie. `<NavigationListener />`).
+
+This package also re-exports all of the API of [`@shopify/performance`](https://www.npmjs.com/package/@shopify/performance).
+
+### Hooks
+
+#### useLifecycleEventListener
+
+A custom hook which takes in callback to invoke whenever the `Performance` context object emits a lifecycleEvent.
+
+```tsx
+import {useLifecycleEventListener} from '@shopify/react-performance';
+
+function SomeComponent() {
+  useLifecycleEventListener(event => {
+    console.log(event);
+  });
+
+  return <div>something</div>;
+}
+```
+
+#### useNavigationListener
+
+A custom hook which takes in a callback to invoke whenever a navigation takes place, whether it is a full-page load (such as the result of `location.assign`) or an incrmental load (such as the result of `router.push` in a ReactRouter app).
+
+```tsx
+import {useNavigationListener} from '@shopify/react-performance';
+
+function SomeComponent() {
+  useNavigationListener(navigation => {
+    console.log(navigation);
+  });
+
+  return <div>something</div>;
+}
+```
+
+#### usePerformanceMark
+
+A custom hook which takes an `id` and `stage` and uses them to generate a tag for a call to `window.performance.mark` when the component is mounted. This can be used to mark specialized moments in your applications startup, or a specific interaction.
+
+```tsx
+import React from 'react';
+import {usePerformanceMark} from '@shopify/react-performance';
+
+function SomeComponent() {
+  usePerformanceMark('some-stage', 'some-id');
+
+  return <div>something</div>;
+}
+```
+
+If the hook is called with a `stage` of `usable` or `complete`, it also calls the appropriate method on the `Performance` object from context, allowing you to trigger the `finish` and `usable` lifecycleEvents based on a particular component mounting.
+
+```tsx
+import React from 'react';
+import {usePerformanceMark} from '@shopify/react-performance';
+
+function ProductPage() {
+  // this will call `performance.finish()` on the Performance object in context
+  usePerformanceMark('complete', 'products');
+
+  return <div>cool product page</div>;
+}
+```
+
+#### usePerformanceReport
+
+> Todo
+
+### Components
+
+#### LifecycleEventListener
+
+A component which takes in an `onEvent` callback as a prop. This callback is invoked whenever the `Performance` context object emits a lifecycleEvent.
+
+```tsx
+import React from 'react';
+import {LifecycleEventListener} from '@shopify/react-performance';
+
+function SomeComponent() {
+  return (
+    <>
+      <LifecycleEventListener onEvent={event => console.log(event)} />
+      <div>something</div>
+    </>
+  );
+}
+```
+
+#### NavigationListener
+
+A component which takes in an `onNavigation` callback as a prop. This callback is invoked whenever the `Performance` context reports a navigation.
+
+```tsx
+import React from 'react';
+import {NavigationListener} from '@shopify/react-performance';
+
+function SomeComponent() {
+  return (
+    <>
+      <NavigationListener
+        onNavigation={navigation => console.log(navigation)}
+      />
+      <div>something</div>
+    </>
+  );
+}
+```
+
+#### PerformanceMark
+
+A componenr which takes both `id` and `stage` props and uses them to generate a tag for a call to `window.performance.mark` when it is mounted. This can be used to mark specialized moments in your applications startup, or a specific interaction.
+
+```tsx
+import React from 'react';
+import {PerformanceMark} from '@shopify/react-performance';
+
+function SomeComponent() {
+  return (
+    <>
+      <PerformanceMark stage="some-stage" id="some-id" />
+      <div>something</div>
+    </>
+  );
+}
+```
+
+If the hook is called with a `stage` of `usable` or `complete`, it also calls the appropriate method on the `Performance` object from context, allowing you to trigger the `finish` and `usable` lifecycleEvents based on a particular component mounting.
+
+```tsx
+import React from 'react';
+import {PerformanceMark} from '@shopify/react-performance';
+
+function ProductPage() {
+  import React from 'react';
+  import {PerformanceMark} from '@shopify/react-performance';
+
+  function ProductPage() {
+    return (
+      <>
+        <PerformanceMark stage="usable" id="ProductPage" />
+        <div>Some cool product page</div>
+      </>
+    );
+  }
+}
+```
+
+#### PerformanceContext
+
+A vanilla `React.createContext` object to provide a `Performance` class through your application's tree.
+
+#### PerformanceReport
+
+> Todo

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@shopify/react-performance",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Primitives to measure your React application&#x27;s performance using @shopify/performance",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-performance/README.md",
+  "dependencies": {
+    "@shopify/performance": "^1.1.8"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0 <17.0.0"
+  },
+  "devDependencies": {
+    "typescript": "~3.2.1"
+  },
+  "files": [
+    "dist/*"
+  ]
+}

--- a/packages/react-performance/src/LifecycleEventListener.tsx
+++ b/packages/react-performance/src/LifecycleEventListener.tsx
@@ -1,0 +1,13 @@
+import {
+  useLifecycleEventListener,
+  LifecycleEventListener as LifecycleEventListenerType,
+} from './lifecycle-event-listener';
+
+export function LifecycleEventListener({
+  onEvent,
+}: {
+  onEvent: LifecycleEventListenerType;
+}) {
+  useLifecycleEventListener(onEvent);
+  return null;
+}

--- a/packages/react-performance/src/NavigationListener.tsx
+++ b/packages/react-performance/src/NavigationListener.tsx
@@ -1,0 +1,14 @@
+import {
+  useNavigationListener,
+  NavigationListener as NavigationlistenerType,
+} from './navigation-listener';
+
+export function NavigationListener({
+  onNavigation,
+}: {
+  onNavigation: NavigationlistenerType;
+}) {
+  useNavigationListener(onNavigation);
+
+  return null;
+}

--- a/packages/react-performance/src/PerformanceMark.tsx
+++ b/packages/react-performance/src/PerformanceMark.tsx
@@ -1,0 +1,12 @@
+import {usePerformanceMark, Stage} from './performance-mark';
+
+interface Props {
+  id: string;
+  stage: Stage;
+}
+
+export function PerformanceMark({stage, id}: Props) {
+  usePerformanceMark(stage, id);
+
+  return null;
+}

--- a/packages/react-performance/src/PerformanceReport.tsx
+++ b/packages/react-performance/src/PerformanceReport.tsx
@@ -1,0 +1,12 @@
+import {usePerformanceReport, ErrorHandler} from './performance-report';
+
+interface Props {
+  url: string;
+  onError?: ErrorHandler;
+}
+
+export function PerformanceReport({url, onError}: Props) {
+  usePerformanceReport(url, {onError});
+
+  return null;
+}

--- a/packages/react-performance/src/context.ts
+++ b/packages/react-performance/src/context.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+import {Performance} from '@shopify/performance';
+
+export const PerformanceContext = React.createContext<Performance | undefined>(
+  undefined,
+);

--- a/packages/react-performance/src/index.ts
+++ b/packages/react-performance/src/index.ts
@@ -1,0 +1,19 @@
+export * from '@shopify/performance';
+
+export {PerformanceContext} from './context';
+export {
+  usePerformanceEffect,
+  PerformanceEffectCallback,
+} from './performance-effect';
+
+export {PerformanceMark} from './PerformanceMark';
+export {usePerformanceMark} from './performance-mark';
+
+export {LifecycleEventListener} from './LifecycleEventListener';
+export {useLifecycleEventListener} from './lifecycle-event-listener';
+
+export {NavigationListener} from './NavigationListener';
+export {useNavigationListener} from './navigation-listener';
+
+export {PerformanceReport} from './PerformanceReport';
+export {usePerformanceReport} from './performance-report';

--- a/packages/react-performance/src/lifecycle-event-listener.ts
+++ b/packages/react-performance/src/lifecycle-event-listener.ts
@@ -1,0 +1,13 @@
+import {LifecycleEvent} from '@shopify/performance';
+
+import {usePerformanceEffect} from './performance-effect';
+
+export interface LifecycleEventListener {
+  (event: LifecycleEvent): void;
+}
+
+export function useLifecycleEventListener(listener: LifecycleEventListener) {
+  usePerformanceEffect(performance =>
+    performance.on('lifecycleEvent', listener),
+  );
+}

--- a/packages/react-performance/src/navigation-listener.ts
+++ b/packages/react-performance/src/navigation-listener.ts
@@ -1,0 +1,11 @@
+import {Navigation} from '@shopify/performance';
+
+import {usePerformanceEffect} from './performance-effect';
+
+export interface NavigationListener {
+  (navigation: Navigation): void;
+}
+
+export function useNavigationListener(listener: NavigationListener) {
+  usePerformanceEffect(performance => performance.on('navigation', listener));
+}

--- a/packages/react-performance/src/performance-effect.ts
+++ b/packages/react-performance/src/performance-effect.ts
@@ -1,0 +1,31 @@
+import {useContext, useEffect} from 'react';
+import {Performance} from '@shopify/performance';
+
+import {PerformanceContext} from './context';
+
+export interface PerformanceEffectCallback {
+  (performance: Performance): VoidFunction | void;
+}
+
+export function usePerformanceEffect(
+  callback: PerformanceEffectCallback,
+  dependencies: unknown[] = [],
+) {
+  const performance = useContext(PerformanceContext);
+
+  useEffect(
+    () => {
+      if (performance == null) {
+        return;
+      }
+
+      const cleanup = callback(performance);
+
+      if (cleanup) {
+        return cleanup;
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [performance, ...dependencies],
+  );
+}

--- a/packages/react-performance/src/performance-mark.ts
+++ b/packages/react-performance/src/performance-mark.ts
@@ -1,0 +1,18 @@
+import {usePerformanceEffect} from './performance-effect';
+
+export type Stage = 'complete' | 'usable';
+
+export function usePerformanceMark(stage: Stage, id: string) {
+  usePerformanceEffect(
+    performance => {
+      if (stage === 'complete') {
+        performance.finish();
+      } else if (stage === 'usable') {
+        performance.usable();
+      }
+
+      performance.mark(stage, id);
+    },
+    [stage, id],
+  );
+}

--- a/packages/react-performance/src/performance-report.ts
+++ b/packages/react-performance/src/performance-report.ts
@@ -1,0 +1,91 @@
+import {useRef, useCallback} from 'react';
+import {Navigation, LifecycleEvent} from '@shopify/performance';
+import {Header, Method} from '@shopify/network';
+
+import {useNavigationListener} from './navigation-listener';
+import {useLifecycleEventListener} from './lifecycle-event-listener';
+
+export interface ErrorHandler {
+  (error: any): void;
+}
+
+export function usePerformanceReport(
+  url: string,
+  {onError = noop}: {onError?: ErrorHandler} = {},
+) {
+  const navigations = useRef<Navigation[]>([]);
+  const events = useRef<LifecycleEvent[]>([]);
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+
+  const sendReport = useCallback(
+    () => {
+      if (timeout.current != null) {
+        return;
+      }
+
+      timeout.current = setTimeout(async () => {
+        if (timeout.current) {
+          clearTimeout(timeout.current);
+          timeout.current = undefined;
+        }
+
+        try {
+          await fetch(url, {
+            method: Method.Post,
+            headers: {
+              [Header.ContentType]: 'application/json',
+            },
+            body: JSON.stringify({
+              connection: serializableClone((navigator as any).connection),
+              events: events.current,
+              navigations: navigations.current.map(navigation => ({
+                details: navigation.toJSON({removeEventMetadata: false}),
+                metadata: navigation.metadata,
+              })),
+              pathname: window.location.pathname,
+            }),
+          });
+        } catch (error) {
+          if (onError) {
+            onError(error);
+          }
+        } finally {
+          events.current = [];
+          navigations.current = [];
+        }
+      }, 1000);
+    },
+    [onError, url],
+  );
+
+  const onNavigation = useCallback(
+    (navigation: Navigation) => {
+      navigations.current.push(navigation);
+      sendReport();
+    },
+    [sendReport],
+  );
+
+  const onLifeCycleEvent = useCallback(
+    (event: LifecycleEvent) => {
+      events.current.push(event);
+      sendReport();
+    },
+    [sendReport],
+  );
+
+  useNavigationListener(onNavigation);
+  useLifecycleEventListener(onLifeCycleEvent);
+}
+
+function serializableClone<T>(object: T) {
+  const output: T = {} as any;
+  // We explicitly want to copy the inherited properties
+  // eslint-disable-next-line guard-for-in
+  for (const key in object) {
+    output[key] = object[key];
+  }
+  return output;
+}
+
+function noop() {}

--- a/packages/react-performance/src/test/LifecycleEventListener.test.tsx
+++ b/packages/react-performance/src/test/LifecycleEventListener.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {mockPerformance} from './utilities';
+import {LifecycleEventListener, PerformanceContext} from '..';
+
+describe('<LifecycleEventListener />', () => {
+  it('sets up a event listener on the Performance context object', () => {
+    const performance = mockPerformance();
+    const listener = jest.fn();
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <LifecycleEventListener onEvent={listener} />
+      </PerformanceContext.Provider>,
+    );
+
+    const event = performance.simulateLifecycleEvent();
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('cleans up the event listener when unmounted', () => {
+    const performance = mockPerformance();
+    const listener = jest.fn();
+
+    const wrapper = mount(
+      <PerformanceContext.Provider value={performance}>
+        <LifecycleEventListener onEvent={listener} />
+      </PerformanceContext.Provider>,
+    );
+
+    listener.mockClear();
+    wrapper.unmount();
+    performance.simulateLifecycleEvent();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-performance/src/test/NavigationListener.test.tsx
+++ b/packages/react-performance/src/test/NavigationListener.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {mockPerformance} from './utilities';
+import {NavigationListener, PerformanceContext} from '..';
+
+describe('<NavigationListener />', () => {
+  it('sets up a navigation listener on the Performance context object', () => {
+    const performance = mockPerformance();
+    const listener = jest.fn();
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <NavigationListener onNavigation={listener} />
+      </PerformanceContext.Provider>,
+    );
+
+    const navigation = performance.simulateNavigation();
+    expect(listener).toHaveBeenCalledWith(navigation);
+  });
+
+  it('cleans up the navigation listener when unmounted', () => {
+    const performance = mockPerformance();
+    const listener = jest.fn();
+
+    const wrapper = mount(
+      <PerformanceContext.Provider value={performance}>
+        <NavigationListener onNavigation={listener} />
+      </PerformanceContext.Provider>,
+    );
+
+    listener.mockClear();
+    wrapper.unmount();
+    performance.simulateNavigation();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-performance/src/test/PerformanceMark.test.tsx
+++ b/packages/react-performance/src/test/PerformanceMark.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {mockPerformance} from './utilities';
+import {PerformanceMark, PerformanceContext} from '..';
+
+describe('<PerformanceMark />', () => {
+  it('calls performance.mark', () => {
+    const performance = mockPerformance({mark: jest.fn()});
+    const stage = 'complete';
+    const id = 'test-id';
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <PerformanceMark stage={stage} id={id} />
+      </PerformanceContext.Provider>,
+    );
+
+    expect(performance.mark).toHaveBeenCalledWith(stage, id);
+  });
+
+  describe('when given a `stage` of `usable`', () => {
+    it('calls Performance.usable', () => {
+      const performance = mockPerformance({usable: jest.fn()});
+
+      mount(
+        <PerformanceContext.Provider value={performance}>
+          <PerformanceMark stage="usable" id="test-id" />
+        </PerformanceContext.Provider>,
+      );
+
+      expect(performance.usable).toHaveBeenCalled();
+    });
+  });
+
+  describe('when given a `stage` of `complete`', () => {
+    it('calls Performance.finish', () => {
+      const performance = mockPerformance({finish: jest.fn()});
+
+      mount(
+        <PerformanceContext.Provider value={performance}>
+          <PerformanceMark stage="complete" id="test-id" />
+        </PerformanceContext.Provider>,
+      );
+
+      expect(performance.finish).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-performance/src/test/PerformanceReport.test.tsx
+++ b/packages/react-performance/src/test/PerformanceReport.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import faker from 'faker';
+import {mount} from '@shopify/react-testing';
+import {fetch, timer, connection} from '@shopify/jest-dom-mocks';
+import {Method, Header} from '@shopify/network';
+
+import {mockPerformance, randomConnection} from './utilities';
+import {PerformanceReport, PerformanceContext} from '..';
+
+describe('<PerformanceReport />', () => {
+  beforeEach(() => {
+    timer.mock();
+    fetch.mock('*', 200);
+  });
+
+  afterEach(() => {
+    if (connection.isMocked()) {
+      connection.restore();
+    }
+    timer.restore();
+    fetch.restore();
+  });
+
+  it('sends a report to the given url when a navigation event occurs', () => {
+    const performance = mockPerformance();
+    const url = faker.internet.url();
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <PerformanceReport url={url} />
+      </PerformanceContext.Provider>,
+    );
+
+    const navigation = performance.simulateNavigation();
+    timer.runAllTimers();
+
+    const [fetchedUrl, {body, method, headers}] = fetch.lastCall();
+    expect(fetchedUrl).toBe(url);
+    expect(method).toBe(Method.Post);
+    expect(headers).toHaveProperty(Header.ContentType, 'application/json');
+    expect(JSON.parse(body!.toString())).toMatchObject({
+      navigations: [
+        {
+          details: navigation.toJSON({removeEventMetadata: false}),
+          metadata: navigation.metadata,
+        },
+      ],
+    });
+  });
+
+  it('sends a report to the given url when a lifeCycleEvent event occurs', () => {
+    const performance = mockPerformance();
+    const url = faker.internet.url();
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <PerformanceReport url={url} />
+      </PerformanceContext.Provider>,
+    );
+
+    const event = performance.simulateLifecycleEvent();
+    timer.runAllTimers();
+
+    const [fetchedUrl, {body, method, headers}] = fetch.lastCall();
+    expect(fetchedUrl).toBe(url);
+    expect(method).toBe(Method.Post);
+    expect(headers).toHaveProperty(Header.ContentType, 'application/json');
+    expect(JSON.parse(body!.toString())).toMatchObject({
+      events: [event],
+    });
+  });
+
+  it('batches multiple navigations and events into one report', () => {
+    const performance = mockPerformance();
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <PerformanceReport url={faker.internet.url()} />
+      </PerformanceContext.Provider>,
+    );
+
+    const navigations = [
+      performance.simulateNavigation(),
+      performance.simulateNavigation(),
+    ];
+    const events = [
+      performance.simulateLifecycleEvent(),
+      performance.simulateLifecycleEvent(),
+    ];
+    timer.runAllTimers();
+
+    const [, {body}] = fetch.lastCall();
+    const parsedBody = JSON.parse(body!.toString());
+
+    expect(parsedBody).toMatchObject({
+      events,
+      navigations: navigations.map(navigation => ({
+        details: navigation.toJSON({removeEventMetadata: false}),
+        metadata: navigation.metadata,
+      })),
+    });
+  });
+
+  it('includes connection details in reports', () => {
+    const performance = mockPerformance();
+    const mockConnection = randomConnection();
+    connection.mock(mockConnection);
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <PerformanceReport url={faker.internet.url()} />
+      </PerformanceContext.Provider>,
+    );
+
+    performance.simulateNavigation();
+    timer.runAllTimers();
+
+    const [, {body}] = fetch.lastCall();
+    expect(JSON.parse(body!.toString())).toMatchObject({
+      connection: mockConnection,
+    });
+  });
+});

--- a/packages/react-performance/src/test/performance-effect.test.tsx
+++ b/packages/react-performance/src/test/performance-effect.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {mockPerformance} from './utilities';
+import {
+  usePerformanceEffect,
+  PerformanceEffectCallback,
+  PerformanceContext,
+} from '..';
+
+describe('usePerformanceEffect', () => {
+  function TestComponent({callback}: {callback: PerformanceEffectCallback}) {
+    usePerformanceEffect(callback);
+    return <div>nothing of note ;P</div>;
+  }
+
+  it('does not call the given callback when there is no Performance in context', () => {
+    const spy = jest.fn();
+    mount(<TestComponent callback={spy} />);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('calls the given callback and passes in the Performance object when there is one in context', () => {
+    const performance = mockPerformance();
+    const spy = jest.fn();
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <TestComponent callback={spy} />
+      </PerformanceContext.Provider>,
+    );
+
+    expect(spy).toHaveBeenCalledWith(performance);
+  });
+
+  it('calls the function returned from the given callback when the component is unmounted', () => {
+    const performance = mockPerformance();
+    const spy = jest.fn();
+
+    const wrapper = mount(
+      <PerformanceContext.Provider value={performance}>
+        <TestComponent callback={() => spy} />
+      </PerformanceContext.Provider>,
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    wrapper.unmount();
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/packages/react-performance/src/test/utilities.ts
+++ b/packages/react-performance/src/test/utilities.ts
@@ -1,0 +1,137 @@
+import faker from 'faker';
+import {
+  Navigation,
+  NavigationResult,
+  Performance,
+  LifecycleEvent,
+  EventType,
+} from '@shopify/performance';
+import {NavigationListener} from '../navigation-listener';
+import {LifecycleEventListener} from '../lifecycle-event-listener';
+
+interface TestInterface {
+  simulateNavigation(navigation?: Navigation): Navigation;
+  simulateLifecycleEvent(event?: LifecycleEvent): LifecycleEvent;
+}
+
+type Event = 'navigation' | 'inflightNavigation' | 'lifecycleEvent';
+
+export function mockPerformance(
+  stubs: Partial<Performance> = {},
+): Performance & TestInterface {
+  let navigationListeners: NavigationListener[] = [];
+  let lifecycleEventListeners: LifecycleEventListener[] = [];
+
+  const {on, ...otherStubs} = stubs;
+
+  return {
+    on: (
+      type: Event,
+      listener: NavigationListener | LifecycleEventListener,
+    ) => {
+      if (type === 'navigation') {
+        navigationListeners.push(listener as NavigationListener);
+      } else if (type === 'lifecycleEvent') {
+        lifecycleEventListeners.push(listener as LifecycleEventListener);
+      }
+
+      const customCleanup = on && on(type, listener);
+
+      return () => {
+        if (type === 'navigation') {
+          navigationListeners = navigationListeners.filter(
+            item => item !== listener,
+          );
+        } else if (type === 'lifecycleEvent') {
+          lifecycleEventListeners = lifecycleEventListeners.filter(
+            item => item !== listener,
+          );
+        }
+
+        if (customCleanup) {
+          customCleanup();
+        }
+      };
+    },
+    mark: noop,
+    finish: noop,
+    usable: noop,
+    ...otherStubs,
+    simulateNavigation(navigation: Navigation = mockNavigation()) {
+      navigationListeners.forEach(listener => {
+        listener(navigation);
+      });
+
+      return navigation;
+    },
+    simulateLifecycleEvent(event: LifecycleEvent = mockLifecycleEvent()) {
+      lifecycleEventListeners.forEach(listener => {
+        listener(event);
+      });
+
+      return event;
+    },
+  } as any;
+}
+
+export function mockLifecycleEvent(): LifecycleEvent {
+  return {
+    type: randomLifecycleEventType(),
+    start: faker.random.number(),
+    duration: faker.random.number(),
+  } as any;
+}
+
+export function randomLifecycleEventType() {
+  const types = [
+    EventType.TimeToFirstByte,
+    EventType.TimeToFirstPaint,
+    EventType.TimeToFirstContentfulPaint,
+    EventType.DomContentLoaded,
+    EventType.FirstInputDelay,
+    EventType.Load,
+  ];
+
+  return faker.random.arrayElement(types) as LifecycleEvent['type'];
+}
+
+export function mockNavigation() {
+  return new Navigation(
+    {
+      start: faker.random.number({min: 0, max: 100000}),
+      duration: faker.random.number({min: 0, max: 100000}),
+      target: faker.internet.url(),
+      events: [],
+      result: randomNavigationResult(),
+    },
+    {
+      index: faker.random.number(),
+      supportsDetailedEvents: faker.random.boolean(),
+      supportsDetailedTime: faker.random.boolean(),
+    },
+  );
+}
+
+export function randomNavigationResult() {
+  const resultTypes = [
+    NavigationResult.Cancelled,
+    NavigationResult.Finished,
+    NavigationResult.TimedOut,
+  ];
+
+  return faker.random.arrayElement(resultTypes);
+}
+
+export function noop() {}
+
+export function randomConnection() {
+  const effectiveTypes = ['2g', '3g', '4g'];
+
+  return {
+    downlink: faker.random.number(),
+    effectiveType: faker.random.arrayElement(effectiveTypes),
+    onchange: null,
+    rtt: faker.random.number(),
+    saveData: faker.random.boolean(),
+  };
+}

--- a/packages/react-performance/tsconfig.build.json
+++ b/packages/react-performance/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Description
This PR adds `@shopify/react-performance`,  a library built on top of `@shopify/performance`, and pulled as-is out of the updated version of these components from https://github.com/Shopify/web/pull/18972.

This ends up being a pretty big diff but the actual runtime code is all currently running in production in web, so all you should need to review are the tests and docs, as well as the tweaks to our mocks to make them work.

### Changes of note from the version in web
- the tests are totally new
- had to add a `navigator.connection` mock to `jest-dom-mocks` to facilitate the tests
- the docs are new, incomplete
- added `mark` to `@shopify/performance`'s `Performance` class since it seemed weird to randomly call out to the window primitive after checking `supportsMarks`, and this makes things easier to test anyway

## Checklist
- [x] I have added a changelog entry, prefixed by the type of change noted above
