### PR TITLE
Update Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "arrowParens": "avoid",
   "singleQuote": true,
   "bracketSpacing": false,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "quoteProps": "as-needed"
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jest-transform-graphql": "^2.1.0",
     "lerna": "^2.9.0",
     "plop": "^2.0.0",
-    "prettier": "^1.14.0",
+    "prettier": "~1.17.1",
     "puppeteer": "^1.20.0",
     "react": "16.9.0-alpha.0",
     "react-apollo": "^3.1.2",

--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -41,17 +41,17 @@ export default class AddressFormatter {
   }
 
   /* Returns the address ordered in an array based based on the country code
-  * Eg.:
-  *   [
-  *     'Shopify',
-  *     'First Name Last Name',
-  *     'Address 1',
-  *     'address2',
-  *     'Montréal',
-  *     'Canada Quebec H2J 4B7',
-  *     '514 444 3333'
-  *   ]
-  */
+   * Eg.:
+   *   [
+   *     'Shopify',
+   *     'First Name Last Name',
+   *     'Address 1',
+   *     'address2',
+   *     'Montréal',
+   *     'Canada Quebec H2J 4B7',
+   *     '514 444 3333'
+   *   ]
+   */
   async format(address: Address): Promise<string[]> {
     const country = await this.getCountry(address.country);
     const layout = country.formatting.show || DEFAULT_SHOW_LAYOUT;
@@ -61,17 +61,17 @@ export default class AddressFormatter {
   }
 
   /* Returns an array that shows how to order fields based on the country code
-  * Eg.:
-  *   [
-  *     ['company'],
-  *     ['firstName', 'lastName'],
-  *     ['address1'],
-  *     ['address2'],
-  *     ['city'],
-  *     ['country', 'province', 'zip'],
-  *     ['phone']
-  *   ]
-  */
+   * Eg.:
+   *   [
+   *     ['company'],
+   *     ['firstName', 'lastName'],
+   *     ['address1'],
+   *     ['address2'],
+   *     ['city'],
+   *     ['country', 'province', 'zip'],
+   *     ['phone']
+   *   ]
+   */
   async getOrderedFields(countryCode: string): Promise<FieldName[][]> {
     const country = await this.getCountry(countryCode);
 

--- a/packages/async/src/types.ts
+++ b/packages/async/src/types.ts
@@ -26,5 +26,5 @@ export interface WindowWithRequestIdleCallback {
     callback: RequestIdleCallback,
     opts?: RequestIdleCallbackOptions,
   ): RequestIdleCallbackHandle;
-  cancelIdleCallback: ((handle: RequestIdleCallbackHandle) => void);
+  cancelIdleCallback: (handle: RequestIdleCallbackHandle) => void;
 }

--- a/packages/enzyme-utilities/src/test/fixtures/Toggle.tsx
+++ b/packages/enzyme-utilities/src/test/fixtures/Toggle.tsx
@@ -15,23 +15,20 @@ export function Toggle({onToggle, deferred}: Props) {
   const [active, setActive] = React.useState(true);
   const statusMarkup = active ? 'active' : 'inactive';
 
-  const handleClick = React.useCallback(
-    () => {
-      if (deferred) {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            setActive(!active);
-            onToggle();
-            resolve();
-          }, DEFERRED_TIMEOUT);
-        });
-      }
-      setActive(!active);
-      onToggle();
-      return Promise.resolve();
-    },
-    [active, deferred, onToggle],
-  );
+  const handleClick = React.useCallback(() => {
+    if (deferred) {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          setActive(!active);
+          onToggle();
+          resolve();
+        }, DEFERRED_TIMEOUT);
+      });
+    }
+    setActive(!active);
+    onToggle();
+    return Promise.resolve();
+  }, [active, deferred, onToggle]);
 
   return (
     <button type="button" onClick={handleClick}>

--- a/packages/graphql-persisted/src/tests/utilities.ts
+++ b/packages/graphql-persisted/src/tests/utilities.ts
@@ -40,7 +40,7 @@ export function executeOnce(link: ApolloLink, query: DocumentNode) {
   });
 }
 
-type BeforeResult = ((operation: Operation) => void);
+type BeforeResult = (operation: Operation) => void;
 type Result = {data: object} | {errors: {message: string}[]} | Error;
 type MultiResult =
   | Result

--- a/packages/graphql-testing/src/links/tests/utilities.ts
+++ b/packages/graphql-testing/src/links/tests/utilities.ts
@@ -40,7 +40,7 @@ export function executeOnce(link: ApolloLink, query: DocumentNode) {
   });
 }
 
-type BeforeResult = ((operation: Operation) => void);
+type BeforeResult = (operation: Operation) => void;
 
 export class SimpleLink extends ApolloLink {
   constructor(

--- a/packages/koa-performance/src/test/middleware.test.ts
+++ b/packages/koa-performance/src/test/middleware.test.ts
@@ -485,7 +485,9 @@ describe('client metrics middleware', () => {
 type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends any[]
     ? T[K]
-    : T[K] extends object ? DeepPartial<T[K]> : T[K]
+    : T[K] extends object
+    ? DeepPartial<T[K]>
+    : T[K]
 };
 
 function createBody({

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -143,16 +143,13 @@ export function createAsyncComponent<
 
     const customPreload = useCustomPreload(props);
 
-    return useCallback(
-      () => {
-        load();
+    return useCallback(() => {
+      load();
 
-        if (customPreload) {
-          customPreload();
-        }
-      },
-      [load, customPreload],
-    );
+      if (customPreload) {
+        customPreload();
+      }
+    }, [load, customPreload]);
   }
 
   function usePrefetch(props: PrefetchOptions) {
@@ -162,16 +159,13 @@ export function createAsyncComponent<
 
     const customPrefetch = useCustomPrefetch(props);
 
-    return useCallback(
-      () => {
-        load();
+    return useCallback(() => {
+      load();
 
-        if (customPrefetch) {
-          customPrefetch();
-        }
-      },
-      [load, customPrefetch],
-    );
+      if (customPrefetch) {
+        customPrefetch();
+      }
+    }, [load, customPrefetch]);
   }
 
   function useKeepFresh(props: KeepFreshOptions) {
@@ -181,16 +175,13 @@ export function createAsyncComponent<
 
     const customKeepFresh = useCustomKeepFresh(props);
 
-    return useCallback(
-      () => {
-        load();
+    return useCallback(() => {
+      load();
 
-        if (customKeepFresh) {
-          customKeepFresh();
-        }
-      },
-      [load, customKeepFresh],
-    );
+      if (customKeepFresh) {
+        customKeepFresh();
+      }
+    }, [load, customKeepFresh]);
   }
 
   function Preload(options: PreloadOptions) {
@@ -203,12 +194,9 @@ export function createAsyncComponent<
   function Prefetch(options: PrefetchOptions) {
     const prefetch = usePrefetch(options);
 
-    useEffect(
-      () => {
-        prefetch();
-      },
-      [prefetch],
-    );
+    useEffect(() => {
+      prefetch();
+    }, [prefetch]);
 
     return null;
   }
@@ -314,16 +302,13 @@ function Loader<T>({
     [load],
   );
 
-  useEffect(
-    () => {
-      if (defer == null || defer === DeferTiming.Mount) {
-        load();
-      } else if (typeof defer === 'function' && defer(props)) {
-        load();
-      }
-    },
-    [defer, load, props],
-  );
+  useEffect(() => {
+    if (defer == null || defer === DeferTiming.Mount) {
+      load();
+    } else if (typeof defer === 'function' && defer(props)) {
+      load();
+    }
+  }, [defer, load, props]);
 
   if (typeof defer === 'function') {
     return null;

--- a/packages/react-async/src/provider.tsx
+++ b/packages/react-async/src/provider.tsx
@@ -47,12 +47,9 @@ export function createAsyncContext<Value>({
       assets: AssetTiming.Immediate,
     });
 
-    useEffect(
-      () => {
-        load();
-      },
-      [load],
-    );
+    useEffect(() => {
+      load();
+    }, [load]);
 
     return <Context.Provider value={resolved} {...props} />;
   }
@@ -76,12 +73,9 @@ export function createAsyncContext<Value>({
   function Prefetch() {
     const preload = usePreload();
 
-    useEffect(
-      () => {
-        preload();
-      },
-      [preload],
-    );
+    useEffect(() => {
+      preload();
+    }, [preload]);
 
     return null;
   }

--- a/packages/react-cookie/src/hooks.ts
+++ b/packages/react-cookie/src/hooks.ts
@@ -20,8 +20,8 @@ export function useCookie(
     throw new Error(NO_MANAGER_ERROR);
   }
 
-  const [cookie, setCookieValue] = useState(
-    () => (manager ? manager.getCookie(key) : undefined),
+  const [cookie, setCookieValue] = useState(() =>
+    manager ? manager.getCookie(key) : undefined,
   );
 
   const setCookie = useCallback(

--- a/packages/react-effect/src/manager.ts
+++ b/packages/react-effect/src/manager.ts
@@ -40,22 +40,20 @@ export class EffectManager {
 
   async betweenEachPass(pass: Pass) {
     await Promise.all(
-      [...this.kinds].map(
-        kind =>
-          typeof kind.betweenEachPass === 'function'
-            ? kind.betweenEachPass(pass)
-            : Promise.resolve(),
+      [...this.kinds].map(kind =>
+        typeof kind.betweenEachPass === 'function'
+          ? kind.betweenEachPass(pass)
+          : Promise.resolve(),
       ),
     );
   }
 
   async afterEachPass(pass: Pass) {
     const results = await Promise.all(
-      [...this.kinds].map(
-        kind =>
-          typeof kind.afterEachPass === 'function'
-            ? kind.afterEachPass(pass)
-            : Promise.resolve(),
+      [...this.kinds].map(kind =>
+        typeof kind.afterEachPass === 'function'
+          ? kind.afterEachPass(pass)
+          : Promise.resolve(),
       ),
     );
 

--- a/packages/react-form/src/hooks/dirty.ts
+++ b/packages/react-form/src/hooks/dirty.ts
@@ -5,23 +5,20 @@ import {isField} from '../utilities';
 export function useDirty(fieldBag: {[key: string]: FieldOutput<any>}) {
   const fields = Object.values(fieldBag);
 
-  return useMemo(
-    () => {
-      return fields.some(item => {
-        if (isField(item)) {
-          return item.dirty;
-        }
+  return useMemo(() => {
+    return fields.some(item => {
+      if (isField(item)) {
+        return item.dirty;
+      }
 
-        if (Array.isArray(item)) {
-          return item.some(fieldsDirty);
-        }
+      if (Array.isArray(item)) {
+        return item.some(fieldsDirty);
+      }
 
-        return fieldsDirty(item);
-      });
-    },
+      return fieldsDirty(item);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [...fields],
-  );
+  }, [...fields]);
 }
 
 function fieldsDirty(fields: FieldDictionary<any>) {

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -154,43 +154,44 @@ export function useField<Value = string>(
     dispatch,
   ]);
 
-  const onBlur = useCallback(
-    () => {
-      if (state.touched === false && state.error == null) {
-        return;
-      }
+  const onBlur = useCallback(() => {
+    if (state.touched === false && state.error == null) {
+      return;
+    }
 
-      runValidation();
-    },
-    [runValidation, state.touched, state.error],
-  );
+    runValidation();
+  }, [runValidation, state.touched, state.error]);
 
   // We want to reset the field whenever a new `value` is passed in
-  useEffect(
-    () => {
-      if (!isEqual(value, state.defaultValue)) {
-        newDefaultValue(value);
-      }
-    },
-    //  We actually do not want this to rerun when our `defaultValue` is updated. It can only happen independently of this callback when `newDefaultValue` is called by a user, and we don't want to undue their hard work by resetting to `value`.
+  useEffect(() => {
+    if (!isEqual(value, state.defaultValue)) {
+      newDefaultValue(value);
+    }
+    // We actually do not want this to rerun when our `defaultValue` is updated. It can
+    // only happen independently of this callback when `newDefaultValue` is called by a user,
+    // and we don't want to undue their hard work by resetting to `value`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [value, newDefaultValue],
-  );
+  }, [value, newDefaultValue]);
 
-  const field = useMemo(
-    () => {
-      return {
-        ...state,
-        onBlur,
-        onChange,
-        newDefaultValue,
-        runValidation,
-        setError,
-        reset,
-      };
-    },
-    [state, onBlur, onChange, newDefaultValue, runValidation, setError, reset],
-  );
+  const field = useMemo(() => {
+    return {
+      ...state,
+      onBlur,
+      onChange,
+      newDefaultValue,
+      runValidation,
+      setError,
+      reset,
+    };
+  }, [
+    state,
+    onBlur,
+    onChange,
+    newDefaultValue,
+    runValidation,
+    setError,
+    reset,
+  ]);
 
   return field as Field<Value>;
 }

--- a/packages/react-form/src/hooks/form.ts
+++ b/packages/react-form/src/hooks/form.ts
@@ -65,23 +65,17 @@ export function useForm<T extends FieldBag>({
   const basicReset = useReset(fields);
   const {submit, submitting, errors, setErrors} = useSubmit(onSubmit, fields);
 
-  const reset = useCallback(
-    () => {
-      setErrors([]);
-      basicReset();
-    },
-    [basicReset, setErrors],
-  );
+  const reset = useCallback(() => {
+    setErrors([]);
+    basicReset();
+  }, [basicReset, setErrors]);
 
   const fieldsRef = useRef(fields);
   fieldsRef.current = fields;
 
-  const validate = useCallback(
-    () => {
-      return validateAll(fieldsRef.current);
-    },
-    [fieldsRef],
-  );
+  const validate = useCallback(() => {
+    return validateAll(fieldsRef.current);
+  }, [fieldsRef]);
 
   return {
     fields,

--- a/packages/react-form/src/hooks/list/list.ts
+++ b/packages/react-form/src/hooks/list/list.ts
@@ -135,14 +135,11 @@ export function useList<Item extends object>(
 ): FieldDictionary<Item>[] {
   const [state, dispatch] = useListReducer(list);
 
-  useEffect(
-    () => {
-      if (!isEqual(list, state.initial)) {
-        dispatch(reinitializeAction(list));
-      }
-    },
-    [list, state.initial, dispatch],
-  );
+  useEffect(() => {
+    if (!isEqual(list, state.initial)) {
+      dispatch(reinitializeAction(list));
+    }
+  }, [list, state.initial, dispatch]);
 
   const validationConfigs = useMemo(
     () =>
@@ -154,92 +151,84 @@ export function useList<Item extends object>(
     [validates, ...validationDependencies],
   );
 
-  const handlers = useMemo(
-    () => {
-      return state.list.map((item, index) => {
-        return mapObject<FieldDictionary<Item>>(
-          item,
-          <Key extends keyof Item & string>(
-            field: FieldState<Item[Key]>,
-            key: Key,
-          ) => {
-            const target = {index, key};
+  const handlers = useMemo(() => {
+    return state.list.map((item, index) => {
+      return mapObject<FieldDictionary<Item>>(
+        item,
+        <Key extends keyof Item & string>(
+          field: FieldState<Item[Key]>,
+          key: Key,
+        ) => {
+          const target = {index, key};
 
-            function validate(value = field.value) {
-              const validates = validationConfigs[key];
+          function validate(value = field.value) {
+            const validates = validationConfigs[key];
 
-              if (validates == null) {
-                return;
-              }
-
-              const siblings = state.list.filter(listItem => listItem !== item);
-
-              runValidation(
-                error =>
-                  dispatch(
-                    updateErrorAction<Item>({target, error: error || ''}),
-                  ),
-                {value, siblings, listItem: item},
-                validates,
-              );
+            if (validates == null) {
+              return;
             }
 
-            return {
-              onChange(value: Item[Key] | ChangeEvent) {
-                const normalizedValue = (isChangeEvent(value)
-                  ? value.target.value
-                  : value) as Item[Key];
+            const siblings = state.list.filter(listItem => listItem !== item);
 
-                dispatch(
-                  updateAction({
-                    target,
-                    value: normalizedValue,
-                  }),
-                );
+            runValidation(
+              error =>
+                dispatch(updateErrorAction<Item>({target, error: error || ''})),
+              {value, siblings, listItem: item},
+              validates,
+            );
+          }
 
-                if (field.error) {
-                  validate(normalizedValue);
-                }
-              },
-              reset() {
-                dispatch(resetAction({target}));
-              },
-              newDefaultValue(value: Item[Key]) {
-                dispatch(newDefaultAction({target, value}));
-              },
-              runValidation: validate,
-              onBlur() {
-                const {touched, error} = field;
-
-                if (touched === false && error == null) {
-                  return;
-                }
-                validate();
-              },
-              setError(error: string) {
-                dispatch(updateErrorAction({target, error}));
-              },
-            };
-          },
-        );
-      });
-    },
-    [dispatch, state.list, validationConfigs],
-  );
-
-  return useMemo(
-    () => {
-      return state.list.map((item, index) => {
-        return mapObject(item, (field, key: keyof Item) => {
           return {
-            ...field,
-            ...(handlers[index][key] as any),
+            onChange(value: Item[Key] | ChangeEvent) {
+              const normalizedValue = (isChangeEvent(value)
+                ? value.target.value
+                : value) as Item[Key];
+
+              dispatch(
+                updateAction({
+                  target,
+                  value: normalizedValue,
+                }),
+              );
+
+              if (field.error) {
+                validate(normalizedValue);
+              }
+            },
+            reset() {
+              dispatch(resetAction({target}));
+            },
+            newDefaultValue(value: Item[Key]) {
+              dispatch(newDefaultAction({target, value}));
+            },
+            runValidation: validate,
+            onBlur() {
+              const {touched, error} = field;
+
+              if (touched === false && error == null) {
+                return;
+              }
+              validate();
+            },
+            setError(error: string) {
+              dispatch(updateErrorAction({target, error}));
+            },
           };
-        });
+        },
+      );
+    });
+  }, [dispatch, state.list, validationConfigs]);
+
+  return useMemo(() => {
+    return state.list.map((item, index) => {
+      return mapObject(item, (field, key: keyof Item) => {
+        return {
+          ...field,
+          ...(handlers[index][key] as any),
+        };
       });
-    },
-    [state.list, handlers],
-  );
+    });
+  }, [state.list, handlers]);
 }
 
 function runValidation<Value, Record extends object>(

--- a/packages/react-form/src/hooks/visitFields.ts
+++ b/packages/react-form/src/hooks/visitFields.ts
@@ -13,27 +13,24 @@ export default function useVisitFields(
   const fieldBagRef = useRef(fieldBag);
   fieldBagRef.current = fieldBag;
 
-  return useCallback(
-    () => {
-      const fields = Object.values(fieldBagRef.current);
+  return useCallback(() => {
+    const fields = Object.values(fieldBagRef.current);
 
-      for (const item of fields) {
-        if (isField(item)) {
-          visitor(item);
-          continue;
-        }
-
-        const visit = visitDictionary(visitor);
-        if (Array.isArray(item)) {
-          item.forEach(visit);
-          continue;
-        }
-
-        visit(item);
+    for (const item of fields) {
+      if (isField(item)) {
+        visitor(item);
+        continue;
       }
-    },
-    [visitor],
-  );
+
+      const visit = visitDictionary(visitor);
+      if (Array.isArray(item)) {
+        item.forEach(visit);
+        continue;
+      }
+
+      visit(item);
+    }
+  }, [visitor]);
 }
 
 function visitDictionary(visitor: FieldVisitor) {

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -97,8 +97,8 @@ export interface SubmitHandler<Fields> {
 type FieldProp<T, K extends keyof Field<any>> = T extends Field<any>
   ? T[K]
   : T extends FieldDictionary<any>
-    ? {[InnerKey in keyof T]: T[InnerKey][K]}
-    : T;
+  ? {[InnerKey in keyof T]: T[InnerKey][K]}
+  : T;
 
 /**
   Represents all of the values for a given key mapped out of a mixed dictionary of Field objects,

--- a/packages/react-graphql/src/async.tsx
+++ b/packages/react-graphql/src/async.tsx
@@ -30,12 +30,9 @@ export function createAsyncQueryComponent<Data, Variables, DeepPartial>({
       assets: AssetTiming.Immediate,
     });
 
-    useEffect(
-      () => {
-        load();
-      },
-      [load],
-    );
+    useEffect(() => {
+      load();
+    }, [load]);
 
     return query ? (
       <Query query={query} {...props as any} />

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -28,30 +28,24 @@ export default function useGraphQLDocument<
 
   const mounted = useMountedRef();
 
-  const loadDocument = useCallback(
-    async () => {
-      if (!isDocumentNode(documentOrComponent)) {
-        try {
-          const resolved = await documentOrComponent.resolver.resolve();
-          if (mounted.current) {
-            setDocument(resolved);
-          }
-        } catch (error) {
-          throw Error('error loading GraphQL document');
+  const loadDocument = useCallback(async () => {
+    if (!isDocumentNode(documentOrComponent)) {
+      try {
+        const resolved = await documentOrComponent.resolver.resolve();
+        if (mounted.current) {
+          setDocument(resolved);
         }
+      } catch (error) {
+        throw Error('error loading GraphQL document');
       }
-    },
-    [documentOrComponent, mounted],
-  );
+    }
+  }, [documentOrComponent, mounted]);
 
-  useEffect(
-    () => {
-      if (!document) {
-        loadDocument();
-      }
-    },
-    [document, loadDocument],
-  );
+  useEffect(() => {
+    if (!document) {
+      loadDocument();
+    }
+  }, [document, loadDocument]);
 
   useAsyncAsset(
     isDocumentNode(documentOrComponent)

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -57,45 +57,39 @@ export default function useQuery<
       ? 'cache-first'
       : fetchPolicy;
   const serializedVariables = variables && JSON.stringify(variables);
-  const watchQueryOptions = useMemo<WatchQueryOptions<Variables> | null>(
-    () => {
-      if (!query) {
-        return null;
-      }
+  const watchQueryOptions = useMemo<WatchQueryOptions<Variables> | null>(() => {
+    if (!query) {
+      return null;
+    }
 
-      return {
-        query,
-        context,
-        variables,
-        fetchPolicy: normalizedFetchPolicy,
-        errorPolicy,
-        pollInterval,
-        notifyOnNetworkStatusChange,
-      };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
+    return {
       query,
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      context && JSON.stringify(context),
-      serializedVariables,
-      normalizedFetchPolicy,
+      context,
+      variables,
+      fetchPolicy: normalizedFetchPolicy,
       errorPolicy,
       pollInterval,
       notifyOnNetworkStatusChange,
-    ],
-  );
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    query,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    context && JSON.stringify(context),
+    serializedVariables,
+    normalizedFetchPolicy,
+    errorPolicy,
+    pollInterval,
+    notifyOnNetworkStatusChange,
+  ]);
 
-  const queryObservable = useMemo(
-    () => {
-      if (skip || !watchQueryOptions) {
-        return;
-      }
+  const queryObservable = useMemo(() => {
+    if (skip || !watchQueryOptions) {
+      return;
+    }
 
-      return client.watchQuery(watchQueryOptions);
-    },
-    [client, skip, watchQueryOptions],
-  );
+    return client.watchQuery(watchQueryOptions);
+  }, [client, skip, watchQueryOptions]);
 
   useServerEffect(() => {
     if (queryObservable == null) {
@@ -114,84 +108,79 @@ export default function useQuery<
 
   const [responseId, setResponseId] = useState(0);
 
-  useEffect(
-    () => {
-      if (skip || !queryObservable) {
-        return;
-      }
+  useEffect(() => {
+    if (skip || !queryObservable) {
+      return;
+    }
 
-      const invalidateCurrentResult = () => {
-        setResponseId(x => x + 1);
-      };
-      const subscription = queryObservable.subscribe(
-        invalidateCurrentResult,
-        invalidateCurrentResult,
-      );
+    const invalidateCurrentResult = () => {
+      setResponseId(x => x + 1);
+    };
+    const subscription = queryObservable.subscribe(
+      invalidateCurrentResult,
+      invalidateCurrentResult,
+    );
 
-      return () => {
-        subscription.unsubscribe();
-      };
-    },
-    [skip, queryObservable],
-  );
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [skip, queryObservable]);
 
   const previousData = useRef<QueryHookResult<Data, Variables>['data']>(
     undefined,
   );
 
-  const currentResult = useMemo<QueryHookResult<Data, Variables>>(
-    () => {
-      // must of the logic below are lifted from
-      // https://github.com/apollographql/react-apollo/blob/22f8ebf52b26b348d6be905d5b7fbbfea51c1541/src/Query.tsx#L410-L477
-      if (skip) {
-        return defaultResult;
-      }
+  const currentResult = useMemo<QueryHookResult<Data, Variables>>(() => {
+    // must of the logic below are lifted from
+    // https://github.com/apollographql/react-apollo/blob/22f8ebf52b26b348d6be905d5b7fbbfea51c1541/src/Query.tsx#L410-L477
+    if (skip) {
+      return defaultResult;
+    }
 
-      if (!queryObservable) {
-        return {
-          ...defaultResult,
-          // while documentNode is loading
-          loading: true,
-        };
-      }
-
-      const result = queryObservable.getCurrentResult();
-      const {fetchPolicy} = queryObservable.options;
-
-      const hasError = result.errors && result.errors.length > 0;
-      let data: QueryHookResult<Data, Variables>['data'] = result.data;
-      if (result.loading) {
-        data =
-          previousData.current || (result && result.data)
-            ? {
-                ...(previousData.current || {}),
-                ...((result && result.data) || {}),
-              }
-            : undefined;
-      } else if (hasError) {
-        data = (queryObservable.getLastResult() || {}).data;
-      } else if (
-        fetchPolicy === 'no-cache' &&
-        Object.keys(result.data).length === 0
-      ) {
-        data = previousData.current;
-      } else {
-        previousData.current = result.data;
-      }
-
+    if (!queryObservable) {
       return {
         ...defaultResult,
-        data,
-        error: hasError
-          ? new ApolloError({graphQLErrors: result.errors})
-          : result.error,
-        networkStatus: result.networkStatus,
-        loading: result.loading,
+        // while documentNode is loading
+        loading: true,
       };
-    },
+    }
+
+    const result = queryObservable.getCurrentResult();
+    const {fetchPolicy} = queryObservable.options;
+
+    const hasError = result.errors && result.errors.length > 0;
+    let data: QueryHookResult<Data, Variables>['data'] = result.data;
+    if (result.loading) {
+      data =
+        previousData.current || (result && result.data)
+          ? {
+              ...(previousData.current || {}),
+              ...((result && result.data) || {}),
+            }
+          : undefined;
+    } else if (hasError) {
+      data = (queryObservable.getLastResult() || {}).data;
+    } else if (
+      fetchPolicy === 'no-cache' &&
+      Object.keys(result.data).length === 0
+    ) {
+      data = previousData.current;
+    } else {
+      previousData.current = result.data;
+    }
+
+    return {
+      ...defaultResult,
+      data,
+      error: hasError
+        ? new ApolloError({graphQLErrors: result.errors})
+        : result.error,
+      networkStatus: result.networkStatus,
+      loading: result.loading,
+    };
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [responseId, skip, queryObservable, defaultResult, previousData],
-  );
+  }, [responseId, skip, queryObservable, defaultResult, previousData]);
 
   return currentResult;
 }

--- a/packages/react-hooks/src/hooks/timeout.tsx
+++ b/packages/react-hooks/src/hooks/timeout.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 
 export default function useTimeout(callback: () => void, delay: number) {
-  React.useEffect(
-    () => {
-      const id = setTimeout(callback, delay);
-      return () => clearTimeout(id);
-    },
-    [callback, delay],
-  );
+  React.useEffect(() => {
+    const id = setTimeout(callback, delay);
+    return () => clearTimeout(id);
+  }, [callback, delay]);
 }

--- a/packages/react-html/src/hooks.ts
+++ b/packages/react-html/src/hooks.ts
@@ -6,7 +6,7 @@ import {HtmlContext} from './context';
 import {HtmlManager} from './manager';
 
 export function useDomEffect(
-  perform: (manager: HtmlManager) => (() => void),
+  perform: (manager: HtmlManager) => () => void,
   inputs: unknown[] = [],
 ) {
   const manager = useContext(HtmlContext);
@@ -74,22 +74,19 @@ export function useBodyAttributes(
 }
 
 export function useClientDomEffect(
-  perform: (manager: HtmlManager) => (() => void),
+  perform: (manager: HtmlManager) => () => void,
   inputs: unknown[] = [],
 ) {
   const manager = useContext(HtmlContext);
 
-  useEffect(
-    () => {
-      perform(manager);
-    },
+  useEffect(() => {
+    perform(manager);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [manager, perform, ...inputs],
-  );
+  }, [manager, perform, ...inputs]);
 }
 
 export function useServerDomEffect(
-  perform: (manager: HtmlManager) => (() => void),
+  perform: (manager: HtmlManager) => () => void,
 ) {
   const manager = useContext(HtmlContext);
 

--- a/packages/react-html/src/serializer.tsx
+++ b/packages/react-html/src/serializer.tsx
@@ -48,14 +48,17 @@ export function createSerializer<T>(id: string) {
   function Serialize({data}: SerializeProps<T>) {
     const manager = React.useContext(HtmlContext);
 
-    useServerEffect(() => {
-      const result = data();
-      const handleResult = manager.setSerialization.bind(manager, id);
+    useServerEffect(
+      () => {
+        const result = data();
+        const handleResult = manager.setSerialization.bind(manager, id);
 
-      return typeof result === 'object' && result != null && isPromise(result)
-        ? result.then(handleResult)
-        : handleResult(result);
-    }, manager ? manager.effect : undefined);
+        return typeof result === 'object' && result != null && isPromise(result)
+          ? result.then(handleResult)
+          : handleResult(result);
+      },
+      manager ? manager.effect : undefined,
+    );
 
     return null;
   }

--- a/packages/react-hydrate/src/HydrationTracker.tsx
+++ b/packages/react-hydrate/src/HydrationTracker.tsx
@@ -4,12 +4,9 @@ import {useHydrationManager} from './hooks';
 export function HydrationTracker() {
   const manager = useHydrationManager();
 
-  React.useEffect(
-    () => {
-      manager.hydrated = true;
-    },
-    [manager],
-  );
+  React.useEffect(() => {
+    manager.hydrated = true;
+  }, [manager]);
 
   return null;
 }

--- a/packages/react-idle/src/hooks.ts
+++ b/packages/react-idle/src/hooks.ts
@@ -11,37 +11,34 @@ export function useIdleCallback(
 ) {
   const handle = useRef<RequestIdleCallbackHandle | null>(null);
 
-  useEffect(
-    () => {
-      if ('requestIdleCallback' in window) {
-        handle.current = (window as WindowWithRequestIdleCallback).requestIdleCallback(
-          () => callback(),
-        );
-      } else if (unsupportedBehavior === UnsupportedBehavior.AnimationFrame) {
-        handle.current = window.requestAnimationFrame(() => {
-          callback();
-        });
-      } else {
+  useEffect(() => {
+    if ('requestIdleCallback' in window) {
+      handle.current = (window as WindowWithRequestIdleCallback).requestIdleCallback(
+        () => callback(),
+      );
+    } else if (unsupportedBehavior === UnsupportedBehavior.AnimationFrame) {
+      handle.current = window.requestAnimationFrame(() => {
         callback();
+      });
+    } else {
+      callback();
+    }
+
+    return () => {
+      const {current: currentHandle} = handle;
+      handle.current = null;
+
+      if (currentHandle == null) {
+        return;
       }
 
-      return () => {
-        const {current: currentHandle} = handle;
-        handle.current = null;
-
-        if (currentHandle == null) {
-          return;
-        }
-
-        if ('cancelIdleCallback' in window) {
-          (window as WindowWithRequestIdleCallback).cancelIdleCallback(
-            currentHandle,
-          );
-        } else if (unsupportedBehavior === UnsupportedBehavior.AnimationFrame) {
-          window.cancelAnimationFrame(currentHandle);
-        }
-      };
-    },
-    [callback, unsupportedBehavior],
-  );
+      if ('cancelIdleCallback' in window) {
+        (window as WindowWithRequestIdleCallback).cancelIdleCallback(
+          currentHandle,
+        );
+      } else if (unsupportedBehavior === UnsupportedBehavior.AnimationFrame) {
+        window.cancelAnimationFrame(currentHandle);
+      }
+    };
+  }, [callback, unsupportedBehavior]);
 }

--- a/packages/react-import-remote/src/ImportRemote.tsx
+++ b/packages/react-import-remote/src/ImportRemote.tsx
@@ -32,18 +32,15 @@ export default function ImportRemote<T = unknown>({
       <div ref={intersectionRef as React.RefObject<HTMLDivElement>} />
     ) : null;
 
-  React.useEffect(
-    () => {
-      switch (result.status) {
-        case Status.Failed:
-          onImported(result.error);
-          return;
-        case Status.Complete:
-          onImported(result.imported);
-      }
-    },
-    [result, onImported],
-  );
+  React.useEffect(() => {
+    switch (result.status) {
+      case Status.Failed:
+        onImported(result.error);
+        return;
+      case Status.Complete:
+        onImported(result.imported);
+    }
+  }, [result, onImported]);
 
   if (preconnect) {
     const url = new URL(source);

--- a/packages/react-import-remote/src/hooks.ts
+++ b/packages/react-import-remote/src/hooks.ts
@@ -67,64 +67,55 @@ export function useImportRemote<Imported = unknown>(
   }
   /* eslint-enable react-hooks/rules-of-hooks */
 
-  const loadRemote = React.useCallback(
-    async () => {
-      try {
-        setResult({status: Status.Loading});
-        const importResult = await load(source, getImport, nonce);
+  const loadRemote = React.useCallback(async () => {
+    try {
+      setResult({status: Status.Loading});
+      const importResult = await load(source, getImport, nonce);
 
-        if (mounted.current) {
-          setResult({status: Status.Complete, imported: importResult});
-        }
-      } catch (error) {
-        if (mounted.current) {
-          setResult({status: Status.Failed, error});
-        }
+      if (mounted.current) {
+        setResult({status: Status.Complete, imported: importResult});
       }
-    },
-    [getImport, mounted, nonce, source],
-  );
+    } catch (error) {
+      if (mounted.current) {
+        setResult({status: Status.Failed, error});
+      }
+    }
+  }, [getImport, mounted, nonce, source]);
 
-  React.useEffect(
-    () => {
+  React.useEffect(() => {
+    if (
+      result.status === Status.Initial &&
+      defer === DeferTiming.InViewport &&
+      intersection &&
+      intersection.isIntersecting
+    ) {
+      loadRemote();
+    }
+  }, [result, defer, intersection, loadRemote]);
+
+  React.useEffect(() => {
+    if (defer === DeferTiming.Idle) {
+      if ('requestIdleCallback' in window) {
+        idleCallbackHandle.current = (window as WindowWithRequestIdleCallback).requestIdleCallback(
+          loadRemote,
+        );
+      } else {
+        loadRemote();
+      }
+    } else if (defer === DeferTiming.Mount) {
+      loadRemote();
+    }
+
+    return () => {
       if (
-        result.status === Status.Initial &&
-        defer === DeferTiming.InViewport &&
-        intersection &&
-        intersection.isIntersecting
+        idleCallbackHandle.current != null &&
+        typeof (window as any).cancelIdleCallback === 'function'
       ) {
-        loadRemote();
+        (window as any).cancelIdleCallback(idleCallbackHandle.current);
+        idleCallbackHandle.current = null;
       }
-    },
-    [result, defer, intersection, loadRemote],
-  );
-
-  React.useEffect(
-    () => {
-      if (defer === DeferTiming.Idle) {
-        if ('requestIdleCallback' in window) {
-          idleCallbackHandle.current = (window as WindowWithRequestIdleCallback).requestIdleCallback(
-            loadRemote,
-          );
-        } else {
-          loadRemote();
-        }
-      } else if (defer === DeferTiming.Mount) {
-        loadRemote();
-      }
-
-      return () => {
-        if (
-          idleCallbackHandle.current != null &&
-          typeof (window as any).cancelIdleCallback === 'function'
-        ) {
-          (window as any).cancelIdleCallback(idleCallbackHandle.current);
-          idleCallbackHandle.current = null;
-        }
-      };
-    },
-    [defer, loadRemote, intersection, nonce, getImport, source],
-  );
+    };
+  }, [defer, loadRemote, intersection, nonce, getImport, source]);
 
   return {result, intersectionRef};
 }

--- a/packages/react-intersection-observer/src/hooks.ts
+++ b/packages/react-intersection-observer/src/hooks.ts
@@ -45,37 +45,38 @@ export function useIntersection({
     time: Date.now(),
   }));
 
-  useEffect(
-    () => {
-      if (!isSupported()) {
-        return;
-      }
+  useEffect(() => {
+    if (!isSupported()) {
+      return;
+    }
 
-      const resolvedRoot =
-        typeof root === 'string' ? document.querySelector(root) : root;
+    const resolvedRoot =
+      typeof root === 'string' ? document.querySelector(root) : root;
 
-      const intersectionObserver = new IntersectionObserver(
-        ([entry]) =>
-          setIntersectingEntry({
-            ...entry,
-            // Normalizes for inconsistent browser support
-            isIntersecting: entry.intersectionRatio > 0,
-          }),
-        {
-          root: resolvedRoot,
-          rootMargin,
-          threshold,
-        },
-      );
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) =>
+        setIntersectingEntry({
+          ...entry,
+          // Normalizes for inconsistent browser support
+          isIntersecting: entry.intersectionRatio > 0,
+        }),
+      {
+        root: resolvedRoot,
+        rootMargin,
+        threshold,
+      },
+    );
 
-      observer.current = intersectionObserver;
+    observer.current = intersectionObserver;
 
-      return () => {
-        intersectionObserver.disconnect();
-      };
-    },
-    [root, rootMargin, Array.isArray(threshold) ? threshold.join() : threshold],
-  );
+    return () => {
+      intersectionObserver.disconnect();
+    };
+  }, [
+    root,
+    rootMargin,
+    Array.isArray(threshold) ? threshold.join() : threshold,
+  ]);
 
   useEffect(() => {
     if (

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -9,11 +9,14 @@ import {NetworkManager} from './manager';
 export function useNetworkEffect(perform: (network: NetworkManager) => void) {
   const network = useContext(NetworkContext);
 
-  useServerEffect(() => {
-    if (network != null) {
-      return perform(network);
-    }
-  }, network ? network.effect : undefined);
+  useServerEffect(
+    () => {
+      if (network != null) {
+        return perform(network);
+      }
+    },
+    network ? network.effect : undefined,
+  );
 }
 
 export function useCspDirective(

--- a/packages/react-performance/src/performance-effect.ts
+++ b/packages/react-performance/src/performance-effect.ts
@@ -13,19 +13,16 @@ export function usePerformanceEffect(
 ) {
   const performance = useContext(PerformanceContext);
 
-  useEffect(
-    () => {
-      if (performance == null) {
-        return;
-      }
+  useEffect(() => {
+    if (performance == null) {
+      return;
+    }
 
-      const cleanup = callback(performance);
+    const cleanup = callback(performance);
 
-      if (cleanup) {
-        return cleanup;
-      }
-    },
+    if (cleanup) {
+      return cleanup;
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [performance, ...dependencies],
-  );
+  }, [performance, ...dependencies]);
 }

--- a/packages/react-router/src/components/Redirect.tsx
+++ b/packages/react-router/src/components/Redirect.tsx
@@ -9,12 +9,9 @@ interface Props {
 type ComposedProps = Props & RouteComponentProps;
 
 function Redirect({url, history}: ComposedProps) {
-  useEffect(
-    () => {
-      history.push(url);
-    },
-    [history, url],
-  );
+  useEffect(() => {
+    history.push(url);
+  }, [history, url]);
   return <NetworkRedirect url={url} />;
 }
 

--- a/packages/react-shopify-app-route-propagator/src/hook.ts
+++ b/packages/react-shopify-app-route-propagator/src/hook.ts
@@ -16,33 +16,30 @@ export default function useRoutePropagation(
 ) {
   const history = useMemo(() => History.create(app), [app]);
 
-  useEffect(
-    () => {
-      const selfWindow = getSelfWindow();
-      const topWindow = getTopWindow();
+  useEffect(() => {
+    const selfWindow = getSelfWindow();
+    const topWindow = getTopWindow();
 
-      const renderedInTheTopWindow = selfWindow === topWindow;
-      const renderedInAModal = selfWindow.name === MODAL_IFRAME_NAME;
+    const renderedInTheTopWindow = selfWindow === topWindow;
+    const renderedInAModal = selfWindow.name === MODAL_IFRAME_NAME;
 
-      if (renderedInTheTopWindow || renderedInAModal) {
-        return;
-      }
+    if (renderedInTheTopWindow || renderedInAModal) {
+      return;
+    }
 
-      const normalizedLocation = getNormalizedURL(location);
+    const normalizedLocation = getNormalizedURL(location);
 
-      /*
+    /*
       We delete this param that ends up unnecassarily stuck on
       the iframe due to oauth when propagating up.
     */
-      normalizedLocation.searchParams.delete('hmac');
+    normalizedLocation.searchParams.delete('hmac');
 
-      const {pathname, search, hash} = normalizedLocation;
-      const locationStr = `${pathname}${search}${hash}`;
+    const {pathname, search, hash} = normalizedLocation;
+    const locationStr = `${pathname}${search}${hash}`;
 
-      history.dispatch(History.Action.REPLACE, locationStr);
-    },
-    [history, location],
-  );
+    history.dispatch(History.Action.REPLACE, locationStr);
+  }, [history, location]);
 }
 
 function getNormalizedURL(location: LocationOrHref) {

--- a/packages/react-shortcuts/src/Shortcut/hooks.ts
+++ b/packages/react-shortcuts/src/Shortcut/hooks.ts
@@ -22,33 +22,38 @@ export default function useShortcut(
   const subscription = React.useRef<Subscription | null>(null);
   const {node, held, ignoreInput, allowDefault} = options;
 
-  React.useEffect(
-    () => {
-      if (node != null) {
+  React.useEffect(() => {
+    if (node != null) {
+      return;
+    }
+
+    if (shortcutManager == null) {
+      return;
+    }
+
+    subscription.current = shortcutManager.subscribe({
+      onMatch,
+      ordered,
+      node,
+      held,
+      ignoreInput: ignoreInput || false,
+      allowDefault: allowDefault || false,
+    });
+
+    return () => {
+      if (subscription.current == null) {
         return;
       }
 
-      if (shortcutManager == null) {
-        return;
-      }
-
-      subscription.current = shortcutManager.subscribe({
-        onMatch,
-        ordered,
-        node,
-        held,
-        ignoreInput: ignoreInput || false,
-        allowDefault: allowDefault || false,
-      });
-
-      return () => {
-        if (subscription.current == null) {
-          return;
-        }
-
-        subscription.current.unsubscribe();
-      };
-    },
-    [node, ordered, onMatch, held, ignoreInput, allowDefault, shortcutManager],
-  );
+      subscription.current.unsubscribe();
+    };
+  }, [
+    node,
+    ordered,
+    onMatch,
+    held,
+    ignoreInput,
+    allowDefault,
+    shortcutManager,
+  ]);
 }

--- a/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
@@ -9,16 +9,13 @@ export default function ShortcutWithFocus(props: Props) {
   const {spy} = props;
   const node = React.useRef<HTMLButtonElement | null>(null);
 
-  React.useEffect(
-    () => {
-      if (!node || !node.current) {
-        return;
-      }
+  React.useEffect(() => {
+    if (!node || !node.current) {
+      return;
+    }
 
-      node.current.focus();
-    },
-    [node],
-  );
+    node.current.focus();
+  }, [node]);
   return (
     <div className="app">
       <button type="button" ref={node} />

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -32,22 +32,19 @@ describe('e2e', () => {
       const [mounted, setMounted] = React.useState(false);
       const element = React.useRef<HTMLElement | null>(null);
 
-      React.useEffect(
-        () => {
-          if (!mounted) {
-            element.current = document.createElement('div');
-            document.body.appendChild(element.current);
-            setMounted(true);
-          }
+      React.useEffect(() => {
+        if (!mounted) {
+          element.current = document.createElement('div');
+          document.body.appendChild(element.current);
+          setMounted(true);
+        }
 
-          return () => {
-            if (element.current != null) {
-              element.current.remove();
-            }
-          };
-        },
-        [mounted],
-      );
+        return () => {
+          if (element.current != null) {
+            element.current.remove();
+          }
+        };
+      }, [mounted]);
 
       return element.current ? createPortal(children, element.current) : null;
     }

--- a/packages/react-testing/src/toReactString.ts
+++ b/packages/react-testing/src/toReactString.ts
@@ -18,11 +18,10 @@ export function toReactString<Props>(
   const props = Object.keys(node.props)
     // we always filter out children no matter what, but unless allProps option
     // is present we will also filter out insigificant props
-    .filter(
-      key =>
-        options.allProps
-          ? key !== 'children'
-          : !/^(children|className)$|^(aria|data)-/.test(key),
+    .filter(key =>
+      options.allProps
+        ? key !== 'children'
+        : !/^(children|className)$|^(aria|data)-/.test(key),
     )
     .reduce(
       (list, key) => {

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -8,8 +8,8 @@ export type PropsFor<
     ? JSX.IntrinsicElements[T]
     : React.HTMLAttributes<T>
   : T extends React.ComponentType<any>
-    ? React.ComponentPropsWithoutRef<T>
-    : never;
+  ? React.ComponentPropsWithoutRef<T>
+  : never;
 
 export type FunctionKeys<T> = {
   [K in keyof T]-?: NonNullable<T[K]> extends ((...args: any[]) => any)
@@ -24,8 +24,10 @@ type DeepPartialObject<T extends object> = {[K in keyof T]?: DeepPartial<T[K]>};
 type DeepPartial<T> = T extends (infer U)[]
   ? DeepPartialArray<U>
   : T extends ReadonlyArray<infer U>
-    ? DeepPartialReadonlyArray<U>
-    : T extends object ? DeepPartialObject<T> : T;
+  ? DeepPartialReadonlyArray<U>
+  : T extends object
+  ? DeepPartialObject<T>
+  : T;
 
 export type DeepPartialArguments<T> = {[K in keyof T]?: DeepPartial<T[K]>} &
   any[];

--- a/packages/react-web-worker/src/hooks.ts
+++ b/packages/react-web-worker/src/hooks.ts
@@ -6,14 +6,11 @@ import {useLazyRef} from '@shopify/react-hooks';
 export function useWorker<T>(creator: () => T) {
   const {current: worker} = useLazyRef(creator);
 
-  useEffect(
-    () => {
-      return () => {
-        // terminate(worker);
-      };
-    },
-    [worker],
-  );
+  useEffect(() => {
+    return () => {
+      // terminate(worker);
+    };
+  }, [worker]);
 
   return worker;
 }

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -19,8 +19,8 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? DeepPartial<U>[]
     : T[P] extends ReadonlyArray<infer U>
-      ? ReadonlyArray<DeepPartial<U>>
-      : DeepPartial<T[P]>
+    ? ReadonlyArray<DeepPartial<U>>
+    : DeepPartial<T[P]>
 };
 
 export type IfEmptyObject<Obj, If, Else = never> = keyof Obj extends {

--- a/packages/web-worker/src/endpoint.ts
+++ b/packages/web-worker/src/endpoint.ts
@@ -94,7 +94,7 @@ export function createEndpoint<T>(
 ): Endpoint<T> {
   const functionStore = new Map<Function, [string, MessagePort]>();
   const functionProxies = new Map<string, Function>();
-  const removeListeners = new WeakMap<MessageEndpoint, (() => void)>();
+  const removeListeners = new WeakMap<MessageEndpoint, () => void>();
   const activeApi = new Map<string, Function>();
 
   makeCallable(messageEndpoint, (apiCall: ApplyApiEndpoint) =>
@@ -150,7 +150,7 @@ export function createEndpoint<T>(
 
   function makeCallable(
     messageEndpoint: MessageEndpoint,
-    getFunction: ((data: any) => Function | undefined),
+    getFunction: (data: any) => Function | undefined,
   ) {
     const remove = removeListeners.get(messageEndpoint);
 

--- a/packages/web-worker/src/types.ts
+++ b/packages/web-worker/src/types.ts
@@ -13,10 +13,12 @@ type ForcePromiseWrapped<T> = T extends infer U | Promise<infer U>
 type ForcePromise<T> = T extends Promise<any>
   ? T
   : T extends (...args: infer Args) => infer TypeReturned
-    ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
-    : T extends Array<infer ArrayElement>
-      ? ForcePromiseArray<ArrayElement>
-      : T extends object ? {[K in keyof T]: ForcePromiseWrapped<T[K]>} : T;
+  ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
+  : T extends Array<infer ArrayElement>
+  ? ForcePromiseArray<ArrayElement>
+  : T extends object
+  ? {[K in keyof T]: ForcePromiseWrapped<T[K]>}
+  : T;
 
 interface ForcePromiseArray<T> extends Array<ForcePromiseWrapped<T>> {}
 
@@ -27,7 +29,9 @@ export type SafeWorkerArgument<T> = T extends (
     ? (...args: Args) => TypeReturned
     : (...args: Args) => TypeReturned | Promise<TypeReturned>
   : T extends Array<infer ArrayElement>
-    ? SafeWorkerArgumentArray<ArrayElement>
-    : T extends object ? {[K in keyof T]: SafeWorkerArgument<T[K]>} : T;
+  ? SafeWorkerArgumentArray<ArrayElement>
+  : T extends object
+  ? {[K in keyof T]: SafeWorkerArgument<T[K]>}
+  : T;
 
 interface SafeWorkerArgumentArray<T> extends Array<SafeWorkerArgument<T>> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,7 +1419,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -1927,7 +1927,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-"apollo-cache-inmemory@>=1.0.0 <2.0.0", apollo-cache-inmemory@^1.3.6, apollo-cache-inmemory@^1.6.2:
+"apollo-cache-inmemory@>=1.0.0 <2.0.0", apollo-cache-inmemory@^1.3.6:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz#826861d20baca4abc45f7ca7a874105905b8525d"
   integrity sha512-S4B/zQNSuYc0M/1Wq8dJDTIO9yRgU0ZwDGnmlqxGGmFombOZb9mLjylewSfQKmjNpciZ7iUIBbJ0mHlPJTzdXg==
@@ -1946,7 +1946,7 @@ apollo-cache@1.3.2, apollo-cache@^1.3.2:
     apollo-utilities "^1.3.2"
     tslib "^1.9.3"
 
-"apollo-client@>=2.0.0 <3.0.0", apollo-client@^2.3.8, apollo-client@^2.6.0:
+"apollo-client@>=2.0.0 <3.0.0", apollo-client@^2.3.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.4.tgz#872c32927263a0d34655c5ef8a8949fbb20b6140"
   integrity sha512-oWOwEOxQ9neHHVZrQhHDbI6bIibp9SHgxaLRVPoGvOFy7OH5XUykZE7hBQAVxq99tQjBzgytaZffQkeWo1B4VQ==
@@ -1973,25 +1973,25 @@ apollo-codegen-core@0.28.1:
     core-js "^2.5.3"
     recast "^0.15.3"
 
-apollo-link-http-common@^0.2.14:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz#d3a195c12e00f4e311c417f121181dcc31f7d0c8"
-  integrity sha512-v6mRU1oN6XuX8beVIRB6OpF4q1ULhSnmy7ScnHnuo1qV6GaFmDcbdvXqxIkAV1Q8SQCo2lsv4HeqJOWhFfApOg==
+apollo-link-http-common@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz#304e67705122bf69a9abaded4351b10bc5efd6d9"
+  integrity sha512-+Heey4S2IPsPyTf8Ag3PugUupASJMW894iVps6hXbvwtg1aHSNMXUYO5VG7iRHkPzqpuzT4HMBanCTXPjtGzxg==
   dependencies:
-    apollo-link "^1.2.12"
+    apollo-link "^1.2.13"
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
-apollo-link-http@^1.5.15:
-  version "1.5.15"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.15.tgz#106ab23bb8997bd55965d05855736d33119652cf"
-  integrity sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==
+"apollo-link-http@>=1.0.0 <2.0.0":
+  version "1.5.16"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.16.tgz#44fe760bcc2803b8a7f57fc9269173afb00f3814"
+  integrity sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==
   dependencies:
-    apollo-link "^1.2.12"
-    apollo-link-http-common "^0.2.14"
+    apollo-link "^1.2.13"
+    apollo-link-http-common "^0.2.15"
     tslib "^1.9.3"
 
-"apollo-link@>=1.0.0 <2.0.0", apollo-link@^1.0.0, apollo-link@^1.2.12, apollo-link@^1.2.13, apollo-link@^1.2.3:
+"apollo-link@>=1.0.0 <2.0.0", apollo-link@^1.0.0, apollo-link@^1.2.13, apollo-link@^1.2.3:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
   integrity sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==
@@ -8749,10 +8749,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
-  integrity sha512-KtQ2EGaUwf2EyDfp1fxyEb0PqGKakVm0WyXwDt6u+cAoxbO2Z2CwKvOe3+b4+F2IlO9lYHi1kqFuRM70ddBnow==
+prettier@~1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
+  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
## Description

This PR updates prettier to version `1.17.0`. Prettier was originally installed in this PR https://github.com/Shopify/quilt/pull/203, and hasn't changed in the ~14 months since. 

When updating our eslint dependencies ([in this PR](https://github.com/Shopify/eslint-plugin-shopify/pull/433)), the updates to `eslint-config-prettier`/`eslint-plugin-prettier` modifies our prettier version. 

Rather than keep the prettier changes for [when we update our eslint/eslint-plugin-shopify versions](https://github.com/Shopify/quilt/pull/1110) (which are distracting and formatting only), I've pulled them out here. I cannot bump this repo right to the latest version (`1.18.2`) because of an incompatibility with our version of Typescript ([documented here](https://github.com/Shopify/quilt/issues/1123)).