### PR TITLE
Adjust types on react-csrf to match usage

### DIFF
--- a/packages/react-csrf/CHANGELOG.md
+++ b/packages/react-csrf/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Changed type from `string | null` to `string | undefined`.
+
 ## [1.0.0] - 2019-08-28
 
 ### Added

--- a/packages/react-csrf/src/context.ts
+++ b/packages/react-csrf/src/context.ts
@@ -1,3 +1,3 @@
 import {createContext} from 'react';
 
-export const CsrfTokenContext = createContext<string | null>(null);
+export const CsrfTokenContext = createContext<string | undefined>(undefined);

--- a/packages/react-csrf/src/hooks.ts
+++ b/packages/react-csrf/src/hooks.ts
@@ -4,7 +4,7 @@ import {CsrfTokenContext} from './context';
 export function useCsrfToken() {
   const csrf = useContext(CsrfTokenContext);
 
-  if (csrf == null) {
+  if (csrf === undefined) {
     throw new Error('No CSRF token found in context.');
   }
 


### PR DESCRIPTION
## Description
This PR adjust the types of `@shopify/react-csrf` to match it's usage. 

If the token is `csrfToken?: string` the type will be `string | undefined`. 

## Type of change

- Type change in `@shopify/react-csrf` 
- `@shopify/react-csrf-universal-provider` depends on it so will need to be bumped.
<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->
- [X] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
