### PR TITLE
🐛 fail fast when there is no location prop on the server

### DIFF
--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [0.0.14] - 2019-10-30
+
+- The `<Router />` component will now give a more useful error message when not given a `location` on the server
+
 ## [0.0.13] - 2019-10-29
 
 - Adds `RouterChildContext` to exported types

--- a/packages/react-router/src/components/Router/Router.tsx
+++ b/packages/react-router/src/components/Router/Router.tsx
@@ -1,18 +1,27 @@
 import React from 'react';
 import {StaticRouter, BrowserRouter} from 'react-router-dom';
-import {isServer} from './utilities';
+import {isClient} from './utilities';
 
 interface Props {
   location?: string;
   children?: React.ReactNode;
 }
 
+export const NO_LOCATION_ERROR =
+  'A location must be passed to <Router /> on the server.';
+
 export default function Router({location, children}: Props) {
-  return isServer() && location ? (
+  if (isClient()) {
+    return <BrowserRouter>{children}</BrowserRouter>;
+  }
+
+  if (location == null) {
+    throw new Error(NO_LOCATION_ERROR);
+  }
+
+  return (
     <StaticRouter location={location} context={{}}>
       {children}
     </StaticRouter>
-  ) : (
-    <BrowserRouter>{children}</BrowserRouter>
   );
 }

--- a/packages/react-router/src/components/Router/test/Router.test.tsx
+++ b/packages/react-router/src/components/Router/test/Router.test.tsx
@@ -1,41 +1,49 @@
 import React from 'react';
 import {BrowserRouter, StaticRouter} from 'react-router-dom';
 import {mount} from '@shopify/react-testing';
-import Router from '../Router';
+import Router, {NO_LOCATION_ERROR} from '../Router';
 
 jest.mock('../utilities', () => ({
-  isServer: jest.fn(),
+  isClient: jest.fn(),
 }));
 
-const {isServer} = require.requireMock('../utilities') as {
-  isServer: jest.Mock;
+const {isClient} = require.requireMock('../utilities') as {
+  isClient: jest.Mock;
 };
 
 describe('Router', () => {
   beforeEach(() => {
-    isServer.mockClear();
-    isServer.mockImplementation(() => false);
+    isClient.mockClear();
+    isClient.mockImplementation(() => true);
   });
 
-  it('renders children', async () => {
+  it('renders children', () => {
     const text = 'Hello router';
-    const wrapper = await mount(<Router>{text}</Router>);
+    const wrapper = mount(<Router>{text}</Router>);
 
     expect(wrapper).toContainReactText(text);
   });
 
-  it('mounts a BrowserRouter by default', async () => {
-    const wrapper = await mount(<Router />);
+  it('mounts a BrowserRouter by default', () => {
+    const wrapper = mount(<Router />);
 
     expect(wrapper).toContainReactComponent(BrowserRouter);
   });
 
-  it('mounts a StaticRouter on the server with the delegated location prop', async () => {
-    isServer.mockReturnValue(true);
+  it('mounts a StaticRouter on the server with the delegated location prop', () => {
+    isClient.mockReturnValue(false);
 
     const location = 'http://www.shopify.com';
-    const wrapper = await mount(<Router location={location} />);
+    const wrapper = mount(<Router location={location} />);
 
     expect(wrapper).toContainReactComponent(StaticRouter, {location});
+  });
+
+  it('throws a useful error when location is omitted on the server', () => {
+    isClient.mockReturnValue(false);
+
+    expect(() => {
+      mount(<Router />);
+    }).toThrow(NO_LOCATION_ERROR);
   });
 });

--- a/packages/react-router/src/components/Router/utilities.ts
+++ b/packages/react-router/src/components/Router/utilities.ts
@@ -1,3 +1,7 @@
 export function isServer() {
   return typeof window === 'undefined';
 }
+
+export function isClient() {
+  return !isServer();
+}


### PR DESCRIPTION
This PR makes a small change to `@shopify/react-router`'s `<Router />` component. The component now throws an error if no `location` prop is present in a server environment.

This should mean that it is much easier to understand the source of errors when a user forgets to pass the `location` on the server. Previously, the `<Router />` component would have happily rendered the `<BrowserRouter />` in this situation, which would then have given a confusing error about needing a DOM.