### PR TITLE
Adjust types on react-csrf and react-universal-provider to match usage

### DIFF
--- a/packages/react-csrf-universal-provider/CHANGELOG.md
+++ b/packages/react-csrf-universal-provider/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Changed type definition from `string` to `string | undefined`
+
 ## [1.0.0] - 2019-08-28
 
 ### Added

--- a/packages/react-csrf-universal-provider/src/CsrfUniversalProvider.ts
+++ b/packages/react-csrf-universal-provider/src/CsrfUniversalProvider.ts
@@ -1,7 +1,6 @@
 import {CsrfTokenContext} from '@shopify/react-csrf';
 import {createUniversalProvider} from '@shopify/react-universal-provider';
 
-export const CsrfUniversalProvider = createUniversalProvider<string>(
-  'csrf-token',
-  CsrfTokenContext,
-);
+export const CsrfUniversalProvider = createUniversalProvider<
+  string | undefined
+>('csrf-token', CsrfTokenContext);

--- a/packages/react-csrf/CHANGELOG.md
+++ b/packages/react-csrf/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Changed type from `string | null` to `string | undefined`.
+
 ## [1.0.0] - 2019-08-28
 
 ### Added

--- a/packages/react-csrf/src/context.ts
+++ b/packages/react-csrf/src/context.ts
@@ -1,3 +1,3 @@
 import {createContext} from 'react';
 
-export const CsrfTokenContext = createContext<string | null>(null);
+export const CsrfTokenContext = createContext<string | undefined>(undefined);

--- a/packages/react-universal-provider/CHANGELOG.md
+++ b/packages/react-universal-provider/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Changed type definition from `Value | null` to `Value | undefined`
+
 ## [1.0.0] - 2019-08-28
 
 ### Added

--- a/packages/react-universal-provider/CHANGELOG.md
+++ b/packages/react-universal-provider/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Changed type definition from `Value | null` to `Value | undefined`
+- Changed type definition from `Value | null` to `Value`
 
 ## [1.0.0] - 2019-08-28
 

--- a/packages/react-universal-provider/src/create-universal-provider.tsx
+++ b/packages/react-universal-provider/src/create-universal-provider.tsx
@@ -8,13 +8,13 @@ export interface UniversalProviderProps<Value> {
 
 export function createUniversalProvider<Value>(
   id: string,
-  Context: React.Context<Value | null>,
+  Context: React.Context<Value>,
 ) {
   const UniversalProvider = React.memo(
     ({value: explicitValue, children}: UniversalProviderProps<Value>) => {
       const [value = explicitValue, Serialize] = useSerialized<Value>(id);
 
-      if (!value) {
+      if (value == null) {
         throw new Error(
           `You must provide a ${id} value, or have one previously serialized.`,
         );

--- a/packages/react-universal-provider/src/test/create-universal-provider.test.tsx
+++ b/packages/react-universal-provider/src/test/create-universal-provider.test.tsx
@@ -8,7 +8,7 @@ import {mount} from '@shopify/react-testing';
 import {createUniversalProvider} from '../create-universal-provider';
 
 const id = 'random';
-const RandomContext = React.createContext<string | null>(null);
+const RandomContext = React.createContext<string | undefined>(undefined);
 const RandomProvider = createUniversalProvider(id, RandomContext);
 
 describe('createUniversalProvider()', () => {
@@ -16,7 +16,7 @@ describe('createUniversalProvider()', () => {
     const randomValue = faker.lorem.word();
     const randomProvider = mount(<RandomProvider value={randomValue} />);
 
-    expect(randomProvider).toProvideReactContext<string | null>(
+    expect(randomProvider).toProvideReactContext<string | undefined>(
       RandomContext,
       randomValue,
     );
@@ -41,7 +41,7 @@ describe('createUniversalProvider()', () => {
       </HtmlContext.Provider>,
     );
 
-    expect(randomProvider).toProvideReactContext<string | null>(
+    expect(randomProvider).toProvideReactContext<string | undefined>(
       RandomContext,
       randomValue,
     );
@@ -67,7 +67,7 @@ describe('createUniversalProvider()', () => {
       </HtmlContext.Provider>,
     );
 
-    expect(randomProvider).toProvideReactContext<string | null>(
+    expect(randomProvider).toProvideReactContext<string | undefined>(
       RandomContext,
       serverRandomValue,
     );


### PR DESCRIPTION
## Description
This PR adjust the types of `@shopify/react-csrf` to match it's usage. 

If the token is `csrfToken?: string` the type will be `string | undefined`. 

## Type of change
- [X] @Shopify/react-csrf  - Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] @shopify/react-csrf-universal-provider  - Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] @shopify/react-universal-provider  - Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
