### PR TITLE
[koa-shopify-auth] Set cookies with SameSite=none option

### DIFF
--- a/packages/koa-shopify-auth/src/auth/create-enable-cookies-redirect.ts
+++ b/packages/koa-shopify-auth/src/auth/create-enable-cookies-redirect.ts
@@ -9,7 +9,9 @@ export default function createEnableCookiesRedirect(path: string) {
 
   return function topLevelOAuthRedirect(ctx: Context) {
     // This is to avoid a redirect loop if the app doesn't use verifyRequest or set the test cookie elsewhere.
-    ctx.cookies.set(TEST_COOKIE_NAME, '1');
+    ctx.cookies.set(TEST_COOKIE_NAME, '1', {
+      sameSite: 'none',
+    });
     redirect(ctx);
   };
 }

--- a/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
+++ b/packages/koa-shopify-auth/src/auth/create-oauth-start.ts
@@ -26,7 +26,9 @@ export default function createOAuthStart(
       return;
     }
 
-    ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
+    ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME, '1', {
+      sameSite: 'none',
+    });
 
     const formattedQueryString = oAuthQueryString(ctx, options, callbackPath);
 

--- a/packages/koa-shopify-auth/src/auth/create-top-level-oauth-redirect.ts
+++ b/packages/koa-shopify-auth/src/auth/create-top-level-oauth-redirect.ts
@@ -8,7 +8,9 @@ export default function createTopLevelOAuthRedirect(path: string) {
   const redirect = createTopLevelRedirect(path);
 
   return function topLevelOAuthRedirect(ctx: Context) {
-    ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME, '1');
+    ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME, '1', {
+      sameSite: 'none',
+    });
     redirect(ctx);
   };
 }

--- a/packages/koa-shopify-auth/src/auth/oauth-query-string.ts
+++ b/packages/koa-shopify-auth/src/auth/oauth-query-string.ts
@@ -16,7 +16,9 @@ export default function oAuthQueryString(
   const {scopes = [], apiKey, accessMode} = options;
 
   const requestNonce = createNonce();
-  cookies.set('shopifyNonce', requestNonce);
+  cookies.set('shopifyNonce', requestNonce, {
+    sameSite: 'none',
+  });
 
   /* eslint-disable @typescript-eslint/camelcase */
   const redirectParams = {

--- a/packages/koa-shopify-auth/src/auth/test/enable-cookies-redirect.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/enable-cookies-redirect.test.ts
@@ -24,7 +24,9 @@ describe('CreateEnableCookiesRedirect', () => {
 
     enableCookiesRedirect(ctx);
 
-    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyTestCookie', '1');
+    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyTestCookie', '1', {
+      sameSite: 'none',
+    });
   });
 
   it('sets up and calls the top level redirect', () => {

--- a/packages/koa-shopify-auth/src/auth/test/oauth-query-string.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-query-string.test.ts
@@ -59,7 +59,9 @@ describe('oAuthQueryString', () => {
 
     oAuthQueryString(ctx, baseConfig, callbackPath);
 
-    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyNonce', fakeNonce);
+    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyNonce', fakeNonce, {
+      sameSite: 'none',
+    });
   });
 
   it('query string includes per-user grant for accessMode: online', () => {

--- a/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/oauth-start.test.ts
@@ -63,7 +63,9 @@ describe('OAuthStart', () => {
 
     oAuthStart(ctx);
 
-    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyTopLevelOAuth');
+    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyTopLevelOAuth', '1', {
+      sameSite: 'none',
+    });
   });
 
   it('redirects to redirectionURL with the returned query string', () => {

--- a/packages/koa-shopify-auth/src/auth/test/top-level-oauth-redirect.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/top-level-oauth-redirect.test.ts
@@ -24,7 +24,9 @@ describe('CreateTopLevelOAuthRedirect', () => {
 
     topLevelOAuthRedirect(ctx);
 
-    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyTopLevelOAuth', '1');
+    expect(ctx.cookies.set).toHaveBeenCalledWith('shopifyTopLevelOAuth', '1', {
+      sameSite: 'none',
+    });
   });
 
   it('sets up and calls the top level redirect', () => {

--- a/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
+++ b/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
@@ -49,9 +49,13 @@ describe('verifyRequest', () => {
 
       verifyRequestMiddleware(ctx, next);
 
-      expect(ctx.cookies.set).toHaveBeenCalledWith(TOP_LEVEL_OAUTH_COOKIE_NAME, '1', {
-        sameSite: 'none',
-      });
+      expect(ctx.cookies.set).toHaveBeenCalledWith(
+        TOP_LEVEL_OAUTH_COOKIE_NAME,
+        '1',
+        {
+          sameSite: 'none',
+        },
+      );
     });
 
     it('redirects to the given authRoute if the token is invalid', async () => {

--- a/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
+++ b/packages/koa-shopify-auth/src/verify-request/tests/verify-request.test.ts
@@ -49,7 +49,9 @@ describe('verifyRequest', () => {
 
       verifyRequestMiddleware(ctx, next);
 
-      expect(ctx.cookies.set).toHaveBeenCalledWith(TOP_LEVEL_OAUTH_COOKIE_NAME);
+      expect(ctx.cookies.set).toHaveBeenCalledWith(TOP_LEVEL_OAUTH_COOKIE_NAME, '1', {
+        sameSite: 'none',
+      });
     });
 
     it('redirects to the given authRoute if the token is invalid', async () => {
@@ -99,7 +101,9 @@ describe('verifyRequest', () => {
 
       verifyRequestMiddleware(ctx, next);
 
-      expect(ctx.cookies.set).toHaveBeenCalledWith(TEST_COOKIE_NAME, '1');
+      expect(ctx.cookies.set).toHaveBeenCalledWith(TEST_COOKIE_NAME, '1', {
+        sameSite: 'none',
+      });
     });
 
     it('redirects to /auth if shop is present on query', () => {

--- a/packages/koa-shopify-auth/src/verify-request/verify-token.ts
+++ b/packages/koa-shopify-auth/src/verify-request/verify-token.ts
@@ -15,7 +15,9 @@ export function verifyToken(routes: Routes) {
     const {session} = ctx;
 
     if (session && session.accessToken) {
-      ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
+      ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME, '1', {
+        sameSite: 'none',
+      });
       // If a user has installed the store previously on their shop, the accessToken can be stored in session.
       // we need to check if the accessToken is valid, and the only way to do this is by hitting the api.
       const response = await fetch(
@@ -38,7 +40,9 @@ export function verifyToken(routes: Routes) {
       return;
     }
 
-    ctx.cookies.set(TEST_COOKIE_NAME, '1');
+    ctx.cookies.set(TEST_COOKIE_NAME, '1', {
+      sameSite: 'none',
+    });
 
     redirectToAuth(routes, ctx);
   };


### PR DESCRIPTION
## Description

Fixes (issue #1099)

In the latest versions of the chrome `koa-shopify-auth` users faced the problem of infinity redirection. Looks like it's because of [new changes](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html) in `SameSite` behavior. Looks like an app can not access cookies from iframe if cookies were set up outside iframe. To fix that now we need to use `SameSite=None; Secure` settings for each cookie we want to receive inside an iframe. 

I propose to use `sameSite: 'none'` option in all `cookies.set` calls.

## Type of change

- [ ] `koa-shopify-auth` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
