### PR TITLE
♻️ have `withTiming` return early if `performance.timing` does not ex…

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Fixed
+
+- `Performance` object constructor will now check if `PerformanceTiming` is supported. [[#1119](https://github.com/Shopify/quilt/pull/1119)]
+
 ## [1.2.1] - 2019-10-11
 
 ### Fixed

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -31,6 +31,7 @@ export class Performance {
   readonly supportsObserver = hasGlobal('PerformanceObserver');
   readonly supportsMarks = hasGlobal('PerformanceMark');
   readonly supportsNavigationEntries = hasGlobal('PerformanceNavigationTiming');
+  readonly supportsTimingEntries = hasGlobal('PerformanceTiming');
   readonly supportsLongtaskEntries = hasGlobal('PerformanceLongTaskTiming');
   readonly supportsResourceEntries = hasGlobal('PerformanceResourceTiming');
   readonly supportsPaintEntries = hasGlobal('PerformancePaintTiming');
@@ -59,7 +60,10 @@ export class Performance {
 
     withNavigation(this.start.bind(this));
 
-    if (!this.supportsDetailedTime || !this.supportsNavigationEntries) {
+    if (
+      this.supportsTimingEntries &&
+      (!this.supportsDetailedTime || !this.supportsNavigationEntries)
+    ) {
       withTiming(
         ({responseStart, domContentLoadedEventStart, loadEventStart}) => {
           // window.performance.timing uses full timestamps, while

--- a/packages/react-performance/src/test/LifecycleEventListener.test.tsx
+++ b/packages/react-performance/src/test/LifecycleEventListener.test.tsx
@@ -3,13 +3,6 @@ import {mount} from '@shopify/react-testing';
 import {mockPerformance} from './utilities';
 import {LifecycleEventListener, PerformanceContext} from '..';
 
-jest.mock('@shopify/performance', () => {
-  return {
-    ...require.requireActual('@shopify/performance'),
-    Performance: jest.fn(),
-  };
-});
-
 describe('<LifecycleEventListener />', () => {
   it('sets up a event listener on the Performance context object', () => {
     const performance = mockPerformance();

--- a/packages/react-performance/src/test/NavigationListener.test.tsx
+++ b/packages/react-performance/src/test/NavigationListener.test.tsx
@@ -3,13 +3,6 @@ import {mount} from '@shopify/react-testing';
 import {mockPerformance} from './utilities';
 import {NavigationListener, PerformanceContext} from '..';
 
-jest.mock('@shopify/performance', () => {
-  return {
-    ...require.requireActual('@shopify/performance'),
-    Performance: jest.fn(),
-  };
-});
-
 describe('<NavigationListener />', () => {
   it('sets up a navigation listener on the Performance context object', () => {
     const performance = mockPerformance();

--- a/packages/react-performance/src/test/PerformanceMark.test.tsx
+++ b/packages/react-performance/src/test/PerformanceMark.test.tsx
@@ -3,13 +3,6 @@ import {mount} from '@shopify/react-testing';
 import {mockPerformance} from './utilities';
 import {PerformanceMark, PerformanceContext} from '..';
 
-jest.mock('@shopify/performance', () => {
-  return {
-    ...require.requireActual('@shopify/performance'),
-    Performance: jest.fn(),
-  };
-});
-
 describe('<PerformanceMark />', () => {
   it('calls performance.mark', () => {
     const performance = mockPerformance({mark: jest.fn()});

--- a/packages/react-performance/src/test/PerformanceReport.test.tsx
+++ b/packages/react-performance/src/test/PerformanceReport.test.tsx
@@ -7,13 +7,6 @@ import {Method, Header} from '@shopify/network';
 import {mockPerformance, randomConnection} from './utilities';
 import {PerformanceReport, PerformanceContext} from '..';
 
-jest.mock('@shopify/performance', () => {
-  return {
-    ...require.requireActual('@shopify/performance'),
-    Performance: jest.fn(),
-  };
-});
-
 describe('<PerformanceReport />', () => {
   beforeEach(() => {
     timer.mock();

--- a/packages/react-performance/src/test/performance-effect.server.test.tsx
+++ b/packages/react-performance/src/test/performance-effect.server.test.tsx
@@ -6,13 +6,6 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import {usePerformanceEffect, PerformanceEffectCallback} from '..';
 
-jest.mock('@shopify/performance', () => {
-  return {
-    ...require.requireActual('@shopify/performance'),
-    Performance: jest.fn(),
-  };
-});
-
 describe('usePerformanceEffect', () => {
   function TestComponent({callback}: {callback: PerformanceEffectCallback}) {
     usePerformanceEffect(callback);

--- a/packages/react-performance/src/test/performance-effect.test.tsx
+++ b/packages/react-performance/src/test/performance-effect.test.tsx
@@ -7,13 +7,6 @@ import {
   PerformanceContext,
 } from '..';
 
-jest.mock('@shopify/performance', () => {
-  return {
-    ...require.requireActual('@shopify/performance'),
-    Performance: jest.fn(),
-  };
-});
-
 describe('usePerformanceEffect', () => {
   function TestComponent({callback}: {callback: PerformanceEffectCallback}) {
     usePerformanceEffect(callback);


### PR DESCRIPTION
…ist.

## Description

The performance mock currently return an empty object which mean calling `new Performance` will run into error during test. 

I feel like I am not getting to the root of the issue with this solution. 

### Musing 1:
I think the performance mock come with [jsdom](https://github.com/jsdom/jsdom/pull/2094), which only mock a portion of the API in `performance` but this does not explain why the mock is an empty object.

### Musing 2:
we are using [`performance.timing`](https://github.com/Shopify/quilt/blob/add-check-to-performance/packages/performance/src/utilities.ts#L90), but checking for [`PerformanceNavigationTiming`](https://github.com/Shopify/quilt/blob/add-check-to-performance/packages/performance/src/performance.ts#L33) before use. Should we check for `PerformanceTiming` as well?

### Musing 3:
`PerformanceTiming` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming) 😂, should the code be updated to use [`performance.navigation`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming) instead? Although the official types have `timing` and `navigation` type listed as [deprecated](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L11669-L11674)

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] @Shopify/react-performance - Major
- [x] @Shopify/performance - Patch

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
