### PR TITLE
react-shopify-app-route-propagator: stop using iframe name

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "@shopify/app-bridge": "^0.7.3",
+    "@shopify/app-bridge": "^1.2.0",
     "@types/enzyme": "^3.1.10",
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/faker": "^4.1.5",

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-shopify-app-route-propagator/README.md",
   "peerDependencies": {
-    "@shopify/app-bridge": "^1.0.0",
+    "@shopify/app-bridge": "^1.2.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   },

--- a/packages/react-shopify-app-route-propagator/src/globals.ts
+++ b/packages/react-shopify-app-route-propagator/src/globals.ts
@@ -9,5 +9,3 @@ export function getTopWindow() {
 export function getOrigin() {
   return location.origin;
 }
-
-export const MODAL_IFRAME_NAME = 'app-modal-iframe';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,10 +1088,10 @@
   dependencies:
     "@shopify/app-bridge" "^1.8.0"
 
-"@shopify/app-bridge@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-0.7.3.tgz#abadfa2ef6293f630764bc5ddca31750caf00f1c"
-  integrity sha512-xDkYvVvN8Gxy3JZduoT4Ohrl6fAuW+wEfhfL+qPzysu0LuJZ7CKgVCdEazPmtcI+V4GQPQLYLzcbCn3mWFU8dg==
+"@shopify/app-bridge@^1.2.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-1.9.0.tgz#8908e1112cc452a084978ddbcebb4adce7e743b8"
+  integrity sha512-GVvBLpSMnyZkLRlxBC/Up+8tw26aOLaSWapfLurzd5AwKV69nUkiqWbibtUbzKay2zyRMiYZhjNrES28jtiFcg==
 
 "@shopify/app-bridge@^1.8.0":
   version "1.8.0"
@@ -11377,6 +11377,11 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+yarn@^1.10.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.19.1.tgz#14b92410dd1ba5bab87a12b4a3d807f4569bea97"
+  integrity sha512-gBnfbL9rYY05Gt0cjJhs/siqQXHYlZalTjK3nXn2QO20xbkIFPob+LlH44ML47GcR4VU9/2dYck1BWFM0Javxw==
 
 yauzl@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
update app-bridge dependency be compatible with 1.2.0

## Description

Fixes https://github.com/Shopify/quilt/issues/1150

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
