### PR TITLE
Support non-href publicPaths

### DIFF
--- a/packages/web-worker/src/create.ts
+++ b/packages/web-worker/src/create.ts
@@ -61,8 +61,10 @@ export function createWorker<T>(script: () => Promise<T>) {
       ) as any;
     }
 
+    const absoluteScript = new URL(script, window.location.href).href;
+
     const workerScript = URL.createObjectURL(
-      new Blob([`importScripts(${JSON.stringify(script)})`]),
+      new Blob([`importScripts(${JSON.stringify(absoluteScript)})`]),
     );
 
     const worker = new Worker(workerScript);

--- a/packages/web-worker/src/test/utilities/webpack.ts
+++ b/packages/web-worker/src/test/utilities/webpack.ts
@@ -15,6 +15,7 @@ export function runWebpack(
         output: {
           path: workspace.buildPath(),
           publicPath: server.assetUrl().href,
+          ...extraConfig.output,
         },
         resolve: {
           extensions: ['.js', '.ts', '.json'],


### PR DESCRIPTION
Adds support for non-href public paths, which are not supported by `importScripts` it would appear. To support them, we just resolve the asset URL relative to `window.location.href`, and take the `href` of the resolved URL.