### PR TITLE
cacheEffectiveness now uses duration=0 as a cache hit

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `cacheEffectiveness` now assumes duration=0 is a cache hit [[#1107](https://github.com/Shopify/quilt/pull/1107)]
+
 ## [1.2.0] - 2019-10-03
 
 ### Changed

--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -104,9 +104,7 @@ export class Navigation implements NavigationDefinition {
       return undefined;
     }
 
-    return (
-      events.filter(({metadata: {size}}) => size === 0).length / events.length
-    );
+    return events.filter(({duration}) => duration === 0).length / events.length;
   }
 
   toJSON({

--- a/packages/performance/src/test/navigation.test.ts
+++ b/packages/performance/src/test/navigation.test.ts
@@ -160,12 +160,12 @@ describe('Navigation', () => {
       expect(navigation).toHaveProperty('cacheEffectiveness', undefined);
     });
 
-    it('returns a ratio of cached (size = 0) resources to uncached ones', () => {
+    it('returns a ratio of cached (duration = 0) resources to uncached ones', () => {
       const navigation = createNavigation({
         events: [
-          createScriptDownloadEvent({metadata: {size: 0}}),
-          createScriptDownloadEvent({metadata: {size: 0}}),
-          createStyleDownloadEvent({metadata: {size: 250}}),
+          createScriptDownloadEvent({duration: 0, metadata: {size: 1000}}),
+          createScriptDownloadEvent({duration: 0, metadata: {size: 250}}),
+          createStyleDownloadEvent({duration: 100, metadata: {size: 250}}),
         ],
       });
       expect(navigation).toHaveProperty('cacheEffectiveness', 2 / 3);


### PR DESCRIPTION
## Description

Now that CDN metrics are available, it looks like `duration === 0` is a better indicator of cache hits:

<img width="218" alt="Chrome development tools screencap showing a navigation timing event containing a 0 duration, and non-0 byte count" src="https://user-images.githubusercontent.com/673655/66618719-44093d00-eba8-11e9-8952-546faf36ea58.png">

Longer term, I'm tempted to just log bytes cached and let Splunk math on `cached` vs `totalDownloadSize` do the rest.

## Type of change
You could argue that this is a breaking change.  IMO, this is just fixing behaviour that maybe never worked, so minor.

- [x] `@shopify/performance` Patch: Bug/ Documentation fix

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
