### PR TITLE
Update graphql-testing docs to include .operations

### DIFF
--- a/packages/graphql-testing/README.md
+++ b/packages/graphql-testing/README.md
@@ -78,16 +78,16 @@ await graphQL.resolveAll();
 const graphQL = createGraphQL(mocks);
 
 // the very first operation, or undefined if no operations have been performed
-graphQL.first();
+graphQL.operations.first();
 
 // the second last operation run with petQuery
-graphQL.nth(-2, {query: petQuery});
+graphQL.operations.nth(-2, {query: petQuery});
 
 // the last operation of any kind
-graphQL.last();
+graphQL.operations.last();
 
 // all mutations with this mutation
-graphQL.all({mutation: addPetMutation});
+graphQL.operations.all({mutation: addPetMutation});
 ```
 
 The `query` and `mutation` options both accept either a regular `DocumentNode`, or an async GraphQL component created with [`@shopify/react-graphql`’s `createAsyncQueryComponent` function](../react-graphql).


### PR DESCRIPTION
## Description

I noticed while using this package that the documentation was slightly different. It explains it well in the paragraph above but for someone skimming through the docs and copying/pasting, this doesn't reflect the way to use the graphQL.operations data structure.

## Type of change

- [x] Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
