### PR TITLE
✨ Add parsed body as payload to webhook data

### DIFF
--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Add payload to webhook data for the `receiveWebhook` middleware
+
+### Fixed
+
 - Fixed a typo in the README
 
 ## [2.1.0] - 2010-10-03

--- a/packages/koa-shopify-webhooks/src/receive.ts
+++ b/packages/koa-shopify-webhooks/src/receive.ts
@@ -47,6 +47,7 @@ export function receiveWebhook({
       ctx.state.webhook = {
         topic: graphqlTopic as Topic,
         domain,
+        payload: JSON.parse(rawBody),
       };
 
       await onReceived(ctx);

--- a/packages/koa-shopify-webhooks/src/test/receive.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/receive.test.ts
@@ -109,6 +109,22 @@ describe('receiveWebhook', () => {
       });
     });
 
+    it('adds webhook payload to state', async () => {
+      const onReceived = jest.fn();
+      const middleware = receiveWebhook({secret, onReceived});
+
+      const context = createMockContext({
+        rawBody,
+        headers: headers({hmac: hmac(secret, rawBody)}),
+      });
+
+      await middleware(context, noop);
+
+      expect(context.state.webhook).toMatchObject({
+        payload: JSON.parse(rawBody),
+      });
+    });
+
     it('returns the Accepted status code', async () => {
       const onReceived = jest.fn();
       const middleware = receiveWebhook({secret, onReceived});


### PR DESCRIPTION
## Description

Adds the parsed body as payload in the webhook object (available using `ctx.state.webhook`)

## Type of change

- [x] koa-shopify-webhooks Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
