### PR TITLE
Use SewingKitKoa Middleware in createRender

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- `createRender` now includes automatic sewing-kit-koa set-up. The `createRender` middleware now accepts an `assetPrefix` that is passed to `sewingKitKoa`'s middleware. [[1160](https://github.com/Shopify/quilt/pull/1160)]
+
 ## [0.7.3] - 2019-09-30
 
 - Added missing `@shopify/react-cookie` dependency

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -1,11 +1,8 @@
 import 'isomorphic-fetch';
 import {Server} from 'http';
-import {join} from 'path';
-import {existsSync} from 'fs';
 import Koa, {Context} from 'koa';
 import compose from 'koa-compose';
 import mount from 'koa-mount';
-import {middleware as sewingKitMiddleware} from '@shopify/sewing-kit-koa';
 import {createRender, RenderFunction} from '../render';
 import {requestLogger} from '../logger';
 import {metricsMiddleware as metrics} from '../metrics';
@@ -29,33 +26,19 @@ interface Options {
 export function createServer(options: Options): Server {
   const {port, assetPrefix, render, serverMiddleware, ip} = options;
   const app = new Koa();
-  const manifestPath = getManifestPath(process.cwd());
 
   app.use(mount('/services/ping', ping));
 
   app.use(requestLogger);
   app.use(metrics);
-  app.use(sewingKitMiddleware({assetPrefix, manifestPath}));
 
   if (serverMiddleware) {
     app.use(compose(serverMiddleware));
   }
 
-  app.use(createRender(render));
+  app.use(createRender(render, {assetPrefix}));
 
   return app.listen(port || 3000, () => {
     logger.log(`started react-server on ${ip}:${port}`);
   });
-}
-
-function getManifestPath(root: string) {
-  const gemFileExists = existsSync(join(root, 'Gemfile'));
-  if (!gemFileExists) {
-    return;
-  }
-
-  // eslint-disable-next-line no-process-env
-  return process.env.NODE_ENV === 'development'
-    ? `tmp/sewing-kit/sewing-kit-manifest.json`
-    : `public/bundles/sewing-kit-manifest.json`;
 }


### PR DESCRIPTION
## Description

This PR adds Sewing Kit Koa's middleware to the `createRender` middleware in `@shopify/react-server`. `createRender` is already tied to the Sewing Kit Koa middleware, this just makes it so users have less to do in their Koa server/ are less likely to hit errors when trying to use it.

The `createRender` middleware now accepts an `assetPrefix` that is passed to the `sewingKitKoa` middleware.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `@shopify/react-server` Major/Breaking
## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
