### PR TITLE
Add type safe APIs

### DIFF
--- a/packages/web-worker/src/index.ts
+++ b/packages/web-worker/src/index.ts
@@ -1,2 +1,3 @@
 export {expose} from './worker';
 export {createWorker} from './parent';
+export {SafeWorkerArgument} from './types';

--- a/packages/web-worker/src/parent.ts
+++ b/packages/web-worker/src/parent.ts
@@ -1,4 +1,8 @@
-export function createWorker<T>(script: () => Promise<T>): () => T {
+import {PromisifyModule} from './types';
+
+export function createWorker<T>(
+  script: () => Promise<T>,
+): () => PromisifyModule<T> {
   return function create() {
     if (typeof Worker === 'undefined') {
       return new Proxy(

--- a/packages/web-worker/src/parent.ts
+++ b/packages/web-worker/src/parent.ts
@@ -1,7 +1,7 @@
 import {PromisifyModule} from './types';
 
 export function createWorker<T>(
-  script: () => Promise<T>,
+  module: () => Promise<T>,
 ): () => PromisifyModule<T> {
   return function create() {
     if (typeof Worker === 'undefined') {
@@ -20,7 +20,7 @@ export function createWorker<T>(
     }
 
     const workerScript = URL.createObjectURL(
-      new Blob([`importScripts(${JSON.stringify(script)})`]),
+      new Blob([`importScripts(${JSON.stringify(module)})`]),
     );
 
     const worker = new Worker(workerScript);

--- a/packages/web-worker/src/types.ts
+++ b/packages/web-worker/src/types.ts
@@ -1,0 +1,31 @@
+export type PromisifyModule<T> = {[K in keyof T]: PromisifyExport<T[K]>};
+
+type PromisifyExport<T> = T extends (...args: infer Args) => infer TypeReturned
+  ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
+  : never;
+
+type ForcePromiseWrapped<T> = T extends infer U | Promise<infer U>
+  ? ForcePromise<U>
+  : ForcePromise<T>;
+
+type ForcePromise<T> = T extends Promise<any>
+  ? T
+  : T extends (...args: infer Args) => infer TypeReturned
+    ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
+    : T extends Array<infer ArrayElement>
+      ? ForcePromiseArray<ArrayElement>
+      : T extends object ? {[K in keyof T]: ForcePromiseWrapped<T[K]>} : T;
+
+interface ForcePromiseArray<T> extends Array<ForcePromiseWrapped<T>> {}
+
+export type SafeWorkerArgument<T> = T extends (
+  ...args: infer Args
+) => infer TypeReturned
+  ? TypeReturned extends Promise<any>
+    ? (...args: Args) => TypeReturned
+    : (...args: Args) => TypeReturned | Promise<TypeReturned>
+  : T extends Array<infer ArrayElement>
+    ? SafeWorkerArgumentArray<ArrayElement>
+    : T extends object ? {[K in keyof T]: SafeWorkerArgument<T[K]>} : T;
+
+interface SafeWorkerArgumentArray<T> extends Array<SafeWorkerArgument<T>> {}


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1044

* Add and use a `PromisifyModule` type in `createWorker` to return a type-safe API for the created web worker api. 
* Exposes a `SafeWorkerArgument` type to be used by consumers to ensure type safe inputs as mentioned in the [docs]https://github.com/Shopify/quilt/tree/master/packages/web-worker#worker)

**`createWorker` with a _promisified_ module:**

<img width="930" alt="Screen Shot 2019-10-04 at 4 03 13 PM" src="https://user-images.githubusercontent.com/6130700/66237558-532d4e00-e6c3-11e9-8a71-29c853292b8d.png">
