### PR TITLE
Remove SSR configuration option

### DIFF
--- a/packages/jest-mock-apollo/CHANGELOG.md
+++ b/packages/jest-mock-apollo/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [4.0.0] - 2019-10-25
+
+### Added
+
+- Remove `ssrMode` option from `configureClient`. ([#1146](https://github.com/Shopify/quilt/pull/1146))
+
 ## [3.1.0] - 2019-06-27
 
 ### Added

--- a/packages/jest-mock-apollo/src/graphqlClient.ts
+++ b/packages/jest-mock-apollo/src/graphqlClient.ts
@@ -16,10 +16,6 @@ export interface GraphQLClientConfig {
   cacheOptions?: ApolloReducerConfig;
 }
 
-export interface GraphQLClientOptions {
-  ssrMode?: boolean;
-}
-
 export type MockGraphQLClient = ApolloClient<any> & {
   graphQLRequests: Requests;
   graphQLResults: Promise<any>[];
@@ -37,10 +33,7 @@ export default function configureClient({
   schema,
   cacheOptions = {},
 }: GraphQLClientConfig) {
-  return function createGraphQLClient(
-    mock: GraphQLMock = defaultGraphQLMock,
-    {ssrMode = true}: GraphQLClientOptions = {},
-  ) {
+  return function createGraphQLClient(mock: GraphQLMock = defaultGraphQLMock) {
     const cache = new InMemoryCache({
       fragmentMatcher: new IntrospectionFragmentMatcher({
         introspectionQueryResultData: {
@@ -75,7 +68,6 @@ export default function configureClient({
     const client = new ApolloClient({
       link: memoryLink.concat(mockLink),
       cache,
-      ssrMode,
     }) as MockGraphQLClient;
 
     client.graphQLRequests = graphQLRequests;

--- a/packages/jest-mock-apollo/src/index.ts
+++ b/packages/jest-mock-apollo/src/index.ts
@@ -1,9 +1,4 @@
-export {
-  default,
-  MockGraphQLClient,
-  GraphQLClientConfig,
-  GraphQLClientOptions,
-} from './graphqlClient';
+export {default, MockGraphQLClient, GraphQLClientConfig} from './graphqlClient';
 
 export {default as MockApolloLink} from './MockApolloLink';
 export * from './types';


### PR DESCRIPTION
## Description
Upgrading to Apollo 3.x in web we're having some trouble with tests passing namely that components using our graphql HOC with `ssr: false` will only pass if {ssrMode: false} param is passed to createGraphQLClient. Tests should use client side GraphQL so I've removed this option in favour of the [default](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/ApolloClient.ts#L117)

I could not find any instances in web where `ssrMode` was being set when mocking the graphql client, but this is potentially breaking change.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

Please delete options that are not relevant.
-->

- [x] `jest-mock-apollo` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
