### PR TITLE
✨ add koa-performance package

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Each package has its own `README` and documentation describing usage.
 | jest-mock-router | [directory](packages/jest-mock-router) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-router.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-router) |
 | koa-liveness-ping | [directory](packages/koa-liveness-ping) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping) |
 | koa-metrics | [directory](packages/koa-metrics) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-metrics.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-metrics) |
+| koa-performance | [directory](packages/koa-performance) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-performance) |
 | koa-shopify-auth | [directory](packages/koa-shopify-auth) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth) |
 | koa-shopify-graphql-proxy | [directory](packages/koa-shopify-graphql-proxy) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy) |
 | koa-shopify-webhooks | [directory](packages/koa-shopify-webhooks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks) |

--- a/packages/koa-performance/CHANGELOG.md
+++ b/packages/koa-performance/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/koa-performance` package

--- a/packages/koa-performance/README.md
+++ b/packages/koa-performance/README.md
@@ -1,0 +1,77 @@
+# `@shopify/koa-performance`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/koa-performance.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/koa-performance.svg)
+
+A middleware which makes it easy to send metrics from your front end application and forward them to a stats-d server of your choice.
+
+Best used with [`@shopify/performance`](https://www.npmjs.com/package/@shopify/performance) and/or [`@shopify/react-performance`](https://www.npmjs.com/package/@shopify/react-performance).
+
+## Installation
+
+```bash
+$ yarn add @shopify/koa-performance
+```
+
+## Usage
+
+### Basic server setup
+
+First add the middleware to your Koa app. We recommend using `koa-mount` or `koa-router` to restrict it to a specific endpoint.
+
+```tsx
+// server.ts
+import Koa from 'koa';
+import mount from 'koa-mount';
+import {clientPerformanceMetrics} from '@shopify/koa-performance';
+
+const app = new Koa();
+
+app.use(mount('/client-metrics', clientPerformanceMetrics({
+  prefix: 'MyApp.',
+  // when development is true the middleware will skip sending metrics
+  development: process.env.NODE_ENV === 'development',
+  // the host of the statsd server you want to send metrics to
+  statsdHost: 'localhost',
+  // the port of the statsd server you want to send metrics to
+  statsdPort: 3000,
+})));
+
+app.listen(3000, () => {
+  console.log('listening on port 3000');
+})
+```
+
+Now the app will respond to requests to `/client-metrics`. The middleware returned from `clientPerformanceMetrics` expects to recieve JSON POST requests meeting the following interface:
+
+```tsx
+interface Metrics {
+  // the path the app was responding to when metrics were collected
+  pathname: string;
+  // data from `navigator.connection`
+  connection: Partial<BrowserConnection>;
+  // @shopify/performance lifecycle events
+  events: LifecycleEvent[];
+  // @shopify/performance navigation data
+  navigations: {
+    details: NavigationDefinition;
+    metadata: NavigationMetadata;
+  }[];
+}
+```
+
+To confirm the endpoint is working we can make a CURL request. Run your server and paste this in your terminal.
+
+```bash
+curl 'http://localhost:3000/client-metrics' -H 'Content-Type: application/json' --data-binary '{"connection":{"onchange":null,"effectiveType":"4g","rtt":100,"downlink":1.75,"saveData":false},"events":[{"type":"ttfb","start":5631.300000008196,"duration":0},{"type":"ttfp","start":5895.370000012917,"duration":0},{"type":"ttfcp","start":5895.370000012917,"duration":0},{"type":"dcl","start":9874.819999997271,"duration":0},{"type":"load","start":10426.089999993565,"duration":0}],"navigations":[],"pathname":"/some-path"}' --compressed
+```
+
+You should get a `200` response back, and see console logs about metrics being skipped (since we are in development).
+
+### Fullstack usage with `@shopify/react-performance`
+
+> Todo
+
+## API
+
+> Todo

--- a/packages/koa-performance/package.json
+++ b/packages/koa-performance/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@shopify/koa-performance",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Creating a middleware that send performance related data through StatsD.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/koa-performance/README.md",
+  "dependencies": {
+    "@shopify/network": "^1.4.2",
+    "@shopify/performance": "^1.2.0",
+    "@shopify/statsd": "^1.0.0",
+    "@types/koa-bodyparser": "*",
+    "@types/koa-compose": "*",
+    "change-case": "^3.1.0",
+    "koa-bodyparser": ">=4.0.0 <5.0.0",
+    "koa-compose": ">=3.0.0 <4.0.0"
+  },
+  "peer-dependencies": {
+    "koa": ">=2.0.0 <3.0.0"
+  },
+  "devDependencies": {
+    "@shopify/with-env": "^1.1.1"
+  },
+  "files": [
+    "dist/*"
+  ]
+}

--- a/packages/koa-performance/src/enums.ts
+++ b/packages/koa-performance/src/enums.ts
@@ -1,0 +1,15 @@
+export enum LifecycleMetric {
+  TimeToFirstByte = 'time_to_first_byte',
+  TimeToFirstContentfulPaint = 'time_to_first_contentful_paint',
+  TimeToFirstPaint = 'time_to_first_paint',
+  DomContentLoaded = 'dom_content_loaded',
+  FirstInputDelay = 'first_input_delay',
+  Load = 'dom_load',
+}
+
+export enum NavigationMetric {
+  Complete = 'navigation_complete',
+  Usable = 'navigation_usable',
+  DownloadSize = 'navigation_download_size',
+  CacheEffectiveness = 'navigation_cache_effectiveness',
+}

--- a/packages/koa-performance/src/index.ts
+++ b/packages/koa-performance/src/index.ts
@@ -1,0 +1,1 @@
+export {clientPerformanceMetrics, Metrics} from './middleware';

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -1,0 +1,226 @@
+import {Context} from 'koa';
+import compose from 'koa-compose';
+import bodyParser from 'koa-bodyparser';
+import {StatusCode, Header} from '@shopify/network';
+import {
+  EventType,
+  Navigation,
+  LifecycleEvent,
+  NavigationDefinition,
+  NavigationMetadata,
+} from '@shopify/performance';
+import {StatsDClient, Logger} from '@shopify/statsd';
+
+import {LifecycleMetric, NavigationMetric} from './enums';
+import {BrowserConnection} from './types';
+
+export interface Options {
+  prefix: string;
+  development: boolean;
+  statsdHost?: string;
+  statsdPort?: number;
+  anomalousNavigationDurationThreshold?: number;
+  logger?: Logger;
+  additionalTags?(
+    metricsBody: Metrics,
+    userAgent: string,
+  ): {[key: string]: string | number | boolean};
+  additionalNavigationTags?(
+    navigation: Navigation,
+  ): {[key: string]: string | number | boolean};
+  additionalNavigationMetrics?(
+    navigation: Navigation,
+  ): {name: string; value: any}[];
+}
+
+export interface Metrics {
+  pathname: string;
+  connection: Partial<BrowserConnection>;
+  events: LifecycleEvent[];
+  navigations: {
+    details: NavigationDefinition;
+    metadata: NavigationMetadata;
+  }[];
+}
+
+export function clientPerformanceMetrics({
+  statsdHost,
+  statsdPort,
+  prefix,
+  development,
+  logger,
+  anomalousNavigationDurationThreshold,
+  additionalTags: getAdditionalTags,
+  additionalNavigationTags: getAdditionalNavigationTags,
+  additionalNavigationMetrics: getAdditionalNavigationMetrics,
+}: Options) {
+  return compose([
+    bodyParser(),
+    async function clientPerformanceMetricsMiddleware(ctx: Context) {
+      const statsLogger: Logger = logger || ctx.state.logger || console;
+
+      const {body} = ctx.request as any;
+      if (!isClientMetricsBody(body)) {
+        ctx.status = StatusCode.UnprocessableEntity;
+        return;
+      }
+
+      const statsd = new StatsDClient({
+        host: statsdHost,
+        port: statsdPort,
+        logger: statsLogger,
+        snakeCase: true,
+        prefix,
+      });
+
+      const userAgent = ctx.get(Header.UserAgent);
+      const {connection, events, navigations} = body;
+
+      const metrics: {
+        name: string;
+        value: any;
+        tags: {[key: string]: string | undefined | null};
+      }[] = [];
+
+      const additionalTags = getAdditionalTags
+        ? getAdditionalTags(body, userAgent)
+        : {};
+
+      const tags = {
+        browserConnectionType: connection.effectiveType,
+        ...additionalTags,
+      };
+
+      statsLogger.log(`Adding event tags: ${JSON.stringify(tags)}`);
+
+      for (const event of events) {
+        const value =
+          event.type === EventType.FirstInputDelay
+            ? event.duration
+            : event.start;
+
+        metrics.push({
+          name: eventMetricName(event),
+          value: Math.round(value),
+          tags,
+        });
+      }
+
+      for (const {details, metadata} of navigations) {
+        const navigation = new Navigation(details, metadata);
+
+        const additionalNavigationTags = getAdditionalNavigationTags
+          ? getAdditionalNavigationTags(navigation)
+          : {};
+
+        const anomalousNavigationDurationTag = anomalousNavigationDurationThreshold
+          ? getAnomalousNavigationDurationTag(
+              navigation,
+              anomalousNavigationDurationThreshold,
+            )
+          : {};
+
+        const navigationTags = {
+          ...tags,
+          ...additionalNavigationTags,
+          ...anomalousNavigationDurationTag,
+        };
+
+        statsLogger.log(
+          `Adding navigation tags: ${JSON.stringify(navigationTags)}`,
+        );
+
+        metrics.push({
+          name: NavigationMetric.Complete,
+          value: navigation.timeToComplete,
+          tags: navigationTags,
+        });
+
+        metrics.push({
+          name: NavigationMetric.Usable,
+          value: navigation.timeToUsable,
+          tags: navigationTags,
+        });
+
+        const {totalDownloadSize, cacheEffectiveness} = navigation;
+
+        if (totalDownloadSize != null) {
+          metrics.push({
+            name: NavigationMetric.DownloadSize,
+            value: totalDownloadSize,
+            tags: navigationTags,
+          });
+        }
+
+        if (cacheEffectiveness != null) {
+          metrics.push({
+            name: NavigationMetric.CacheEffectiveness,
+            value: cacheEffectiveness,
+            tags: navigationTags,
+          });
+        }
+
+        if (getAdditionalNavigationMetrics) {
+          metrics.push(
+            ...getAdditionalNavigationMetrics(navigation).map(
+              ({name, value}) => ({name, value, tags: navigationTags}),
+            ),
+          );
+        }
+      }
+
+      const distributions = metrics.map(({name, value, tags}) => {
+        if (development) {
+          statsLogger.log(`Skipping sending metric in dev ${name}: ${value}`);
+        } else {
+          statsLogger.log(`Sending metric ${name}: ${value}`);
+          return statsd.distribution(name, value, tags);
+        }
+      });
+
+      try {
+        await Promise.all(distributions);
+      } catch (error) {
+        ctx.status = StatusCode.InternalServerError;
+      } finally {
+        await statsd.close();
+        ctx.status = StatusCode.Ok;
+      }
+    },
+  ]);
+}
+
+function isClientMetricsBody(value: any): value is Metrics {
+  return (
+    typeof value === 'object' &&
+    value != null &&
+    value.connection != null &&
+    typeof value.connection === 'object' &&
+    Array.isArray(value.events) &&
+    Array.isArray(value.navigations) &&
+    typeof value.pathname === 'string'
+  );
+}
+
+function getAnomalousNavigationDurationTag(
+  navigation: Navigation,
+  anomalousNavigationDurationThreshold: number,
+) {
+  return {
+    anomalous: navigation.duration > anomalousNavigationDurationThreshold,
+  };
+}
+
+const EVENT_METRIC_MAPPING = {
+  [EventType.TimeToFirstByte]: LifecycleMetric.TimeToFirstByte,
+  [EventType.TimeToFirstContentfulPaint]:
+    LifecycleMetric.TimeToFirstContentfulPaint,
+  [EventType.TimeToFirstPaint]: LifecycleMetric.TimeToFirstPaint,
+  [EventType.DomContentLoaded]: LifecycleMetric.DomContentLoaded,
+  [EventType.FirstInputDelay]: LifecycleMetric.FirstInputDelay,
+  [EventType.Load]: LifecycleMetric.Load,
+};
+
+function eventMetricName(event: LifecycleEvent) {
+  return EVENT_METRIC_MAPPING[event.type] || event.type;
+}

--- a/packages/koa-performance/src/test/middleware.test.ts
+++ b/packages/koa-performance/src/test/middleware.test.ts
@@ -1,0 +1,541 @@
+import {createMockContext} from '@shopify/jest-koa-mocks';
+import {StatusCode, Method, Header} from '@shopify/network';
+import {
+  LifecycleEvent,
+  EventType,
+  Navigation,
+  NavigationDefinition,
+  NavigationResult,
+  NavigationMetadata,
+} from '@shopify/performance';
+import withEnv from '@shopify/with-env';
+
+import {clientPerformanceMetrics, Metrics} from '../middleware';
+
+jest.mock('@shopify/statsd', () => {
+  return {
+    StatsDClient: class StatsDClient {
+      static distributionSpy = jest.fn();
+      static closeSpy = jest.fn();
+      close = StatsDClient.closeSpy;
+      distribution = StatsDClient.distributionSpy;
+    },
+  };
+});
+
+const config = {
+  statsdHost: 'foo.com',
+  statsdPort: 3000,
+  prefix: 'tests',
+  development: false,
+  logger: {log: jest.fn()},
+};
+
+const StatsDClient = require.requireMock('@shopify/statsd').StatsDClient;
+
+describe('client metrics middleware', () => {
+  beforeEach(() => {
+    config.logger.log.mockReset();
+    StatsDClient.distributionSpy.mockReset();
+    StatsDClient.closeSpy.mockReset();
+  });
+
+  it('returns Ok if the request body contains metrics information', async () => {
+    const context = createMockContext({
+      method: Method.Post,
+      requestBody: createBody(),
+    });
+
+    await withEnv('production', async () => {
+      await clientPerformanceMetrics(config)(context);
+    });
+
+    expect(context.status).toBe(StatusCode.Ok);
+  });
+
+  it('returns UnprocessableEntity if the request body is missing keys', async () => {
+    const context = createMockContext({
+      method: Method.Post,
+      requestBody: {},
+    });
+
+    await withEnv('production', async () => {
+      await clientPerformanceMetrics(config)(context);
+    });
+
+    expect(context.status).toBe(StatusCode.UnprocessableEntity);
+  });
+
+  describe('tags', () => {
+    it('includes connection speed data in distributions in snake_case', async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          connection: {
+            effectiveType: '3G',
+          },
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      StatsDClient.distributionSpy.mock.calls.forEach(
+        ([, , tags]: [never, never, any]) => {
+          expect(tags).toHaveProperty('browser_connection_type', '3G');
+        },
+      );
+    });
+
+    it("sets connection speed data to 'Really fast' when it is above 5", async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          connection: {
+            effectiveType: '3G',
+          },
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      StatsDClient.distributionSpy.mock.calls.forEach(
+        ([, , tags]: [never, never, any]) => {
+          expect(tags).toHaveProperty('browser_connection_type', '3G');
+        },
+      );
+    });
+
+    it('sends connection tags as `Unknown` when data is missing', async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          connection: {
+            effectiveType: undefined,
+          },
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      StatsDClient.distributionSpy.mock.calls.forEach(
+        ([, , tags]: [never, never, any]) => {
+          expect(tags).toHaveProperty('browser_connection_type', 'Unknown');
+        },
+      );
+    });
+
+    it('calls additionalTags with metrics body and the userAgent', async () => {
+      const additionalTagsSpy = jest.fn(() => ({}));
+      const body = createBody();
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: body,
+        headers: {
+          [Header.UserAgent]: 'something',
+        },
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics({
+          ...config,
+          additionalTags: additionalTagsSpy,
+        })(context);
+      });
+
+      expect(additionalTagsSpy).toHaveBeenCalledWith(
+        body,
+        context.get(Header.UserAgent),
+      );
+    });
+
+    it('includes additionalTags for each metric', async () => {
+      const additionalTags = {fooBar: true};
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          events: [createLifecycleEvent()],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics({
+          ...config,
+          additionalTags: () => additionalTags,
+        })(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining(additionalTags),
+      );
+    });
+  });
+
+  describe('events', () => {
+    it('sends distributions for each event in snake_case', async () => {
+      const ttfbEvent = createLifecycleEvent(EventType.TimeToFirstByte, 123);
+      const ttfcpEvent = createLifecycleEvent(
+        EventType.TimeToFirstContentfulPaint,
+        123,
+      );
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          events: [ttfbEvent, ttfcpEvent],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'time_to_first_byte',
+        ttfbEvent.start,
+        expect.any(Object),
+      );
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'time_to_first_contentful_paint',
+        ttfcpEvent.start,
+        expect.any(Object),
+      );
+    });
+
+    it('sends distribution for first-input-delay duration', async () => {
+      const firstInputDelayEvent = createLifecycleEvent(
+        EventType.FirstInputDelay,
+        123,
+        456,
+      );
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          events: [firstInputDelayEvent],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'first_input_delay',
+        456,
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('navigations', () => {
+    it('sends distributions for time to complete and usable', async () => {
+      const complete = 123;
+      const usable = 99;
+      const navigation = createNavigation({
+        duration: complete,
+        events: [
+          {
+            type: EventType.Usable,
+            duration: 0,
+            start: usable,
+          },
+        ],
+      });
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          navigations: [navigation],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'navigation_complete',
+        complete,
+        expect.any(Object),
+      );
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'navigation_usable',
+        usable,
+        expect.any(Object),
+      );
+    });
+
+    it('does not send cache_effectiveness and download_size metrics by default', async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          navigations: [createNavigation()],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      expect(StatsDClient.distributionSpy).not.toHaveBeenCalledWith(
+        'navigation_download_size',
+        expect.any(Number),
+        expect.any(Object),
+      );
+
+      expect(StatsDClient.distributionSpy).not.toHaveBeenCalledWith(
+        'navigation_cache_effectiveness',
+        expect.any(Number),
+        expect.any(Object),
+      );
+    });
+
+    it('sends cache_effectiveness and download_size if available', async () => {
+      const size = 12345;
+      const navigation = createNavigation({
+        events: [
+          {
+            type: EventType.ScriptDownload,
+            duration: 50,
+            start: 0,
+            metadata: {
+              name: 'script.js',
+              size,
+            },
+          },
+        ],
+      });
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          navigations: [navigation],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'navigation_cache_effectiveness',
+        0,
+        expect.any(Object),
+      );
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'navigation_download_size',
+        size,
+        expect.any(Object),
+      );
+    });
+
+    it('attaches custom tags from the config', async () => {
+      const additionalTags = {fooBar: 'baz'};
+      const spy = jest.fn(() => additionalTags);
+      const navigation = createNavigation();
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          navigations: [navigation],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics({
+          ...config,
+          additionalNavigationTags: spy,
+        })(context);
+      });
+
+      expect(spy).toHaveBeenCalledWith(expect.any(Navigation));
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'navigation_complete',
+        expect.any(Number),
+        expect.objectContaining(additionalTags),
+      );
+    });
+
+    it('sends custom metrics from the config', async () => {
+      const additionalMetric = {name: 'navigation_metric', value: 123};
+      const spy = jest.fn(() => [additionalMetric]);
+      const navigation = createNavigation();
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          navigations: [navigation],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics({
+          ...config,
+          additionalNavigationMetrics: spy,
+        })(context);
+      });
+
+      expect(spy).toHaveBeenCalledWith(expect.any(Navigation));
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        additionalMetric.name,
+        additionalMetric.value,
+        expect.any(Object),
+      );
+    });
+
+    it('attaches anomalous:true tag if anomalousNavigationDurationThreshold is exceeded', async () => {
+      const anomalousNavigationDurationThreshold = 10000;
+      const navigation = createNavigation({
+        duration: anomalousNavigationDurationThreshold + 1,
+      });
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          navigations: [navigation],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics({
+          ...config,
+          anomalousNavigationDurationThreshold,
+        })(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'navigation_complete',
+        expect.any(Number),
+        expect.objectContaining({anomalous: true}),
+      );
+    });
+
+    it('attaches anomalous:false tag if anomalousNavigationDurationThreshold is not exceeded', async () => {
+      const anomalousNavigationDurationThreshold = 10000;
+      const navigation = createNavigation({
+        duration: anomalousNavigationDurationThreshold - 1,
+      });
+
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          navigations: [navigation],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics({
+          ...config,
+          anomalousNavigationDurationThreshold,
+        })(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        'navigation_complete',
+        expect.any(Number),
+        expect.objectContaining({anomalous: false}),
+      );
+    });
+  });
+
+  describe('development', () => {
+    it('does not send metrics', async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          events: [createLifecycleEvent()],
+        }),
+      });
+
+      await withEnv('development', async () => {
+        await clientPerformanceMetrics({...config, development: true})(context);
+      });
+
+      expect(StatsDClient.distributionSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs distributions', async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          events: [createLifecycleEvent()],
+        }),
+      });
+
+      await withEnv('development', async () => {
+        await clientPerformanceMetrics({...config, development: true})(context);
+      });
+
+      expect(config.logger.log).toHaveBeenCalled();
+    });
+  });
+});
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends any[]
+    ? T[K]
+    : T[K] extends object ? DeepPartial<T[K]> : T[K]
+};
+
+function createBody({
+  connection,
+  events = [],
+  navigations = [],
+  pathname = '/some-path',
+}: DeepPartial<Metrics> = {}): Metrics {
+  return {
+    connection: {
+      downlink: 29,
+      effectiveType: '4G',
+      ...connection,
+    },
+    events,
+    navigations,
+    pathname,
+  };
+}
+
+function createLifecycleEvent(
+  type: LifecycleEvent['type'] = EventType.TimeToFirstByte,
+  time = 100,
+  duration = 0,
+) {
+  return {
+    type,
+    duration,
+    start: time,
+  } as LifecycleEvent;
+}
+
+function createNavigation(
+  navigation: DeepPartial<NavigationDefinition> = {},
+  metadata: Partial<NavigationMetadata> = {},
+): {details: NavigationDefinition; metadata: NavigationMetadata} {
+  return {
+    details: {
+      target: '/some-page',
+      duration: 100,
+      start: 0,
+      result: NavigationResult.Finished,
+      events: [],
+      ...navigation,
+    },
+    metadata: {
+      supportsDetailedTime: true,
+      supportsDetailedEvents: false,
+      index: 1,
+      ...metadata,
+    },
+  };
+}

--- a/packages/koa-performance/src/types.ts
+++ b/packages/koa-performance/src/types.ts
@@ -1,0 +1,8 @@
+// this should eventually be replace by official Typings for Network Information
+export interface BrowserConnection {
+  downlink: number;
+  effectiveType: string;
+  rtt: number;
+  type: string;
+  saveData: boolean;
+}

--- a/packages/koa-performance/tsconfig.build.json
+++ b/packages/koa-performance/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,6 +3169,30 @@ change-case@^3.0.1:
     upper-case "^1.1.1"
     upper-case-first "^1.1.0"
 
+change-case@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
+  integrity sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==
+  dependencies:
+    camel-case "^3.0.0"
+    constant-case "^2.0.0"
+    dot-case "^2.1.0"
+    header-case "^1.0.0"
+    is-lower-case "^1.1.0"
+    is-upper-case "^1.1.0"
+    lower-case "^1.1.1"
+    lower-case-first "^1.0.0"
+    no-case "^2.3.2"
+    param-case "^2.1.0"
+    pascal-case "^2.0.0"
+    path-case "^2.1.0"
+    sentence-case "^2.1.0"
+    snake-case "^2.1.0"
+    swap-case "^1.1.0"
+    title-case "^2.1.0"
+    upper-case "^1.1.1"
+    upper-case-first "^1.1.0"
+
 character-entities-html4@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.3.tgz#5ce6e01618e47048ac22f34f7f39db5c6fd679ef"


### PR DESCRIPTION
## Description

This PR adds the koa companion library to `@shopify/react-performance`. It is mostly the same as the impelmentation in Shopify-web, with a few minor changes:

- it bundles in body parsing using `koa-compose`
- it no longer exposes the `browser` abstraction to custom tag functions, instead it just passes the `user-agent` header directly
- we add a bit of a README

## Checklist
- [x] I have added a changelog entry, prefixed by the type of change noted above
