### PR TITLE
Add embeddedApp setting to koa-shopify-auth

### DIFF
--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+- Add option to allow non-embedded apps to bypass cookie redirection
+
 ## 3.1.37 - 2019-09-23
 
 ### Fixed

--- a/packages/koa-shopify-auth/README.md
+++ b/packages/koa-shopify-auth/README.md
@@ -42,6 +42,8 @@ app.use(
     scopes: ['write_orders, write_products'],
     // set access mode, default is 'online'
     accessMode: 'offline',
+    // set if app is embedded, default is true
+    embeddedApp: true,
     // callback for when auth is completed
     afterAuth(ctx) {
       const {shop, accessToken} = ctx.session;

--- a/packages/koa-shopify-auth/src/auth/index.ts
+++ b/packages/koa-shopify-auth/src/auth/index.ts
@@ -28,10 +28,11 @@ export default function createShopifyAuth(options: OAuthStartOptions) {
     prefix: '',
     myShopifyDomain: DEFAULT_MYSHOPIFY_DOMAIN,
     accessMode: DEFAULT_ACCESS_MODE,
+    embeddedApp: true,
     ...options,
   };
 
-  const {prefix} = config;
+  const {prefix, embeddedApp}  = config;
 
   const oAuthStartPath = `${prefix}/auth`;
   const oAuthCallbackPath = `${oAuthStartPath}/callback`;
@@ -47,7 +48,7 @@ export default function createShopifyAuth(options: OAuthStartOptions) {
   const enableCookiesRedirect = createEnableCookiesRedirect(enableCookiesPath);
 
   return async function shopifyAuth(ctx: Context, next: NextFunction) {
-    if (ctx.path === oAuthStartPath && !hasCookieAccess(ctx)) {
+    if (ctx.path === oAuthStartPath && (!hasCookieAccess(ctx) && embeddedApp)) {
       await enableCookiesRedirect(ctx);
       return;
     }

--- a/packages/koa-shopify-auth/src/auth/index.ts
+++ b/packages/koa-shopify-auth/src/auth/index.ts
@@ -32,7 +32,7 @@ export default function createShopifyAuth(options: OAuthStartOptions) {
     ...options,
   };
 
-  const {prefix, embeddedApp}  = config;
+  const {prefix, embeddedApp} = config;
 
   const oAuthStartPath = `${prefix}/auth`;
   const oAuthCallbackPath = `${oAuthStartPath}/callback`;


### PR DESCRIPTION
## Description

Allow non-embedded apps to forgo cookie redirection since cookies are being added to top-level domain. 

## Type of change

- [X] koa-shopify-auth Minor: add new `embeddedApp` setting to bypass cookie redirection

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
