### PR TITLE
Return a properly typed web worker api

### DIFF
--- a/packages/web-worker/src/create.ts
+++ b/packages/web-worker/src/create.ts
@@ -1,5 +1,4 @@
 import {createEndpoint, Endpoint} from './endpoint';
-import {PromisifyExport} from './types';
 
 const workerEndpointCache = new WeakMap<Endpoint<any>['call'], Endpoint<any>>();
 
@@ -15,9 +14,7 @@ export function getEndpoint(caller: Endpoint<any>['call']) {
   return workerEndpointCache.get(caller);
 }
 
-export function createWorker<T extends {[K in keyof T]: T[K]}>(
-  script: () => Promise<T>,
-): () => {[K in keyof T]: PromisifyExport<T[K]>} {
+export function createWorker<T>(script: () => Promise<T>) {
   return function create(): Endpoint<T>['call'] {
     if (typeof Worker === 'undefined') {
       return new Proxy(
@@ -39,11 +36,11 @@ export function createWorker<T extends {[K in keyof T]: T[K]}>(
     );
 
     const worker = new Worker(workerScript);
-    const endpoint = createEndpoint<T>(worker);
+    const endpoint = createEndpoint(worker);
     const {call: caller} = endpoint;
 
     workerEndpointCache.set(caller, endpoint);
 
-    return caller;
+    return caller as any;
   };
 }

--- a/packages/web-worker/src/create.ts
+++ b/packages/web-worker/src/create.ts
@@ -1,4 +1,5 @@
 import {createEndpoint, Endpoint} from './endpoint';
+import {PromisifyExport} from './types';
 
 const workerEndpointCache = new WeakMap<Endpoint<any>['call'], Endpoint<any>>();
 
@@ -14,9 +15,9 @@ export function getEndpoint(caller: Endpoint<any>['call']) {
   return workerEndpointCache.get(caller);
 }
 
-export function createWorker<T extends {[key: string]: () => Promise<any>}>(
+export function createWorker<T extends {[K in keyof T]: T[K]}>(
   script: () => Promise<T>,
-) {
+): () => {[K in keyof T]: PromisifyExport<T[K]>} {
   return function create(): Endpoint<T>['call'] {
     if (typeof Worker === 'undefined') {
       return new Proxy(

--- a/packages/web-worker/src/endpoint.ts
+++ b/packages/web-worker/src/endpoint.ts
@@ -1,3 +1,5 @@
+import {PromisifyModule} from './types';
+
 import {
   RETAIN_METHOD,
   RELEASE_METHOD,
@@ -79,18 +81,14 @@ interface Options {
   uuid?(): string;
 }
 
-export interface Endpoint<
-  T extends {[key: string]: (...args: any) => Promise<any>} = {}
-> {
-  call: T;
+export interface Endpoint<T> {
+  call: PromisifyModule<T>;
   expose(api: {[key: string]: Function | undefined}): void;
   revoke(value: Function): void;
   exchange(value: Function, newValue: Function): void;
 }
 
-export function createEndpoint<
-  T extends {[key: string]: (...args: any) => Promise<any>} = {}
->(
+export function createEndpoint<T>(
   messageEndpoint: MessageEndpoint,
   {uuid = defaultUuid}: Options = {},
 ): Endpoint<T> {

--- a/packages/web-worker/src/index.ts
+++ b/packages/web-worker/src/index.ts
@@ -1,2 +1,3 @@
 export {createWorker} from './create';
 export {retain, release} from './memory';
+export {SafeWorkerArgument} from './types';

--- a/packages/web-worker/src/types.ts
+++ b/packages/web-worker/src/types.ts
@@ -1,3 +1,5 @@
+export type PromisifyModule<T> = {[K in keyof T]: PromisifyExport<T[K]>};
+
 export type PromisifyExport<T> = T extends (
   ...args: infer Args
 ) => infer TypeReturned

--- a/packages/web-worker/src/types.ts
+++ b/packages/web-worker/src/types.ts
@@ -1,6 +1,6 @@
-export type PromisifyModule<T> = {[K in keyof T]: PromisifyExport<T[K]>};
-
-type PromisifyExport<T> = T extends (...args: infer Args) => infer TypeReturned
+export type PromisifyExport<T> = T extends (
+  ...args: infer Args
+) => infer TypeReturned
   ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
   : never;
 


### PR DESCRIPTION
## Description

Returns a properly typed module for a web worker that we communicate with via our new bridge,  https://github.com/Shopify/quilt/pull/1104.


Tested in web-proving-ground. The worker types get augmented as expected. 

<img width="980" alt="Screen Shot 2019-10-10 at 12 26 41 PM" src="https://user-images.githubusercontent.com/6130700/66587839-3c6e7780-eb59-11e9-8344-f4a434ce686c.png">

