### PR TITLE
🔥 clean up the typescripts dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Each package has its own `README` and documentation describing usage.
 | react-import-remote | [directory](packages/react-import-remote) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-import-remote.svg)](https://badge.fury.io/js/%40shopify%2Freact-import-remote) |
 | react-intersection-observer | [directory](packages/react-intersection-observer) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg)](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer) |
 | react-network | [directory](packages/react-network) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-network.svg)](https://badge.fury.io/js/%40shopify%2Freact-network) |
+| react-performance | [directory](packages/react-performance) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-performance.svg)](https://badge.fury.io/js/%40shopify%2Freact-performance) |
 | react-router | [directory](packages/react-router) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-router.svg)](https://badge.fury.io/js/%40shopify%2Freact-router) |
 | react-serialize | [directory](packages/react-serialize) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-serialize.svg)](https://badge.fury.io/js/%40shopify%2Freact-serialize) |
 | react-server | [directory](packages/react-server) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-server.svg)](https://badge.fury.io/js/%40shopify%2Freact-server) |

--- a/packages/ast-utilities/package.json
+++ b/packages/ast-utilities/package.json
@@ -31,8 +31,7 @@
     "@babel/types": "7.5.5",
     "@types/babel__core": "7.1.2",
     "@types/babel__traverse": "^7.0.7",
-    "@types/unist": "^2.0.3",
-    "typescript": "~3.2.1"
+    "@types/unist": "^2.0.3"
   },
   "files": [
     "dist/*"

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -35,9 +35,6 @@
     "react": "^16.3.2",
     "react-dom": "^16.3.2"
   },
-  "devDependencies": {
-    "typescript": "~3.2.1"
-  },
   "files": [
     "dist/*"
   ]

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -29,9 +29,6 @@
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0"
   },
-  "devDependencies": {
-    "typescript": "~3.2.1"
-  },
   "files": [
     "dist/*"
   ]

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -27,9 +27,6 @@
     "change-case": "^3.0.1",
     "hot-shots": "^5.9.1"
   },
-  "devDependencies": {
-    "typescript": "~3.2.1"
-  },
   "files": [
     "dist/*"
   ]


### PR DESCRIPTION
## Description

We removed monorepo package level TS dependencies here https://github.com/Shopify/quilt/pull/975

but forgot to update the new package generation template till 3 days ago https://github.com/Shopify/quilt/pull/1092/files#diff-141c84893154b056d95469c4ea210db7

This PR cleaned up all the new packages that don't need the  typescripts dependencies 

