### PR TITLE
✨ added locale to missing translation error

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] -->
 
+### Added
+
+- Added locale to be part of `MissingTranslationError` ([#1178](https://github.com/Shopify/quilt/pull/1178))
+
 ## [2.1.0] - 2019-10-07
 
 ### Added

--- a/packages/react-i18n/src/errors.ts
+++ b/packages/react-i18n/src/errors.ts
@@ -1,8 +1,8 @@
 import {Replacements} from './types';
 
 export class MissingTranslationError extends Error {
-  constructor(key: string) {
-    super(`Missing translation for key: ${key}`);
+  constructor(key: string, locale: string) {
+    super(`Missing translation for key: ${key} in locale: ${locale}`);
   }
 }
 export class MissingReplacementError extends Error {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -174,7 +174,7 @@ describe('I18n', () => {
 
     it('rethrows a missing translation error by default', () => {
       const key = 'hello';
-      const error = new MissingTranslationError(key);
+      const error = new MissingTranslationError(key, defaultDetails.locale);
       getTranslationTree.mockImplementation(() => {
         throw error;
       });
@@ -185,7 +185,7 @@ describe('I18n', () => {
 
     it('rethrows a missing translation error with the missing key message', () => {
       const key = 'hello';
-      const error = new MissingTranslationError(key);
+      const error = new MissingTranslationError(key, defaultDetails.locale);
       getTranslationTree.mockImplementation(() => {
         throw error;
       });
@@ -199,7 +199,7 @@ describe('I18n', () => {
     it('calls an onError handler', () => {
       const key = 'hello';
       const spy = jest.fn();
-      const error = new MissingTranslationError(key);
+      const error = new MissingTranslationError(key, defaultDetails.locale);
       getTranslationTree.mockImplementation(() => {
         throw error;
       });
@@ -217,7 +217,7 @@ describe('I18n', () => {
     it('returns an empty string when an onError handler does not rethrow', () => {
       const key = 'key';
       getTranslationTree.mockImplementation(() => {
-        throw new MissingTranslationError(key);
+        throw new MissingTranslationError(key, defaultDetails.locale);
       });
 
       const i18n = new I18n(defaultTranslations, {
@@ -374,7 +374,7 @@ describe('I18n', () => {
 
     it('rethrows a missing translation error by default', () => {
       const key = 'hello';
-      const error = new MissingTranslationError(key);
+      const error = new MissingTranslationError(key, defaultDetails.locale);
       translate.mockImplementation(() => {
         throw error;
       });
@@ -385,7 +385,7 @@ describe('I18n', () => {
 
     it('rethrows a missing translation error with the missing key message', () => {
       const key = 'hello';
-      const error = new MissingTranslationError(key);
+      const error = new MissingTranslationError(key, defaultDetails.locale);
       translate.mockImplementation(() => {
         throw error;
       });
@@ -399,7 +399,7 @@ describe('I18n', () => {
     it('calls an onError handler', () => {
       const key = 'hello';
       const spy = jest.fn();
-      const error = new MissingTranslationError(key);
+      const error = new MissingTranslationError(key, defaultDetails.locale);
       translate.mockImplementation(() => {
         throw error;
       });
@@ -417,7 +417,7 @@ describe('I18n', () => {
     it('returns an empty string when an onError handler does not rethrow', () => {
       const key = 'hello';
       translate.mockImplementation(() => {
-        throw new MissingTranslationError(key);
+        throw new MissingTranslationError(key, defaultDetails.locale);
       });
 
       const i18n = new I18n(defaultTranslations, {
@@ -1462,7 +1462,7 @@ describe('I18n', () => {
 
     it('returns false if the translation key does not exist', () => {
       const key = 'foo';
-      const error = new MissingTranslationError(key);
+      const error = new MissingTranslationError(key, defaultDetails.locale);
       translate.mockImplementation(() => {
         throw error;
       });

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -83,7 +83,7 @@ export function getTranslationTree(
     }
   }
 
-  throw new MissingTranslationError(id);
+  throw new MissingTranslationError(id, locale);
 }
 
 export function translate(
@@ -128,7 +128,7 @@ export function translate(
     }
   }
 
-  throw new MissingTranslationError(id);
+  throw new MissingTranslationError(id, locale);
 }
 
 function translateWithDictionary(


### PR DESCRIPTION
## Description

I was debugging something and found it to be really useful if the translation error also included which locale the missing error was from.

sample error message:
```
Error: Missing translation for key: title in locale: fr
```

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
