### PR TITLE
[react-i18n] Remove leading zero from time in humanized dates

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `memoizedPluralRules` utility function ([#1065](https://github.com/Shopify/quilt/pull/1065)
 - Added `memoizedNumberFormatter` utility function ([#1065](https://github.com/Shopify/quilt/pull/1065)
 
+### Changed
+
+- Removed leading zero from hours of time output by `I18n#humanizeDate` method ([#1093](https://github.com/Shopify/quilt/pull/1093))
+
 ### Fixed
 
 - Removed creation of `Intl.PluralRules` object from `I18n` constructor which caused backwards incompatibility for any platforms needing a polyfill for `Intl.Plualrules` support ([#1065](https://github.com/Shopify/quilt/pull/1065)

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -439,7 +439,8 @@ export class I18n {
 
     const time = this.formatDate(date, {
       ...options,
-      style: DateStyle.Time,
+      hour: 'numeric',
+      minute: '2-digit',
     }).toLocaleLowerCase();
 
     if (isToday(date)) {


### PR DESCRIPTION
## Description

Removes leading zero from hours of time output by `I18n#humanizeDate` method.

### Before

`Friday, October 4 at 08:25 am`

### After

`Friday, October 4 at 8:25 am`

## Type of change

- [x] `@shopify/react-i18n` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
