### PR TITLE
update `eslint-plugin-shopify` v32x

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "eslint": "^6.5.1",
-    "eslint-plugin-shopify": "^31.0.0",
+    "eslint-plugin-shopify": "^32.0.0",
     "faker": "^4.1.0",
     "full-icu": "^1.3.0",
     "get-port": "^5.0.0",

--- a/packages/address-mocks/src/fixtures/index.ts
+++ b/packages/address-mocks/src/fixtures/index.ts
@@ -6,7 +6,6 @@ import {
 const countryCAFr: LoadCountryResponse = require('./country_ca_fr').default;
 const countryCAEn: LoadCountryResponse = require('./country_ca_en').default;
 const countryCAJa: LoadCountryResponse = require('./country_ca_ja').default;
-
 const countriesEn: LoadCountriesResponse = require('./countries_en').default;
 const countriesJa: LoadCountriesResponse = require('./countries_ja').default;
 

--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -1,4 +1,5 @@
 import {Address, FieldName, Country} from '@shopify/address-consts';
+
 import {renderLineTemplate, FIELDS_MAPPING} from './utilities';
 import {loadCountry, loadCountries} from './loader';
 

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -8,6 +8,7 @@ import {
   HEADERS,
   GraphqlOperationName,
 } from '@shopify/address-consts';
+
 import query from './graphqlQuery';
 
 export const loadCountries: (

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -1,8 +1,9 @@
 import {fetch} from '@shopify/jest-dom-mocks';
 import {Address} from '@shopify/address-consts';
+
 import {mockCountryRequests} from '../../../address-mocks/src';
 import {toSupportedLocale} from '../loader';
-import AddressFormatter from '..';
+import AddressFormatter from '../AddressFormatter';
 
 const address: Address = {
   company: 'Shopify',
@@ -17,170 +18,172 @@ const address: Address = {
   phone: '514 xxx xxxx',
 };
 
-beforeEach(() => mockCountryRequests());
-afterEach(() => fetch.restore());
+describe('AddressFormatter', () => {
+  beforeEach(() => mockCountryRequests());
+  afterEach(() => fetch.restore());
 
-describe('updateLocale()', () => {
-  it('returns the country information in the default locale for that country', async () => {
-    const addressFormatter = new AddressFormatter('ja');
-    let country = await addressFormatter.getCountry('CA');
+  describe('updateLocale()', () => {
+    it('returns the country information in the default locale for that country', async () => {
+      const addressFormatter = new AddressFormatter('ja');
+      let country = await addressFormatter.getCountry('CA');
 
-    expect(country.name).toStrictEqual('カナダ');
+      expect(country.name).toStrictEqual('カナダ');
 
-    addressFormatter.updateLocale('en');
-    country = await addressFormatter.getCountry('CA');
+      addressFormatter.updateLocale('en');
+      country = await addressFormatter.getCountry('CA');
 
-    expect(country.name).toStrictEqual('Canada');
-  });
-});
-
-describe('getCountry()', () => {
-  it('returns a country object', async () => {
-    const addressFormatter = new AddressFormatter('ja');
-    const country = await addressFormatter.getCountry('JP');
-
-    expect(Object.keys(country)).toStrictEqual([
-      'name',
-      'code',
-      'phoneNumberPrefix',
-      'autocompletionField',
-      'continent',
-      'labels',
-      'formatting',
-      'zones',
-      'provinceKey',
-    ]);
+      expect(country.name).toStrictEqual('Canada');
+    });
   });
 
-  it('does not call the API again for the same country if the locale is the same', async () => {
-    const addressFormatter = new AddressFormatter('pt-br');
+  describe('getCountry()', () => {
+    it('returns a country object', async () => {
+      const addressFormatter = new AddressFormatter('ja');
+      const country = await addressFormatter.getCountry('JP');
 
-    await addressFormatter.getCountry('CA');
-    await addressFormatter.getCountry('CA');
-
-    expect(fetch.calls()).toHaveLength(1);
-  });
-
-  it('does call the API again for the same country if the locale changes', async () => {
-    const addressFormatter = new AddressFormatter('fr');
-    await addressFormatter.getCountry('CA');
-
-    expect(fetch.calls()).toHaveLength(1);
-
-    addressFormatter.updateLocale('es');
-    await addressFormatter.getCountry('CA');
-
-    expect(fetch.calls()).toHaveLength(2);
-  });
-
-  it('does not call the API again for a country if all the countries have been loaded', async () => {
-    const addressFormatter = new AddressFormatter('ja');
-    await addressFormatter.getCountries();
-    await addressFormatter.getCountry('JP');
-
-    expect(fetch.calls()).toHaveLength(1);
-  });
-
-  it('does call the API again for a country in another locale even if all the countries have been loaded', async () => {
-    const addressFormatter = new AddressFormatter('en');
-    await addressFormatter.getCountries();
-    addressFormatter.updateLocale('fr');
-    await addressFormatter.getCountry('JP');
-
-    expect(fetch.calls()).toHaveLength(2);
-  });
-});
-
-describe('getCountries()', () => {
-  it('returns all countries', async () => {
-    const addressFormatter = new AddressFormatter('ja');
-    const loadedCountries = await addressFormatter.getCountries();
-
-    expect(loadedCountries).toHaveLength(242);
-  });
-
-  it('does not call the API again for the countries if the locale is the same.', async () => {
-    // Bypass the cache by using a non existant locale
-    const addressFormatter = new AddressFormatter('pt-br');
-    await addressFormatter.getCountries();
-    await addressFormatter.getCountries();
-
-    expect(fetch.calls()).toHaveLength(1);
-  });
-
-  it('does call the API again for the countries if the locale has been updated.', async () => {
-    const addressFormatter = new AddressFormatter('nl');
-    await addressFormatter.getCountries();
-    addressFormatter.updateLocale('it');
-    await addressFormatter.getCountries();
-
-    expect(fetch.calls()).toHaveLength(2);
-  });
-});
-
-describe('format()', () => {
-  it('returns an array of parts of the address', async () => {
-    const addressFormatter = new AddressFormatter('ja');
-    const result = await addressFormatter.format(address);
-
-    expect(result).toStrictEqual([
-      '日本',
-      '〒100-8994 東京都 目黒区 八重洲1-5-3',
-      'Shopify',
-      '田中 恵子様',
-      '514 xxx xxxx',
-    ]);
-  });
-
-  it('does not return {province} if the address does not have it', async () => {
-    const addressFormatter = new AddressFormatter('ja');
-    const result = await addressFormatter.format({
-      ...address,
-      province: '',
+      expect(Object.keys(country)).toStrictEqual([
+        'name',
+        'code',
+        'phoneNumberPrefix',
+        'autocompletionField',
+        'continent',
+        'labels',
+        'formatting',
+        'zones',
+        'provinceKey',
+      ]);
     });
 
-    expect(result).toStrictEqual([
-      '日本',
-      '〒100-8994 目黒区 八重洲1-5-3',
-      'Shopify',
-      '田中 恵子様',
-      '514 xxx xxxx',
-    ]);
-  });
-});
+    it('does not call the API again for the same country if the locale is the same', async () => {
+      const addressFormatter = new AddressFormatter('pt-br');
 
-describe('getOrderedFields()', () => {
-  it('return fields ordered based on the country', async () => {
-    const addressFormatter = new AddressFormatter('ja');
-    const result = await addressFormatter.getOrderedFields('JP');
+      await addressFormatter.getCountry('CA');
+      await addressFormatter.getCountry('CA');
 
-    expect(result).toMatchObject([
-      ['company'],
-      ['lastName', 'firstName'],
-      ['zip'],
-      ['country'],
-      ['province', 'city'],
-      ['address1'],
-      ['address2'],
-      ['phone'],
-    ]);
-  });
-});
+      expect(fetch.calls()).toHaveLength(1);
+    });
 
-describe('toSupportedLocale', () => {
-  it('changes the lowercase locale to uppercase', () => {
-    expect(toSupportedLocale('ja')).toStrictEqual('JA');
-  });
+    it('does call the API again for the same country if the locale changes', async () => {
+      const addressFormatter = new AddressFormatter('fr');
+      await addressFormatter.getCountry('CA');
 
-  it('replaces - with _ and returns the locale in uppercase', () => {
-    expect(toSupportedLocale('pt-br')).toStrictEqual('PT_BR');
-  });
+      expect(fetch.calls()).toHaveLength(1);
 
-  it('returns default locale if locale is not supported', () => {
-    expect(toSupportedLocale('LOL')).toStrictEqual('EN');
+      addressFormatter.updateLocale('es');
+      await addressFormatter.getCountry('CA');
+
+      expect(fetch.calls()).toHaveLength(2);
+    });
+
+    it('does not call the API again for a country if all the countries have been loaded', async () => {
+      const addressFormatter = new AddressFormatter('ja');
+      await addressFormatter.getCountries();
+      await addressFormatter.getCountry('JP');
+
+      expect(fetch.calls()).toHaveLength(1);
+    });
+
+    it('does call the API again for a country in another locale even if all the countries have been loaded', async () => {
+      const addressFormatter = new AddressFormatter('en');
+      await addressFormatter.getCountries();
+      addressFormatter.updateLocale('fr');
+      await addressFormatter.getCountry('JP');
+
+      expect(fetch.calls()).toHaveLength(2);
+    });
   });
 
-  it('returns most similar locale available if complex', () => {
-    expect(toSupportedLocale('fr-FR')).toStrictEqual('FR');
+  describe('getCountries()', () => {
+    it('returns all countries', async () => {
+      const addressFormatter = new AddressFormatter('ja');
+      const loadedCountries = await addressFormatter.getCountries();
+
+      expect(loadedCountries).toHaveLength(242);
+    });
+
+    it('does not call the API again for the countries if the locale is the same.', async () => {
+      // Bypass the cache by using a non existant locale
+      const addressFormatter = new AddressFormatter('pt-br');
+      await addressFormatter.getCountries();
+      await addressFormatter.getCountries();
+
+      expect(fetch.calls()).toHaveLength(1);
+    });
+
+    it('does call the API again for the countries if the locale has been updated.', async () => {
+      const addressFormatter = new AddressFormatter('nl');
+      await addressFormatter.getCountries();
+      addressFormatter.updateLocale('it');
+      await addressFormatter.getCountries();
+
+      expect(fetch.calls()).toHaveLength(2);
+    });
+  });
+
+  describe('format()', () => {
+    it('returns an array of parts of the address', async () => {
+      const addressFormatter = new AddressFormatter('ja');
+      const result = await addressFormatter.format(address);
+
+      expect(result).toStrictEqual([
+        '日本',
+        '〒100-8994 東京都 目黒区 八重洲1-5-3',
+        'Shopify',
+        '田中 恵子様',
+        '514 xxx xxxx',
+      ]);
+    });
+
+    it('does not return {province} if the address does not have it', async () => {
+      const addressFormatter = new AddressFormatter('ja');
+      const result = await addressFormatter.format({
+        ...address,
+        province: '',
+      });
+
+      expect(result).toStrictEqual([
+        '日本',
+        '〒100-8994 目黒区 八重洲1-5-3',
+        'Shopify',
+        '田中 恵子様',
+        '514 xxx xxxx',
+      ]);
+    });
+  });
+
+  describe('getOrderedFields()', () => {
+    it('return fields ordered based on the country', async () => {
+      const addressFormatter = new AddressFormatter('ja');
+      const result = await addressFormatter.getOrderedFields('JP');
+
+      expect(result).toMatchObject([
+        ['company'],
+        ['lastName', 'firstName'],
+        ['zip'],
+        ['country'],
+        ['province', 'city'],
+        ['address1'],
+        ['address2'],
+        ['phone'],
+      ]);
+    });
+  });
+
+  describe('toSupportedLocale', () => {
+    it('changes the lowercase locale to uppercase', () => {
+      expect(toSupportedLocale('ja')).toStrictEqual('JA');
+    });
+
+    it('replaces - with _ and returns the locale in uppercase', () => {
+      expect(toSupportedLocale('pt-br')).toStrictEqual('PT_BR');
+    });
+
+    it('returns default locale if locale is not supported', () => {
+      expect(toSupportedLocale('LOL')).toStrictEqual('EN');
+    });
+
+    it('returns most similar locale available if complex', () => {
+      expect(toSupportedLocale('fr-FR')).toStrictEqual('FR');
+    });
   });
 });

--- a/packages/admin-graphql-api-utilities/src/test/index.test.ts
+++ b/packages/admin-graphql-api-utilities/src/test/index.test.ts
@@ -1,4 +1,5 @@
 import {v4} from 'uuid';
+
 import {parseGid, composeGid, nodesFromEdges, keyFromEdges} from '..';
 
 describe('admin-graphql-api-utilities', () => {

--- a/packages/ast-utilities/src/javascript/addComponentProps/tests/addComponentProps.test.ts
+++ b/packages/ast-utilities/src/javascript/addComponentProps/tests/addComponentProps.test.ts
@@ -1,4 +1,5 @@
 import * as t from '@babel/types';
+
 import {transform} from '../../transform';
 import addComponentProps from '../addComponentProps';
 

--- a/packages/ast-utilities/src/javascript/addImportSpecifier/addImportSpecifier.ts
+++ b/packages/ast-utilities/src/javascript/addImportSpecifier/addImportSpecifier.ts
@@ -1,5 +1,6 @@
 import * as traverse from '@babel/traverse';
 import * as t from '@babel/types';
+
 import {astFrom} from '../utilities';
 
 export default function addImportSpecifier(

--- a/packages/ast-utilities/src/javascript/addImportStatement/addImportStatement.ts
+++ b/packages/ast-utilities/src/javascript/addImportStatement/addImportStatement.ts
@@ -1,5 +1,6 @@
 import * as traverse from '@babel/traverse';
 import * as t from '@babel/types';
+
 import {astFrom} from '../utilities';
 
 export default function addImportStatement(statement: string | string[]) {

--- a/packages/ast-utilities/src/javascript/addInterface/addInterface.ts
+++ b/packages/ast-utilities/src/javascript/addInterface/addInterface.ts
@@ -1,5 +1,6 @@
 import * as traverse from '@babel/traverse';
 import * as t from '@babel/types';
+
 import {astFrom} from '../utilities';
 
 export default function addInterface(newInterface: string) {

--- a/packages/ast-utilities/src/javascript/addVariableDeclaratorProps/tests/addVariableDeclaratorProps.test.ts
+++ b/packages/ast-utilities/src/javascript/addVariableDeclaratorProps/tests/addVariableDeclaratorProps.test.ts
@@ -1,5 +1,4 @@
 import {transform} from '../../transform';
-
 import addVariableDeclaratorProps from '../addVariableDeclaratorProps';
 
 describe('addVariableDeclaratorProps', () => {

--- a/packages/ast-utilities/src/javascript/replaceJsxBody/replaceJsxBody.ts
+++ b/packages/ast-utilities/src/javascript/replaceJsxBody/replaceJsxBody.ts
@@ -1,5 +1,6 @@
 import * as traverse from '@babel/traverse';
 import * as t from '@babel/types';
+
 import {astFrom} from '../utilities';
 
 export default function replaceJSXBody(parent: string, children: string) {

--- a/packages/ast-utilities/src/javascript/transform.ts
+++ b/packages/ast-utilities/src/javascript/transform.ts
@@ -1,4 +1,5 @@
 import * as babel from '@babel/core';
+
 import {parse, parseSync} from './parse';
 import {compose} from './utilities';
 

--- a/packages/async/src/tests/babel-plugin.test.ts
+++ b/packages/async/src/tests/babel-plugin.test.ts
@@ -1,4 +1,5 @@
 import {transformAsync} from '@babel/core';
+
 import asyncBabelPlugin, {Options} from '../babel-plugin';
 
 const defaultPackage = 'some-async-package';

--- a/packages/dates/src/get-date-time-parts.ts
+++ b/packages/dates/src/get-date-time-parts.ts
@@ -1,4 +1,5 @@
 import {memoize} from '@shopify/decorators';
+
 import {formatDate} from './utilities/formatDate';
 import {sanitiseDateString} from './sanitise-date-string';
 

--- a/packages/dates/src/tests/is-future-date.test.ts
+++ b/packages/dates/src/tests/is-future-date.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isFutureDate} from '../is-future-date';
 
 describe('isFutureDate()', () => {

--- a/packages/dates/src/tests/is-less-than-one-day-ago.test.ts
+++ b/packages/dates/src/tests/is-less-than-one-day-ago.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isLessThanOneDayAgo} from '../is-less-than-one-day-ago';
 
 describe('isLessThanOneDayAgo()', () => {

--- a/packages/dates/src/tests/is-less-than-one-hour-ago.test.ts
+++ b/packages/dates/src/tests/is-less-than-one-hour-ago.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isLessThanOneHourAgo} from '../is-less-than-one-hour-ago';
 
 describe('isLessThanOneHourAgo()', () => {

--- a/packages/dates/src/tests/is-less-than-one-minute-ago.test.ts
+++ b/packages/dates/src/tests/is-less-than-one-minute-ago.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isLessThanOneMinuteAgo} from '../is-less-than-one-minute-ago';
 
 describe('isLessThanOneMinuteAgo()', () => {

--- a/packages/dates/src/tests/is-less-than-one-week-ago.test.ts
+++ b/packages/dates/src/tests/is-less-than-one-week-ago.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isLessThanOneWeekAgo} from '../is-less-than-one-week-ago';
 
 describe('isLessThanOneWeekAgo()', () => {

--- a/packages/dates/src/tests/is-less-than-one-year-ago.test.ts
+++ b/packages/dates/src/tests/is-less-than-one-year-ago.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isLessThanOneYearAgo} from '../is-less-than-one-year-ago';
 
 describe('isLessThanOneYearAgo()', () => {

--- a/packages/dates/src/tests/is-today.test.ts
+++ b/packages/dates/src/tests/is-today.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isToday} from '../is-today';
 
 describe('isToday()', () => {

--- a/packages/dates/src/tests/is-tomorrow.test.ts
+++ b/packages/dates/src/tests/is-tomorrow.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isTomorrow} from '../is-tomorrow';
 
 describe('isTomorrow()', () => {

--- a/packages/dates/src/tests/is-yesterday.test.ts
+++ b/packages/dates/src/tests/is-yesterday.test.ts
@@ -1,4 +1,5 @@
 import {clock} from '@shopify/jest-dom-mocks';
+
 import {isYesterday} from '../is-yesterday';
 
 describe('isYesterday()', () => {

--- a/packages/enzyme-utilities/src/test/index.test.tsx
+++ b/packages/enzyme-utilities/src/test/index.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mount} from 'enzyme';
+
 import {Toggle} from './fixtures/Toggle';
 import {ActionList, Action} from './fixtures/Actions';
+
 import {trigger, findById} from '..';
 
 function noop() {}

--- a/packages/graphql-persisted/src/apollo.ts
+++ b/packages/graphql-persisted/src/apollo.ts
@@ -1,4 +1,5 @@
 import {ApolloLink, Operation, NextLink, Observable} from 'apollo-link';
+
 import {CacheMissBehavior} from './shared';
 
 interface Options {

--- a/packages/graphql-persisted/src/tests/apollo.test.ts
+++ b/packages/graphql-persisted/src/tests/apollo.test.ts
@@ -4,6 +4,7 @@ import {ApolloLink} from 'apollo-link';
 
 import {createPersistedLink} from '../apollo';
 import {CacheMissBehavior} from '../shared';
+
 import {executeOnce, SimpleLink} from './utilities';
 
 describe('PersistedLink', () => {

--- a/packages/graphql-persisted/src/tests/koa-middleware.test.ts
+++ b/packages/graphql-persisted/src/tests/koa-middleware.test.ts
@@ -2,6 +2,7 @@ import faker from 'faker';
 import {Header} from '@shopify/network';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {setAssets} from '@shopify/sewing-kit-koa';
+
 import {
   Cache,
   CacheMissBehavior,

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -1,5 +1,6 @@
 import {ApolloLink, Observable, Operation} from 'apollo-link';
 import {ExecutionResult, GraphQLError} from 'graphql';
+
 import {GraphQLMock, MockGraphQLFunction} from '../types';
 
 export class MockLink extends ApolloLink {

--- a/packages/graphql-testing/src/links/tests/mocks.test.ts
+++ b/packages/graphql-testing/src/links/tests/mocks.test.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
-
 import {GraphQLError} from 'graphql';
+
 import {MockGraphQLResponse} from '../../types';
 import {MockLink} from '../mocks';
 

--- a/packages/graphql-testing/src/matchers/index.ts
+++ b/packages/graphql-testing/src/matchers/index.ts
@@ -1,4 +1,5 @@
 import {GraphQLOperation} from 'graphql-typed';
+
 import {toHavePerformedGraphQLOperation} from './operations';
 
 declare global {

--- a/packages/graphql-testing/src/matchers/operations.ts
+++ b/packages/graphql-testing/src/matchers/operations.ts
@@ -4,13 +4,14 @@ import {
   EXPECTED_COLOR as expectedColor,
 } from 'jest-matcher-utils';
 import {GraphQLOperation, DocumentNode} from 'graphql-typed';
-
 import {Operation} from 'apollo-link';
+
 import {GraphQL} from '../graphql-controller';
 import {
   operationNameFromDocument,
   operationTypeFromDocument,
 } from '../utilities';
+
 import {assertIsGraphQL, diffVariablesForOperation} from './utilities';
 
 export function toHavePerformedGraphQLOperation<Variables>(

--- a/packages/graphql-testing/src/matchers/utilities.ts
+++ b/packages/graphql-testing/src/matchers/utilities.ts
@@ -7,6 +7,7 @@ import {
   printReceived,
 } from 'jest-matcher-utils';
 import {Operation} from 'apollo-link';
+
 import {GraphQL} from '../graphql-controller';
 
 export function assertIsGraphQL(

--- a/packages/graphql-testing/src/operations.ts
+++ b/packages/graphql-testing/src/operations.ts
@@ -1,4 +1,5 @@
 import {Operation} from 'apollo-link';
+
 import {operationNameFromFindOptions} from './utilities';
 import {FindOptions} from './types';
 

--- a/packages/graphql-testing/src/test/operations.test.ts
+++ b/packages/graphql-testing/src/test/operations.test.ts
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+
 import {Operations} from '../operations';
 
 const queryOne = gql`

--- a/packages/graphql-testing/src/utilities.ts
+++ b/packages/graphql-testing/src/utilities.ts
@@ -1,4 +1,5 @@
 import {DocumentNode, OperationDefinitionNode} from 'graphql';
+
 import {FindOptions} from './types';
 
 export function operationNameFromFindOptions({

--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -1,5 +1,6 @@
 import {URL} from 'url';
 import stream from 'stream';
+
 import httpMocks, {RequestMethod} from 'node-mocks-http';
 import Koa, {Context} from 'koa';
 

--- a/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
@@ -1,4 +1,5 @@
 import {Context} from 'koa';
+
 import createContext from '../create-mock-context';
 
 const STORE_URL = 'http://mystore.com/admin';

--- a/packages/jest-mock-apollo/src/MockApolloLink.ts
+++ b/packages/jest-mock-apollo/src/MockApolloLink.ts
@@ -12,6 +12,7 @@ import {
   isUnionType,
 } from 'graphql';
 import {compile, Field} from 'graphql-tool-utilities';
+
 import {GraphQLMock, MockGraphQLFunction} from './types';
 
 export default class MockApolloLink extends ApolloLink {

--- a/packages/jest-mock-apollo/src/graphqlClient.ts
+++ b/packages/jest-mock-apollo/src/graphqlClient.ts
@@ -6,6 +6,7 @@ import {
   IntrospectionFragmentMatcher,
 } from 'apollo-cache-inmemory';
 import ApolloClient from 'apollo-client';
+
 import {GraphQLMock} from './types';
 import MockApolloLink from './MockApolloLink';
 import Requests from './Requests';

--- a/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
+++ b/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
@@ -1,5 +1,6 @@
 import {readFileSync} from 'fs';
 import path from 'path';
+
 import {buildSchema, GraphQLError} from 'graphql';
 
 import MockApolloLink from '../MockApolloLink';

--- a/packages/jest-mock-apollo/src/test/index.test.tsx
+++ b/packages/jest-mock-apollo/src/test/index.test.tsx
@@ -1,14 +1,15 @@
 import {readFileSync} from 'fs';
 import path from 'path';
+
 import React from 'react';
 import {ApolloClient} from 'apollo-client';
 import {graphql, ApolloProvider} from 'react-apollo';
-
 import {buildSchema} from 'graphql';
 import {createMount} from '@shopify/react-testing';
 
 import unionOrIntersectionTypes from './fixtures/schema-unions-and-interfaces.json';
 import petQuery from './fixtures/PetQuery.graphql';
+
 import configureClient from '..';
 
 // setup

--- a/packages/koa-liveness-ping/src/test/index.test.ts
+++ b/packages/koa-liveness-ping/src/test/index.test.ts
@@ -1,5 +1,6 @@
 import mount from 'koa-mount';
 import {createMockContext} from '@shopify/jest-koa-mocks';
+
 import ping from '..';
 
 describe('koa-liveness-ping', () => {

--- a/packages/koa-metrics/src/middleware.ts
+++ b/packages/koa-metrics/src/middleware.ts
@@ -1,10 +1,9 @@
 import {Context} from 'koa';
-
 import {StatsDClient, Logger} from '@shopify/statsd';
+
 import {tagsForRequest, tagsForResponse} from './tags';
 import {getQueuingTime} from './timing';
 import {getContentLength} from './content';
-
 import {initTimer, Timer} from './timer';
 
 export enum CustomMetric {

--- a/packages/koa-metrics/src/test/middleware.test.ts
+++ b/packages/koa-metrics/src/test/middleware.test.ts
@@ -1,5 +1,6 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {StatsDClient} from '@shopify/statsd';
+
 import {Tag} from '../tags';
 import metrics, {CustomMetric} from '../middleware';
 

--- a/packages/koa-shopify-auth/src/auth/create-enable-cookies-redirect.ts
+++ b/packages/koa-shopify-auth/src/auth/create-enable-cookies-redirect.ts
@@ -1,6 +1,7 @@
 import {Context} from 'koa';
 
 import createTopLevelRedirect from './create-top-level-redirect';
+
 import {TEST_COOKIE_NAME} from './index';
 
 export default function createEnableCookiesRedirect(path: string) {

--- a/packages/koa-shopify-auth/src/auth/create-enable-cookies.ts
+++ b/packages/koa-shopify-auth/src/auth/create-enable-cookies.ts
@@ -1,6 +1,7 @@
 import {Context} from 'koa';
 
 import {OAuthStartOptions} from '../types';
+
 import Error from './errors';
 
 const HEADING = 'Enable cookies';

--- a/packages/koa-shopify-auth/src/auth/create-oauth-callback.ts
+++ b/packages/koa-shopify-auth/src/auth/create-oauth-callback.ts
@@ -1,7 +1,9 @@
 import querystring from 'querystring';
+
 import {Context} from 'koa';
 
 import {AuthConfig} from '../types';
+
 import Error from './errors';
 import validateHmac from './validate-hmac';
 

--- a/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
+++ b/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
@@ -1,8 +1,10 @@
 import {Context} from 'koa';
 
 import {OAuthStartOptions} from '../types';
+
 import Error from './errors';
 import oAuthQueryString from './oauth-query-string';
+
 import {TOP_LEVEL_OAUTH_COOKIE_NAME} from './index';
 
 export default function createOAuthStart(

--- a/packages/koa-shopify-auth/src/auth/create-top-level-oauth-redirect.ts
+++ b/packages/koa-shopify-auth/src/auth/create-top-level-oauth-redirect.ts
@@ -1,6 +1,7 @@
 import {Context} from 'koa';
 
 import createTopLevelRedirect from './create-top-level-redirect';
+
 import {TOP_LEVEL_OAUTH_COOKIE_NAME} from './index';
 
 export default function createTopLevelOAuthRedirect(path: string) {

--- a/packages/koa-shopify-auth/src/auth/create-top-level-redirect.ts
+++ b/packages/koa-shopify-auth/src/auth/create-top-level-redirect.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {Context} from 'koa';
 
 import redirectionPage from './redirection-page';

--- a/packages/koa-shopify-auth/src/auth/index.ts
+++ b/packages/koa-shopify-auth/src/auth/index.ts
@@ -1,6 +1,7 @@
 import {Context} from 'koa';
 
 import {OAuthStartOptions, AccessMode, NextFunction} from '../types';
+
 import createOAuthStart from './create-oauth-start';
 import createOAuthCallback from './create-oauth-callback';
 import createEnableCookies from './create-enable-cookies';

--- a/packages/koa-shopify-auth/src/auth/oauth-query-string.ts
+++ b/packages/koa-shopify-auth/src/auth/oauth-query-string.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {Context} from 'koa';
 import nonce from 'nonce';
 

--- a/packages/koa-shopify-auth/src/auth/test/enable-cookies-redirect.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/enable-cookies-redirect.test.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import createEnableCookiesRedirect from '../create-enable-cookies-redirect';

--- a/packages/koa-shopify-auth/src/auth/test/enable-cookies.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/enable-cookies.test.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import createEnableCookies from '../create-enable-cookies';

--- a/packages/koa-shopify-auth/src/auth/test/index.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/index.test.ts
@@ -1,7 +1,6 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import createShopifyAuth from '../index';
-
 import createTopLevelOAuthRedirect from '../create-top-level-oauth-redirect';
 import createEnableCookiesRedirect from '../create-enable-cookies-redirect';
 import {OAuthStartOptions} from '../../types';

--- a/packages/koa-shopify-auth/src/auth/test/oauth-callback.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-callback.test.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
 

--- a/packages/koa-shopify-auth/src/auth/test/oauth-query-string.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-query-string.test.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import oAuthQueryString from '../oauth-query-string';

--- a/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
@@ -1,10 +1,10 @@
 import querystring from 'querystring';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import createOAuthStart from '../create-oauth-start';
 import Error from '../errors';
 import {OAuthStartOptions} from '../../types';
-
 import oAuthQueryString from '../oauth-query-string';
 
 jest.mock('../oauth-query-string', () => ({

--- a/packages/koa-shopify-auth/src/auth/test/top-level-oauth-redirect.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/top-level-oauth-redirect.test.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import createTopLevelOAuthRedirect from '../create-top-level-oauth-redirect';

--- a/packages/koa-shopify-auth/src/auth/test/top-level-redirect.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/top-level-redirect.test.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import createTopLevelRedirect from '../create-top-level-redirect';

--- a/packages/koa-shopify-auth/src/auth/validate-hmac.ts
+++ b/packages/koa-shopify-auth/src/auth/validate-hmac.ts
@@ -1,5 +1,6 @@
 import querystring from 'querystring';
 import crypto from 'crypto';
+
 import {Context} from 'koa';
 import safeCompare from 'safe-compare';
 

--- a/packages/koa-shopify-auth/src/verify-request/login-again-if-different-shop.ts
+++ b/packages/koa-shopify-auth/src/verify-request/login-again-if-different-shop.ts
@@ -1,5 +1,7 @@
 import {Context} from 'koa';
+
 import {NextFunction} from '../types';
+
 import {Routes} from './types';
 import {clearSession, redirectToAuth} from './utilities';
 

--- a/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
+++ b/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
@@ -1,6 +1,7 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {fetch} from '@shopify/jest-dom-mocks';
 import {StatusCode} from '@shopify/network';
+
 import verifyRequest from '../verify-request';
 import {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} from '../../index';
 

--- a/packages/koa-shopify-auth/src/verify-request/utilities.ts
+++ b/packages/koa-shopify-auth/src/verify-request/utilities.ts
@@ -1,4 +1,5 @@
 import {Context} from 'koa';
+
 import {Routes} from './types';
 
 export function redirectToAuth(

--- a/packages/koa-shopify-auth/src/verify-request/verify-request.ts
+++ b/packages/koa-shopify-auth/src/verify-request/verify-request.ts
@@ -1,4 +1,5 @@
 import compose from 'koa-compose';
+
 import {loginAgainIfDifferentShop} from './login-again-if-different-shop';
 import {verifyToken} from './verify-token';
 import {Options, Routes} from './types';

--- a/packages/koa-shopify-auth/src/verify-request/verify-token.ts
+++ b/packages/koa-shopify-auth/src/verify-request/verify-token.ts
@@ -3,6 +3,7 @@ import {Method, Header, StatusCode} from '@shopify/network';
 
 import {NextFunction} from '../types';
 import {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} from '../index';
+
 import {Routes} from './types';
 import {redirectToAuth} from './utilities';
 

--- a/packages/koa-shopify-webhooks/src/receive.ts
+++ b/packages/koa-shopify-webhooks/src/receive.ts
@@ -1,4 +1,5 @@
 import {createHmac} from 'crypto';
+
 import safeCompare from 'safe-compare';
 import bodyParser from 'koa-bodyparser';
 import mount from 'koa-mount';

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -1,4 +1,5 @@
 import {Method, Header} from '@shopify/network';
+
 import {WebhookHeader, Topic} from './types';
 
 export enum ApiVersion {

--- a/packages/koa-shopify-webhooks/src/test/receive.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/receive.test.ts
@@ -1,7 +1,10 @@
 import {createHmac} from 'crypto';
+
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {StatusCode} from '@shopify/network';
+
 import {WebhookHeader} from '../types';
+
 import {receiveWebhook} from '..';
 
 const secret = 'kitties are cute';

--- a/packages/koa-shopify-webhooks/src/test/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/register.test.ts
@@ -1,6 +1,8 @@
 import {Header} from '@shopify/network';
 import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
+
 import {ApiVersion} from '../register';
+
 import {registerWebhook, Options, WebhookHeader} from '..';
 
 const successResponse = {

--- a/packages/performance/src/test/performance.test.ts
+++ b/packages/performance/src/test/performance.test.ts
@@ -1,4 +1,5 @@
 import {FirstArgument} from '@shopify/useful-types';
+
 import {Performance} from '../performance';
 import {Navigation} from '../navigation';
 import {EventType} from '../types';

--- a/packages/react-app-bridge-universal-provider/src/test/AppBridgeUniversalProvider.test.tsx
+++ b/packages/react-app-bridge-universal-provider/src/test/AppBridgeUniversalProvider.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import faker from 'faker';
-
 import {Provider as AppBridgeProvider} from '@shopify/app-bridge-react';
 import {extract} from '@shopify/react-effect/server';
 import {mount} from '@shopify/react-testing';

--- a/packages/react-async/src/PrefetchRoute.tsx
+++ b/packages/react-async/src/PrefetchRoute.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Omit} from '@shopify/useful-types';
+
 import {PrefetchContext, PrefetchManager} from './context/prefetch';
 
 interface Props {

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -5,7 +5,6 @@ import React, {
   ReactNode,
   ComponentType,
 } from 'react';
-
 import {createResolver, ResolverOptions, DeferTiming} from '@shopify/async';
 import {IntersectionObserver} from '@shopify/react-intersection-observer';
 import {OnIdle, useIdleCallback} from '@shopify/react-idle';

--- a/packages/react-async/src/context/assets.ts
+++ b/packages/react-async/src/context/assets.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import {EffectKind} from '@shopify/react-effect';
+
 import {AssetTiming} from '../types';
 
 export interface AssetSelector {

--- a/packages/react-async/src/context/tests/assets.test.ts
+++ b/packages/react-async/src/context/tests/assets.test.ts
@@ -1,4 +1,5 @@
 import {random} from 'faker';
+
 import {AssetTiming} from '../../types';
 import {AsyncAssetManager} from '../assets';
 

--- a/packages/react-async/src/tests/Prefetcher.test.tsx
+++ b/packages/react-async/src/tests/Prefetcher.test.tsx
@@ -5,6 +5,7 @@ import {clock} from '@shopify/jest-dom-mocks';
 import {EventListener} from '../EventListener';
 import {Prefetcher, INTENTION_DELAY_MS} from '../Prefetcher';
 import {PrefetchContext} from '../context/prefetch';
+
 import {createPrefetchManager} from './utilities';
 
 jest.mock('../EventListener', () => ({

--- a/packages/react-cookie/src/BrowserCookieManager.ts
+++ b/packages/react-cookie/src/BrowserCookieManager.ts
@@ -1,4 +1,5 @@
 import cookie from 'cookie';
+
 import {CookieValue, Cookie} from './types';
 
 export {CookieContext} from './context';

--- a/packages/react-cookie/src/CookieUniversalProvider.tsx
+++ b/packages/react-cookie/src/CookieUniversalProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useNetworkManager} from '@shopify/react-network';
 import {useLazyRef} from '@shopify/react-hooks';
+
 import {BrowserCookieManager} from './BrowserCookieManager';
 import {CookieContext} from './context';
 import {hasDocumentCookie} from './utilities';

--- a/packages/react-cookie/src/context.ts
+++ b/packages/react-cookie/src/context.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {CookieManager} from './types';
 
 export const CookieContext = React.createContext<CookieManager | null>(null);

--- a/packages/react-cookie/src/hooks.ts
+++ b/packages/react-cookie/src/hooks.ts
@@ -1,5 +1,6 @@
 import {useContext, useState, useCallback} from 'react';
 import {CookieSerializeOptions} from 'cookie';
+
 import {CookieContext} from './context';
 
 const NO_MANAGER_ERROR = [

--- a/packages/react-cookie/src/tests/CookieUniversalProvider.test.tsx
+++ b/packages/react-cookie/src/tests/CookieUniversalProvider.test.tsx
@@ -5,6 +5,7 @@ import {
   NetworkContext,
   ServerCookieManager,
 } from '@shopify/react-network';
+
 import {CookieUniversalProvider} from '../CookieUniversalProvider';
 import {CookieContext} from '../context';
 import {BrowserCookieManager} from '../BrowserCookieManager';

--- a/packages/react-cookie/src/tests/hooks.test.tsx
+++ b/packages/react-cookie/src/tests/hooks.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import {NetworkManager, NetworkContext} from '@shopify/react-network';
 import {createMount} from '@shopify/react-testing';
+
 import {CookieUniversalProvider} from '../CookieUniversalProvider';
 import {useCookie} from '../hooks';
+
 import {clearCookies} from './utilities';
 
 const {hasDocumentCookie} = require.requireMock('../utilities');

--- a/packages/react-csrf-universal-provider/src/test/CsrfUniversalProvider.test.tsx
+++ b/packages/react-csrf-universal-provider/src/test/CsrfUniversalProvider.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import faker from 'faker';
-
 import {extract} from '@shopify/react-effect/server';
 import {CsrfTokenContext} from '@shopify/react-csrf';
 import {mount} from '@shopify/react-testing';

--- a/packages/react-csrf/src/hooks.ts
+++ b/packages/react-csrf/src/hooks.ts
@@ -1,4 +1,5 @@
 import {useContext} from 'react';
+
 import {CsrfTokenContext} from './context';
 
 export function useCsrfToken() {

--- a/packages/react-csrf/src/test/hooks.test.tsx
+++ b/packages/react-csrf/src/test/hooks.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import faker from 'faker';
-
 import {mount} from '@shopify/react-testing';
 
 import {CsrfTokenContext} from '../context';

--- a/packages/react-effect/src/context.ts
+++ b/packages/react-effect/src/context.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {EffectManager} from './manager';
 
 export const EffectContext = React.createContext<EffectManager | null>(null);

--- a/packages/react-effect/src/server.tsx
+++ b/packages/react-effect/src/server.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
+
 import {EffectContext} from './context';
 import {EffectManager} from './manager';
 import {Pass} from './types';

--- a/packages/react-form-state/src/index.ts
+++ b/packages/react-form-state/src/index.ts
@@ -1,5 +1,4 @@
 import FormState from './FormState';
-
 import {
   asChoiceField,
   ChoiceFieldDescriptor,

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -3,8 +3,10 @@ import faker from 'faker';
 import {mount} from 'enzyme';
 
 import {validateList} from '../validators';
+
 import {lastCallArgs} from './utilities';
 import {Input, InputField} from './components';
+
 import FormState, {validate, validateNested} from '..';
 
 describe('<FormState />', () => {

--- a/packages/react-form-state/src/tests/array-utilities.test.tsx
+++ b/packages/react-form-state/src/tests/array-utilities.test.tsx
@@ -1,4 +1,5 @@
 import faker from 'faker';
+
 import {push, replace, remove} from '../utilities';
 
 describe('array-utilities', () => {

--- a/packages/react-form-state/src/tests/components/InputField.tsx
+++ b/packages/react-form-state/src/tests/components/InputField.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {FieldState} from '../../types';
 
 export interface Props {

--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -1,4 +1,5 @@
 import faker from 'faker';
+
 import {
   validate,
   validateRequired,

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -1,4 +1,5 @@
 import isEqual from 'fast-deep-equal';
+
 import {FieldDescriptor} from './types';
 
 export {isEqual};

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -8,6 +8,7 @@ import {
   isNumericString,
   isPositiveNumericString,
 } from '@shopify/predicates';
+
 import {mapObject} from './utilities';
 
 interface Matcher<Input, Fields = any> {

--- a/packages/react-form/src/hooks/dirty.ts
+++ b/packages/react-form/src/hooks/dirty.ts
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+
 import {FieldDictionary, FieldOutput} from '../types';
 import {isField} from '../utilities';
 

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -3,6 +3,7 @@ import isEqual from 'fast-deep-equal';
 
 import {Validates, Field} from '../../types';
 import {normalizeValidation, isChangeEvent} from '../../utilities';
+
 import {
   updateAction,
   updateErrorAction,

--- a/packages/react-form/src/hooks/field/reducer.ts
+++ b/packages/react-form/src/hooks/field/reducer.ts
@@ -1,4 +1,5 @@
 import {useReducer, Reducer} from 'react';
+
 import {FieldState, ErrorValue} from '../../types';
 
 interface UpdateErrorAction {

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import faker from 'faker';
 import {mount} from '@shopify/react-testing';
+
 import {asChoiceField, useChoiceField, useField, FieldConfig} from '../field';
 
 describe('useField', () => {

--- a/packages/react-form/src/hooks/form.ts
+++ b/packages/react-form/src/hooks/form.ts
@@ -1,6 +1,8 @@
 import {useCallback, useRef} from 'react';
+
 import {SubmitHandler, FormMapping, FieldBag, Form} from '../types';
 import {validateAll} from '../utilities';
+
 import {useDirty} from './dirty';
 import {useReset} from './reset';
 import {useSubmit} from './submit';

--- a/packages/react-form/src/hooks/list/list.ts
+++ b/packages/react-form/src/hooks/list/list.ts
@@ -12,6 +12,7 @@ import {
   ListValidationContext,
 } from '../../types';
 import {mapObject, normalizeValidation, isChangeEvent} from '../../utilities';
+
 import {
   updateAction,
   updateErrorAction,

--- a/packages/react-form/src/hooks/list/reducer.ts
+++ b/packages/react-form/src/hooks/list/reducer.ts
@@ -1,4 +1,5 @@
 import {useReducer, Reducer} from 'react';
+
 import {FieldStates, ErrorValue} from '../../types';
 import {
   reduceField,

--- a/packages/react-form/src/hooks/list/test/list.test.tsx
+++ b/packages/react-form/src/hooks/list/test/list.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import faker from 'faker';
 import {mount} from '@shopify/react-testing';
+
 import {useList, FieldListConfig} from '../list';
 import {ListValidationContext} from '../../../types';
 

--- a/packages/react-form/src/hooks/reset.ts
+++ b/packages/react-form/src/hooks/reset.ts
@@ -1,4 +1,5 @@
 import {FieldBag, Field} from '../types';
+
 import useVisitFields from './visitFields';
 
 export function useReset(fieldBag: FieldBag) {

--- a/packages/react-form/src/hooks/submit.ts
+++ b/packages/react-form/src/hooks/submit.ts
@@ -1,5 +1,6 @@
 import {useState, useCallback, useRef} from 'react';
 import {useMountedRef} from '@shopify/react-hooks';
+
 import {
   FormMapping,
   SubmitHandler,

--- a/packages/react-form/src/hooks/test/form.test.tsx
+++ b/packages/react-form/src/hooks/test/form.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import faker from 'faker';
 import {mount} from '@shopify/react-testing';
+
 import {SubmitHandler} from '../../types';
 import {positiveNumericString, notEmpty} from '../../validation';
+
 import {useList, useField, useForm, submitSuccess, submitFail} from '..';
 
 interface SimpleProduct {

--- a/packages/react-form/src/hooks/visitFields.ts
+++ b/packages/react-form/src/hooks/visitFields.ts
@@ -1,4 +1,5 @@
 import {useCallback, useRef} from 'react';
+
 import {FieldDictionary, FieldOutput, Field} from '../types';
 import {isField} from '../utilities';
 

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -1,5 +1,4 @@
 import {ChangeEvent} from 'react';
-
 import get from 'get-value';
 
 import {

--- a/packages/react-form/src/validation/test/validator.test.ts
+++ b/packages/react-form/src/validation/test/validator.test.ts
@@ -1,4 +1,5 @@
 import faker from 'faker';
+
 import {validator} from '..';
 
 describe('validator', () => {

--- a/packages/react-form/src/validation/validators.ts
+++ b/packages/react-form/src/validation/validators.ts
@@ -1,4 +1,5 @@
 import * as predicates from '@shopify/predicates';
+
 import {ErrorContent, validator} from './validator';
 
 export function lengthMoreThan(length, error: ErrorContent<string>) {

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import ApolloClient, {ApolloClientOptions} from 'apollo-client';
 import {useSerialized} from '@shopify/react-html';
 import {ApolloProvider, createSsrExtractableLink} from '@shopify/react-graphql';

--- a/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {ApolloClient} from 'apollo-client';
 import {InMemoryCache} from 'apollo-cache-inmemory';
 import {ApolloLink} from 'apollo-link';
-
 import {extract} from '@shopify/react-effect/server';
 import {mount} from '@shopify/react-testing';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';

--- a/packages/react-graphql/src/Prefetch.tsx
+++ b/packages/react-graphql/src/Prefetch.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {Query} from './Query';
 import {QueryProps} from './types';
 

--- a/packages/react-graphql/src/async/query.ts
+++ b/packages/react-graphql/src/async/query.ts
@@ -1,5 +1,4 @@
 import {DocumentNode} from 'graphql-typed';
-
 import {createResolver, ResolverOptions} from '@shopify/async';
 import {useAsync, AssetTiming} from '@shopify/react-async';
 

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -1,11 +1,9 @@
 import React, {ReactElement} from 'react';
 import {random, name} from 'faker';
-
 import gql from 'graphql-tag';
 import ApolloClient from 'apollo-client';
 import {ApolloLink} from 'apollo-link';
 import {InMemoryCache} from 'apollo-cache-inmemory';
-
 import {getUsedAssets as baseGetUsedAssets} from '@shopify/react-async/testing';
 import {createMount} from '@shopify/react-testing';
 import {

--- a/packages/react-graphql/src/hooks/apollo-client.tsx
+++ b/packages/react-graphql/src/hooks/apollo-client.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ApolloClient from 'apollo-client';
+
 import {ApolloContext} from '../ApolloContext';
 
 export default function useApolloClient<CacheShape>(

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -13,6 +13,7 @@ import {useServerEffect} from '@shopify/react-effect';
 import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
 
 import {AsyncDocumentNode} from '../types';
+
 import {QueryHookOptions, QueryHookResult} from './types';
 import useApolloClient from './apollo-client';
 import useGraphQLDocument from './graphql-document';

--- a/packages/react-graphql/src/hooks/tests/mutation.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/mutation.test.tsx
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 
 import useMutation from '../mutation';
+
 import {mountWithGraphQL} from './utilities';
 
 const updatePetMutation = gql`

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -7,6 +7,7 @@ import {createGraphQLFactory} from '@shopify/graphql-testing';
 
 import {createAsyncQueryComponent} from '../../async';
 import useQuery from '../query';
+
 import {mountWithGraphQL, createResolvablePromise} from './utilities';
 
 const petQuery = gql`

--- a/packages/react-graphql/src/hooks/tests/utilities.tsx
+++ b/packages/react-graphql/src/hooks/tests/utilities.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import {createGraphQLFactory, GraphQL} from '@shopify/graphql-testing';
 import {createMount} from '@shopify/react-testing';
 

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -10,6 +10,7 @@ import {
   OperationVariables,
 } from 'react-apollo';
 import {Omit, IfAllNullableKeys} from '@shopify/useful-types';
+
 import {VariableOptions} from '../types';
 
 export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<

--- a/packages/react-hooks/src/hooks/tests/timeout.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/timeout.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {timer} from '@shopify/jest-dom-mocks';
+
 import useTimeout from '../timeout';
 
 describe('useTimeout', () => {

--- a/packages/react-html/src/components/AppleHomeScreen.tsx
+++ b/packages/react-html/src/components/AppleHomeScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {Meta} from './Meta';
 import {Link} from './Link';
 

--- a/packages/react-html/src/components/BodyAttributes.tsx
+++ b/packages/react-html/src/components/BodyAttributes.tsx
@@ -1,4 +1,5 @@
 import {FirstArgument} from '@shopify/useful-types';
+
 import {useBodyAttributes} from '../hooks';
 
 type Props = FirstArgument<typeof useBodyAttributes>;

--- a/packages/react-html/src/components/HtmlAttributes.tsx
+++ b/packages/react-html/src/components/HtmlAttributes.tsx
@@ -1,4 +1,5 @@
 import {FirstArgument} from '@shopify/useful-types';
+
 import {useHtmlAttributes} from '../hooks';
 
 type Props = FirstArgument<typeof useHtmlAttributes>;

--- a/packages/react-html/src/components/Link.tsx
+++ b/packages/react-html/src/components/Link.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {useLink} from '../hooks';
 
 type Props = React.HTMLProps<HTMLLinkElement>;

--- a/packages/react-html/src/components/Meta.tsx
+++ b/packages/react-html/src/components/Meta.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {useMeta} from '../hooks';
 
 type Props = React.HTMLProps<HTMLMetaElement>;

--- a/packages/react-html/src/components/tests/AppleHomeScreen.test.tsx
+++ b/packages/react-html/src/components/tests/AppleHomeScreen.test.tsx
@@ -3,7 +3,6 @@ import {mount} from '@shopify/react-testing';
 
 import {Link} from '../Link';
 import {Meta} from '../Meta';
-
 import {AppleHomeScreen, IconSize} from '../AppleHomeScreen';
 
 describe('<AppleHomeScreen />', () => {

--- a/packages/react-html/src/components/tests/Script.test.tsx
+++ b/packages/react-html/src/components/tests/Script.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+
 import {Script} from '../Script';
 
 describe('<Script />', () => {

--- a/packages/react-html/src/components/tests/Style.test.tsx
+++ b/packages/react-html/src/components/tests/Style.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+
 import {Style} from '../Style';
 
 describe('<Style />', () => {

--- a/packages/react-html/src/context.tsx
+++ b/packages/react-html/src/context.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {HtmlManager} from './manager';
 
 export const HtmlContext = React.createContext(new HtmlManager());

--- a/packages/react-html/src/manager.ts
+++ b/packages/react-html/src/manager.ts
@@ -1,4 +1,5 @@
 import {EffectKind} from '@shopify/react-effect';
+
 import {getSerializationsFromDocument} from './utilities';
 
 interface Title {

--- a/packages/react-html/src/serializer.tsx
+++ b/packages/react-html/src/serializer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {useServerEffect} from '@shopify/react-effect';
+
 import {HtmlContext} from './context';
 import {useServerDomEffect} from './hooks';
 

--- a/packages/react-html/src/server/components/Serialize.tsx
+++ b/packages/react-html/src/server/components/Serialize.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import serialize from 'serialize-javascript';
+
 import {SERIALIZE_ATTRIBUTE} from '../../utilities';
 
 interface Props {

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -5,7 +5,6 @@ import {mount} from '@shopify/react-testing';
 import {Script, Style} from '../../../components';
 import {HtmlManager} from '../../../manager';
 import {MANAGED_ATTRIBUTE} from '../../../utilities';
-
 import Html from '../Html';
 import Serialize from '../Serialize';
 

--- a/packages/react-html/src/server/stream.ts
+++ b/packages/react-html/src/server/stream.ts
@@ -1,4 +1,5 @@
 import {Readable} from 'stream';
+
 import {ReactElement} from 'react';
 import {renderToStaticNodeStream} from 'react-dom/server';
 import multistream from 'multistream';

--- a/packages/react-html/src/server/tests/stream.test.tsx
+++ b/packages/react-html/src/server/tests/stream.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import stream from '../stream';
 
 describe('stream', () => {

--- a/packages/react-html/src/tests/serializer.test.tsx
+++ b/packages/react-html/src/tests/serializer.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {extract} from '@shopify/react-effect/server';
+
 import {render, Html} from '../server';
+
 import {useSerialized, HtmlContext, HtmlManager} from '..';
 
 describe('useSerialized', () => {

--- a/packages/react-hydrate/src/HydrationTracker.tsx
+++ b/packages/react-hydrate/src/HydrationTracker.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {useHydrationManager} from './hooks';
 
 export function HydrationTracker() {

--- a/packages/react-hydrate/src/Hydrator.tsx
+++ b/packages/react-hydrate/src/Hydrator.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useLazyRef} from '@shopify/react-hooks';
 import {useServerEffect} from '@shopify/react-effect';
+
 import {HydrationContext} from './context';
 import {HYDRATION_ATTRIBUTE} from './shared';
 

--- a/packages/react-hydrate/src/context.ts
+++ b/packages/react-hydrate/src/context.ts
@@ -1,4 +1,5 @@
 import {createContext} from 'react';
+
 import {HydrationManager} from './manager';
 
 export const HydrationContext = createContext<HydrationManager>(

--- a/packages/react-hydrate/src/hooks.ts
+++ b/packages/react-hydrate/src/hooks.ts
@@ -1,4 +1,5 @@
 import {useContext} from 'react';
+
 import {HydrationContext} from './context';
 
 export function useHydrationManager() {

--- a/packages/react-hydrate/src/manager.ts
+++ b/packages/react-hydrate/src/manager.ts
@@ -1,4 +1,5 @@
 import {EffectKind} from '@shopify/react-effect';
+
 import {HYDRATION_ATTRIBUTE} from './shared';
 
 const DEFAULT_HYDRATION_ID = Symbol('defaultId');

--- a/packages/react-i18n-universal-provider/src/I18nUniversalProvider.tsx
+++ b/packages/react-i18n-universal-provider/src/I18nUniversalProvider.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import {useLazyRef} from '@shopify/react-hooks';
 import {useSerialized, useHtmlAttributes} from '@shopify/react-html';
 import {I18nContext, I18nDetails, I18nManager} from '@shopify/react-i18n';

--- a/packages/react-i18n/src/babel-plugin.ts
+++ b/packages/react-i18n/src/babel-plugin.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import glob from 'glob';
 import {TemplateBuilder} from '@babel/template';
 import Types from '@babel/types';

--- a/packages/react-i18n/src/context.ts
+++ b/packages/react-i18n/src/context.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {I18nManager} from './manager';
 import {I18n} from './i18n';
 

--- a/packages/react-i18n/src/decorator.tsx
+++ b/packages/react-i18n/src/decorator.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {NonReactStatics} from '@shopify/useful-types';
+
 import {RegisterOptions} from './manager';
 import {useI18n} from './hooks';
 import {I18n} from './i18n';

--- a/packages/react-i18n/src/hooks.tsx
+++ b/packages/react-i18n/src/hooks.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import {useLazyRef} from '@shopify/react-hooks';
 
 import {I18n} from './i18n';

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -10,6 +10,7 @@ import {
 import {memoize as memoizeFn} from '@shopify/function-enhancers';
 import {memoize} from '@shopify/decorators';
 import {languageFromLocale, regionFromLocale} from '@shopify/i18n';
+
 import {
   I18nDetails,
   PrimitiveReplacementDictionary,

--- a/packages/react-i18n/src/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/test/babel-plugin.test.ts
@@ -1,5 +1,7 @@
 import path from 'path';
+
 import {transformAsync, TransformOptions} from '@babel/core';
+
 import i18nBabelPlugin from '../babel-plugin';
 
 jest.mock('string-hash', () => () => {

--- a/packages/react-i18n/src/test/e2e/server.test.tsx
+++ b/packages/react-i18n/src/test/e2e/server.test.tsx
@@ -7,6 +7,7 @@ import '../matchers';
 import React from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {extract, Effect} from '@shopify/react-effect/server';
+
 import {I18nManager} from '../../manager';
 import {useI18n} from '../../hooks';
 import {I18nContext} from '../../context';

--- a/packages/react-i18n/src/test/e2e/translations.test.tsx
+++ b/packages/react-i18n/src/test/e2e/translations.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
+
 import {I18nManager} from '../../manager';
 import {useI18n} from '../../hooks';
 import {I18nContext} from '../../context';

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
   translate,
   getTranslationTree,

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -4,6 +4,7 @@ import {
   pseudotranslate as pseudotranslateString,
   PseudotranslateOptions,
 } from '@shopify/i18n';
+
 import {
   TranslationDictionary,
   ComplexReplacementDictionary,

--- a/packages/react-idle/src/hooks.ts
+++ b/packages/react-idle/src/hooks.ts
@@ -1,4 +1,5 @@
 import {useEffect, useRef} from 'react';
+
 import {
   RequestIdleCallbackHandle,
   WindowWithRequestIdleCallback,

--- a/packages/react-import-remote/src/hooks.ts
+++ b/packages/react-import-remote/src/hooks.ts
@@ -6,6 +6,7 @@ import {
   RequestIdleCallbackHandle,
 } from '@shopify/async';
 import {useMountedRef} from '@shopify/react-hooks';
+
 import load from './load';
 
 interface Options<Imported> {

--- a/packages/react-import-remote/src/test/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/test/ImportRemote.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {DeferTiming} from '@shopify/async';
 import {mount} from '@shopify/react-testing';
-
 import {
   requestIdleCallback,
   intersectionObserver,
 } from '@shopify/jest-dom-mocks';
 import {Preconnect} from '@shopify/react-html';
+
 import ImportRemote, {Props} from '../ImportRemote';
 
 function noop() {}

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {useIntersection, useValueTracking} from './hooks';
 import {UnsupportedBehavior} from './types';
 

--- a/packages/react-network/src/components/BaseUri.tsx
+++ b/packages/react-network/src/components/BaseUri.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/BlockAllMixedContent.tsx
+++ b/packages/react-network/src/components/BlockAllMixedContent.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/ChildSource.tsx
+++ b/packages/react-network/src/components/ChildSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/ConnectSource.tsx
+++ b/packages/react-network/src/components/ConnectSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/DefaultSource.tsx
+++ b/packages/react-network/src/components/DefaultSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/FontSource.tsx
+++ b/packages/react-network/src/components/FontSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/FormAction.tsx
+++ b/packages/react-network/src/components/FormAction.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/FrameAncestors.tsx
+++ b/packages/react-network/src/components/FrameAncestors.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/FrameSource.tsx
+++ b/packages/react-network/src/components/FrameSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/ImageSource.tsx
+++ b/packages/react-network/src/components/ImageSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/ManifestSource.tsx
+++ b/packages/react-network/src/components/ManifestSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/MediaSource.tsx
+++ b/packages/react-network/src/components/MediaSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/ObjectSource.tsx
+++ b/packages/react-network/src/components/ObjectSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/PluginTypes.tsx
+++ b/packages/react-network/src/components/PluginTypes.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/PrefetchSource.tsx
+++ b/packages/react-network/src/components/PrefetchSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/Redirect.tsx
+++ b/packages/react-network/src/components/Redirect.tsx
@@ -1,4 +1,5 @@
 import {StatusCode} from '@shopify/network';
+
 import {useRedirect} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/ReportUri.tsx
+++ b/packages/react-network/src/components/ReportUri.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/RequireSriFor.tsx
+++ b/packages/react-network/src/components/RequireSriFor.tsx
@@ -1,4 +1,5 @@
 import {CspDirective, SriAsset} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/Sandbox.tsx
+++ b/packages/react-network/src/components/Sandbox.tsx
@@ -1,4 +1,5 @@
 import {CspDirective, CspSandboxAllow} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/ScriptSource.tsx
+++ b/packages/react-network/src/components/ScriptSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/Status.tsx
+++ b/packages/react-network/src/components/Status.tsx
@@ -1,4 +1,5 @@
 import {StatusCode} from '@shopify/network';
+
 import {useStatus} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/StyleSource.tsx
+++ b/packages/react-network/src/components/StyleSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/UpgradeInsecureRequests.tsx
+++ b/packages/react-network/src/components/UpgradeInsecureRequests.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/WebRtcSource.tsx
+++ b/packages/react-network/src/components/WebRtcSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/components/WorkerSource.tsx
+++ b/packages/react-network/src/components/WorkerSource.tsx
@@ -1,4 +1,5 @@
 import {CspDirective} from '@shopify/network';
+
 import {useCspDirective} from '../hooks';
 
 interface Props {

--- a/packages/react-network/src/context.ts
+++ b/packages/react-network/src/context.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {NetworkManager} from './manager';
 
 export const NetworkContext = React.createContext<NetworkManager | null>(null);

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -1,4 +1,5 @@
 import {Context} from 'koa';
+
 import {NetworkManager, EFFECT_ID} from './manager';
 
 export {NetworkContext} from './context';

--- a/packages/react-network/src/test/hooks.test.tsx
+++ b/packages/react-network/src/test/hooks.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {createMount} from '@shopify/react-testing';
 import {Header} from '@shopify/network';
 import {FirstArgument} from '@shopify/useful-types';
+
 import {NetworkManager} from '../manager';
 import {NetworkContext} from '../context';
 import {useAcceptLanguage} from '../hooks';

--- a/packages/react-performance/src/test/LifecycleEventListener.test.tsx
+++ b/packages/react-performance/src/test/LifecycleEventListener.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+
 import {mockPerformance} from './utilities';
+
 import {LifecycleEventListener, PerformanceContext} from '..';
 
 describe('<LifecycleEventListener />', () => {

--- a/packages/react-performance/src/test/NavigationListener.test.tsx
+++ b/packages/react-performance/src/test/NavigationListener.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+
 import {mockPerformance} from './utilities';
+
 import {NavigationListener, PerformanceContext} from '..';
 
 describe('<NavigationListener />', () => {

--- a/packages/react-performance/src/test/PerformanceMark.test.tsx
+++ b/packages/react-performance/src/test/PerformanceMark.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+
 import {mockPerformance} from './utilities';
+
 import {PerformanceMark, PerformanceContext, Stage} from '..';
 
 describe('<PerformanceMark />', () => {

--- a/packages/react-performance/src/test/PerformanceReport.test.tsx
+++ b/packages/react-performance/src/test/PerformanceReport.test.tsx
@@ -5,6 +5,7 @@ import {fetch, timer, connection} from '@shopify/jest-dom-mocks';
 import {Method, Header} from '@shopify/network';
 
 import {mockPerformance, randomConnection} from './utilities';
+
 import {PerformanceReport, PerformanceContext} from '..';
 
 describe('<PerformanceReport />', () => {

--- a/packages/react-performance/src/test/performance-effect.server.test.tsx
+++ b/packages/react-performance/src/test/performance-effect.server.test.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
+
 import {usePerformanceEffect, PerformanceEffectCallback} from '..';
 
 describe('usePerformanceEffect', () => {

--- a/packages/react-performance/src/test/performance-effect.test.tsx
+++ b/packages/react-performance/src/test/performance-effect.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+
 import {mockPerformance} from './utilities';
+
 import {
   usePerformanceEffect,
   PerformanceEffectCallback,

--- a/packages/react-performance/src/test/utilities.ts
+++ b/packages/react-performance/src/test/utilities.ts
@@ -6,6 +6,7 @@ import {
   LifecycleEvent,
   EventType,
 } from '@shopify/performance';
+
 import {NavigationListener} from '../navigation-listener';
 import {LifecycleEventListener} from '../lifecycle-event-listener';
 

--- a/packages/react-router/src/components/Router/Router.tsx
+++ b/packages/react-router/src/components/Router/Router.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {StaticRouter, BrowserRouter} from 'react-router-dom';
+
 import {isClient} from './utilities';
 
 interface Props {

--- a/packages/react-router/src/components/Router/test/Router.test.tsx
+++ b/packages/react-router/src/components/Router/test/Router.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {BrowserRouter, StaticRouter} from 'react-router-dom';
 import {mount} from '@shopify/react-testing';
+
 import Router, {NO_LOCATION_ERROR} from '../Router';
 
 jest.mock('../utilities', () => ({

--- a/packages/react-serialize/src/Serializer.tsx
+++ b/packages/react-serialize/src/Serializer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import serialize from 'serialize-javascript';
+
 import {serializedID} from './utilities';
 
 export interface Props {

--- a/packages/react-serialize/src/tests/utilities.test.ts
+++ b/packages/react-serialize/src/tests/utilities.test.ts
@@ -1,4 +1,5 @@
 import serialize from 'serialize-javascript';
+
 import {getSerialized, serializedID} from '../utilities';
 
 describe('getSerialized()', () => {

--- a/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
+++ b/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
@@ -1,5 +1,6 @@
 import {join, resolve} from 'path';
 import {existsSync, readdirSync} from 'fs';
+
 import {Compiler} from 'webpack';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 

--- a/packages/react-server-webpack-plugin/src/test/react-server-webpack-plugin.test.ts
+++ b/packages/react-server-webpack-plugin/src/test/react-server-webpack-plugin.test.ts
@@ -1,6 +1,9 @@
 import path from 'path';
+
 import webpack, {Compiler} from 'webpack';
+
 import {HEADER, Options} from '../react-server-webpack-plugin';
+
 import {withWorkspace} from './utilities/workspace';
 
 const BUILD_TIMEOUT = 10000;

--- a/packages/react-server-webpack-plugin/src/test/utilities/workspace.ts
+++ b/packages/react-server-webpack-plugin/src/test/utilities/workspace.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+
 import * as fs from 'fs-extra';
 
 export class Workspace {

--- a/packages/react-server/src/logger/logger.ts
+++ b/packages/react-server/src/logger/logger.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-process-env */
 import {Context, Request} from 'koa';
 import chalk from 'chalk';
+
 import {KoaNextFunction} from '../types';
 
 export const LOGGER = Symbol('logger');

--- a/packages/react-server/src/metrics/test/metric.test.tsx
+++ b/packages/react-server/src/metrics/test/metric.test.tsx
@@ -1,4 +1,5 @@
 import {Server} from 'http';
+
 import React from 'react';
 import request from 'supertest';
 import getPort from 'get-port';

--- a/packages/react-server/src/providers/providers.tsx
+++ b/packages/react-server/src/providers/providers.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {useRequestHeader} from '@shopify/react-network';
 import {CsrfUniversalProvider} from '@shopify/react-csrf-universal-provider';
 import {CookieUniversalProvider} from '@shopify/react-cookie';
+
 import {ConditionalProvider} from './ConditionalProvider';
 
 interface Options {

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -1,5 +1,6 @@
 import {join} from 'path';
 import {existsSync} from 'fs';
+
 import React from 'react';
 import {Context} from 'koa';
 import compose from 'koa-compose';
@@ -27,6 +28,7 @@ import {
   getAssets,
   middleware as sewingKitMiddleware,
 } from '@shopify/sewing-kit-koa';
+
 import {getLogger} from '../logger';
 
 export {Context};

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -3,6 +3,7 @@ import {Effect} from '@shopify/react-effect/server';
 import {middleware as sewingKitKoaMiddleware} from '@shopify/sewing-kit-koa';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import withEnv from '@shopify/with-env';
+
 import {createRender} from '../render';
 import {mockMiddleware} from '../../test/utilities';
 

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -1,8 +1,10 @@
 import 'isomorphic-fetch';
 import {Server} from 'http';
+
 import Koa, {Context} from 'koa';
 import compose from 'koa-compose';
 import mount from 'koa-mount';
+
 import {createRender, RenderFunction} from '../render';
 import {requestLogger} from '../logger';
 import {metricsMiddleware as metrics} from '../metrics';

--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {useTitle} from '@shopify/react-html';
 import {useCookie, CookieUniversalProvider} from '@shopify/react-cookie';
-import {createServer} from '../server';
 
+import {createServer} from '../server';
 import {mockMiddleware, TestRack} from '../../test/utilities';
 
 const rack = new TestRack();

--- a/packages/react-server/src/test/utilities.ts
+++ b/packages/react-server/src/test/utilities.ts
@@ -1,4 +1,5 @@
 import {Server} from 'http';
+
 import {Context} from 'koa';
 import getPort from 'get-port';
 

--- a/packages/react-shopify-app-route-propagator/src/hook.ts
+++ b/packages/react-shopify-app-route-propagator/src/hook.ts
@@ -1,8 +1,8 @@
 import {useMemo, useEffect} from 'react';
 import {ClientApplication} from '@shopify/app-bridge';
 import {History} from '@shopify/app-bridge/actions';
-import {LocationOrHref} from './types';
 
+import {LocationOrHref} from './types';
 import {
   getSelfWindow,
   getTopWindow,

--- a/packages/react-shopify-app-route-propagator/src/route-propagator.tsx
+++ b/packages/react-shopify-app-route-propagator/src/route-propagator.tsx
@@ -1,4 +1,5 @@
 import {ClientApplication} from '@shopify/app-bridge';
+
 import useRoutePropagation from './hook';
 import {LocationOrHref} from './types';
 

--- a/packages/react-shopify-app-route-propagator/src/test/route-propagator.test.tsx
+++ b/packages/react-shopify-app-route-propagator/src/test/route-propagator.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {ClientApplication} from '@shopify/app-bridge';
 import {History as AppBridgeHistory} from '@shopify/app-bridge/actions';
 import {mount} from '@shopify/react-testing';
+
 import {MODAL_IFRAME_NAME} from '../globals';
 import RoutePropagator from '../route-propagator';
 

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,4 +1,5 @@
 import Key, {HeldKey} from '../keys';
+
 import useShortcut from './hooks';
 
 export interface Props {

--- a/packages/react-shortcuts/src/Shortcut/hooks.ts
+++ b/packages/react-shortcuts/src/Shortcut/hooks.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {ShortcutContext} from '../ShortcutProvider';
 import Key, {HeldKey} from '../keys';
 

--- a/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
+++ b/packages/react-shortcuts/src/ShortcutProvider/ShortcutProvider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ShortcutManager from '../ShortcutManager';
 
 export interface Props {

--- a/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Shortcut from '../Shortcut';
 
 interface Props {

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -3,6 +3,7 @@ import {
   Arguments,
   MaybeFunctionReturnType as ReturnType,
 } from '@shopify/useful-types';
+
 import {nodeName, toReactString} from './toReactString';
 import {
   Tag,

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -7,6 +7,7 @@ import {
 } from 'jest-matcher-utils';
 
 import {Node, PropsFor} from '../types';
+
 import {
   assertIsNode,
   assertIsType,

--- a/packages/react-testing/src/matchers/context.ts
+++ b/packages/react-testing/src/matchers/context.ts
@@ -7,6 +7,7 @@ import {
 } from 'jest-matcher-utils';
 
 import {Node} from '../types';
+
 import {assertIsNode, diffs, printType} from './utilities';
 
 export function toProvideReactContext<Type>(

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,6 +1,7 @@
 import {ComponentType, Context as ReactContext} from 'react';
 
 import {Node, PropsFor} from '../types';
+
 import {toHaveReactProps, toHaveReactDataProps} from './props';
 import {
   toContainReactComponent,

--- a/packages/react-testing/src/matchers/props.ts
+++ b/packages/react-testing/src/matchers/props.ts
@@ -4,7 +4,9 @@ import {
   printExpected,
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
+
 import {Node} from '../types';
+
 import {assertIsNode, diffPropsForNode} from './utilities';
 
 export function toHaveReactProps<Props>(

--- a/packages/react-testing/src/matchers/strings.ts
+++ b/packages/react-testing/src/matchers/strings.ts
@@ -5,7 +5,9 @@ import {
   RECEIVED_COLOR as receivedColor,
   INVERTED_COLOR as invertedColor,
 } from 'jest-matcher-utils';
+
 import {Node} from '../types';
+
 import {assertIsNode} from './utilities';
 
 export function toContainReactText<Props>(

--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import {IfAllOptionalKeys} from '@shopify/useful-types';
+
 import {Root, Options as RootOptions} from './root';
 import {Element} from './element';
 

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {createPortal} from 'react-dom';
+
 import {mount} from '../mount';
 
 describe('e2e', () => {

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {Element} from '../element';
 import {Root} from '../root';
 import {Tag} from '../types';

--- a/packages/react-testing/src/toReactString.ts
+++ b/packages/react-testing/src/toReactString.ts
@@ -1,4 +1,5 @@
 import {stringify} from 'jest-matcher-utils';
+
 import {DebugOptions, Node} from './types';
 
 export function toReactString<Props>(

--- a/packages/react-universal-provider/src/test/create-universal-provider.test.tsx
+++ b/packages/react-universal-provider/src/test/create-universal-provider.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import faker from 'faker';
-
 import {extract} from '@shopify/react-effect/server';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';
 import {mount} from '@shopify/react-testing';

--- a/packages/react-web-worker/src/hooks.ts
+++ b/packages/react-web-worker/src/hooks.ts
@@ -1,6 +1,4 @@
 import {useEffect} from 'react';
-// import {terminate} from '@shopify/web-worker';
-
 import {useLazyRef} from '@shopify/react-hooks';
 
 export function useWorker<T>(creator: () => T) {

--- a/packages/react-web-worker/src/test/hooks.test.tsx
+++ b/packages/react-web-worker/src/test/hooks.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+
 import {useWorker} from '../index';
 
 interface Props {

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -1,4 +1,5 @@
 import {join} from 'path';
+
 import {readJson} from 'fs-extra';
 import {matchesUA} from 'browserslist-useragent';
 import appRoot from 'app-root-path';

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -1,10 +1,10 @@
 import {join} from 'path';
+
 import {Context, Middleware} from 'koa';
 import serve from 'koa-static';
 import compose from 'koa-compose';
 import mount from 'koa-mount';
 import appRoot from 'app-root-path';
-
 import {Header} from '@shopify/network';
 
 import Assets, {Asset} from './assets';

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -1,6 +1,8 @@
 import {join, basename} from 'path';
+
 import appRoot from 'app-root-path';
 import withEnv from '@shopify/with-env';
+
 import Assets, {
   internalOnlyClearCache,
   Asset,

--- a/packages/sewing-kit-koa/src/tests/middleware.test.ts
+++ b/packages/sewing-kit-koa/src/tests/middleware.test.ts
@@ -1,5 +1,6 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {Header} from '@shopify/network';
+
 import middleware, {getAssets} from '../middleware';
 import Assets from '../assets';
 

--- a/packages/statsd/src/test/client.test.ts
+++ b/packages/statsd/src/test/client.test.ts
@@ -1,4 +1,5 @@
 import {StatsD} from 'hot-shots';
+
 import {StatsDClient} from '../client';
 
 jest.mock('hot-shots');

--- a/packages/web-worker/src/endpoint.ts
+++ b/packages/web-worker/src/endpoint.ts
@@ -1,5 +1,4 @@
 import {PromisifyModule} from './types';
-
 import {
   RETAIN_METHOD,
   RELEASE_METHOD,

--- a/packages/web-worker/src/test/e2e.test.ts
+++ b/packages/web-worker/src/test/e2e.test.ts
@@ -3,10 +3,12 @@
  */
 
 import * as path from 'path';
+
 import {DefinePlugin} from 'webpack';
 import {Page, Worker, JSHandle} from 'puppeteer';
 
 import {WebWorkerPlugin} from '../webpack-parts';
+
 import {withContext, Context, runWebpack as runWebpackBase} from './utilities';
 
 const babelPlugin = path.resolve(__dirname, '../babel-plugin.ts');

--- a/packages/web-worker/src/test/utilities/browser.ts
+++ b/packages/web-worker/src/test/utilities/browser.ts
@@ -1,4 +1,5 @@
 import {URL} from 'url';
+
 import puppeteer, {Browser} from 'puppeteer';
 
 export class AppBrowser {

--- a/packages/web-worker/src/test/utilities/webpack.ts
+++ b/packages/web-worker/src/test/utilities/webpack.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
+
 import webpack from 'webpack';
+
 import {Context} from './context';
 
 export function runWebpack(

--- a/packages/web-worker/src/test/utilities/workspace.ts
+++ b/packages/web-worker/src/test/utilities/workspace.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+
 import * as fs from 'fs-extra';
 
 export class Workspace {

--- a/packages/web-worker/src/webpack-parts/loader.ts
+++ b/packages/web-worker/src/webpack-parts/loader.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
-import {getOptions} from 'loader-utils';
 
+import {getOptions} from 'loader-utils';
 import SingleEntryPlugin from 'webpack/lib/SingleEntryPlugin';
 import WebWorkerTemplatePlugin from 'webpack/lib/webworker/WebWorkerTemplatePlugin';
 import FetchCompileWasmTemplatePlugin from 'webpack/lib/web/FetchCompileWasmTemplatePlugin';

--- a/packages/web-worker/src/webpack-parts/plugin.ts
+++ b/packages/web-worker/src/webpack-parts/plugin.ts
@@ -1,4 +1,5 @@
 import VirtualModulesPlugin from 'webpack-virtual-modules';
+
 import {PLUGIN} from '../common';
 
 type Plugin = import('webpack').Plugin;

--- a/test/each-test.ts
+++ b/test/each-test.ts
@@ -11,6 +11,7 @@ if (typeof window !== 'undefined') {
   addClosest(window);
 }
 
+// eslint-disable-next-line jest/require-top-level-describe
 afterEach(() => {
   destroyAll();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,24 +1653,24 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@typescript-eslint/eslint-plugin@^2.3.3":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.4.0.tgz#aaf6b542ff75b78f4191a8bf1c519184817caa24"
-  integrity sha512-se/YCk7PUoyMwSm/u3Ii9E+BgDUc736uw/lXCDpXEqRgPGsoBTtS8Mntue/vZX8EGyzGplYuePBuVyhZDM9EpQ==
+"@typescript-eslint/eslint-plugin@^2.5.0":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1.tgz#e34972a24f8aba0861f9ccf7130acd74fd11e079"
+  integrity sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.4.0"
+    "@typescript-eslint/experimental-utils" "2.6.1"
     eslint-utils "^1.4.2"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.4.0.tgz#dd8f3f466be25c3610a06fed22cfb6e6aa17f6d9"
-  integrity sha512-2cvhNaJoWavgTtnC7e1jUSPZQ7e4U2X9Yoy5sQmkS7lTESuyuZrlRcaoNuFfYEd6hgrmMU7+QoSp8Ad+kT1nfA==
+"@typescript-eslint/experimental-utils@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1.tgz#eddaca17a399ebf93a8628923233b4f93793acfd"
+  integrity sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.4.0"
+    "@typescript-eslint/typescript-estree" "2.6.1"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/experimental-utils@^1.13.0":
@@ -1682,14 +1682,14 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/parser@^2.3.3":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.4.0.tgz#fe43ed5fec14af03d3594fce2c3b7ec4c8df0243"
-  integrity sha512-IouAKi/grJ4MFrwdXIJ1GHAwbPWYgkT3b/x8Q49F378c9nwgxVkO76e0rZeUVpwHMaUuoKG2sUeK0XGkwdlwkw==
+"@typescript-eslint/parser@^2.5.0":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.6.1.tgz#3c00116baa0d696bc334ca18ac5286b34793993c"
+  integrity sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.4.0"
-    "@typescript-eslint/typescript-estree" "2.4.0"
+    "@typescript-eslint/experimental-utils" "2.6.1"
+    "@typescript-eslint/typescript-estree" "2.6.1"
     eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/typescript-estree@1.13.0":
@@ -1700,16 +1700,17 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@typescript-eslint/typescript-estree@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.4.0.tgz#722c95493e1b7682893edaaaec0e69f36917feef"
-  integrity sha512-/DzDAtMqF5d9IlXrrvu/Id/uoKjnSxf/3FbtKK679a/T7lbDM8qQuirtGvFy6Uh+x0hALuCMwnMfUf0P24/+Iw==
+"@typescript-eslint/typescript-estree@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1.tgz#fb363dd4ca23384745c5ea4b7f4c867432b00d31"
+  integrity sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==
   dependencies:
-    chokidar "^3.0.2"
+    debug "^4.1.1"
     glob "^7.1.4"
     is-glob "^4.0.1"
     lodash.unescape "4.0.1"
     semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -2038,14 +2039,6 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
-
-anymatch@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
-  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
 
 "apollo-cache-inmemory@>=1.0.0 <2.0.0", apollo-cache-inmemory@^1.3.6:
   version "1.6.3"
@@ -2615,11 +2608,6 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
-binary-extensions@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
-  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
-
 bluebird@^3.5.5:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
@@ -2658,13 +2646,6 @@ braces@^2.3.1, braces@^2.3.2:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
-
-braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
-  dependencies:
-    fill-range "^7.0.1"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -3085,21 +3066,6 @@ chokidar@^2.0.2:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.0.2:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.2.1.tgz#4634772a1924512d990d4505957bf3a510611387"
-  integrity sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.1.3"
-  optionalDependencies:
-    fsevents "~2.1.0"
 
 chownr@^1.1.1:
   version "1.1.3"
@@ -4380,10 +4346,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz#f429a53bde9fc7660e6353910fd996d6284d3c25"
-  integrity sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==
+eslint-config-prettier@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.4.0.tgz#0a04f147e31d33c6c161b2dd0971418ac52d0477"
+  integrity sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -4410,13 +4376,13 @@ eslint-plugin-babel@5.3.0:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-eslint-plugin-es@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz#12acae0f4953e76ba444bfd1b2271081ac620998"
-  integrity sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==
+eslint-plugin-es@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz#0f5f5da5f18aa21989feebe8a73eadefb3432976"
+  integrity sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==
   dependencies:
     eslint-utils "^1.4.2"
-    regexpp "^2.0.1"
+    regexpp "^3.0.0"
 
 eslint-plugin-eslint-comments@3.1.2:
   version "3.1.2"
@@ -4451,10 +4417,10 @@ eslint-plugin-import@2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
-eslint-plugin-jest@22.15.2:
-  version "22.15.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.15.2.tgz#e3c10d9391f787744e31566f69ebb70c3a98e398"
-  integrity sha512-p4NME9TgXIt+KgpxcXyNBvO30ZKxwFAO1dJZBc2OGfDnXVEtPwEyNs95GSr6RIE3xLHdjd8ngDdE2icRRXrbxg==
+eslint-plugin-jest@22.20.0:
+  version "22.20.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.20.0.tgz#a3c3615c516fcbd20d50dbf395ea37361bd9e3b2"
+  integrity sha512-UwHGXaYprxwd84Wer8H7jZS+5C3LeEaU8VD7NqORY6NmPJrs+9Ugbq3wyjqO3vWtSsDaLar2sqEB8COmOZA4zw==
   dependencies:
     "@typescript-eslint/experimental-utils" "^1.13.0"
 
@@ -4473,22 +4439,22 @@ eslint-plugin-jsx-a11y@6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
-eslint-plugin-node@9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-9.1.0.tgz#f2fd88509a31ec69db6e9606d76dabc5adc1b91a"
-  integrity sha512-ZwQYGm6EoV2cfLpE1wxJWsfnKUIXfM/KM09/TlorkukgCAwmkgajEJnPCmyzoFPQQkmvo5DrW/nyKutNIw36Mw==
+eslint-plugin-node@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz#fd1adbc7a300cf7eb6ac55cf4b0b6fc6e577f5a6"
+  integrity sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==
   dependencies:
-    eslint-plugin-es "^1.4.0"
-    eslint-utils "^1.3.1"
+    eslint-plugin-es "^2.0.0"
+    eslint-utils "^1.4.2"
     ignore "^5.1.1"
     minimatch "^3.0.4"
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-prettier@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
-  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
+eslint-plugin-prettier@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
+  integrity sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -4497,15 +4463,15 @@ eslint-plugin-promise@4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
   integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
 
-eslint-plugin-react-hooks@^2.0.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.1.2.tgz#1358d2acb2c5e02b7e90c37e611ac258a488e3a7"
-  integrity sha512-ZR+AyesAUGxJAyTFlF3MbzeVHAcQTFQt1fFVe5o0dzY/HFoj1dgQDMoIkiM+ltN/HhlHBYX4JpJwYonjxsyQMA==
+eslint-plugin-react-hooks@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.2.0.tgz#078264e9e388da6929ace09d6abe92c85963aff4"
+  integrity sha512-jSlnBjV2cmyIeL555H/FbvuSbQ1AtpHjLMHuPrQnt1eVA6lX8yufdygh7AArI2m8ct7ChHGx2uOaCuxq2MUn6g==
 
-eslint-plugin-react@7.15.1:
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.15.1.tgz#db5f8ed66c6ba46922518f08e1df9dac52ccaa49"
-  integrity sha512-YotSItgMPwLGlr3df44MGVyXnHkmKcpkHTzpte3QwJtocr3nFqCXCuoxFZeBtnT8RHdj038NlTvam3dcAFrMcA==
+eslint-plugin-react@7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz#9928e4f3e2122ed3ba6a5b56d0303ba3e41d8c09"
+  integrity sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
@@ -4517,28 +4483,28 @@ eslint-plugin-react@7.15.1:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
-eslint-plugin-shopify@^31.0.0:
-  version "31.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-31.0.0.tgz#e1ec99aba8220bc6fea37c65a196ddcaf28796f2"
-  integrity sha512-jn5OUC5OuIuYKIXOi21R0io7FpH7bVWzJdXc0yUmZ5BMzYsNtqgqZhA9jSaZiKo+23hRLbbJgSxvheBt2lz7LA==
+eslint-plugin-shopify@^32.0.0:
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-32.0.0.tgz#39922fbe712906a6b1a4e23c44827523dd7baf7f"
+  integrity sha512-lwKMsWcg7RHxvt/FgWGfeefj3JfodvsCbKP2FzF3Zrr0aS4fr2tsw0h88sW2Lx9c0VWVf5kN/fy2xtBia6zjIQ==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "^2.3.3"
-    "@typescript-eslint/parser" "^2.3.3"
+    "@typescript-eslint/eslint-plugin" "^2.5.0"
+    "@typescript-eslint/parser" "^2.5.0"
     babel-eslint "10.0.3"
     common-tags "^1.8.0"
-    eslint-config-prettier "6.0.0"
+    eslint-config-prettier "6.4.0"
     eslint-module-utils "2.4.1"
     eslint-plugin-babel "5.3.0"
     eslint-plugin-eslint-comments "3.1.2"
     eslint-plugin-graphql "3.1.0"
     eslint-plugin-import "2.18.2"
-    eslint-plugin-jest "22.15.2"
+    eslint-plugin-jest "22.20.0"
     eslint-plugin-jsx-a11y "6.2.3"
-    eslint-plugin-node "9.1.0"
-    eslint-plugin-prettier "3.1.0"
+    eslint-plugin-node "10.0.0"
+    eslint-plugin-prettier "3.1.1"
     eslint-plugin-promise "4.2.1"
-    eslint-plugin-react "7.15.1"
-    eslint-plugin-react-hooks "^2.0.1"
+    eslint-plugin-react "7.16.0"
+    eslint-plugin-react-hooks "2.2.0"
     eslint-plugin-sort-class-members "1.6.0"
     eslint-plugin-typescript "0.14.0"
     merge "1.2.1"
@@ -4579,7 +4545,7 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1, eslint-utils@^1.4.2:
+eslint-utils@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
@@ -4950,13 +4916,6 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
-  dependencies:
-    to-regex-range "^5.0.1"
-
 find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -5166,11 +5125,6 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-fsevents@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.1.tgz#74c64e21df71721845d0c44fe54b7f56b82995a9"
-  integrity sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==
-
 full-icu@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.0.tgz#1fb4d60050103ad9dcf53735c000e4a03d80c574"
@@ -5331,7 +5285,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
   integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
@@ -5981,13 +5935,6 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-boolean-object@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
@@ -6122,7 +6069,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -6152,11 +6099,6 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
-
-is-number@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
-  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-obj@^1.0.0:
   version "1.0.1"
@@ -8023,7 +7965,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -8605,11 +8547,6 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-
-picomatch@^2.0.4:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
-  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -9238,13 +9175,6 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.1.3.tgz#d6e011ed5b9240a92f08651eeb40f7942ceb6cc1"
-  integrity sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==
-  dependencies:
-    picomatch "^2.0.4"
-
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
@@ -9336,6 +9266,11 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+regexpp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
+  integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
 
 regexpu-core@^4.6.0:
   version "4.6.0"
@@ -10498,13 +10433,6 @@ to-regex-range@^2.1.0:
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
-
-to-regex-range@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
-  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
-  dependencies:
-    is-number "^7.0.0"
 
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## Description

This PR updates `eslint-plugin-shopify` to version 32x. The main changes here are the grouping of imports and [requiring top-level describe](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/require-top-level-describe.md) when using jest hooks in tests. Otherwise this is a really straightforward bump.