### PR TITLE
[quilt_rails] Bump statsd-instruments to 2.8

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Changed
+
+- Bumped `statsd-instruments` gem to version `2.8` [#1152](https://github.com/Shopify/quilt/pull/1152)
+
 ## [1.9.1] - 2019-10-24
 
 ## Fixed

--- a/gems/quilt_rails/Gemfile.lock
+++ b/gems/quilt_rails/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     quilt_rails (1.9.1)
       rails-reverse-proxy (~> 0.9.0)
       railties (>= 3.2.0)
-      statsd-instrument (~> 2.7.0)
+      statsd-instrument (~> 2.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -144,7 +144,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    statsd-instrument (2.7.1)
+    statsd-instrument (2.8.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)

--- a/gems/quilt_rails/quilt_rails.gemspec
+++ b/gems/quilt_rails/quilt_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'railties', '>= 3.2.0'
   spec.add_dependency 'rails-reverse-proxy', '~> 0.9.0'
-  spec.add_dependency 'statsd-instrument', '~> 2.7.0'
+  spec.add_dependency 'statsd-instrument', '~> 2.8.0'
 
   spec.add_development_dependency 'rubocop', '~> 0.74'
   spec.add_development_dependency 'rubocop-git', '~> 0.1.3'


### PR DESCRIPTION
## Description

I was trying to use the performance tracking abilities of `quilt_rails` in the partners repo but the versions of `statsd-instruments` were mismatched so I couldn't install the gem version with performance reporting.

I checked the gem and it doesn't look like it's affected by the changes in the `2.8` version of `statsd-instruments`.


## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
