### PR TITLE
react-server: add missing dependency

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.3] - 2019-09-30
+
+- Added missing `@shopify/react-cookie` dependency
+
 ## [0.7.0] - 2019-09-12
 
 - Added universal cookies support using `@shopify/react-cookie`. [#1002](https://github.com/Shopify/quilt/pull/1002)

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -32,6 +32,7 @@
     "@shopify/react-hydrate": "^1.1.4",
     "@shopify/react-network": "^3.3.1",
     "@shopify/sewing-kit-koa": "^6.1.2",
+    "@shopify/react-cookie": "^0.0.2",
     "chalk": "^2.4.2",
     "koa": "^2.5.0",
     "koa-compose": "^4.1.0",


### PR DESCRIPTION
## Description

Adds the missing `react-cookie` dependency to `react-server`.

- [x] `react-server` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
