### PR TITLE
Allow multiple worker files to be generated

### DIFF
--- a/packages/web-worker/README.md
+++ b/packages/web-worker/README.md
@@ -65,6 +65,8 @@ const result = await worker.default(
 ); // 'Hello, Tobi'
 ```
 
+##### Terminating the worker
+
 When the web worker is no longer required, you can terminate the worker using `terminate()`. This will immediately terminate any ongoing operations. If an attempt is made to make calls to a terminated worker, an error will be thrown.
 
 > Note: A worker can only be terminated from the main thread. A worker can not terminate itself from within the worker module.
@@ -79,6 +81,20 @@ const worker = createWorker();
 
 terminate(worker);
 ```
+
+##### Naming the worker file
+
+By default, worker files created using `createWorkerFactory` are given incrementing IDs as the file name. This strategy is generally less than ideal for long-term caching, as the name of the file depends on the order in which it was encountered during the build. For long-term caching, it is better to provide a static name for the worker file. This can be done by supplying the [`webpackChunkName` comment](https://webpack.js.org/api/module-methods/#magic-comments) before your import:
+
+```tsx
+import {createWorkerFactory, terminate} from '@shopify/web-worker;
+
+// Note: only webpackChunkName is currently supported. Don’t try to use
+// other magic webpack comments.
+const createWorker = createWorkerFactory(() => import(/* webpackChunkName: 'myWorker' */ './worker'));
+```
+
+This name will be used as the prefix for the worker file. The worker will always end in `.worker.js`, and may also include additional hashes or other content (this library re-uses your `output.filename` and `output.chunkFilename` webpack options).
 
 #### Worker
 

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/web-workers/README.md",
   "dependencies": {
     "@types/webpack": "^4.0.0",
+    "loader-utils": "^1.0.0",
     "webpack-virtual-modules": "^0.1.12"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@types/babel__core": ">=7.0.0",
     "@types/babel__traverse": ">=7.0.0",
     "@types/koa-mount": "^3.0.1",
+    "@types/loader-utils": "^1.0.0",
     "@types/webpack-virtual-modules": "^0.1.0",
     "koa-mount": "^3.0.0"
   },

--- a/packages/web-worker/src/webpack-parts/plugin.ts
+++ b/packages/web-worker/src/webpack-parts/plugin.ts
@@ -14,6 +14,7 @@ export class WebWorkerPlugin implements Plugin {
   }
 
   public readonly virtualModules = new VirtualModulesPlugin({});
+  public workerId = 0;
   private readonly [PLUGIN] = true;
 
   constructor(public readonly options: Options = {}) {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,6 +1375,14 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
+"@types/loader-utils@^1.0.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/loader-utils/-/loader-utils-1.1.3.tgz#82b9163f2ead596c68a8c03e450fbd6e089df401"
+  integrity sha512-euKGFr2oCB3ASBwG39CYJMR3N9T0nanVqXdiH7Zu/Nqddt6SmFRxytq/i2w9LQYNQekEtGBz+pE3qG6fQTNvRg==
+  dependencies:
+    "@types/node" "*"
+    "@types/webpack" "*"
+
 "@types/lodash@^4.14.65":
   version "4.14.106"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.106.tgz#6093e9a02aa567ddecfe9afadca89e53e5dce4dd"
@@ -1419,7 +1427,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
@@ -7186,7 +7194,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==


### PR DESCRIPTION
We never tested the build config for `@shopify/web-worker` with multiple workers. As it turns out, they just don't work at all; I used the same name for the entry of every worker, which means that they all get output (at least in dev) as `worker.worker.js`. This PR updates the naming strategy to be much better:

1. By default, we give each worker an incrementing ID as the filename (so, `0.worker.js` and so on)
2. If we see the `webpackChunkName` before the async import we use as the basis for the worker library, we use that as the name instead.