### PR TITLE
Refactor babel plugin and add noop mode and additional packages to process

### DIFF
--- a/packages/web-worker/src/babel-plugin.ts
+++ b/packages/web-worker/src/babel-plugin.ts
@@ -2,6 +2,7 @@ import {resolve} from 'path';
 
 const DEFAULT_PACKAGES_TO_PROCESS = {
   '@shopify/web-worker': ['createWorker'],
+  '@shopify/react-web-worker': ['createWorker'],
 };
 
 const loader = resolve(__dirname, 'webpack-parts/loader');
@@ -19,9 +20,27 @@ interface State {
 
 export default function workerBabelPlugin({
   types: t,
+  template,
 }: {
   types: typeof import('@babel/types');
+  template: typeof import('@babel/template').default;
 }): import('@babel/core').PluginObj<State> {
+  const noopBinding = (template(
+    `() => (
+      new Proxy(
+        {},
+        {
+          get() {
+            return () => {
+              throw new Error('You can’t call a method on a noop worker');
+            };
+          },
+        },
+      )
+    );`,
+    {sourceType: 'module'},
+  ) as unknown) as () => import('@babel/types').ArrowFunctionExpression;
+
   return {
     visitor: {
       Program(program, state) {
@@ -32,45 +51,102 @@ export default function workerBabelPlugin({
           ),
         );
       },
-      CallExpression(nodePath) {
-        const callee = nodePath.get('callee');
-        if (!callee.isIdentifier()) {
-          return;
-        }
-
-        if (callee.node.name !== 'createWorker') {
-          return;
-        }
-
-        const dynamicImports = new Set();
-
-        nodePath.traverse({
-          Import({parentPath}) {
-            if (parentPath.isCallExpression()) {
-              dynamicImports.add(parentPath);
-            }
-          },
-        });
-
-        if (dynamicImports.size === 0) {
-          return;
-        }
-
-        const {value: imported} = [...dynamicImports][0]
-          .get('arguments')[0]
-          .evaluate();
-
-        nodePath.replaceWith(
-          t.callExpression(callee.node, [
-            t.memberExpression(
-              t.callExpression(t.identifier('require'), [
-                t.stringLiteral(`${loader}!${imported}`),
-              ]),
-              t.identifier('default'),
-            ),
-          ]),
+      ImportDeclaration(importDeclaration, state) {
+        const processImports = state.process.get(
+          importDeclaration.node.source.value,
         );
+
+        if (processImports == null) {
+          return;
+        }
+
+        for (const specifier of importDeclaration.get('specifiers')) {
+          if (
+            !specifier.isImportSpecifier() ||
+            !processImports.includes(specifier.get('imported').node.name)
+          ) {
+            continue;
+          }
+
+          const binding = specifier.scope.getBinding(
+            specifier.get('imported').node.name,
+          );
+
+          if (binding == null) {
+            continue;
+          }
+
+          processBinding(binding, state);
+        }
       },
     },
   };
+
+  function processBinding(
+    binding: import('@babel/traverse').Binding,
+    state: State,
+  ) {
+    const {program, opts: options = {}} = state;
+    const {noop = false} = options;
+
+    const callingReferences = binding.referencePaths.filter(referencePath =>
+      referencePath.parentPath.isCallExpression(),
+    );
+
+    type CallExpressionNodePath = import('@babel/traverse').NodePath<
+      import('@babel/types').CallExpression
+    >;
+
+    for (const referencePath of callingReferences) {
+      const callExpression: CallExpressionNodePath = referencePath.parentPath as any;
+      const dynamicImports = new Set<CallExpressionNodePath>();
+
+      callExpression.traverse({
+        Import({parentPath}) {
+          if (parentPath.isCallExpression()) {
+            dynamicImports.add(parentPath);
+          }
+        },
+      });
+
+      if (dynamicImports.size === 0) {
+        return;
+      }
+
+      if (dynamicImports.size > 1) {
+        throw new Error(
+          'You made more than one dynamic import in the body of a web worker create function. Only one such import is allowed.',
+        );
+      }
+
+      const dynamicallyImported = [...dynamicImports][0].get('arguments')[0];
+      const {value: imported, confident} = dynamicallyImported.evaluate();
+
+      if (typeof imported !== 'string' || !confident) {
+        throw new Error(
+          `Failed to evaluate a dynamic import to a string to create a web worker (${dynamicallyImported.getSource()})`,
+        );
+      }
+
+      if (noop) {
+        callExpression.replaceWith(noopBinding());
+        return;
+      }
+
+      const importId = callExpression.scope.generateUidIdentifier('worker');
+
+      program
+        .get('body')[0]
+        .insertBefore(
+          t.importDeclaration(
+            [t.importDefaultSpecifier(importId)],
+            t.stringLiteral(`${loader}!${imported}`),
+          ),
+        );
+
+      callExpression.replaceWith(
+        t.callExpression(callExpression.get('callee').node, [importId]),
+      );
+    }
+  }
 }

--- a/packages/web-worker/src/babel-plugin.ts
+++ b/packages/web-worker/src/babel-plugin.ts
@@ -1,9 +1,20 @@
 import {resolve} from 'path';
 
+const DEFAULT_PACKAGES_TO_PROCESS = {
+  '@shopify/web-worker': ['createWorker'],
+};
+
 const loader = resolve(__dirname, 'webpack-parts/loader');
 
+export interface Options {
+  noop?: boolean;
+  packages?: {[key: string]: string[]};
+}
+
 interface State {
+  process: Map<string, string[]>;
   program: import('@babel/traverse').NodePath<import('@babel/types').Program>;
+  opts?: Options;
 }
 
 export default function workerBabelPlugin({
@@ -15,6 +26,11 @@ export default function workerBabelPlugin({
     visitor: {
       Program(program, state) {
         state.program = program;
+        state.process = new Map(
+          Object.entries(
+            (state.opts && state.opts.packages) || DEFAULT_PACKAGES_TO_PROCESS,
+          ),
+        );
       },
       CallExpression(nodePath) {
         const callee = nodePath.get('callee');


### PR DESCRIPTION
## Description

This PR adds three features to our babel plugin:

1. Allows you to select what modules/ exports from those modules will be processed
2. Removes the `require` statements the plugin generated, so we stay in an all-ES module world
3. Lets you pass a `noop` option, which will turn any calls into functions that return noop proxies (for environments like the server, where producing a worker file is useless).
