### PR TITLE
adding enzyme-like .debug() feature to Node instances

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- new `debug()` function added to `Root` and `Element` to inspect mounted structure ([#1088](https://github.com/Shopify/quilt/pull/1088))
 
 ## [1.7.10] - 2019-09-30
 

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -11,6 +11,7 @@ A library for testing React components according to [Shopify conventions](https:
 1. [Usage](#usage)
    1. [`Root`](#root)
    1. [`Element`](#element)
+   1. [`debug()`](#debug)
    1. [`mount()`](#mount)
    1. [`createMount()`](#createMount)
    1. [`destroyAll()`](#destroyAll)
@@ -292,6 +293,48 @@ const myComponent = mount(
 );
 myComponent.triggerKeypath('action.onAction');
 expect(spy).toHaveBeenCalled();
+```
+
+### <a name="debug"></a> `debug(options?: {allProps?: boolean, depth?: number, verbosity?: number}): string`
+
+Returns a text representation of either the root node, or any element within the mounted graph. `debug()` output can be tweaked using the `options` parameter.
+
+- `allProps` overrides the default props filtering behaviour and instead includes all props in the output, by default `className`, `aria-*`, and `data-*` props are omitted.
+- `depth` defines the number of children printed, by default all children are printed.
+- `verbosity` defines the level of expansion that non-scalar props experience, the default value of `1` will expand objects one level deep
+
+Typical usage should not require providing any options as the default `verbosity` and `depth` should be appropriate for the majority of inspections.
+
+```tsx
+function ObjectText({data}: {data: {}}) {
+  return <span>{JSON.stringify(data)}</span>;
+}
+
+function Container({children}: PropsWithChildren<{}>) {
+  return children;
+}
+
+function MyComponent({onClick}: {onClick(id: string): void}) {
+  return (
+    <Container>
+      <button type="button" onClick={() => onClick(String(Math.random()))}>
+        <ObjectText data={{a: {very: {deep: {data: {object: 'with text'}}}}}} />
+      </button>
+    </Container>
+  );
+}
+
+const wrapper = mount(<MyComponent />);
+// print the whole structure with one level of prop verbosity
+console.log(wrapper.debug());
+// print only the Container and button without any other children
+console.log(wrapper.find(Container)!.debug({depth: 1}));
+// find button by name and print all children with verbose props details
+console.log(
+  wrapper
+    .findWhere(type => type && type.name === 'button')!
+    .debug({verbosity: 9}),
+);
 ```
 
 ### <a name="mount"></a> `mount(element: React.ReactElement<any>)`

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -3,6 +3,7 @@ import {
   Arguments,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
+import {nodeName, toReactString} from './toReactString';
 import {
   Tag,
   Node,
@@ -10,6 +11,7 @@ import {
   FunctionKeys,
   DeepPartialArguments,
   PropsFor,
+  DebugOptions,
 } from './types';
 
 type Root = import('./root').Root<any>;
@@ -220,17 +222,12 @@ export class Element<Props> implements Node<Props> {
     });
   }
 
+  debug(options?: DebugOptions) {
+    return toReactString(this, options);
+  }
+
   toString() {
-    const {type} = this;
-
-    if (type == null) {
-      return '<Element />';
-    }
-
-    const name =
-      typeof type === 'string' ? type : type.displayName || type.name;
-
-    return `<${name} />`;
+    return `<${nodeName(this)} />`;
   }
 }
 

--- a/packages/react-testing/src/index.ts
+++ b/packages/react-testing/src/index.ts
@@ -3,3 +3,4 @@ export {Element} from './element';
 export {Node} from './types';
 export * from './mount';
 export * from './destroy';
+export * from './toReactString';

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -17,6 +17,7 @@ import {
   FunctionKeys,
   DeepPartialArguments,
   PropsFor,
+  DebugOptions,
 } from './types';
 
 // Manually casting `act()` until @types/react is updated to include
@@ -241,6 +242,11 @@ export class Root<Props> implements Node<Props> {
   forceUpdate() {
     this.ensureRoot();
     this.act(() => this.wrapper!.forceUpdate());
+  }
+
+  debug(options?: DebugOptions) {
+    this.ensureRoot();
+    return this.root!.debug(options);
   }
 
   toString() {

--- a/packages/react-testing/src/toReactString.ts
+++ b/packages/react-testing/src/toReactString.ts
@@ -1,0 +1,112 @@
+import {stringify} from 'jest-matcher-utils';
+import {DebugOptions, Node} from './types';
+
+export function toReactString<Props>(
+  node: Node<Props>,
+  options: DebugOptions = {},
+  level = 0,
+) {
+  // if this is an array node then print all children at the current level
+  if (!node.type && node.children.length > 0) {
+    return node.children
+      .map(child => toReactString(child, options, level))
+      .join('\n');
+  }
+
+  const name = nodeName(node);
+  const indent = '  '.repeat(level);
+  const props = Object.keys(node.props)
+    // we always filter out children no matter what, but unless allProps option
+    // is present we will also filter out insigificant props
+    .filter(
+      key =>
+        options.allProps
+          ? key !== 'children'
+          : !/^(children|className)$|^(aria|data)-/.test(key),
+    )
+    .reduce(
+      (list, key) => {
+        if (!key) {
+          return list;
+        }
+
+        const value = node.props[key];
+
+        if (value === undefined && !options.allProps) {
+          return list;
+        }
+
+        list.push(toPropString(key, value, options.verbosity));
+
+        return list;
+      },
+      [] as string[],
+    );
+  const hasChildren = node.children.length > 0 && !['svg'].includes(name);
+  const open = `${indent}<${name}${
+    props.length > 0 ? ` ${props.join(' ')}` : ''
+  }${hasChildren ? '>' : ' />'}`;
+
+  if (!hasChildren) {
+    return open;
+  }
+
+  const close = `${indent}</${name}>`;
+
+  if (options.depth != null && level >= options.depth) {
+    return [
+      open,
+      `${indent}  {/* <${node.children.length} child${
+        node.children.length === 1 ? '' : 'ren'
+      }... /> */}`,
+      close,
+    ].join('\n');
+  }
+
+  return [
+    open,
+    ...node.children.map(child => toReactString(child, options, level + 1)),
+    close,
+  ].join('\n');
+}
+
+export function toPropString(key: string, value: unknown, verbosity = 1) {
+  if (value === undefined) {
+    return `${key}={undefined}`;
+  }
+
+  if (value === null) {
+    return `${key}={null}`;
+  }
+
+  if (typeof value === 'string') {
+    return `${key}="${value}"`;
+  }
+
+  if (typeof value === 'boolean' && value) {
+    return value ? `${key}` : `${key}={false}`;
+  }
+
+  if (value instanceof Array) {
+    return `${key}={${stringify(value, verbosity + 1)}}`;
+  }
+
+  return `${key}={${stringify(value, verbosity)}}`;
+}
+
+export function nodeName<Props>({type}: Node<Props>) {
+  if (type && typeof type === 'object' && '_context' in type) {
+    const context = (type as any)._context;
+    return `${context.displayName || 'Context'}.${
+      type === context.Provider ? 'Provider' : 'Consumer'
+    }`;
+  }
+
+  if (type == null) {
+    return 'Node';
+  }
+
+  return typeof type === 'string'
+    ? type
+    : type.displayName || type.name || 'Component';
+}

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -112,5 +112,12 @@ export interface Node<Props> {
   ): MaybeFunctionReturnType<NonNullable<Props[K]>>;
   triggerKeypath<T = unknown>(keypath: string, ...args: unknown[]): T;
 
+  debug(options?: DebugOptions): string;
   toString(): string;
+}
+
+export interface DebugOptions {
+  allProps?: boolean;
+  depth?: number;
+  verbosity?: number;
 }


### PR DESCRIPTION
## Description

Fixes (issue #) _do we have an issue for this???_

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Similar to how [enzyme handles `.debug()`](https://github.com/airbnb/enzyme/blob/master/packages/enzyme/src/Debug.js), we can now emit mounted structure (and sub-structure) using `wrapper.debug()` or `wrapper.find(Foo)!.debug()`.

increase (or decrease) verbosity of the props object expansion by changing the `verbosity` option (default is `1`, `wrapper.debug(3)`). limit how deep to walk the graph by changing the `depth` option (default is undefined, walk the entire graph). Use either position parameters (`wrapper.debug(verbosity, depth)`) or a single options object (`wrapper.debug({depth, verbosity})`)

Test it out in your project using the debug console, `wrapper.findWhere((type) => type && type.name === 'Breadcrumbs')!.debug(5)`

```tsx
<Header breadcrumbs={[{"content": "Settings", "url": "/admin/settings"}]} title="Capital" separator polaris={{"appBridge": undefined, "intl": {"translate": [Function anonymous], "translation": [Object]}, "link": undefined, "scrollLockManager": {"locked": false, "scrollLocks": 0}, "stickyManager": {"handleResize": [Function debounced], "handleScroll": [Function debounced], "stickyItems": [Array], "stuckItems": [Array], "topBarOffset": 0}, "theme": {"logo": null}}}>
  <div>
    <div>
      <div>
        <Breadcrumbs breadcrumbs={[{"content": "Settings", "url": "/admin/settings"}]}>
          <nav role="navigation">
            <Component url="/admin/settings" onMouseUp={[Function handleMouseUpByBlurring]}>
              <Component url="/admin/settings" onMouseUp={[Function handleMouseUpByBlurring]}>
                <a onMouseUp={[Function handleMouseUpByBlurring]} href="/admin/settings">
                  <span>
                    <Icon source={[Function SvgChevronLeftMinor]}>
                      <span>
                        <SvgChevronLeftMinor focusable="false">
                          <svg viewBox="0 0 20 20" focusable="false" />
                        </SvgChevronLeftMinor>
                      </span>
                    </Icon>
                  </span>
                  <span />
                </a>
              </Component>
            </Component>
          </nav>
        </Breadcrumbs>
      </div>
    </div>
    <div>
      <div>
        <Title title="Foo">
          <div>
            <div>
              <div>
                <DisplayText size="large" element="h1">
                  <h1 />
                </DisplayText>
              </div>
            </div>
          </div>
        </Title>
      </div>
    </div>
    <EventListener event="resize" handler={[Function debounced]} passive />
  </div>
</Header>
```

I'm open to changing the name from `.debug()`, but maybe we want to keep it the same (or at least an alias to it) for posterity?

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
