### PR TITLE
Add usePrevious react hook

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added a `usePrevious` hook ([#1145](https://github.com/Shopify/quilt/pull/1145))
+
 ## [1.2.0] - 2019-04-25
 
 - Added a `useMountedRef` hook ([#663](https://github.com/Shopify/quilt/pull/663))

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -84,3 +84,21 @@ function MockComponent() {
   );
 }
 ```
+
+### `usePrevious()`
+
+This hook will store the previous value of a given variable.
+
+```tsx
+function Score({value}) {
+  const previousValue = usePrevious(value);
+  const newRecord = value > previousValue ? <p>We have a new record!</p> : null;
+
+  return (
+    <>
+      <p>Current score: {value}</p>
+      {newRecord}
+    </>
+  );
+}
+```

--- a/packages/react-hooks/src/hooks/index.ts
+++ b/packages/react-hooks/src/hooks/index.ts
@@ -2,3 +2,4 @@ export {useLazyRef} from './lazy-ref';
 export {default as useTimeout} from './timeout';
 export {default as useOnValueChange} from './on-value-change';
 export {useMountedRef} from './mounted-ref';
+export {default as usePrevious} from './previous';

--- a/packages/react-hooks/src/hooks/previous.ts
+++ b/packages/react-hooks/src/hooks/previous.ts
@@ -1,0 +1,10 @@
+import {useRef, useEffect} from 'react';
+
+export default function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}

--- a/packages/react-hooks/src/hooks/tests/previous.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/previous.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import usePrevious from '../previous';
+
+describe('usePrevious', () => {
+  function Score({value}) {
+    const previousValue = usePrevious(value);
+    const newRecord =
+      value > previousValue ? <p>We have a new record!</p> : null;
+
+    return (
+      <>
+        <p>Current score: {value}</p>
+        {newRecord}
+      </>
+    );
+  }
+
+  it('returns undefined initially', () => {
+    const value = 100;
+
+    const wrapper = mount(<Score value={value} />);
+
+    expect(wrapper).toContainReactText(`Current score: ${value}`);
+    expect(wrapper).not.toContainReactText('We have a new record!');
+  });
+
+  it('displays previous value after updating value', () => {
+    const value = 100;
+    const nextValue = 200;
+
+    const wrapper = mount(<Score value={value} />);
+
+    wrapper.setProps({value: nextValue});
+
+    expect(wrapper).toContainReactText(`Current score: ${nextValue}`);
+    expect(wrapper).toContainReactText('We have a new record!');
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/web/issues/20093

`web` is already using this hook at several places. Instead of copy pasting it over and over I guess it would be nice to put it here.

More details about this hook: https://usehooks.com/usePrevious/

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
