### PR TITLE
Enhance documentation for using performance libraries together

### DIFF
--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -439,20 +439,17 @@ post '/performance_report', to: 'performance_report#create'
 
 ### Add annotations
 
-Add a [`<PerformanceMark />`](https://github.com/Shopify/quilt/tree/master/packages/react-performance#performancemark) to each of your route-level components.
+Add a [`usePerformanceMark`](https://github.com/Shopify/quilt/tree/master/packages/react-performance#useperformancemark) call to each of your route-level components.
 
 ```tsx
 // app/ui/features/Home/Home.tsx
-import {PerformanceMark} from '@shopify/react-performance';
+import {usePerformanceMark} from '@shopify/react-performance';
 
 export function Home() {
-  return (
-    <div>
-      My Cool Home Page
-      {/* tell the library the page has finished rendering completely */}
-      <PerformanceMark stage="complete" id="Home" />
-    </div>
-  );
+  // tell the library the page has finished rendering completely
+  usePerformanceMark('complete', 'Home');
+
+  return <>{/* your Home page JSX goes here*/}</>;
 }
 ```
 

--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -589,14 +589,40 @@ The params sent to the controller are expected to be of type `application/json`.
 }
 ```
 
-the above controller would send the following metrics:
+given the the above controller input, the library would send the following metrics:
 
 ```ruby
-StatsD.distribution('time_to_first_byte', 2, ['browser_connection_type:3g'])
-StatsD.distribution('time_to_first_byte', 2, ['browser_connection_type:3g'])
-StatsD.distribution('navigation_complete', 23924, ['browser_connection_type:3g'])
-StatsD.distribution('navigation_usable', 23924, ['browser_connection_type:3g'])
+StatsD.distribution('time_to_first_byte', 2, tags: {
+  browser_connection_type:'3g',
+})
+StatsD.distribution('time_to_first_byte', 2, tags: {
+  browser_connection_type:'3g' ,
+})
+StatsD.distribution('navigation_complete', 23924, tags: {
+  browser_connection_type:'3g' ,
+})
+StatsD.distribution('navigation_usable', 23924, tags: {
+  browser_connection_type:'3g' ,
+})
 ```
+
+##### Default Metrics
+
+The full list of metrics sent by default are as follows:
+
+###### For full-page load
+- `AppName.time_to_first_byte`, representing the time from the start of the request to when the server began responding with data.
+- `AppName.time_to_first_paint`, representing the time from the start of the request to when the browser rendered anything to the screen.
+- `AppName.time_to_first_contentful_paint` representing the time from the start of the request to when the browser rendered meaningful content to the screen.
+- `AppName.dom_content_loaded` representing the time from the start of the request to when the browser fired the [DOMContentLoaded](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event) event.
+- `AppName.dom_load` representing the time from the start of the request to when the browser fired the [window.load](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event) event.
+
+###### For both full-page navigations and client-side page transitions
+- `AppName.navigation_usable`, representing the time it took before for the page to be rendered in a usable state. Usually this does not include data fetching or asynchronous tasks.
+- `AppName.navigation_complete` representing the time it took for the page to be fully loaded, including any data fetching which blocks above-the-fold content.
+- `AppName.navigation_download_size`, representing the total weight of all client-side assets (eg. CSS, JS, images). This will only be sent if there are any events with a `type` of `script` or `style`.
+- `AppName.navigation_cache_effectiveness`, representing what percentage of client-side assets (eg. CSS, JS, images) were returned from the browser's cache. This will only be sent if there are any events with a `type` of `script` or `style`.
+
 
 ##### Customizing `process_report` with a block
 

--- a/packages/koa-performance/CHANGELOG.md
+++ b/packages/koa-performance/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] 2019-10-23
+
+### Added
+
+- `clientMetricsMiddleware` no longer requires `development?` to be explicitly set in it's `options` parameter. If the parameter is missing it will default to `true` when `process.env.NODE_ENV` is `true`, and `false` otherwise.
+
 ## [1.0.0] 2019-10-08
 
 ### Added

--- a/packages/koa-performance/README.md
+++ b/packages/koa-performance/README.md
@@ -3,21 +3,38 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/koa-performance.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/koa-performance.svg)
 
-A middleware which makes it easy to send metrics from your front end application and forward them to a stats-d server of your choice.
+A middleware which makes it easy to send metrics from your front end application and forward them to a StatsD server of your choice.
 
 Best used with [`@shopify/performance`](https://www.npmjs.com/package/@shopify/performance) and/or [`@shopify/react-performance`](https://www.npmjs.com/package/@shopify/react-performance).
 
-## Installation
+## Table of Contents
+
+- [Quick-start](#quick-start)
+
+  - [Install the package](install-the-package)
+  - [Add the middleware](add-the-middleware)
+  - [Verify with CURL](verify-with-curl)
+  - [Send data from the frontend](send-data-from-the-frontend)
+  - [Process report data and forward it to StatsD](process-report-data-and-forward-it-to-statsd)
+
+- [API](#api)
+  - [Hooks](#hooks)
+  - [Components](#components)
+  - [Other](#other)
+
+## Quick-start
+
+### Install the package
+
+First we will need to install the npm package.
 
 ```bash
 $ yarn add @shopify/koa-performance
 ```
 
-## Usage
+### Add the middleware
 
-### Basic server setup
-
-First add the middleware to your Koa app. We recommend using `koa-mount` or `koa-router` to restrict it to a specific endpoint.
+Next we import the `clientPerformanceMetrics` factory into our server, use it to create a middleware to collect performance data, and mount it. We use something `koa-mount` to restrict it to a specific endpoint. If your application uses `koa-router`, you can use that instead.
 
 ```tsx
 // server.ts
@@ -25,24 +42,32 @@ import Koa from 'koa';
 import mount from 'koa-mount';
 import {clientPerformanceMetrics} from '@shopify/koa-performance';
 
+// create our Koa instance for the server
 const app = new Koa();
 
-app.use(mount('/client-metrics', clientPerformanceMetrics({
-  prefix: 'MyApp.',
-  // when development is true the middleware will skip sending metrics
-  development: process.env.NODE_ENV === 'development',
-  // the host of the statsd server you want to send metrics to
-  statsdHost: 'localhost',
-  // the port of the statsd server you want to send metrics to
-  statsdPort: 3000,
-})));
+app.use(
+  mount(
+    '/client-metrics',
+    clientPerformanceMetrics({,
+      // the prefix for metrics sent to StatsD
+      prefix: 'ExampleCode.',
+      // the host of the statsd server you want to send metrics to
+      statsdHost: 'YOUR STATSD HOST HERE'
+      // the port of the statsd server you want to send metrics to
+      statsdPort: 3000,
+    }),
+  ),
+);
+
+// other middleware for your app
+// ...
 
 app.listen(3000, () => {
   console.log('listening on port 3000');
-})
+});
 ```
 
-Now the app will respond to requests to `/client-metrics`. The middleware returned from `clientPerformanceMetrics` expects to receive JSON POST requests meeting the following interface:
+Now the app will respond to requests to `/performance-report`. The middleware returned from `clientPerformanceMetrics` expects to receive JSON POST requests meeting the following interface:
 
 ```tsx
 interface Metrics {
@@ -60,18 +85,110 @@ interface Metrics {
 }
 ```
 
+### Verify with CURL
+
 To confirm the endpoint is working we can make a CURL request. Run your server and paste this in your terminal.
 
 ```bash
-curl 'http://localhost:3000/client-metrics' -H 'Content-Type: application/json' --data-binary '{"connection":{"onchange":null,"effectiveType":"4g","rtt":100,"downlink":1.75,"saveData":false},"events":[{"type":"ttfb","start":5631.300000008196,"duration":0},{"type":"ttfp","start":5895.370000012917,"duration":0},{"type":"ttfcp","start":5895.370000012917,"duration":0},{"type":"dcl","start":9874.819999997271,"duration":0},{"type":"load","start":10426.089999993565,"duration":0}],"navigations":[],"pathname":"/some-path"}' --compressed
+curl 'http://localhost:3000/performance-report' -H 'Content-Type: application/json' --data-binary '{"connection":{"onchange":null,"effectiveType":"4g","rtt":100,"downlink":1.75,"saveData":false},"events":[{"type":"ttfb","start":5631.300000008196,"duration":0},{"type":"ttfp","start":5895.370000012917,"duration":0},{"type":"ttfcp","start":5895.370000012917,"duration":0},{"type":"dcl","start":9874.819999997271,"duration":0},{"type":"load","start":10426.089999993565,"duration":0}],"navigations":[],"pathname":"/some-path"}' --compressed
 ```
 
 You should get a `200` response back, and see console logs about metrics being skipped (since we are in development).
 
-### Fullstack usage with `@shopify/react-performance`
+#### Send data from the frontend
 
-> Todo
+We have verified that our middleware is setup correctly and ready to recieve reports. However, it is only useful if we send it real data from a our frontend code.
+
+React applications can use components from `@shopify/react-performance` to collect and send metrics to the server in the right format. Check out [`@shopify/react-performance`'s README](../react-performance/README.md) for details.
+
+Non-React applications must use [`@shopify/performance`](../performance/README.md) directly and setup their own performance reports with it's API.
 
 ## API
 
-> Todo
+### clientPerformanceMetrics
+
+A middleware factory which returns a Koa middleware for parsing and sanitizing performance reports sent as JSON, and sending them to a StatsD server.
+
+It takes options conforming to the following interface:
+
+```ts
+interface Options {
+  // the prefix for metrics sent to StatsD
+  prefix: string;
+  // whether the app is being run in development mode.
+  development?: boolean;
+  // the host of the statsd server you want to send metrics to
+  statsdHost?: string;
+  // the port of the statsd server you want to send metrics to
+  statsdPort?: number;
+  // threshold in milliseconds to skip metrics
+  anomalousNavigationDurationThreshold?: number;
+  // instance to use to log metrics
+  logger?: Logger;
+  // a function to use to customize the tags to be sent with all metrics
+  additionalTags?(
+    metricsBody: Metrics,
+    userAgent: string,
+  ): {[key: string]: string | number | boolean};
+  // a function to use to customize the tags to be sent with navigation metrics
+  additionalNavigationTags?(
+    navigation: Navigation,
+  ): {[key: string]: string | number | boolean};
+  // a function to use to send extra metrics for each navigation
+  additionalNavigationMetrics?(
+    navigation: Navigation,
+  ): {name: string; value: any}[];
+}
+```
+
+### Examples
+
+#### Basic
+
+The simplest use of the middleware factory passes only the connection information for an application's StatsD server, and the `prefix`.
+
+```ts
+  const middleware = clientPerformanceMetrics({,
+    prefix: 'ExampleCode.',
+    statsdHost: process.env.STATSD_HOST,
+    statsdPort: process.env.STATSD_PORT,
+  });
+```
+
+#### Extra tags
+
+Often, applications will want to categorize distribution data using custom tags. The `additionalTags` and `additionalNavigationTags` allow custom tags to be derived from the data sent to the middleware. The tags will then be attached to outgoing StatsD distribution calls.
+
+```ts
+  const middleware = clientPerformanceMetrics({,
+    prefix: 'ExampleCode.',
+    statsdHost: process.env.STATSD_HOST,
+    statsdPort: process.env.STATSD_PORT,
+    additionalNavigationTags: (navigation) => ({navigationTarget: navigation.target}),
+    additionalTags: (metricsBody) => ({rtt: metricsBody.connection.rtt}),
+  });
+```
+
+#### Extra metrics
+
+Applications also commonly need to send custom distribution data. The `additionalNavigationMetrics` option allow custom metrics to be derived from the data sent to the middleware. These will then be sent using `StatsD`'s `distribution` method.
+
+```ts
+  const middleware = clientPerformanceMetrics({,
+    prefix: 'ExampleCode.',
+    statsdHost: process.env.STATSD_HOST,
+    statsdPort: process.env.STATSD_PORT,
+    additionalNavigationMetrics: ({events}) => {
+      const weight = navigation.events
+        .filter((event) => event.size != null)
+        .reduce((total, event) => {
+          total + event.size
+        }, 0);
+
+      return [{
+        name: 'navigationTotalResourceWeight',
+        value: weight
+      }];
+    },
+  });
+```

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -16,7 +16,7 @@ import {BrowserConnection} from './types';
 
 export interface Options {
   prefix: string;
-  development: boolean;
+  development?: boolean;
   statsdHost?: string;
   statsdPort?: number;
   anomalousNavigationDurationThreshold?: number;
@@ -47,7 +47,8 @@ export function clientPerformanceMetrics({
   statsdHost,
   statsdPort,
   prefix,
-  development,
+  // eslint-disable-next-line no-process-env
+  development = process.env.NODE_ENV === 'development',
   logger,
   anomalousNavigationDurationThreshold,
   additionalTags: getAdditionalTags,

--- a/packages/react-performance/CHANGELOG.md
+++ b/packages/react-performance/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.1] - 2019-10-11
+
+### Added
+
+- special values for `PerformanceMark`'s `stage` prop are now exposed as a `Stage` enum [#1137](https://github.com/Shopify/quilt/pull/1137)
+
 ## [1.1.0] - 2019-10-11
 
 ### Added

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -5,30 +5,72 @@
 
 Primitives to measure your React application's performance using `@shopify/performance`
 
-## Installation
+## Table of Contents
+
+- [Quick-start](#quick-start)
+
+  - [Install the package](install-the-package)
+  - [Track some stats](track-some-stats)
+  - [Display real-time navigation data](display-real-time-navigation-data)
+  - [Send report data to a server](send-report-data-to-a-server)
+  - [Process report data and forward it to StatsD](process-report-data-and-forward-it-to-statsd)
+
+- [API](#api)
+  - [Hooks](#hooks)
+  - [Components](#components)
+  - [Other](#other)
+
+## Quick-start
+
+### Install the package
+
+First we will need to install the npm package.
 
 ```bash
 $ yarn add @shopify/react-performance
 ```
 
-## Quick-start
+### Track some stats
 
-### Basic
+The `@shopify/react-performance` library automatically handles creating a shared `Performance` instance (from [`@shopify/performance`](../performance)) for you when it is imported. This `Performance` instance automatically wraps the browser's built in performance and connection information and calculates some basic page-load stats. A long as we import `@shopify/react-performance` somewhere in our app the instance will be there for us.
 
-The most basic way to use the tools in this package is to record information and display it locally to the user. In practice you usually only want to do this in development so that developers can easily see performance information.
+That said, we will need to add some calls to the `usePerformanceMark` hook to our application in order to help `@shopify/react-performance` determine when a page is fully loaded and React has finished mounting components.
 
-#### Display data using NavigationListener
+```tsx
+//Cats.tsx
+import React from 'react';
+import {PerformanceMark} from '@shopify/react-performance';
 
-To demonstrate, we'll create a component called `LastNavigationDetails` and use it to display some basic data about our app's performance.
+// Represents an entire page of our application
+export function Cats() {
+  // Tell the @shopify/react-performance the page is completely loaded
+  usePerformanceMark('complete', 'cats');
+
+  return 'Kokusho, Moe, The Dude';
+}
+```
+
+**note:** In production apps, it is important to always have one `usePerformanceMark` on each page level component. Otherwise, client-side navigations may not be recorded properly. When `usePerformanceMark` calls are omitted in some pages but not others, it is common to see strange results such as:
+
+- Navigation data which makes it look like some page takes infinitely long to load
+- Navigation data in which some page sometimes randomly takes several times longer than usual
+- Missing data for a particular page
+
+### Display real-time navigation data
+
+To demonstrate the data we have so far, we'll create a component called `LastNavigationDetails` and use it to display some basic data about our app's performance.
 
 ```tsx
 // LastNavigationDetails.tsx
 import React, {useState} from 'react';
 import {useNavigationListener, Navigation} from '@shopify/react-performance';
 
+// A component which displays simple performance stats about the last navigation performed by the user
 export function LastNavigationDetails() {
+  // create some state to hold the last navigation
   const [lastNavigation, setLastNavigation] = useState<Navigation | null>(null);
 
+  // listen for subsequent client-side navigations and update our state
   useNavigationListener(navigation => {
     setLastNavigation(navigation);
   });
@@ -37,7 +79,9 @@ export function LastNavigationDetails() {
     return <p>no data</p>;
   }
 
-  const {duration, isFullPageNavigation, target};
+  const {duration, isFullPageNavigation, target} = lastNavigation;
+
+  // output some information about the last navigation
   const navigationType = isFullPageNavigation
     ? 'full page navigation'
     : 'single-page-app style navigation';
@@ -50,18 +94,26 @@ export function LastNavigationDetails() {
 }
 ```
 
-We can render this component anywhere in our application, but lets do so in our App component from earlier.
+We can render this component anywhere in our application, but lets do so in our top level App component.
 
 ```tsx
 // App.tsx
-import React from 'react';
-import {LastNavigationDetails} from './LastNavigationDetails';
 
+import React from 'react';
+import {PerformanceMark} from '@shopify/react-performance';
+// our component from above which calls `useNavigationListener`
+import {LastNavigationDetails} from './LastNavigationDetails';
+// our component from above which calls usePerformanceMark
+import {Cats} from './Cats';
+
+// the top level component of our application
 function App() {
   return (
     <>
-      {/* The rest of your app */}
+      {/* render our LastNavigationDetails component to give devs some useful stats */}
       <LastNavigationDetails />
+      {/* render the "Cats" page */}
+      <Cats />
     </>
   );
 }
@@ -69,17 +121,43 @@ function App() {
 
 Now our developers will have access to up-to-date information about how long initial page-loads and incremental navigations take to complete without needing to open their devtools or dig into DOM APIs manually.
 
-### Reporting data to the server
+### Send report data to a server
 
-Performance metrics data is most useful when it can be aggregated and used to make smart optimization decisions or warn you when your app is beginning to become slow. To aggregate such data you'll need to be able to send it to a server. `@shopify/react-performance` provides the `PerformanceReport` component to facilitate this.
+Performance metrics data is only truly useful when it can be aggregated and used to make smart optimization decisions or warn you when your app is beginning to become slow. To aggregate such data you'll need to be able to send it to a server. `@shopify/react-performance` provides the `usePerformanceReport` hook to facilitate this.
 
-> This section is a work in progress. It will be filled out as helper libraries for marshalling data on the server are added to Quilt.
+```tsx
+// App.tsx
+
+import React from 'react';
+import {
+  PerformanceMark,
+  usePerformanceReport,
+} from '@shopify/react-performance';
+
+/**
+ *  The top level component of our application, it should handle rendering all top level providers and determining what pages to render
+ */
+function App() {
+  // send a performance report to `/performance_report`
+  usePerformanceReport('/performance_report');
+
+  return <>{/* rest of the app */}</>;
+}
+```
+
+Assuming our App sets up some `<PerformanceMark />` components, our code will send a performance report to the `/performance_report` url as JSON. Generally, the easiest way to set up a server to make use of the reported data is to use one of our server-side companion libraries.
+
+### Process report data and forward it to StatsD
+
+#### Using Node (`@shopify/koa-performance`)
+
+For Node services based on `Koa`, we provide [@shopify/koa-performance](https://www.npmjs.com/package/@shopify/koa-performance) to parse `PerformanceReport` payloads and send them forward to a [StatsD](https://github.com/statsd/statsd) endpoint as `distribution`s.
+
+#### Using Rails (`quilt_rails`)
+
+For Rails services we provide [quilt_rails](https://github.com/Shopify/quilt/tree/master/gems/quilt_rails#performance-tracking-a-react-app)'s `Quilt::Performance::Reportable` mixin for parsing `PerformanceReport` payloads and sending them forward to a [StatsD](https://github.com/statsd/statsd) endpoint as `distribution`s.
 
 ## API
-
-Most APIs provided by this package are available as both hooks (ie. `useNavigationListener`), as well as components (ie. `<NavigationListener />`).
-
-This package also re-exports all of the API of [`@shopify/performance`](https://www.npmjs.com/package/@shopify/performance).
 
 ### Hooks
 
@@ -117,7 +195,7 @@ function SomeComponent() {
 
 #### usePerformanceMark
 
-A custom hook which takes an `id` and `stage` and uses them to generate a tag for a call to `window.performance.mark` when the component is mounted. This can be used to mark specialized moments in your applications startup, or a specific interaction.
+A component which takes a `stage` and an `id` and uses them to generate a tag for a call to `window.performance.mark`. This can be used to mark specialized moments in your applications startup, or a specific interaction.
 
 ```tsx
 import React from 'react';
@@ -130,107 +208,76 @@ function SomeComponent() {
 }
 ```
 
-If the hook is called with a `stage` of `usable` or `complete`, it also calls the appropriate method on the `Performance` object from context, allowing you to trigger the `finish` and `usable` lifecycleEvents based on a particular component mounting.
+##### Special `stage` values
+
+Though you can use `usePerformanceMark` with any arbitrary string passed as the `stage` parameter, two special values exist with predetermined meanings and extra side-effects.
+
+- **usable**: Marks the page _usable_ using `performance.usable()`. A page should be considered `usable` when the bare-minimum of functionality is present. Usually this just means when the React application has mounted the page, but the application is still waiting on some asynchronous data.
+- **complete**: Marks the page _complete_ using `performance.finish()`. A page should be considered `complete` when all data is fetched and the page is fully rendered.
+
+For page level components, you should always have _at least_ a `usePerformanceMark` call with a `stage` of `"complete"`.
 
 ```tsx
 import React from 'react';
-import {usePerformanceMark} from '@shopify/react-performance';
+import {PerformanceMark} from '@shopify/react-performance';
 
-function ProductPage() {
-  // this will call `performance.finish()` on the Performance object in context
-  usePerformanceMark('complete', 'products');
+function CatsPage() {
+  // mark the component as complete immediately upon rendering
+  usePerformanceMark('complete', 'ProductPage');
 
-  return <div>cool product page</div>;
+  return 'Kokusho, Moe, Smoky, Mama Cat';
+}
+```
+
+In a more complex application with calls for remote data or other asynchronous work which blocks some portion of the tree from rendering it is common to need more granular data about the lifecycle of a page load. To gather this data we can make the `stage` parameter we pass to `usePerformanceMark` dynamic, and give it `complete` only when data has loaded.
+
+```tsx
+// ProductPage.tsx
+
+import React, {useState, useEffect} from 'react';
+import {PerformanceMark} from '@shopify/react-performance';
+import {useRemoteKitties} from './hooks';
+
+export function CatsPage() {
+  // get some data from a remote API
+  const {data, error} = useRemoteKitties();
+  // we consider the page complete when we have either our data, or the call for data has returned an error.
+  const stage = data || error ? 'complete' : 'usable';
+  usePerformanceMark(stage, 'CatsPage');
+
+  return data || error;
 }
 ```
 
 #### usePerformanceReport
 
-> Todo
+A custom hook which takes a url and sends a detailed breakdown of all navigations and events which took place while the page was loading. This hook should generally only be used once at the top of your component tree.
+
+```tsx
+// App.tsx
+import React from 'react';
+import {usePerformanceReport} from '@shopify/react-performance';
+import {ProductPage} from './ProductPage';
+
+function App() {
+  usePerformanceReport('/performance-report');
+  return <ProductPage />;
+}
+```
+
+To get sensical data, applications using `usePerformanceReport` should be sure to have at least on performance mark on each top level page.
 
 ### Components
 
-#### LifecycleEventListener
+This library also provides the following component implementations of the above hooks:
 
-A component which takes in an `onEvent` callback as a prop. This callback is invoked whenever the `Performance` context object emits a lifecycleEvent.
+- `<NavigationListener />`, the component version of `useNavigationListener`
+- `<LifecycleEventListener />`, the component version of `useLifecycleEventListener`
+- `<PerformanceReport />`, the component version of `usePerformanceReport`
+- `<PerformanceMark />`, the component version of `usePerformanceMark`
 
-```tsx
-import React from 'react';
-import {LifecycleEventListener} from '@shopify/react-performance';
+The components are provided primarily for backwards compatibility, and the hook implementations should be preferred.
 
-function SomeComponent() {
-  return (
-    <>
-      <LifecycleEventListener onEvent={event => console.log(event)} />
-      <div>something</div>
-    </>
-  );
-}
-```
+### Other
 
-#### NavigationListener
-
-A component which takes in an `onNavigation` callback as a prop. This callback is invoked whenever the `Performance` context reports a navigation.
-
-```tsx
-import React from 'react';
-import {NavigationListener} from '@shopify/react-performance';
-
-function SomeComponent() {
-  return (
-    <>
-      <NavigationListener
-        onNavigation={navigation => console.log(navigation)}
-      />
-      <div>something</div>
-    </>
-  );
-}
-```
-
-#### PerformanceMark
-
-A component which takes both `id` and `stage` props and uses them to generate a tag for a call to `window.performance.mark` when it is mounted. This can be used to mark specialized moments in your applications startup, or a specific interaction.
-
-```tsx
-import React from 'react';
-import {PerformanceMark} from '@shopify/react-performance';
-
-function SomeComponent() {
-  return (
-    <>
-      <PerformanceMark stage="some-stage" id="some-id" />
-      <div>something</div>
-    </>
-  );
-}
-```
-
-If the hook is called with a `stage` of `usable` or `complete`, it also calls the appropriate method on the `Performance` object from context, allowing you to trigger the `finish` and `usable` lifecycleEvents based on a particular component mounting.
-
-```tsx
-import React from 'react';
-import {PerformanceMark} from '@shopify/react-performance';
-
-function ProductPage() {
-  import React from 'react';
-  import {PerformanceMark} from '@shopify/react-performance';
-
-  function ProductPage() {
-    return (
-      <>
-        <PerformanceMark stage="usable" id="ProductPage" />
-        <div>Some cool product page</div>
-      </>
-    );
-  }
-}
-```
-
-#### PerformanceContext
-
-A vanilla `React.createContext` object to provide a `Performance` class through your application's tree.
-
-#### PerformanceReport
-
-> Todo
+This package also re-exports all of the API from [`@shopify/performance`](../performance/README.md).

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -39,12 +39,12 @@ That said, we will need to add some calls to the `usePerformanceMark` hook to ou
 ```tsx
 //Cats.tsx
 import React from 'react';
-import {PerformanceMark} from '@shopify/react-performance';
+import {usePerformanceMark, Stage} from '@shopify/react-performance';
 
 // Represents an entire page of our application
 export function Cats() {
   // Tell the @shopify/react-performance the page is completely loaded
-  usePerformanceMark('complete', 'cats');
+  usePerformanceMark(Stage.Complete, 'cats');
 
   return 'Kokusho, Moe, The Dude';
 }
@@ -210,20 +210,20 @@ function SomeComponent() {
 
 ##### Special `stage` values
 
-Though you can use `usePerformanceMark` with any arbitrary string passed as the `stage` parameter, two special values exist with predetermined meanings and extra side-effects.
+Though you can use `usePerformanceMark` with any arbitrary string passed as the `stage` parameter, two special values exist with predetermined meanings and extra side-effects. These values are contained in the `Stage` enum.
 
-- **usable**: Marks the page _usable_ using `performance.usable()`. A page should be considered `usable` when the bare-minimum of functionality is present. Usually this just means when the React application has mounted the page, but the application is still waiting on some asynchronous data.
-- **complete**: Marks the page _complete_ using `performance.finish()`. A page should be considered `complete` when all data is fetched and the page is fully rendered.
+- `Stage.Usable`: Marks the page _usable_ using `performance.usable()`. A page should be considered `usable` when the bare-minimum of functionality is present. Usually this just means when the React application has mounted the page, but the application is still waiting on some asynchronous data.
+- `Stage.Complete`: Marks the page _complete_ using `performance.finish()`. A page should be considered `complete` when all data is fetched and the page is fully rendered.
 
-For page level components, you should always have _at least_ a `usePerformanceMark` call with a `stage` of `"complete"`.
+For page level components, you should always have _at least_ a `usePerformanceMark` call with a `stage` of `Stage.Complete`.
 
 ```tsx
 import React from 'react';
-import {PerformanceMark} from '@shopify/react-performance';
+import {usePerformanceMark, Stage} from '@shopify/react-performance';
 
 function CatsPage() {
   // mark the component as complete immediately upon rendering
-  usePerformanceMark('complete', 'ProductPage');
+  usePerformanceMark(Stage.Complete, 'ProductPage');
 
   return 'Kokusho, Moe, Smoky, Mama Cat';
 }
@@ -235,14 +235,14 @@ In a more complex application with calls for remote data or other asynchronous w
 // ProductPage.tsx
 
 import React, {useState, useEffect} from 'react';
-import {PerformanceMark} from '@shopify/react-performance';
+import {usePerformanceMark, Stage} from '@shopify/react-performance';
 import {useRemoteKitties} from './hooks';
 
 export function CatsPage() {
   // get some data from a remote API
   const {data, error} = useRemoteKitties();
   // we consider the page complete when we have either our data, or the call for data has returned an error.
-  const stage = data || error ? 'complete' : 'usable';
+  const stage = data || error ? Stage.Complete : Stage.Usable;
   usePerformanceMark(stage, 'CatsPage');
 
   return data || error;

--- a/packages/react-performance/src/PerformanceMark.tsx
+++ b/packages/react-performance/src/PerformanceMark.tsx
@@ -1,8 +1,8 @@
-import {usePerformanceMark, Stage} from './performance-mark';
+import {usePerformanceMark} from './performance-mark';
 
 interface Props {
   id: string;
-  stage: Stage;
+  stage: string;
 }
 
 export function PerformanceMark({stage, id}: Props) {

--- a/packages/react-performance/src/index.ts
+++ b/packages/react-performance/src/index.ts
@@ -17,3 +17,5 @@ export {useNavigationListener} from './navigation-listener';
 
 export {PerformanceReport} from './PerformanceReport';
 export {usePerformanceReport} from './performance-report';
+
+export {Stage} from './types';

--- a/packages/react-performance/src/performance-mark.ts
+++ b/packages/react-performance/src/performance-mark.ts
@@ -1,11 +1,12 @@
 import {usePerformanceEffect} from './performance-effect';
+import {Stage} from './types';
 
 export function usePerformanceMark(stage: string, id: string) {
   usePerformanceEffect(
     performance => {
-      if (stage === 'complete') {
+      if (stage === Stage.Complete) {
         performance.finish();
-      } else if (stage === 'usable') {
+      } else if (stage === Stage.Usable) {
         performance.usable();
       }
 

--- a/packages/react-performance/src/performance-mark.ts
+++ b/packages/react-performance/src/performance-mark.ts
@@ -1,8 +1,6 @@
 import {usePerformanceEffect} from './performance-effect';
 
-export type Stage = 'complete' | 'usable';
-
-export function usePerformanceMark(stage: Stage, id: string) {
+export function usePerformanceMark(stage: string, id: string) {
   usePerformanceEffect(
     performance => {
       if (stage === 'complete') {

--- a/packages/react-performance/src/test/PerformanceMark.test.tsx
+++ b/packages/react-performance/src/test/PerformanceMark.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {mockPerformance} from './utilities';
-import {PerformanceMark, PerformanceContext} from '..';
+import {PerformanceMark, PerformanceContext, Stage} from '..';
 
 describe('<PerformanceMark />', () => {
   it('calls performance.mark', () => {
     const performance = mockPerformance({mark: jest.fn()});
-    const stage = 'complete';
+    const stage = 'some custom stage';
     const id = 'test-id';
 
     mount(
@@ -24,7 +24,7 @@ describe('<PerformanceMark />', () => {
 
       mount(
         <PerformanceContext.Provider value={performance}>
-          <PerformanceMark stage="usable" id="test-id" />
+          <PerformanceMark stage={Stage.Usable} id="test-id" />
         </PerformanceContext.Provider>,
       );
 
@@ -38,7 +38,7 @@ describe('<PerformanceMark />', () => {
 
       mount(
         <PerformanceContext.Provider value={performance}>
-          <PerformanceMark stage="complete" id="test-id" />
+          <PerformanceMark stage={Stage.Complete} id="test-id" />
         </PerformanceContext.Provider>,
       );
 

--- a/packages/react-performance/src/types.ts
+++ b/packages/react-performance/src/types.ts
@@ -1,0 +1,4 @@
+export enum Stage {
+  Complete = 'complete',
+  Usable = 'usable',
+}


### PR DESCRIPTION
This PR takes a stab at filling out some of the unfinished documentation for our performance tracking libraries, and clarifying how to use them together with stronger in depth examples.