### PR TITLE
[graphql-testing] fixing fetch policy issues

### DIFF
--- a/packages/graphql-testing/CHANGELOG.md
+++ b/packages/graphql-testing/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Adding `TestingApolloClient` to unset some `fetchPolicy` values to avoid React events firing outside of an `act` scope ([#1198](https://github.com/Shopify/quilt/pull/1198))
+- Adding `TestingApolloClient` to fix scenarios where some `fetchPolicy` values produce React events firing outside of an `act` scope ([#1198](https://github.com/Shopify/quilt/pull/1198))
 
 ## [4.0.0] - 2019-07-03
 

--- a/packages/graphql-testing/CHANGELOG.md
+++ b/packages/graphql-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Adding `TestingApolloClient` to unset some `fetchPolicy` values to avoid React events firing outside of an `act` scope ([#1198](https://github.com/Shopify/quilt/pull/1198))
+
 ## [4.0.0] - 2019-07-03
 
 ### Changed

--- a/packages/graphql-testing/src/client.ts
+++ b/packages/graphql-testing/src/client.ts
@@ -1,0 +1,75 @@
+import {
+  ApolloClient,
+  MutationOptions,
+  OperationVariables,
+  QueryOptions,
+  SubscriptionOptions,
+  WatchQueryOptions,
+} from 'apollo-client';
+import {FetchResult, Observable} from 'apollo-link';
+
+type AnyFetchPolicy =
+  | MutationOptions['fetchPolicy']
+  | QueryOptions['fetchPolicy']
+  | SubscriptionOptions['fetchPolicy']
+  | WatchQueryOptions['fetchPolicy'];
+
+// no-cache and network-only fetch policies cause an initial async event to be
+// produced which is not properly caught inside of a react-testing act scope.
+const invalidFetchPolicies: AnyFetchPolicy[] = ['no-cache', 'network-only'];
+
+// unset fetch policies that produce observable events after mounting so we
+// don't run into issues with events firing outside of an act scope
+function normalizeFetchPolicy<T extends AnyFetchPolicy>(
+  fetchPolicy: T | undefined,
+) {
+  return !fetchPolicy || invalidFetchPolicies.includes(fetchPolicy)
+    ? undefined
+    : fetchPolicy;
+}
+
+// override mutate, query, subscribe, and watchQuery to normalize the
+// fetchPolicy option before the call
+export class TestingApolloClient<TCacheShape> extends ApolloClient<
+  TCacheShape
+> {
+  mutate<T = any, TVariables = OperationVariables>({
+    fetchPolicy,
+    ...options
+  }: MutationOptions<T, TVariables>): Promise<FetchResult<T>> {
+    return super.mutate<T, TVariables>({
+      ...options,
+      fetchPolicy: normalizeFetchPolicy(fetchPolicy),
+    });
+  }
+
+  query<T = any, TVariables = OperationVariables>({
+    fetchPolicy,
+    ...options
+  }: QueryOptions<TVariables>) {
+    return super.query<T, TVariables>({
+      ...options,
+      fetchPolicy: normalizeFetchPolicy(fetchPolicy),
+    });
+  }
+
+  subscribe<T = any, TVariables = OperationVariables>({
+    fetchPolicy,
+    ...options
+  }: SubscriptionOptions<TVariables>): Observable<FetchResult<T>> {
+    return super.subscribe<T, TVariables>({
+      ...options,
+      fetchPolicy: normalizeFetchPolicy(fetchPolicy),
+    });
+  }
+
+  watchQuery<T = any, TVariables = OperationVariables>({
+    fetchPolicy,
+    ...options
+  }: WatchQueryOptions<TVariables>) {
+    return super.watchQuery<T, TVariables>({
+      ...options,
+      fetchPolicy: normalizeFetchPolicy(fetchPolicy),
+    });
+  }
+}

--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -6,6 +6,7 @@ import {
 } from 'apollo-cache-inmemory';
 import {ApolloClient} from 'apollo-client';
 
+import {TestingApolloClient} from './client';
 import {MockLink, InflightLink} from './links';
 import {Operations} from './operations';
 import {operationNameFromFindOptions} from './utilities';
@@ -50,7 +51,7 @@ export class GraphQL {
       new MockLink(mock || defaultGraphQLMock),
     ]);
 
-    this.client = new ApolloClient({
+    this.client = new TestingApolloClient({
       link,
       cache,
     });


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

the way `apollo-client`'s `QueryManager` handles the fetch policy can cause issues with react testing and `act` scoping. if you use `no-cache` or `network-only` there is some `apollo-client` code that forces the result to be marked as non-partial response. non-partial responses are automatically scheduled on the query observable, whereas partial responses are returned synchronously (find this code in `ObservableQuery`'s `getCurrentResult`).

This PR creates a new `TestingApolloClient` that patches all query functions to _normalize_ the `fetchPolicy` option for testing.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

This should be a non-breaking change as no tests should be relying on network only fetching.

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
