### PR TITLE
Fix translationKeyExists to work with onError handler

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- `translationKeyExists` on i18n works as expected with onError handler ([#1162](https://github.com/Shopify/quilt/pull/1162))
+
 
 ## [2.1.7] - 2019-11-12
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -206,7 +206,7 @@ export class I18n {
 
   translationKeyExists(id: string) {
     try {
-      this.translate(id);
+      getTranslationTree(id, this.translations, this.locale);
       return true;
     } catch (error) {
       return false;

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1451,8 +1451,8 @@ describe('I18n', () => {
 
   describe('#translationKeyExists', () => {
     it('returns true if the translation key exists', () => {
-      const mockResult = 'translated string';
-      translate.mockReturnValue(mockResult);
+      const mockResult = {hello: 'translated string'};
+      getTranslationTree.mockReturnValue(mockResult);
 
       const i18n = new I18n(defaultTranslations, defaultDetails);
       const result = i18n.translationKeyExists('hello');
@@ -1463,13 +1463,28 @@ describe('I18n', () => {
     it('returns false if the translation key does not exist', () => {
       const key = 'foo';
       const error = new MissingTranslationError(key, defaultDetails.locale);
-      translate.mockImplementation(() => {
+      getTranslationTree.mockImplementation(() => {
         throw error;
       });
 
       const i18n = new I18n(defaultTranslations, defaultDetails);
       const result = i18n.translationKeyExists(key);
 
+      expect(result).toBe(false);
+    });
+
+    it('returns false if the translation key does not exist and onError is overridden', () => {
+      const key = 'foo';
+      const error = new MissingTranslationError(key, defaultDetails.locale);
+      getTranslationTree.mockImplementation(() => {
+        throw error;
+      });
+      const i18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        onError: jest.fn(),
+      });
+
+      const result = i18n.translationKeyExists(key);
       expect(result).toBe(false);
     });
   });


### PR DESCRIPTION
## Description
With custom onError handler in i18n `translate` doesn't raise an exception causing `translationKeyExists` to always return true.

Also considered testing if the resulting string from translate was empty AND we weren't using the default on error. i.e.

```ts
translationKeyExists(id: string) {
  try {
    const translation = this.translate(id);
    return translation !== '' || this.onError !== defaultOnError;
  } catch (error) {
    return false;
  }
}
```

## Type of change


- [x] `react-i18n` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
