### PR TITLE
React i18n webpack plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Each package has its own `README` and documentation describing usage.
 | react-hydrate | [directory](packages/react-hydrate) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-hydrate.svg)](https://badge.fury.io/js/%40shopify%2Freact-hydrate) |
 | react-i18n | [directory](packages/react-i18n) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-i18n.svg)](https://badge.fury.io/js/%40shopify%2Freact-i18n) |
 | react-i18n-universal-provider | [directory](packages/react-i18n-universal-provider) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-i18n-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-i18n-universal-provider) |
+| react-i18n-webpack-plugin | [directory](packages/react-i18n-webpack-plugin) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-i18n-webpack-plugin.svg)](https://badge.fury.io/js/%40shopify%2Freact-i18n-webpack-plugin) |
 | react-idle | [directory](packages/react-idle) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-idle.svg)](https://badge.fury.io/js/%40shopify%2Freact-idle) |
 | react-import-remote | [directory](packages/react-import-remote) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-import-remote.svg)](https://badge.fury.io/js/%40shopify%2Freact-import-remote) |
 | react-intersection-observer | [directory](packages/react-intersection-observer) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg)](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer) |

--- a/config/typescript/webpack.d.ts
+++ b/config/typescript/webpack.d.ts
@@ -1,0 +1,29 @@
+import webpack, {Module} from 'webpack';
+import BasicEvaluatedExpression from 'webpack/lib/BasicEvaluatedExpression';
+import {Tapable, HookMap, SyncBailHook} from 'tapable';
+import {Expression, Statement, Literal} from 'estree';
+
+declare module 'webpack' {
+  export type ImportSource = Literal | string | null | undefined;
+
+  interface ParserHooks {
+    evaluate: HookMap<
+      SyncBailHook<[Expression], BasicEvaluatedExpression | undefined | null>
+    >;
+    importSpecifier: SyncBailHook<
+      [Statement, ImportSource, string, string],
+      boolean | void
+    >;
+  }
+
+  export class Parser extends Tapable {
+    hooks: ParserHooks;
+    state: {
+      module: {
+        resource: string;
+        context: string;
+      };
+      [key: string]: any;
+    };
+  }
+}

--- a/packages/react-i18n-webpack-plugin/CHANGELOG.md
+++ b/packages/react-i18n-webpack-plugin/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/react-i18n-webpack-plugin` package

--- a/packages/react-i18n-webpack-plugin/README.md
+++ b/packages/react-i18n-webpack-plugin/README.md
@@ -1,0 +1,14 @@
+# `@shopify/react-i18n-webpack-plugin`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-i18n-webpack-plugin.svg)](https://badge.fury.io/js/%40shopify%2Freact-i18n-webpack-plugin.svg) 
+
+A webpack plugin that automatically filled in &#x60;@shopify/react-i18n&#x60;s &#x60;useI18n&#x60;s or &#x60;withI18n&#x60;s call arguments.
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-i18n-webpack-plugin
+```
+
+## Usage

--- a/packages/react-i18n-webpack-plugin/babel.d.ts
+++ b/packages/react-i18n-webpack-plugin/babel.d.ts
@@ -1,0 +1,2 @@
+export {default} from './dist/babel-plugin';
+export * from './dist/babel-plugin';

--- a/packages/react-i18n-webpack-plugin/babel.js
+++ b/packages/react-i18n-webpack-plugin/babel.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/babel-plugin');

--- a/packages/react-i18n-webpack-plugin/package.json
+++ b/packages/react-i18n-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/react-i18n-webpack-plugin",
-  "version": "0.0.0",
+  "version": "0.0.0-cache-buster-beta.2",
   "license": "MIT",
   "description": "A webpack plugin that automatically filled in &#x60;@shopify/react-i18n&#x60;s &#x60;useI18n&#x60;s or &#x60;withI18n&#x60;s call arguments.",
   "main": "dist/index.js",
@@ -26,8 +26,8 @@
   "dependencies": {
     "@types/webpack": "^4.0.0",
     "change-case": "^3.1.0",
-    "string-hash": "^1.1.3",
     "glob": "^7.1.4",
+    "string-hash": "^1.1.3",
     "webpack-virtual-modules": "^0.1.12"
   },
   "devDependencies": {
@@ -36,9 +36,9 @@
     "@types/webpack-virtual-modules": "^0.1.0"
   },
   "optionalDependencies": {
-    "webpack": "^4.40.0",
     "@babel/template": "^7.0.0",
-    "@babel/traverse": "^7.0.0"
+    "@babel/traverse": "^7.0.0",
+    "webpack": "^4.40.0"
   },
   "files": [
     "dist/*",

--- a/packages/react-i18n-webpack-plugin/package.json
+++ b/packages/react-i18n-webpack-plugin/package.json
@@ -27,14 +27,22 @@
     "@types/webpack": "^4.0.0",
     "change-case": "^3.1.0",
     "string-hash": "^1.1.3",
+    "glob": "^7.1.4",
     "webpack-virtual-modules": "^0.1.12"
   },
-  "files": ["dist/*"],
   "devDependencies": {
+    "@babel/types": ">=7.0.0",
     "@types/estree": "^0.0.39",
     "@types/webpack-virtual-modules": "^0.1.0"
   },
   "optionalDependencies": {
-    "webpack": "^4.40.0"
-  }
+    "webpack": "^4.40.0",
+    "@babel/template": "^7.0.0",
+    "@babel/traverse": "^7.0.0"
+  },
+  "files": [
+    "dist/*",
+    "babel.d.ts",
+    "babel.js"
+  ]
 }

--- a/packages/react-i18n-webpack-plugin/package.json
+++ b/packages/react-i18n-webpack-plugin/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@shopify/react-i18n-webpack-plugin",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A webpack plugin that automatically filled in &#x60;@shopify/react-i18n&#x60;s &#x60;useI18n&#x60;s or &#x60;withI18n&#x60;s call arguments.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --p tsconfig.build.json",
+    "prepublishOnly": "yarn run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-i18n-webpack-plugin/README.md",
+  "dependencies": {
+    "@types/webpack": "^4.0.0",
+    "change-case": "^3.1.0",
+    "string-hash": "^1.1.3",
+    "webpack-virtual-modules": "^0.1.12"
+  },
+  "files": ["dist/*"],
+  "devDependencies": {
+    "@types/estree": "^0.0.39",
+    "@types/webpack-virtual-modules": "^0.1.0"
+  },
+  "optionalDependencies": {
+    "webpack": "^4.40.0"
+  }
+}

--- a/packages/react-i18n-webpack-plugin/src/babel-plugin.ts
+++ b/packages/react-i18n-webpack-plugin/src/babel-plugin.ts
@@ -1,0 +1,169 @@
+import path from 'path';
+
+import glob from 'glob';
+import {TemplateBuilder} from '@babel/template';
+import Types from '@babel/types';
+import {Node, NodePath} from '@babel/traverse';
+import stringHash from 'string-hash';
+
+interface State {
+  program: NodePath<Types.Program>;
+}
+
+export default function injectWithI18nArguments({
+  types: t,
+  template,
+}: {
+  types: typeof Types;
+  template: TemplateBuilder<Types.ImportDeclaration | Types.ObjectExpression>;
+}) {
+  function fallbackTranslationsImport({id}) {
+    return template(`import ${id} from './translations/en.json';`, {
+      sourceType: 'module',
+    })() as Types.ImportDeclaration;
+  }
+
+  function i18nCallExpression({id, fallbackID, bindingName, translations}) {
+    return template(
+      `${bindingName}({
+        id: '${id}',
+        fallback: ${fallbackID},
+        translations(locale) {
+          const __shopify__i18n_translations = [${translations
+            .filter(locale => !locale.endsWith('en.json'))
+            .map(locale =>
+              JSON.stringify(path.basename(locale, path.extname(locale))),
+            )
+            .sort()
+            .join(', ')}];
+          if (__shopify__i18n_translations.indexOf(locale) < 0) {
+            return;
+          }
+          return (async () => {
+            const dictionary = await import(/* webpackChunkName: "${id}-i18n", webpackMode: "lazy-once" */ \`./translations/$\{locale}.json\`);
+            return dictionary && dictionary.default;
+          })();
+        },
+      })`,
+      {
+        sourceType: 'module',
+        plugins: ['dynamicImport'],
+        preserveComments: true,
+      },
+    )();
+  }
+
+  function addI18nArguments({
+    binding,
+    bindingName,
+    filename,
+    fallbackID,
+    insertImport,
+  }) {
+    const {referencePaths} = binding;
+
+    const referencePathsToRewrite = referencePaths.filter(referencePath => {
+      const parent: Node = referencePath.parent;
+      return (
+        parent.type === 'CallExpression' &&
+        (!parent.arguments || parent.arguments.length === 0)
+      );
+    });
+
+    if (referencePathsToRewrite.length === 0) {
+      return;
+    }
+
+    if (referencePathsToRewrite.length > 1) {
+      throw new Error(
+        `You attempted to use ${bindingName} ${
+          referencePathsToRewrite.length
+        } times in a single file. This is not supported by the Babel plugin that automatically inserts translations.`,
+      );
+    }
+
+    const translations = getTranslations(filename);
+
+    if (translations.length === 0) {
+      return;
+    }
+
+    insertImport();
+
+    referencePathsToRewrite[0].parentPath.replaceWith(
+      i18nCallExpression({
+        id: generateID(filename),
+        fallbackID,
+        bindingName,
+        translations,
+      }),
+    );
+  }
+
+  return {
+    visitor: {
+      Program(nodePath: NodePath<Types.Program>, state: State) {
+        state.program = nodePath;
+      },
+      ImportDeclaration(
+        nodePath: NodePath<Types.ImportDeclaration>,
+        state: State,
+      ) {
+        if (nodePath.node.source.value !== '@shopify/react-i18n') {
+          return;
+        }
+        const {specifiers} = nodePath.node;
+        for (const specifier of specifiers) {
+          if (
+            !t.isImportSpecifier(specifier) ||
+            (specifier.imported.name !== 'withI18n' &&
+              specifier.imported.name !== 'useI18n')
+          ) {
+            continue;
+          }
+
+          const bindingName = specifier.local.name;
+          const binding = nodePath.scope.getBinding(bindingName);
+
+          if (binding != null) {
+            const fallbackID = nodePath.scope.generateUidIdentifier('en').name;
+            const {filename} = this.file.opts;
+
+            addI18nArguments({
+              binding,
+              bindingName,
+              filename,
+              fallbackID,
+              insertImport() {
+                const {program} = state;
+                program.node.body.unshift(
+                  fallbackTranslationsImport({id: fallbackID}),
+                );
+              },
+            });
+          }
+        }
+      },
+    },
+  };
+}
+
+function getTranslations(filename: string): string[] {
+  return glob.sync(
+    path.resolve(path.dirname(filename), 'translations', '*.json'),
+    {
+      nodir: true,
+    },
+  );
+}
+
+// based on postcss-modules implementation
+// see https://github.com/css-modules/postcss-modules/blob/60920a97b165885683c41655e4ca594d15ec2aa0/src/generateScopedName.js
+function generateID(filename: string) {
+  const hash = stringHash(filename)
+    .toString(36)
+    .substr(0, 5);
+  const extension = path.extname(filename);
+  const legible = path.basename(filename, extension);
+  return `${legible}_${hash}`;
+}

--- a/packages/react-i18n-webpack-plugin/src/i18n-options.ts
+++ b/packages/react-i18n-webpack-plugin/src/i18n-options.ts
@@ -1,0 +1,53 @@
+import path from 'path';
+
+import {camelCase} from 'change-case';
+
+export function buildI18nOptions({
+  id,
+  chunkName,
+  fallbackLocale,
+  translationFiles,
+}: {
+  id: string;
+  chunkName: string;
+  fallbackLocale: string;
+  translationFiles: string[];
+}) {
+  const fallBackExist = translationFiles.includes(`${fallbackLocale}.json`);
+
+  const fallbackLocaleID = camelCase(fallbackLocale);
+  const fallBackFileRelativePath = `./${fallbackLocale}.json`;
+
+  const translations = translationFiles
+    .filter(
+      translationFile => !translationFile.endsWith(`${fallbackLocale}.json`),
+    )
+    .map(translationFile =>
+      JSON.stringify(
+        path.basename(translationFile, path.extname(translationFile)),
+      ),
+    )
+    .sort()
+    .join(', ');
+
+  const importFallback = fallBackExist
+    ? `import ${fallbackLocaleID} from '${fallBackFileRelativePath}';`
+    : '';
+
+  return `
+    ${importFallback}
+    export const i18nOptions = {
+      id: '${id}',
+      ${fallBackExist ? `fallback: ${fallbackLocaleID},` : ''}
+      async translations(locale) {
+        const translations = [${translations}];
+        if (!translations.includes(locale)) {
+          return;
+        }
+        const dictionary = await import(
+          /* webpackChunkName: "${chunkName}", webpackMode: "lazy-once" */ \`./$\{locale}.json\`
+        );
+        return dictionary && dictionary.default;
+        }
+    }`;
+}

--- a/packages/react-i18n-webpack-plugin/src/i18n-options.ts
+++ b/packages/react-i18n-webpack-plugin/src/i18n-options.ts
@@ -40,8 +40,7 @@ export function buildI18nOptions({
       id: '${id}',
       ${fallBackExist ? `fallback: ${fallbackLocaleID},` : ''}
       async translations(locale) {
-        const translations = [${translations}];
-        if (!translations.includes(locale)) {
+        if (![${translations}].includes(locale)) {
           return;
         }
         const dictionary = await import(

--- a/packages/react-i18n-webpack-plugin/src/index.ts
+++ b/packages/react-i18n-webpack-plugin/src/index.ts
@@ -1,0 +1,1 @@
+export {ReactI18nPlugin} from './react-i18n-webpack-plugin';

--- a/packages/react-i18n-webpack-plugin/src/index.ts
+++ b/packages/react-i18n-webpack-plugin/src/index.ts
@@ -1,1 +1,2 @@
 export {ReactI18nPlugin} from './react-i18n-webpack-plugin';
+export {ReactI18nCacheBusterPlugin} from './react-i18n-cache-buster-plugin';

--- a/packages/react-i18n-webpack-plugin/src/react-i18n-cache-buster-plugin.ts
+++ b/packages/react-i18n-webpack-plugin/src/react-i18n-cache-buster-plugin.ts
@@ -1,0 +1,96 @@
+import path from 'path';
+
+import webpack from 'webpack';
+import ParserHelpers from 'webpack/lib/ParserHelpers';
+
+const PLUGIN_NAME = 'ReactI18nCacheBusterPlugin';
+const TRANSLATION_DIRECTORY_NAME = 'translations';
+// const I18N_CALL_NAMES = ['useI18n', 'withI18n'];
+
+export interface Options {
+  fallbackLocale: string;
+  currentLocale?: string;
+}
+
+export const defaultOptions: Options = {
+  fallbackLocale: 'en',
+};
+
+export class ReactI18nCacheBusterPlugin {
+  private options: Options;
+
+  constructor(options: Partial<Options> = {}) {
+    this.options = {
+      ...defaultOptions,
+      ...options,
+    };
+  }
+
+  apply(compiler: webpack.Compiler) {
+    compiler.hooks.normalModuleFactory.tap(
+      PLUGIN_NAME,
+      (normalModuleFactory: webpack.compilation.NormalModuleFactory) => {
+        const handler = (parser: any) => {
+          parser.hooks.statement.tap(PLUGIN_NAME, statement => {
+            if (
+              parser.state.module.resource.indexOf('node_modules') !== -1 ||
+              statement.type !== 'VariableDeclaration' ||
+              statement.declarations[0].id.name !==
+                '__shopify__i18n_translations'
+            ) {
+              return;
+            }
+
+            const componentDirectory = parser.state.module.context;
+            const translationsDirectoryPath = `${componentDirectory}/${TRANSLATION_DIRECTORY_NAME}`;
+
+            let translationFiles: string[] = [];
+            try {
+              translationFiles = parser.state.compilation.compiler.inputFileSystem.readdirSync(
+                translationsDirectoryPath,
+              );
+            } catch (error) {
+              // do nothing if the directory does not exist
+            }
+
+            if (translationFiles.length === 0) {
+              return;
+            }
+
+            const availableTranslations = translationFiles
+              .filter(
+                translationFile =>
+                  !translationFile.endsWith(
+                    `${this.options.fallbackLocale}.json`,
+                  ),
+              )
+              .map(translationFile =>
+                JSON.stringify(
+                  path.basename(translationFile, path.extname(translationFile)),
+                ),
+              )
+              .sort()
+              .join(', ');
+
+            ParserHelpers.toConstantDependency(
+              parser,
+              `[${availableTranslations}]`,
+            )(statement.declarations[0].init);
+          });
+        };
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/auto')
+          .tap('HarmonyModulesPlugin', handler);
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/esm')
+          .tap('HarmonyModulesPlugin', handler);
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/dynamic')
+          .tap('HarmonyModulesPlugin', handler);
+      },
+    );
+  }
+}

--- a/packages/react-i18n-webpack-plugin/src/react-i18n-index-plugin.ts
+++ b/packages/react-i18n-webpack-plugin/src/react-i18n-index-plugin.ts
@@ -1,0 +1,99 @@
+import path from 'path';
+
+import webpack, {Parser} from 'webpack';
+import VirtualModulesPlugin from 'webpack-virtual-modules';
+
+const PLUGIN_NAME = 'ReactI18nIndexPlugin';
+const TRANSLATION_DIRECTORY_NAME = 'translations';
+const I18N_CALL_NAMES = ['useI18n', 'withI18n'];
+
+export interface Options {
+  fallbackLocale: string;
+  currentLocale?: string;
+}
+
+export const defaultOptions: Options = {
+  fallbackLocale: 'en',
+};
+
+export class ReactI18nIndexPlugin {
+  private options: Options;
+  private virtualModules = new VirtualModulesPlugin();
+
+  constructor(options: Partial<Options> = {}) {
+    this.options = {
+      ...defaultOptions,
+      ...options,
+    };
+  }
+
+  apply(compiler: webpack.Compiler) {
+    this.virtualModules.apply(compiler);
+
+    compiler.hooks.normalModuleFactory.tap(
+      PLUGIN_NAME,
+      (normalModuleFactory: webpack.compilation.NormalModuleFactory) => {
+        const handler = (parser: Parser) => {
+          parser.hooks.importSpecifier.tap(
+            PLUGIN_NAME,
+            (_statement, _source, exportName: string) => {
+              if (!I18N_CALL_NAMES.includes(exportName)) {
+                return;
+              }
+
+              const componentDirectory = parser.state.module.context;
+              const translationsDirectoryPath = `${componentDirectory}/${TRANSLATION_DIRECTORY_NAME}`;
+
+              let translationFiles: string[] = [];
+              try {
+                translationFiles = parser.state.compilation.compiler.inputFileSystem.readdirSync(
+                  translationsDirectoryPath,
+                );
+              } catch (error) {
+                // do nothing if the directory does not exist
+              }
+
+              if (translationFiles.length === 0) {
+                return;
+              }
+
+              const indexPath = `${componentDirectory}/${TRANSLATION_DIRECTORY_NAME}/index.js`;
+              const availableTranslations = translationFiles
+                .filter(
+                  translationFile =>
+                    !translationFile.endsWith(
+                      `${this.options.fallbackLocale}.json`,
+                    ),
+                )
+                .map(translationFile =>
+                  JSON.stringify(
+                    path.basename(
+                      translationFile,
+                      path.extname(translationFile),
+                    ),
+                  ),
+                )
+                .sort()
+                .join(', ');
+              const indexSource = `export default [${availableTranslations}];`;
+
+              this.virtualModules.writeModule(indexPath, indexSource);
+            },
+          );
+        };
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/auto')
+          .tap('HarmonyModulesPlugin', handler);
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/esm')
+          .tap('HarmonyModulesPlugin', handler);
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/dynamic')
+          .tap('HarmonyModulesPlugin', handler);
+      },
+    );
+  }
+}

--- a/packages/react-i18n-webpack-plugin/src/react-i18n-parser-plugin.ts
+++ b/packages/react-i18n-webpack-plugin/src/react-i18n-parser-plugin.ts
@@ -1,0 +1,146 @@
+import VirtualModulesPlugin from 'webpack-virtual-modules';
+import ParserHelpers from 'webpack/lib/ParserHelpers';
+import {CallExpression} from 'estree';
+
+import {buildI18nOptions} from './i18n-options';
+import {generateID} from './utilities';
+
+const PLUGIN_NAME = 'ReactI18nParserPlugin';
+const TRANSLATION_DIRECTORY_NAME = 'translations';
+const I18N_CALL_NAMES = ['useI18n', 'withI18n'];
+
+export interface Options {
+  fallbackLocale: string;
+  currentLocale?: string;
+}
+
+export class ReactI18nParserPlugin {
+  private options: Options;
+  private virtualModules: VirtualModulesPlugin;
+
+  constructor(options: Options, virtualModules: VirtualModulesPlugin) {
+    this.options = options;
+    this.virtualModules = virtualModules;
+  }
+
+  apply(parser) {
+    // get all the import and the identifier
+    parser.hooks.importSpecifier.tap(
+      PLUGIN_NAME,
+      (_statement, _source, exportName: string, identifierName: string) => {
+        if (!I18N_CALL_NAMES.includes(exportName)) {
+          return;
+        }
+
+        const componentPath = parser.state.module.resource;
+
+        if (!parser.state.i18nImports)
+          parser.state.i18nImports = new Map<string, string[]>();
+
+        let exitingImportMap = parser.state.i18nImports.get(componentPath);
+        if (!exitingImportMap) {
+          exitingImportMap = [];
+        }
+
+        exitingImportMap.push(identifierName);
+        parser.state.i18nImports.set(componentPath, exitingImportMap);
+      },
+    );
+
+    // replace useI18n & withI18n call arguments
+    parser.hooks.evaluate
+      .for('CallExpression')
+      .tap(PLUGIN_NAME, (originalExpression: CallExpression) => {
+        if (
+          parser.state.module.resource.indexOf('node_modules') !== -1 ||
+          !parser.state.i18nImports
+        ) {
+          return;
+        }
+
+        const componentPath = parser.state.module.resource;
+        const componentDirectory = parser.state.module.context;
+        const importIdentifiers:
+          | string[]
+          | undefined = parser.state.i18nImports.get(componentPath);
+
+        if (
+          !importIdentifiers ||
+          originalExpression.callee.type !== 'Identifier'
+        ) {
+          return;
+        }
+
+        const expressions: CallExpression[] = [];
+
+        if (
+          importIdentifiers.includes(originalExpression.callee.name) &&
+          originalExpression.arguments.length === 0
+        ) {
+          expressions.push(originalExpression);
+        } else if (originalExpression.callee.name === 'compose') {
+          originalExpression.arguments.map(node => {
+            if (
+              node.type === 'CallExpression' &&
+              node.callee.type === 'Identifier' &&
+              importIdentifiers.includes(node.callee.name) &&
+              node.arguments.length === 0
+            ) {
+              expressions.push(node);
+            }
+          });
+        }
+
+        // skip calls where consumer manually added arguments
+        if (expressions.length === 0) {
+          return;
+        }
+
+        let translationFiles = [];
+        const translationsDirectoryPath = `${componentDirectory}/${TRANSLATION_DIRECTORY_NAME}`;
+
+        try {
+          translationFiles = parser.state.compilation.compiler.inputFileSystem.readdirSync(
+            translationsDirectoryPath,
+          );
+        } catch (error) {
+          // do nothing if the directory does not exist
+        }
+
+        if (translationFiles.length === 0) {
+          return;
+        }
+
+        // add i18n options dynamically from a virtual module
+        const id = generateID(componentPath);
+        const i18nOptionsName = '__webpack__i18n_options';
+
+        const optionsPath = `${componentDirectory}/${TRANSLATION_DIRECTORY_NAME}/i18nOptions.js`;
+        const optionsSource = buildI18nOptions({
+          id,
+          chunkName: `${id}-i18n`,
+          fallbackLocale: this.options.fallbackLocale,
+          translationFiles,
+        });
+        this.virtualModules.writeModule(optionsPath, optionsSource);
+
+        const asyncTranslationFactoryExpression = ParserHelpers.requireFileAsExpression(
+          parser.state.module.context,
+          optionsPath,
+        );
+        ParserHelpers.addParsedVariableToModule(
+          parser,
+          i18nOptionsName,
+          asyncTranslationFactoryExpression,
+        );
+
+        // Replace i18n call arguments
+        expressions.map(expression => {
+          ParserHelpers.toConstantDependency(
+            parser,
+            `(${i18nOptionsName}.i18nOptions)`,
+          )(expression);
+        });
+      });
+  }
+}

--- a/packages/react-i18n-webpack-plugin/src/react-i18n-webpack-plugin.ts
+++ b/packages/react-i18n-webpack-plugin/src/react-i18n-webpack-plugin.ts
@@ -1,0 +1,47 @@
+import webpack, {Parser} from 'webpack';
+import VirtualModulesPlugin from 'webpack-virtual-modules';
+
+import {ReactI18nParserPlugin, Options} from './react-i18n-parser-plugin';
+
+export const defaultOptions: Options = {
+  fallbackLocale: 'en',
+};
+
+export class ReactI18nPlugin {
+  private options: Options;
+  private virtualModules = new VirtualModulesPlugin();
+
+  constructor(options: Partial<Options> = {}) {
+    this.options = {
+      ...defaultOptions,
+      ...options,
+    };
+  }
+
+  apply(compiler: webpack.Compiler) {
+    this.virtualModules.apply(compiler);
+
+    compiler.hooks.normalModuleFactory.tap(
+      'ReactI18nPlugin',
+      (normalModuleFactory: webpack.compilation.NormalModuleFactory) => {
+        const handler = (parser: Parser) => {
+          new ReactI18nParserPlugin(this.options, this.virtualModules).apply(
+            parser,
+          );
+        };
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/auto')
+          .tap('HarmonyModulesPlugin', handler);
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/esm')
+          .tap('HarmonyModulesPlugin', handler);
+
+        normalModuleFactory.hooks.parser
+          .for('javascript/dynamic')
+          .tap('HarmonyModulesPlugin', handler);
+      },
+    );
+  }
+}

--- a/packages/react-i18n-webpack-plugin/src/react-i18n-webpack-plugin.ts
+++ b/packages/react-i18n-webpack-plugin/src/react-i18n-webpack-plugin.ts
@@ -21,9 +21,14 @@ export class ReactI18nPlugin {
   apply(compiler: webpack.Compiler) {
     this.virtualModules.apply(compiler);
 
-    compiler.hooks.normalModuleFactory.tap(
+    compiler.hooks.beforeCompile.tapAsync(
       'ReactI18nPlugin',
-      (normalModuleFactory: webpack.compilation.NormalModuleFactory) => {
+      (
+        {
+          normalModuleFactory,
+        }: {normalModuleFactory: webpack.compilation.NormalModuleFactory},
+        callback,
+      ) => {
         const handler = (parser: Parser) => {
           new ReactI18nParserPlugin(this.options, this.virtualModules).apply(
             parser,
@@ -41,6 +46,8 @@ export class ReactI18nPlugin {
         normalModuleFactory.hooks.parser
           .for('javascript/dynamic')
           .tap('HarmonyModulesPlugin', handler);
+
+        callback();
       },
     );
   }

--- a/packages/react-i18n-webpack-plugin/src/test/react-i18n-parser-plugin.test.ts
+++ b/packages/react-i18n-webpack-plugin/src/test/react-i18n-parser-plugin.test.ts
@@ -1,0 +1,256 @@
+import VirtualModulesPlugin from 'webpack-virtual-modules';
+
+import {ReactI18nParserPlugin, Options} from '../react-i18n-parser-plugin';
+
+import {createParser} from './utilities';
+
+jest.mock('webpack/lib/ParserHelpers', () => ({
+  requireFileAsExpression: jest.fn(),
+  addParsedVariableToModule: jest.fn(),
+  toConstantDependency: jest.fn(() => jest.fn()),
+}));
+
+describe('ReactI18nParserPlugin', () => {
+  const defaultOptions: Options = {
+    fallbackLocale: 'en',
+  };
+
+  describe('importSpecifier', () => {
+    it('called importSpecifier tap with plugin name', () => {
+      const mockTap = jest.fn();
+      const parser = createParser({
+        importSpecifierTap: mockTap,
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(
+        defaultOptions,
+        new VirtualModulesPlugin(),
+      );
+      reactI18nParserPlugin.apply(parser);
+
+      expect(mockTap).toHaveBeenCalledWith(
+        'ReactI18nParserPlugin',
+        expect.any(Function),
+      );
+    });
+
+    it('adds to i18nImports if exportName is useI18n', () => {
+      const componentPath = '/abc/path';
+      const exportName = 'useI18n';
+      const identifierName = 'useI18nAlias';
+
+      const parser = createParser({
+        componentPath,
+        importSpecifierTap: jest.fn((_name, callback) => {
+          callback({} as any, '', exportName, identifierName);
+        }),
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(
+        defaultOptions,
+        new VirtualModulesPlugin(),
+      );
+      reactI18nParserPlugin.apply(parser);
+
+      expect(parser.state.i18nImports).not.toBeUndefined();
+      const importIdentifiers = parser.state.i18nImports.get(componentPath);
+
+      expect(importIdentifiers).not.toBeUndefined();
+      expect(importIdentifiers).toContain(identifierName);
+    });
+
+    it('adds to i18nImports if exportName is withI18n', () => {
+      const componentPath = '/abc/path';
+      const exportName = 'withI18n';
+      const identifierName = 'withI18nAlias';
+
+      const parser = createParser({
+        componentPath,
+        importSpecifierTap: jest.fn((_name, callback) => {
+          callback({} as any, '', exportName, identifierName);
+        }),
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(
+        defaultOptions,
+        new VirtualModulesPlugin(),
+      );
+      reactI18nParserPlugin.apply(parser);
+
+      expect(parser.state.i18nImports).not.toBeUndefined();
+      const importIdentifiers = parser.state.i18nImports.get(componentPath);
+
+      expect(importIdentifiers).not.toBeUndefined();
+      expect(importIdentifiers).toContain(identifierName);
+    });
+
+    it('adds to i18nImports twice when both type of export exist', () => {
+      const componentPath = '/abc/path';
+      const exportNameOne = 'useI18n';
+      const identifierNameOne = 'useI18nAlias';
+      const exportNameTwo = 'withI18n';
+      const identifierNameTwo = 'withI18nAlias';
+
+      const parser = createParser({
+        componentPath,
+        importSpecifierTap: jest.fn((_name, callback) => {
+          callback({} as any, '', exportNameOne, identifierNameOne);
+          callback({} as any, '', exportNameTwo, identifierNameTwo);
+        }),
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(
+        defaultOptions,
+        new VirtualModulesPlugin(),
+      );
+      reactI18nParserPlugin.apply(parser);
+
+      expect(parser.state.i18nImports).not.toBeUndefined();
+      const importIdentifiers = parser.state.i18nImports.get(componentPath);
+
+      expect(importIdentifiers).not.toBeUndefined();
+      expect(importIdentifiers).toContain(identifierNameOne);
+      expect(importIdentifiers).toContain(identifierNameTwo);
+    });
+
+    it('does not add to i18nImports if exportName is not useI18n or withI18n', () => {
+      const componentPath = '/abc/path';
+      const exportName = 'something';
+
+      const parser = createParser({
+        componentPath,
+        importSpecifierTap: jest.fn((_name, callback) => {
+          callback({} as any, '', exportName, 'alias');
+        }),
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(
+        defaultOptions,
+        new VirtualModulesPlugin(),
+      );
+      reactI18nParserPlugin.apply(parser);
+
+      expect(parser.state.i18nImports).toBeUndefined();
+    });
+  });
+
+  describe('does not replace i18n call', () => {
+    it('does not call writeModule if the path included node_modules', () => {
+      const componentPath = '/abc/node_modules/path';
+      const mockWriteModule = jest.fn();
+      const mockTap = jest.fn();
+      const parser = createParser({
+        i18nImports: new Map([[componentPath, ['useI18n', 'useI18nAlias']]]),
+        evaluateTap: mockTap,
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(defaultOptions, {
+        writeModule: mockWriteModule,
+      } as any);
+      reactI18nParserPlugin.apply(parser);
+
+      expect(mockWriteModule).not.toHaveBeenCalled();
+    });
+
+    it('does not call writeModule if parser.state.i18nImports does not exist', () => {
+      const componentPath = '/abc/path';
+      const mockWriteModule = jest.fn();
+      const mockTap = jest.fn();
+      const parser = createParser({
+        i18nImports: new Map([[componentPath, ['useI18n', 'useI18nAlias']]]),
+        evaluateTap: mockTap,
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(defaultOptions, {
+        writeModule: mockWriteModule,
+      } as any);
+      reactI18nParserPlugin.apply(parser);
+
+      expect(mockWriteModule).not.toHaveBeenCalled();
+    });
+
+    it('does not call writeModule if the current path cannot be found in parser.state.i18nImports', () => {
+      const componentPath = '/abc/path1';
+      const mockWriteModule = jest.fn();
+      const mockTap = jest.fn();
+      const parser = createParser({
+        i18nImports: new Map([[componentPath, ['useI18n', 'useI18nAlias']]]),
+        evaluateTap: mockTap,
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(defaultOptions, {
+        writeModule: mockWriteModule,
+      } as any);
+      reactI18nParserPlugin.apply(parser);
+
+      expect(mockWriteModule).not.toHaveBeenCalled();
+    });
+
+    it('does not call writeModule if the expression type if not Identifier', () => {
+      const componentPath = 'abc/path';
+      const componentDirectory = 'abc';
+      const mockWriteModule = jest.fn();
+      const identifierName = 'useI18nAlias';
+      const parser = createParser({
+        componentPath,
+        componentDirectory,
+        i18nImports: new Map([[componentPath, [identifierName]]]),
+        evaluateTap: jest.fn((_name, callback) => {
+          callback(
+            {
+              type: 'CallExpression',
+              callee: {
+                type: 'ThisExpression',
+              },
+              arguments: [],
+            },
+            {} as any,
+            {} as any,
+          );
+        }),
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(defaultOptions, {
+        writeModule: mockWriteModule,
+      } as any);
+      reactI18nParserPlugin.apply(parser);
+
+      expect(mockWriteModule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('replace i18n call', () => {
+    it('calls writeModule successfully', () => {
+      const componentPath = 'abc/path';
+      const componentDirectory = 'abc';
+      const mockWriteModule = jest.fn();
+      const identifierName = 'useI18nAlias';
+      const parser = createParser({
+        componentPath,
+        componentDirectory,
+        i18nImports: new Map([[componentPath, [identifierName]]]),
+        evaluateTap: jest.fn((_name, callback) => {
+          callback(
+            {
+              type: 'CallExpression',
+              callee: {
+                type: 'Identifier',
+                name: identifierName,
+              },
+              arguments: [],
+            },
+            {} as any,
+            {} as any,
+          );
+        }),
+      });
+
+      const reactI18nParserPlugin = new ReactI18nParserPlugin(defaultOptions, {
+        writeModule: mockWriteModule,
+      } as any);
+      reactI18nParserPlugin.apply(parser);
+
+      expect(mockWriteModule).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-i18n-webpack-plugin/src/test/utilities.test.ts
+++ b/packages/react-i18n-webpack-plugin/src/test/utilities.test.ts
@@ -1,0 +1,21 @@
+import {generateID} from '../utilities';
+
+describe('generateID', () => {
+  it('generate an ID with the filename as the prefix', () => {
+    expect(generateID('abc/path/to/something/FileName.tsx')).toMatch(
+      /^FileName_/,
+    );
+  });
+
+  it('generate the same ID with the same file path', () => {
+    const filePath = 'abc/path/to/something/FileName.tsx';
+
+    expect(generateID(filePath)).toMatch(generateID(filePath));
+  });
+
+  it('generate different ID with the different file path', () => {
+    expect(generateID('abc/path1/to/something/FileName.tsx')).not.toMatch(
+      generateID('abc/path2/to/something/FileName.tsx'),
+    );
+  });
+});

--- a/packages/react-i18n-webpack-plugin/src/test/utilities.ts
+++ b/packages/react-i18n-webpack-plugin/src/test/utilities.ts
@@ -1,0 +1,74 @@
+import {Parser, ImportSource} from 'webpack';
+import {Hook} from 'tapable';
+import {Expression, Statement} from 'estree';
+
+export function createParser({
+  componentPath,
+  componentDirectory,
+  importSpecifierTap,
+  evaluateTap,
+  i18nImports,
+  translationFiles,
+}: {
+  componentPath?: string;
+  componentDirectory?: string;
+  importSpecifierTap?: Hook<Statement, ImportSource, string, string>['tap'];
+  evaluateTap?: Hook<Expression>['tap'];
+  i18nImports?: Map<string, string[]>;
+  translationFiles?: string[];
+}): Parser {
+  const mockParser = {
+    state: {
+      module: {
+        resource: componentPath ? componentPath : 'abc/path',
+        context: componentDirectory ? componentDirectory : 'abc',
+      },
+      i18nImports: i18nImports ? i18nImports : undefined,
+      compilation: {
+        compiler: {
+          inputFileSystem: {
+            readdirSync: jest.fn(() =>
+              translationFiles ? translationFiles : ['en.json'],
+            ),
+          },
+        },
+      },
+    },
+    hooks: {
+      importSpecifier: {
+        get: jest.fn(),
+        for: jest.fn(),
+        taps: [],
+        interceptors: [],
+        call: jest.fn(),
+        promise: jest.fn(),
+        callAsync: jest.fn(),
+        compile: jest.fn(),
+        tap: importSpecifierTap ? importSpecifierTap : jest.fn(),
+        tapAsync: jest.fn(),
+        tapPromise: jest.fn(),
+        intercept: jest.fn(),
+      },
+      evaluate: {
+        get: jest.fn(),
+        for: jest.fn(),
+        taps: [],
+        interceptors: [],
+        call: jest.fn(),
+        promise: jest.fn(),
+        callAsync: jest.fn(),
+        compile: jest.fn(),
+        tap: evaluateTap ? evaluateTap : jest.fn(),
+        tapAsync: jest.fn(),
+        tapPromise: jest.fn(),
+        intercept: jest.fn(),
+      },
+    },
+  };
+
+  jest.spyOn(mockParser.hooks.evaluate, 'for').mockImplementation(() => {
+    return mockParser.hooks.evaluate;
+  });
+
+  return (mockParser as unknown) as Parser;
+}

--- a/packages/react-i18n-webpack-plugin/src/utilities.ts
+++ b/packages/react-i18n-webpack-plugin/src/utilities.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+
+import stringHash from 'string-hash';
+
+// based on postcss-modules implementation
+// see https://github.com/css-modules/postcss-modules/blob/60920a97b165885683c41655e4ca594d15ec2aa0/src/generateScopedName.js
+export function generateID(filePath: string) {
+  const hash = stringHash(filePath)
+    .toString(36)
+    .substr(0, 5);
+  const extension = path.extname(filePath);
+  const legible = path.basename(filePath, extension);
+  return `${legible}_${hash}`;
+}

--- a/packages/react-i18n-webpack-plugin/tsconfig.build.json
+++ b/packages/react-i18n-webpack-plugin/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "rootDir": "./src"
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,6 +1274,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/estree@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1506,7 +1511,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
+"@types/react-dom@16.8.3", "@types/react-dom@^16.0.11", "@types/react-dom@^16.8.3":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==


### PR DESCRIPTION
## Description
Part of https://github.com/Shopify/sewing-kit/issues/1572

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

This is a new package

## To 🎩 

In consuming project
remove the babel plugin from sewing-kit in `node_modules/@shopify/sewing-kit/dist/src/tools/webpack/config/rules.js`

```
// remove babel plugin from sewing-kit
yarn add @shopify/sewing-kit@0.111.1-remove-babel-beta.4 

// this branch up to `ReactI18nCacheBusterPlugin`
yarn add @shopify/react-i18n-webpack-plugin@0.0.0-cache-buster-beta.2
```

In quilt
- `yarn tophat react-i18n-webpack-plugin ../path-to-project`

Do performance testing using instructions here https://github.com/Shopify/sewing-kit/issues/1572#issuecomment-555037501 


-----------
### Performance Testing with web

#### Using CI
Baseline vs ReactI18nPlugin On CI
Build time: 10m 33s vs 9m 28s
Size: +31B vs +878,046 B (+1.1%)

#### Using local laptop
MacBook Pro 13" 2.7Ghz Core i7, 16 GM Memory

##### Baseline:
https://github.com/Shopify/web/pull/20935

✅ All 635 assets have valid integrity hashes

1st Run: no cache
[client (baseline)] Finished compiling (10m16s, 3613 MB heap used)

2nd Run: with cache
[client (baseline)] Finished compiling (5m37s, 3478 MB heap used)

3rd Run: with cache
[client (baseline)] Finished compiling (5m36s, 3731 MB heap used)

##### Webpack Plugin: `ReactI18nPlugin`
https://github.com/Shopify/web/pull/20927

✅ All 1389 assets have valid integrity hashes

1st Run: no cached
[client (baseline)] Finished compiling (15m06s, 4362 MB heap used)

2nd Run: with cache
[client (baseline)] Finished compiling (10m17s, 4903 MB heap used)

3rd Run: with cache
[client (baseline)] Finished compiling (8m31s, 3265 MB heap used)

4th Run: with cache
[client (baseline)] Finished compiling (8m15s, 4143 MB heap used)

5th Run: with cache
[client (baseline)] Finished compiling (11m22s, 3962 MB heap used)


##### Webpack Cache Buster Plugin + babel Plugin (web)
https://github.com/Shopify/web/pull/20927 (commit 3)
`ReactI18nCacheBusterPlugin` + `'@shopify/react-i18n-webpack-plugin/babel`

✅ All 1389 assets have valid integrity hashes

1st Run: no cached
[client (baseline)] Finished compiling (17m41s, 5723 MB heap used)

2nd Run: with cache
[client (baseline)] Finished compiling (6m23s, 4847 MB heap used)

3rd Run: with cache
[client (baseline)] Finished compiling (6m38s, 4981 MB heap used)

4th Run: with cache
[client (baseline)] Finished compiling (6m19s, 5216 MB heap used)

5th Run: with cache
[client (baseline)] Finished compiling (6m13s, 4199 MB heap used)

##### Index File Generation + babel (web)
https://github.com/Shopify/web/pull/21090
`node translations.js` + `plugins.push(['@shopify/react-i18n-webpack-plugin/babel', {mode: 'from-generated-index'}]);`

✅ All 1392 assets have valid integrity hashes

1st Run: no cached
[client (baseline)] Finished compiling (10m57s, 4599 MB heap used)

2nd Run: with cache
[client (baseline)] Finished compiling (7m20s, 6158 MB heap used)

3rd Run: with cache
[client (baseline)] Finished compiling (9m01s, 4850 MB heap used)

4th Run: with cache
[client (baseline)] Finished compiling (8m26s, 5350 MB heap used)

5th Run: with cache
[client (baseline)] Finished compiling (8m06s, 5160 MB heap used)

##### Webpack Plugin: `ReactI18nPlugin` with `compiler.hooks.beforeCompile.tapAsync`
✅ All 1389 assets have valid integrity hashes

1st Run: no cached
[client (baseline)] Finished compiling (23m29s, 4866 MB heap used)

2nd Run: with cache
[client (baseline)] Finished compiling (6m46s, 4046 MB heap used)

3rd Run: with cache
[client (baseline)] Finished compiling (7m11s, 5467 MB heap used)