### PR TITLE
web-worker cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "publish": "lerna publish",
     "prebuild": "yarn run clean",
     "build": "lerna run build",
-    "lint": "yarn eslint '**/*.{ts,tsx}'",
+    "lint": "eslint '**/*.{ts,tsx}'",
     "ci:lint-docs": "yarn generate docs && test -z \"$(git status --porcelain)\" || echo 'The root README has not been updated. Run `yarn generate docs` in the root of your quilt directory and try again.'",
     "test": "NODE_ICU_DATA=node_modules/full-icu jest --maxWorkers=3 --coverage=false",
     "check": "lerna run check",
     "release": "lerna publish",
     "clean": "rimraf './packages/*/dist/**/*.{js,d.ts}'",
-    "generate": "yarn plop",
-    "generate:package": "yarn plop package && yarn plop docs"
+    "generate": "plop",
+    "generate:package": "plop package && yarn plop docs"
   },
   "repository": {
     "type": "git",

--- a/packages/react-web-worker/README.md
+++ b/packages/react-web-worker/README.md
@@ -13,33 +13,33 @@ $ yarn add @shopify/react-web-worker
 
 ## Usage
 
-This package provides a `useWorker` hook to leverage web workers in React.
+This package provides a `useWorker` hook to leverage web workers in React. For convenience, it also re-exports the entirety of [`@shopify/web-worker`](https://github.com/Shopify/quilt/tree/master/packages/web-worker), so you only need to install this package to get access to those additional exports.
 
-This library also re-exports the entirety of [`@shopify/web-worker`](https://github.com/Shopify/quilt/tree/master/packages/web-worker). These packages are distributed seperately to ensure that the [tooling](https://github.com/Shopify/quilt/tree/master/packages/web-worker#tooling) provided by `@shopify/web-worker` does not pull in `react` as a dependency.
+### `useWorker()`
 
-### Application
-
-`useWorker` allows your React applications to take advantage of [web workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) provided by `createWorker`. This hook creates a web worker during render and terminates it when the component unmounts.
+`useWorker` allows your React applications to take advantage of [web workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) provided by `createWorkerFactory` from `@shopify/web-worker`. This hook creates a web worker during render and terminates it when the component unmounts.
 
 ```tsx
 import React, {useEffect} from 'react';
 import {Page} from '@shopify/polaris';
-import {createWorker, useWorker} from '@shopify/react-web-worker';
+import {createWorkerFactory, useWorker} from '@shopify/react-web-worker';
 
 // assume ./worker.ts contains
 // export function hello(name) {
 //  return `Hello, ${name}`;
 // }
 
-const create = createWorker(() => import('./worker'));
+const createWorker = createWorkerFactory(() => import('./worker'));
 
 function Home() {
-  const worker = useWorker(create);
+  const worker = useWorker(createWorker);
   const [message, setMessage] = React.useState(null);
 
   useEffect(
     () => {
       (async () => {
+        // Note: in your actual app code, make sure to check if Home
+        // is still mounted before setting state asynchronously!
         const webWorkerMessage = await worker.hello('Tobi');
         setMessage(webWorkerMessage);
       })();

--- a/packages/react-web-worker/src/index.ts
+++ b/packages/react-web-worker/src/index.ts
@@ -1,3 +1,2 @@
-export {useWorker} from './hooks';
-
 export * from '@shopify/web-worker';
+export {useWorker} from './hooks';

--- a/packages/web-worker/src/babel-plugin.ts
+++ b/packages/web-worker/src/babel-plugin.ts
@@ -1,8 +1,8 @@
 import {resolve} from 'path';
 
 const DEFAULT_PACKAGES_TO_PROCESS = {
-  '@shopify/web-worker': ['createWorker'],
-  '@shopify/react-web-worker': ['createWorker'],
+  '@shopify/web-worker': ['createWorkerFactory'],
+  '@shopify/react-web-worker': ['createWorkerFactory'],
 };
 
 const loader = resolve(__dirname, 'webpack-parts/loader');

--- a/packages/web-worker/src/create.ts
+++ b/packages/web-worker/src/create.ts
@@ -23,8 +23,8 @@ export function getEndpoint(caller: Endpoint<any>['call']) {
   return workerEndpointCache.get(caller);
 }
 
-export function createWorker<T>(script: () => Promise<T>) {
-  return function create(): Endpoint<T>['call'] {
+export function createWorkerFactory<T>(script: () => Promise<T>) {
+  return function createWorker(): Endpoint<T>['call'] {
     // The babel plugin that comes with this package actually turns the argument
     // into a string (the public path of the worker script). If it’s a function,
     // it’s because we’re in an environment where we didn’t transform it into a

--- a/packages/web-worker/src/index.ts
+++ b/packages/web-worker/src/index.ts
@@ -1,3 +1,3 @@
-export {createWorker, terminate, expose} from './create';
+export {createWorkerFactory, terminate, expose} from './create';
 export {retain, release} from './memory';
 export {SafeWorkerArgument} from './types';

--- a/packages/web-worker/src/memory.ts
+++ b/packages/web-worker/src/memory.ts
@@ -28,11 +28,12 @@ export function retain(value: any, {deep = true} = {}) {
   if (deep) {
     if (Array.isArray(value)) {
       return value.reduce(
-        (canRetain, item) => retain(item, {deep: true}) || canRetain,
+        (canRetain, item) => retain(item, {deep}) || canRetain,
+        canRetain,
       );
     } else if (typeof value === 'object' && value != null) {
       return Object.keys(value).reduce(
-        (canRetain, key) => retain(value[key]) || canRetain,
+        (canRetain, key) => retain(value[key], {deep}) || canRetain,
         canRetain,
       );
     }
@@ -51,11 +52,12 @@ export function release(value: any, {deep = true} = {}) {
   if (deep) {
     if (Array.isArray(value)) {
       return value.reduce(
-        (canRelease, item) => release(item, {deep: true}) || canRelease,
+        (canRelease, item) => release(item, {deep}) || canRelease,
+        canRelease,
       );
     } else if (typeof value === 'object' && value != null) {
       return Object.keys(value).reduce(
-        (canRelease, key) => release(value[key]) || canRelease,
+        (canRelease, key) => release(value[key], {deep}) || canRelease,
         canRelease,
       );
     }

--- a/packages/web-worker/src/test/e2e.test.ts
+++ b/packages/web-worker/src/test/e2e.test.ts
@@ -27,9 +27,9 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
-          const worker = createWorker(() => import('./worker'))();
+          const worker = createWorkerFactory(() => import('./worker'))();
 
           (async () => {
             const result = await worker.greet(${JSON.stringify(
@@ -74,9 +74,9 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
-          const worker = createWorker(() => import('./worker'))();
+          const worker = createWorkerFactory(() => import('./worker'))();
 
           (async () => {
             let content = '';
@@ -128,9 +128,9 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
-          const worker = createWorker(() => import('./worker'))();
+          const worker = createWorkerFactory(() => import('./worker'))();
 
           (async () => {
             const element = document.createElement('div');
@@ -181,9 +181,9 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
-          const worker = createWorker(() => import('./worker'))();
+          const worker = createWorkerFactory(() => import('./worker'))();
 
           (async () => {
             const result = await worker.greet(${JSON.stringify(
@@ -233,9 +233,9 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
-          const worker = createWorker(() => import('./worker'))();
+          const worker = createWorkerFactory(() => import('./worker'))();
 
           const users = [
             {getName: () => ${JSON.stringify(nameOne)}},
@@ -288,7 +288,7 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
           self.prepare = () => {
             start();
@@ -298,7 +298,7 @@ describe('web-worker', () => {
 
             // Store this on self so we retain it and its function store,
             // which should lead to memory leaks if the function store is not cleaned.
-            self.worker = createWorker(() => import('./worker'))();
+            self.worker = createWorkerFactory(() => import('./worker'))();
 
             // Store this on self so we can get access to it to
             // count the non-GC'ed instances
@@ -385,12 +385,12 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
           // See previous test for details of these test utilities
           self.WorkerTestClass = class WorkerTestClass {}
           self.memoryTracker = new WeakMap();
-          self.worker = createWorker(() => import('./worker'))();
+          self.worker = createWorkerFactory(() => import('./worker'))();
 
           self.retain = async () => {
             start();
@@ -488,12 +488,12 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
           // See previous test for details of these test utilities
           self.WorkerTestClass = class WorkerTestClass {}
           self.memoryTracker = new WeakMap();
-          self.worker = createWorker(() => import('./worker'))();
+          self.worker = createWorkerFactory(() => import('./worker'))();
 
           self.retain = async () => {
             start();
@@ -611,9 +611,9 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
-          const worker = createWorker(() => import('./worker'))();
+          const worker = createWorkerFactory(() => import('./worker'))();
 
           (async () => {
             const result = await worker.greet(${JSON.stringify(
@@ -660,9 +660,9 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker} from '@shopify/web-worker';
+          import {createWorkerFactory} from '@shopify/web-worker';
 
-          const worker = createWorker(() => import('./worker'))();
+          const worker = createWorkerFactory(() => import('./worker'))();
 
           (async () => {
             const element = document.createElement('div');
@@ -704,8 +704,8 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-        import {createWorker, terminate} from '@shopify/web-worker';
-        self.worker = createWorker(() => import('./worker'))();
+        import {createWorkerFactory, terminate} from '@shopify/web-worker';
+        self.worker = createWorkerFactory(() => import('./worker'))();
 
         (async () => {
           const result = await self.worker.greet();
@@ -756,8 +756,8 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker, terminate} from '@shopify/web-worker';
-          self.worker = createWorker(() => import('./worker'))();
+          import {createWorkerFactory, terminate} from '@shopify/web-worker';
+          self.worker = createWorkerFactory(() => import('./worker'))();
           (async () => {
             terminate(self.worker);
             let result;
@@ -807,11 +807,11 @@ describe('web-worker', () => {
       await workspace.write(
         mainFile,
         `
-          import {createWorker, terminate} from '@shopify/web-worker';
+          import {createWorkerFactory, terminate} from '@shopify/web-worker';
 
           self.WorkerTestClass = class WorkerTestClass {}
           self.memoryTracker = new WeakMap();
-          self.worker = createWorker(() => import('./worker'))();
+          self.worker = createWorkerFactory(() => import('./worker'))();
 
 
           self.retain = async () => {
@@ -903,8 +903,8 @@ describe('web-worker', () => {
         await workspace.write(
           mainFile,
           `
-          import {createWorker} from '@shopify/web-worker';
-          self.worker = createWorker(() => import('./worker'))();
+          import {createWorkerFactory} from '@shopify/web-worker';
+          self.worker = createWorkerFactory(() => import('./worker'))();
 
           (async () => {
             await self.worker.terminateAttemptFromWorker();

--- a/packages/web-worker/src/types.ts
+++ b/packages/web-worker/src/types.ts
@@ -13,10 +13,12 @@ type ForcePromiseWrapped<T> = T extends infer U | Promise<infer U>
 type ForcePromise<T> = T extends Promise<any>
   ? T
   : T extends (...args: infer Args) => infer TypeReturned
-    ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
-    : T extends Array<infer ArrayElement>
-      ? ForcePromiseArray<ArrayElement>
-      : T extends object ? {[K in keyof T]: ForcePromiseWrapped<T[K]>} : T;
+  ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
+  : T extends Array<infer ArrayElement>
+  ? ForcePromiseArray<ArrayElement>
+  : T extends object
+  ? {[K in keyof T]: ForcePromiseWrapped<T[K]>}
+  : T;
 
 interface ForcePromiseArray<T> extends Array<ForcePromiseWrapped<T>> {}
 
@@ -27,7 +29,9 @@ export type SafeWorkerArgument<T> = T extends (
     ? (...args: Args) => TypeReturned
     : (...args: Args) => TypeReturned | Promise<TypeReturned>
   : T extends Array<infer ArrayElement>
-    ? SafeWorkerArgumentArray<ArrayElement>
-    : T extends object ? {[K in keyof T]: SafeWorkerArgument<T[K]>} : T;
+  ? SafeWorkerArgumentArray<ArrayElement>
+  : T extends object
+  ? {[K in keyof T]: SafeWorkerArgument<T[K]>}
+  : T;
 
 interface SafeWorkerArgumentArray<T> extends Array<SafeWorkerArgument<T>> {}

--- a/packages/web-worker/src/types.ts
+++ b/packages/web-worker/src/types.ts
@@ -13,12 +13,10 @@ type ForcePromiseWrapped<T> = T extends infer U | Promise<infer U>
 type ForcePromise<T> = T extends Promise<any>
   ? T
   : T extends (...args: infer Args) => infer TypeReturned
-  ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
-  : T extends Array<infer ArrayElement>
-  ? ForcePromiseArray<ArrayElement>
-  : T extends object
-  ? {[K in keyof T]: ForcePromiseWrapped<T[K]>}
-  : T;
+    ? (...args: Args) => Promise<ForcePromiseWrapped<TypeReturned>>
+    : T extends Array<infer ArrayElement>
+      ? ForcePromiseArray<ArrayElement>
+      : T extends object ? {[K in keyof T]: ForcePromiseWrapped<T[K]>} : T;
 
 interface ForcePromiseArray<T> extends Array<ForcePromiseWrapped<T>> {}
 
@@ -29,9 +27,7 @@ export type SafeWorkerArgument<T> = T extends (
     ? (...args: Args) => TypeReturned
     : (...args: Args) => TypeReturned | Promise<TypeReturned>
   : T extends Array<infer ArrayElement>
-  ? SafeWorkerArgumentArray<ArrayElement>
-  : T extends object
-  ? {[K in keyof T]: SafeWorkerArgument<T[K]>}
-  : T;
+    ? SafeWorkerArgumentArray<ArrayElement>
+    : T extends object ? {[K in keyof T]: SafeWorkerArgument<T[K]>} : T;
 
 interface SafeWorkerArgumentArray<T> extends Array<SafeWorkerArgument<T>> {}


### PR DESCRIPTION
Gets on the new name for the primary API (`createWorkerFactory`), and some minor README cleanup.