### PR TITLE
sewing-kit-koa now checks for matching locales

### DIFF
--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -7,6 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- [Minor] If an `assets.json.gz` file exists, it will be read and unzipped ([1199](https://github.com/Shopify/quilt/pull/1199))
+- [Minor] Manifests may now contain an `identity` attribute; this contains extra metadata about a manifest's support (e.g., locales) ([1199](https://github.com/Shopify/quilt/pull/1199))
+- [Minor] A `locale` can now be passed to `assets` / `asyncAssets` / `script` / `style` helpers. If a locale is provided, and manifests with a matching `identity.locales` array are found, locale-specific assets will be returned.
+  - Note: use `@shopify/react-i18n` and its `from-generated-index` mode to create locale-specific builds
+
 ## 6.1.0 - 2019-07-17
 
 - [Minor] Adds configurable path/to/assets.json as `manifestPath` in the middleware options ([794](https://github.com/Shopify/quilt/pull/794))

--- a/packages/sewing-kit-koa/package.json
+++ b/packages/sewing-kit-koa/package.json
@@ -33,13 +33,15 @@
     "koa-compose": ">=3.0.0 <4.0.0",
     "koa-mount": "^4.0.0",
     "koa-static": "^5.0.0",
+    "node-gzip": "^1.1.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@shopify/jest-koa-mocks": "^2.1.10",
     "@shopify/with-env": "^1.1.4",
     "@types/app-root-path": "^1.2.4",
-    "@types/fs-extra": "^5.0.4"
+    "@types/fs-extra": "^5.0.4",
+    "@types/node-gzip": "^1.1.0"
   },
   "files": [
     "dist/*"

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -1,34 +1,12 @@
 import {join} from 'path';
 
 import {readJson} from 'fs-extra';
-import {matchesUA} from 'browserslist-useragent';
 import appRoot from 'app-root-path';
 
-export interface Asset {
-  path: string;
-  integrity?: string;
-}
+import {Manifest} from './types';
+import {Manifests} from './manifests';
 
-export interface Entrypoint {
-  js: Asset[];
-  css: Asset[];
-}
-
-export interface AsyncAsset {
-  id?: string;
-  file: string;
-  publicPath: string;
-  integrity?: string;
-}
-
-export interface Manifest {
-  name?: string;
-  browsers?: string[];
-  entrypoints: {[key: string]: Entrypoint};
-  asyncAssets: {[key: string]: AsyncAsset[]};
-}
-
-export type ConsolidatedManifest = Manifest[];
+export {Asset} from './types';
 
 interface Options {
   assetPrefix: string;
@@ -43,6 +21,7 @@ interface AssetSelector {
 }
 
 interface AssetOptions {
+  locale?: string;
   name?: string;
   asyncAssets?: Iterable<string | RegExp | AssetSelector>;
 }
@@ -52,24 +31,22 @@ enum AssetKind {
   Scripts = 'js',
 }
 
-const DEFAULT_MANIFEST_PATH = 'build/client/assets.json';
-
 export default class Assets {
   assetPrefix: string;
   userAgent?: string;
-  manifestPath: string;
+  private manifests: Manifests;
   private resolvedManifestEntry?: Manifest;
 
   constructor({assetPrefix, userAgent, manifestPath}: Options) {
     this.assetPrefix = assetPrefix;
     this.userAgent = userAgent;
-    this.manifestPath = manifestPath || DEFAULT_MANIFEST_PATH;
+    this.manifests = new Manifests(manifestPath);
   }
 
   async scripts(options: AssetOptions = {}) {
     const js = getAssetsFromManifest(
       {...options, kind: AssetKind.Scripts},
-      await this.getResolvedManifest(),
+      await this.getResolvedManifest(options.locale),
     );
 
     const scripts =
@@ -86,16 +63,25 @@ export default class Assets {
   async styles(options: AssetOptions = {}) {
     return getAssetsFromManifest(
       {...options, kind: AssetKind.Styles},
-      await this.getResolvedManifest(),
+      await this.getResolvedManifest(options.locale),
     );
   }
 
   async assets(options: AssetOptions) {
-    return getAssetsFromManifest(options, await this.getResolvedManifest());
+    return getAssetsFromManifest(
+      options,
+      await this.getResolvedManifest(options.locale),
+    );
   }
 
-  async asyncAssets(ids: Iterable<string | RegExp | AssetSelector>) {
-    return getAsyncAssetsFromManifest(ids, await this.getResolvedManifest());
+  async asyncAssets(
+    ids: Iterable<string | RegExp | AssetSelector>,
+    locale?: string,
+  ) {
+    return getAsyncAssetsFromManifest(
+      ids,
+      await this.getResolvedManifest(locale),
+    );
   }
 
   async graphQLSource(id: string) {
@@ -103,66 +89,31 @@ export default class Assets {
     return graphQLManifest.get(id) || null;
   }
 
-  private async getResolvedManifestEntry() {
+  private async getResolvedManifestEntry(
+    locale: string | undefined,
+  ): Promise<Manifest> {
     if (this.resolvedManifestEntry) {
       return this.resolvedManifestEntry;
     }
 
-    const consolidatedManifest = await loadConsolidatedManifest(
-      this.manifestPath,
-    );
     const {userAgent} = this;
+    const manifest = await this.manifests.resolve(userAgent, {
+      locale,
+    });
 
-    const lastManifestEntry =
-      consolidatedManifest[consolidatedManifest.length - 1];
-
-    // We do the following to determine the correct manifest to use:
-    //
-    // 1. If there is no user agent, use the "last" manifest, which is the
-    // least restrictive set of browsers.
-    // 2. If there is only one manifest, use it, regardless of how well it
-    // matches the user agent.
-    // 3. If there is a user agent, find the first manifest where the
-    // browsers it was compiled for matches the user agent, or where there
-    // is no browser restriction on the bundle.
-    // 4. If no matching manifests are found, fall back to the last manifest.
-    if (userAgent == null || consolidatedManifest.length === 1) {
-      this.resolvedManifestEntry = lastManifestEntry;
-    } else {
-      this.resolvedManifestEntry =
-        consolidatedManifest.find(
-          ({browsers}) =>
-            browsers == null ||
-            matchesUA(userAgent, {
-              browsers,
-              ignoreMinor: true,
-              ignorePatch: true,
-              allowHigherVersions: true,
-            }),
-        ) || lastManifestEntry;
-    }
-
-    return this.resolvedManifestEntry;
+    this.resolvedManifestEntry = manifest;
+    return manifest;
   }
 
-  private async getResolvedManifest(): Promise<Manifest> {
-    const manifest = await this.getResolvedManifestEntry();
+  private async getResolvedManifest(
+    locale: string | undefined,
+  ): Promise<Manifest> {
+    const manifest = await this.getResolvedManifestEntry(locale);
     return manifest;
   }
 }
 
-let consolidatedManifestPromise: Promise<ConsolidatedManifest> | null = null;
 let graphQLManifestPromise: Promise<Map<string, string>> | null = null;
-
-function loadConsolidatedManifest(manifestPath: string) {
-  if (consolidatedManifestPromise) {
-    return consolidatedManifestPromise;
-  }
-
-  consolidatedManifestPromise = readJson(join(appRoot.path, manifestPath));
-
-  return consolidatedManifestPromise;
-}
 
 function loadGraphQLManifest() {
   if (graphQLManifestPromise) {
@@ -177,7 +128,6 @@ function loadGraphQLManifest() {
 }
 
 export function internalOnlyClearCache() {
-  consolidatedManifestPromise = null;
   graphQLManifestPromise = null;
 }
 

--- a/packages/sewing-kit-koa/src/manifests.ts
+++ b/packages/sewing-kit-koa/src/manifests.ts
@@ -1,0 +1,144 @@
+import {join} from 'path';
+
+import {readFile, readJson, pathExists} from 'fs-extra';
+import {matchesUA} from 'browserslist-useragent';
+import appRoot from 'app-root-path';
+import {ungzip} from 'node-gzip';
+
+import {ConsolidatedManifest, Manifest} from './types';
+
+const DEFAULT_MANIFEST_PATH = 'build/client/assets.json';
+const MULTI_ASYNC_LANGUAGE_MANIFESTS = 'noLocales';
+
+export interface ResolveOptions {
+  locale?: string | undefined;
+}
+
+export class Manifests {
+  path: string;
+  private resolvedEntry?: Manifest;
+
+  constructor(path: string | null = null) {
+    this.path = path || DEFAULT_MANIFEST_PATH;
+  }
+
+  async resolve(userAgent, {locale}: ResolveOptions = {}): Promise<Manifest> {
+    const manifestsByLocale = await loadConsolidatedManifest(this.path);
+
+    const multiAsyncLanguageManifests = manifestsByLocale.get(
+      MULTI_ASYNC_LANGUAGE_MANIFESTS,
+    )!;
+
+    // We do the following to determine the correct manifest to use:
+    //
+    // For manifests with a matching `locale`:
+    // 1. If there is no user agent, use the "last" manifest, which is the
+    // least restrictive set of browsers.
+    // 2. If there is only one manifest, use it, regardless of how well it
+    // matches the user agent.
+    // 3. If there is a user agent, find the first manifest where the
+    // browsers it was compiled for matches the user agent, or where there
+    // is no browser restriction on the bundle.
+    // 4. If no matching manifests are found, fall back to the last manifest.
+    //
+    // If a locale-specific match is not found, then the above process is
+    // repeated for manifests with multi-language support (i.e., no locale
+    // attribute).
+
+    this.resolvedEntry =
+      find(manifestsByLocale.get(locale!), userAgent) ||
+      find(multiAsyncLanguageManifests, userAgent) ||
+      multiAsyncLanguageManifests[multiAsyncLanguageManifests.length - 1];
+
+    return this.resolvedEntry;
+  }
+}
+
+let loadPromise: Promise<Map<string, ConsolidatedManifest>> | null = null;
+
+function readGzipped(resolvedPath: string) {
+  return readFile(resolvedPath)
+    .then(zippedContent => ungzip(zippedContent))
+    .then(unzippedStr => JSON.parse(unzippedStr.toString()));
+}
+
+function loadConsolidatedManifest(manifestPath: string) {
+  if (loadPromise) {
+    return loadPromise;
+  }
+
+  const resolvedPath = join(appRoot.path, manifestPath);
+  const resolvedZippedPath = `${resolvedPath}.gz`;
+  loadPromise = pathExists(resolvedZippedPath)
+    .then(gzippedVersionExists => {
+      return gzippedVersionExists
+        ? readGzipped(resolvedZippedPath)
+        : readJson(resolvedPath);
+    })
+    .then((manifests: Manifest[]) => {
+      return manifests
+        .map(backfillIdentity)
+        .reduce(
+          groupByLocale,
+          new Map<string, ConsolidatedManifest>([
+            [MULTI_ASYNC_LANGUAGE_MANIFESTS, []],
+          ]),
+        );
+    });
+
+  return loadPromise;
+}
+
+export function internalOnlyClearCache() {
+  loadPromise = null;
+}
+
+function find(manifests: Manifest[] | undefined, userAgent) {
+  if (!manifests || manifests.length === 0) {
+    return undefined;
+  }
+
+  if (!userAgent) {
+    return manifests[manifests.length - 1];
+  }
+
+  return (
+    manifests.find(
+      ({browsers}) =>
+        browsers == null ||
+        matchesUA(userAgent, {
+          browsers,
+          ignoreMinor: true,
+          ignorePatch: true,
+          allowHigherVersions: true,
+        }),
+    ) || manifests[manifests.length - 1]
+  );
+}
+
+function backfillIdentity(manifest: Manifest) {
+  if (!manifest.identifier) {
+    manifest.identifier = {target: manifest.name};
+  }
+  return manifest;
+}
+
+function groupByLocale(
+  acc: Map<string, ConsolidatedManifest>,
+  manifest: Manifest,
+) {
+  const locales = manifest.identifier!.locales;
+  if (locales) {
+    locales.forEach(locale => {
+      let manifests = acc.get(locale);
+      if (!manifests) {
+        manifests = [];
+        acc.set(locale, manifests);
+      }
+      manifests.push(manifest);
+    });
+  } else {
+    acc.get(MULTI_ASYNC_LANGUAGE_MANIFESTS)!.push(manifest);
+  }
+  return acc;
+}

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -1,79 +1,54 @@
-import {join, basename} from 'path';
-
-import appRoot from 'app-root-path';
 import withEnv from '@shopify/with-env';
 
-import Assets, {
-  internalOnlyClearCache,
-  Asset,
-  AsyncAsset,
-  ConsolidatedManifest,
-  Manifest,
-} from '../assets';
+import Assets, {internalOnlyClearCache as clearAssetsCache} from '../assets';
+import {Manifests} from '../manifests';
 
-jest.mock('fs-extra', () => ({
-  ...require.requireActual('fs-extra'),
-  readJson: jest.fn(() => []),
-}));
+import {
+  mockAsset,
+  mockAsyncAsset,
+  mockEntrypoint,
+  mockManifest,
+} from './test-utilities';
 
-const {readJson} = require.requireMock('fs-extra');
+jest.mock('../manifests');
+
+const ManifestsMock = Manifests as jest.Mock;
+const resolvedManifestMock = jest.fn();
+
+function setManifest(manifest) {
+  resolvedManifestMock.mockReturnValue(Promise.resolve(manifest));
+}
+
+ManifestsMock.mockImplementation(
+  jest.fn(() => {
+    return {
+      resolve: resolvedManifestMock,
+    };
+  }),
+);
 
 describe('Assets', () => {
   const defaultOptions = {assetPrefix: '/assets/'};
 
   beforeEach(() => {
-    readJson.mockReset();
-    readJson.mockImplementation(() =>
-      mockConsolidatedManifest([
-        {entrypoints: {main: mockEntrypoint()}, asyncAssets: {}},
-      ]),
-    );
+    clearAssetsCache();
+    resolvedManifestMock.mockReset();
   });
 
-  afterEach(() => {
-    internalOnlyClearCache();
-  });
-
-  it('reads the asset cache', async () => {
-    const assets = new Assets(defaultOptions);
-
-    await assets.styles();
-
-    expect(readJson).toHaveBeenCalledWith(
-      join(appRoot.path, 'build/client/assets.json'),
-    );
-  });
-
-  it('only reads the asset cache once', async () => {
-    await new Assets(defaultOptions).styles();
-    await new Assets(defaultOptions).scripts();
-
-    expect(readJson).toHaveBeenCalledTimes(1);
-  });
-
-  it('reads the asset cache from a custom path', async () => {
-    const manifestPath = 'path/to/manifest';
-    const assets = new Assets({...defaultOptions, manifestPath});
-
-    await assets.styles();
-
-    expect(readJson).toHaveBeenCalledWith(join(appRoot.path, manifestPath));
-  });
+  afterEach(() => {});
 
   describe('scripts', () => {
     it('returns the main scripts by default', async () => {
       const js = '/style.js';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              main: mockEntrypoint({
-                scripts: [mockAsset(js)],
-              }),
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(js)],
+            }),
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -84,8 +59,8 @@ describe('Assets', () => {
     it('returns the scripts for a named bundle', async () => {
       const js = '/style.js';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
+      setManifest(
+        Promise.resolve(
           mockManifest({
             entrypoints: {
               custom: mockEntrypoint({
@@ -93,7 +68,7 @@ describe('Assets', () => {
               }),
             },
           }),
-        ]),
+        ),
       );
 
       const assets = new Assets(defaultOptions);
@@ -107,20 +82,18 @@ describe('Assets', () => {
       const js = '/custom.js';
       const asyncJs = '/used.js';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                scripts: [mockAsset(js)],
-              }),
-            },
-            asyncAssets: {
-              unused: [mockAsyncAsset('/unused.js')],
-              used: [mockAsyncAsset(asyncJs), mockAsyncAsset('/used.css')],
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              scripts: [mockAsset(js)],
+            }),
+          },
+          asyncAssets: {
+            unused: [mockAsyncAsset('/unused.js')],
+            used: [mockAsyncAsset(asyncJs), mockAsyncAsset('/used.css')],
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -131,6 +104,16 @@ describe('Assets', () => {
     });
 
     it('throws an error when no scripts exist for the passed entrypoint', async () => {
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset('foo.js')],
+            }),
+          },
+        }),
+      );
+
       const assets = new Assets(defaultOptions);
       await expect(
         assets.scripts({name: 'non-existent'}),
@@ -141,16 +124,14 @@ describe('Assets', () => {
       const js = '/style.js';
       const assetPrefix = '/sewing-kit-assets/';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                scripts: [mockAsset(js)],
-              }),
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              scripts: [mockAsset(js)],
+            }),
+          },
+        }),
       );
 
       const assets = new Assets({...defaultOptions, assetPrefix});
@@ -169,16 +150,14 @@ describe('Assets', () => {
     it('returns the main styles by default', async () => {
       const css = '/style.css';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              main: mockEntrypoint({
-                styles: [mockAsset(css)],
-              }),
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            main: mockEntrypoint({
+              styles: [mockAsset(css)],
+            }),
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -189,16 +168,14 @@ describe('Assets', () => {
     it('returns the styles for a named bundle', async () => {
       const css = '/style.css';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                styles: [mockAsset(css)],
-              }),
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              styles: [mockAsset(css)],
+            }),
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -212,20 +189,18 @@ describe('Assets', () => {
       const css = '/custom.css';
       const asyncCss = '/used.css';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                styles: [mockAsset(css)],
-              }),
-            },
-            asyncAssets: {
-              unused: [mockAsyncAsset('/unused.js')],
-              used: [mockAsyncAsset(asyncCss), mockAsyncAsset('/used.js')],
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              styles: [mockAsset(css)],
+            }),
+          },
+          asyncAssets: {
+            unused: [mockAsyncAsset('/unused.js')],
+            used: [mockAsyncAsset(asyncCss), mockAsyncAsset('/used.js')],
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -250,20 +225,18 @@ describe('Assets', () => {
       const js = '/script.js';
       const asyncJs = 'mypage.js';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                styles: [mockAsset(css)],
-                scripts: [mockAsset(js)],
-              }),
-            },
-            asyncAssets: {
-              mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              styles: [mockAsset(css)],
+              scripts: [mockAsset(js)],
+            }),
+          },
+          asyncAssets: {
+            mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -286,20 +259,18 @@ describe('Assets', () => {
       const js = '/script.js';
       const asyncJs = 'mypage.js';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                styles: [mockAsset(css)],
-                scripts: [mockAsset(js)],
-              }),
-            },
-            asyncAssets: {
-              mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              styles: [mockAsset(css)],
+              scripts: [mockAsset(js)],
+            }),
+          },
+          asyncAssets: {
+            mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -316,20 +287,18 @@ describe('Assets', () => {
       const js = '/script.js';
       const asyncJs = 'mypage.js';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                styles: [mockAsset(css)],
-                scripts: [mockAsset(js)],
-              }),
-            },
-            asyncAssets: {
-              mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              styles: [mockAsset(css)],
+              scripts: [mockAsset(js)],
+            }),
+          },
+          asyncAssets: {
+            mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -345,20 +314,18 @@ describe('Assets', () => {
       const js = '/script.js';
       const asyncJs = 'mypage.js';
 
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              custom: mockEntrypoint({
-                styles: [mockAsset(css)],
-                scripts: [mockAsset(js)],
-              }),
-            },
-            asyncAssets: {
-              mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
-            },
-          }),
-        ]),
+      setManifest(
+        mockManifest({
+          entrypoints: {
+            custom: mockEntrypoint({
+              styles: [mockAsset(css)],
+              scripts: [mockAsset(js)],
+            }),
+          },
+          asyncAssets: {
+            mypage: [mockAsyncAsset(asyncCss), mockAsyncAsset(asyncJs)],
+          },
+        }),
       );
 
       const assets = new Assets(defaultOptions);
@@ -370,128 +337,4 @@ describe('Assets', () => {
       ).toStrictEqual([{path: asyncCss}, {path: asyncJs}]);
     });
   });
-
-  describe('userAgent', () => {
-    const scriptOne = 'script-one.js';
-    const scriptTwo = 'script-two.js';
-    const chrome71 =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36';
-
-    it('uses the last manifest when no useragent exists', async () => {
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            entrypoints: {
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptOne)],
-              }),
-            },
-          }),
-
-          mockManifest({
-            entrypoints: {
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptTwo)],
-              }),
-            },
-          }),
-        ]),
-      );
-
-      const assets = new Assets(defaultOptions);
-
-      expect(await assets.scripts()).toStrictEqual([{path: scriptTwo}]);
-    });
-
-    it('uses the last manifest when no manifest matches', async () => {
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            browsers: ['firefox > 1'],
-            entrypoints: {
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptOne)],
-              }),
-            },
-          }),
-
-          mockManifest({
-            browsers: ['safari > 1'],
-            entrypoints: {
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptTwo)],
-              }),
-            },
-          }),
-        ]),
-      );
-
-      const assets = new Assets({...defaultOptions, userAgent: chrome71});
-
-      expect(await assets.scripts()).toStrictEqual([{path: scriptTwo}]);
-    });
-
-    it('uses the first matching manifest', async () => {
-      readJson.mockImplementation(() =>
-        mockConsolidatedManifest([
-          mockManifest({
-            browsers: ['chrome > 60'],
-            entrypoints: {
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptOne)],
-              }),
-            },
-          }),
-          mockManifest({
-            browsers: ['chrome > 1'],
-            entrypoints: {
-              main: mockEntrypoint({
-                scripts: [mockAsset(scriptTwo)],
-              }),
-            },
-          }),
-        ]),
-      );
-
-      const assets = new Assets({...defaultOptions, userAgent: chrome71});
-
-      expect(await assets.scripts()).toStrictEqual([{path: scriptOne}]);
-    });
-  });
 });
-
-function mockAsset(path: string): Asset {
-  return {path};
-}
-
-function mockAsyncAsset(path: string): AsyncAsset {
-  return {publicPath: path, file: basename(path)};
-}
-
-function mockEntrypoint({
-  scripts = [],
-  styles = [],
-}: {
-  scripts?: Asset[];
-  styles?: Asset[];
-} = {}) {
-  return {js: scripts, css: styles};
-}
-
-function mockManifest({
-  name = 'mockedManifest',
-  browsers,
-  entrypoints = {},
-  asyncAssets = {},
-}: Partial<Manifest>): Manifest {
-  return {
-    name,
-    browsers,
-    entrypoints,
-    asyncAssets,
-  };
-}
-
-function mockConsolidatedManifest(manifests: Manifest[]): ConsolidatedManifest {
-  return manifests;
-}

--- a/packages/sewing-kit-koa/src/tests/manifests-locales.test.ts
+++ b/packages/sewing-kit-koa/src/tests/manifests-locales.test.ts
@@ -1,0 +1,245 @@
+import {
+  internalOnlyClearCache as clearManifestsCache,
+  Manifests,
+} from '../manifests';
+
+import {
+  mockAsset,
+  mockConsolidatedManifest,
+  mockEntrypoint,
+  mockManifest,
+} from './test-utilities';
+
+jest.mock('fs-extra', () => ({
+  ...require.requireActual('fs-extra'),
+  pathExists: jest.fn(() => Promise.resolve(false)),
+  readFile: jest.fn(() => '[]'),
+  readJson: jest.fn(() => []),
+}));
+
+const {pathExists, readFile, readJson} = require.requireMock('fs-extra');
+
+describe('Manifests locales', () => {
+  beforeEach(() => {
+    pathExists.mockReset();
+    pathExists.mockReturnValue(Promise.resolve(false));
+
+    readFile.mockReset();
+
+    readJson.mockReset();
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        {entrypoints: {main: mockEntrypoint()}, asyncAssets: {}},
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    clearManifestsCache();
+  });
+
+  const enScriptOne = 'en-script-one.js';
+  const enScriptTwo = 'en-script-two.js';
+  const frScriptOne = 'fr-script-one.js';
+  const noLocaleScriptOne = 'no-locale-script-one.js';
+  const noLocaleScriptTwo = 'no-locale-script-two.js';
+
+  const chrome71 =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36';
+
+  it('uses the first manifest with a compatible user-agent and locale', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['fr']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(frScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          browsers: ['chrome > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptTwo)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71, {
+      locale: 'fr',
+    });
+
+    expect(manifest).toHaveProperty('entrypoints.main.js.0.path', frScriptOne);
+  });
+
+  it('uses the first manifest with a compatible user-agent and matching multi-locale', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['de', 'fr']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(frScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          browsers: ['chrome > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptTwo)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71, {
+      locale: 'fr',
+    });
+
+    expect(manifest).toHaveProperty('entrypoints.main.js.0.path', frScriptOne);
+  });
+
+  it('falls back to the most-polyfilled build for a locale', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 74'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset('en-chrome74.js')],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 73'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          browsers: ['chrome > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset('noLocale-chrome1.js')],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71, {
+      locale: 'en',
+    });
+
+    expect(manifest).toHaveProperty('entrypoints.main.js.0.path', enScriptOne);
+  });
+
+  it('falls back to the first manifest with a compatible user-agent and a non-locale build', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          browsers: ['chrome > 70'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(noLocaleScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          browsers: ['chrome > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(noLocaleScriptTwo)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71, {
+      locale: 'pt-BR',
+    });
+
+    expect(manifest).toHaveProperty(
+      'entrypoints.main.js.0.path',
+      noLocaleScriptOne,
+    );
+  });
+
+  it('falls back to the last manifest when nothing matches', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          browsers: ['safari > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(noLocaleScriptOne)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71, {
+      locale: 'pt-BR',
+    });
+
+    expect(manifest).toHaveProperty(
+      'entrypoints.main.js.0.path',
+      noLocaleScriptOne,
+    );
+  });
+});

--- a/packages/sewing-kit-koa/src/tests/manifests-read.test.ts
+++ b/packages/sewing-kit-koa/src/tests/manifests-read.test.ts
@@ -1,0 +1,99 @@
+import {join} from 'path';
+
+import appRoot from 'app-root-path';
+import {gzip} from 'node-gzip';
+
+import {
+  internalOnlyClearCache as clearManifestsCache,
+  Manifests,
+} from '../manifests';
+
+import {
+  mockConsolidatedManifest,
+  mockEntrypoint,
+  mockManifest,
+} from './test-utilities';
+
+jest.mock('fs-extra', () => ({
+  ...require.requireActual('fs-extra'),
+  pathExists: jest.fn(() => Promise.resolve(false)),
+  readFile: jest.fn(() => '[]'),
+  readJson: jest.fn(() => []),
+}));
+
+const {pathExists, readFile, readJson} = require.requireMock('fs-extra');
+
+describe('Manifests read', () => {
+  beforeEach(() => {
+    pathExists.mockReset();
+    pathExists.mockReturnValue(Promise.resolve(false));
+
+    readFile.mockReset();
+
+    readJson.mockReset();
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        {entrypoints: {main: mockEntrypoint()}, asyncAssets: {}},
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    clearManifestsCache();
+  });
+
+  it('prioritizes reading from a gzipped manifests file if it exists', async () => {
+    const manifests = new Manifests();
+    pathExists.mockReturnValueOnce(Promise.resolve(true));
+    readFile.mockReturnValueOnce(
+      gzip(
+        JSON.stringify(
+          mockConsolidatedManifest([
+            mockManifest({
+              entrypoints: {
+                main: mockEntrypoint({}),
+              },
+            }),
+          ]),
+        ),
+      ),
+    );
+
+    await manifests.resolve('Chrome 73');
+
+    expect(readFile).toHaveBeenCalledWith(
+      join(appRoot.path, 'build/client/assets.json.gz'),
+    );
+  });
+
+  it('falls back to reading from a non-gzipped manifests file', async () => {
+    const manifests = new Manifests();
+
+    await manifests.resolve('Chrome 73');
+
+    expect(readJson).toHaveBeenCalledWith(
+      join(appRoot.path, 'build/client/assets.json'),
+    );
+  });
+
+  it('only reads manifests once', async () => {
+    const manifests = new Manifests();
+
+    await manifests.resolve('Chrome 71');
+    await manifests.resolve('Chrome 73');
+
+    expect(readJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads manifests from a custom path', async () => {
+    const manifestPath = 'path/to/manifest';
+    const manifests = new Manifests(manifestPath);
+
+    await manifests.resolve('Chrome 73');
+
+    expect(pathExists).toHaveBeenCalledWith(
+      join(appRoot.path, `${manifestPath}.gz`),
+    );
+    expect(readJson).toHaveBeenCalledWith(join(appRoot.path, manifestPath));
+  });
+});

--- a/packages/sewing-kit-koa/src/tests/manifests-user-agent.test.ts
+++ b/packages/sewing-kit-koa/src/tests/manifests-user-agent.test.ts
@@ -1,0 +1,135 @@
+import {
+  internalOnlyClearCache as clearManifestsCache,
+  Manifests,
+} from '../manifests';
+
+import {
+  mockAsset,
+  mockConsolidatedManifest,
+  mockEntrypoint,
+  mockManifest,
+} from './test-utilities';
+
+jest.mock('fs-extra', () => ({
+  ...require.requireActual('fs-extra'),
+  pathExists: jest.fn(() => Promise.resolve(false)),
+  readFile: jest.fn(() => '[]'),
+  readJson: jest.fn(() => []),
+}));
+
+const {pathExists, readFile, readJson} = require.requireMock('fs-extra');
+
+describe('Manifests user agents', () => {
+  beforeEach(() => {
+    pathExists.mockReset();
+    pathExists.mockReturnValue(Promise.resolve(false));
+
+    readFile.mockReset();
+
+    readJson.mockReset();
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        {entrypoints: {main: mockEntrypoint()}, asyncAssets: {}},
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    clearManifestsCache();
+  });
+
+  const scriptOne = 'script-one.js';
+  const scriptTwo = 'script-two.js';
+  const chrome71 =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36';
+
+  it('uses the last manifest when no useragent exists', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(scriptOne)],
+            }),
+          },
+        }),
+
+        mockManifest({
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(scriptTwo)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(undefined);
+
+    expect(manifest.entrypoints.main.js[0]).toStrictEqual({
+      path: scriptTwo,
+    });
+  });
+
+  it('uses the last manifest when no manifest matches', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          browsers: ['firefox > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(scriptOne)],
+            }),
+          },
+        }),
+
+        mockManifest({
+          browsers: ['safari > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(scriptTwo)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71);
+
+    expect(manifest.entrypoints.main.js[0]).toStrictEqual({
+      path: scriptTwo,
+    });
+  });
+
+  it('uses the first matching manifest', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(scriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          browsers: ['chrome > 1'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(scriptTwo)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71);
+
+    expect(manifest.entrypoints.main.js[0]).toStrictEqual({
+      path: scriptOne,
+    });
+  });
+});

--- a/packages/sewing-kit-koa/src/tests/middleware.test.ts
+++ b/packages/sewing-kit-koa/src/tests/middleware.test.ts
@@ -3,8 +3,18 @@ import {Header} from '@shopify/network';
 
 import middleware, {getAssets} from '../middleware';
 import Assets from '../assets';
+import {Manifests} from '../manifests';
+
+jest.mock('../manifests');
+
+const ManifestsMock = Manifests as jest.Mock;
+ManifestsMock.mockImplementation(jest.fn());
 
 describe('middleware', () => {
+  afterEach(() => {
+    ManifestsMock.mockReset();
+  });
+
   it('adds an instance of Assets with the specified assetPrefix to state', async () => {
     const assetPrefix = '/sewing-kit-assets/';
     const context = createMockContext();
@@ -40,20 +50,11 @@ describe('middleware', () => {
     expect(getAssets(context)).toHaveProperty('userAgent', userAgent);
   });
 
-  it('defaults the manifest path to `build/client/assets.json`', async () => {
-    const context = createMockContext();
-    await middleware()(context, () => Promise.resolve());
-    expect(getAssets(context)).toHaveProperty(
-      'manifestPath',
-      'build/client/assets.json',
-    );
-  });
-
-  it('accespts a custom value for the manifest path', async () => {
+  it('accepts a custom value for the manifest path', async () => {
     const context = createMockContext();
     const manifestPath = 'path/to/manifest';
     await middleware({manifestPath})(context, () => Promise.resolve());
-    expect(getAssets(context)).toHaveProperty('manifestPath', manifestPath);
+    expect(Manifests).toHaveBeenCalledWith(manifestPath);
   });
 
   it('calls the next middleware', async () => {

--- a/packages/sewing-kit-koa/src/tests/test-utilities.ts
+++ b/packages/sewing-kit-koa/src/tests/test-utilities.ts
@@ -1,0 +1,43 @@
+import {basename} from 'path';
+
+import {Asset, AsyncAsset, ConsolidatedManifest, Manifest} from '../types';
+
+export function mockAsset(path: string): Asset {
+  return {path};
+}
+
+export function mockAsyncAsset(path: string): AsyncAsset {
+  return {publicPath: path, file: basename(path)};
+}
+
+export function mockEntrypoint({
+  scripts = [],
+  styles = [],
+}: {
+  scripts?: Asset[];
+  styles?: Asset[];
+} = {}) {
+  return {js: scripts, css: styles};
+}
+
+export function mockManifest({
+  identifier = undefined,
+  name = 'mockedManifest',
+  browsers,
+  entrypoints = {},
+  asyncAssets = {},
+}: Partial<Manifest>): Manifest {
+  return {
+    identifier,
+    name,
+    browsers,
+    entrypoints,
+    asyncAssets,
+  };
+}
+
+export function mockConsolidatedManifest(
+  manifests: Manifest[],
+): ConsolidatedManifest {
+  return manifests;
+}

--- a/packages/sewing-kit-koa/src/types.ts
+++ b/packages/sewing-kit-koa/src/types.ts
@@ -1,0 +1,26 @@
+export interface Asset {
+  path: string;
+  integrity?: string;
+}
+
+export interface Entrypoint {
+  js: Asset[];
+  css: Asset[];
+}
+
+export interface AsyncAsset {
+  id?: string;
+  file: string;
+  publicPath: string;
+  integrity?: string;
+}
+
+export interface Manifest {
+  identifier?: {locales?: string[]; target?: string};
+  name?: string;
+  browsers?: string[];
+  entrypoints: {[key: string]: Entrypoint};
+  asyncAssets: {[key: string]: AsyncAsset[]};
+}
+
+export type ConsolidatedManifest = Manifest[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,6 +1484,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-gzip@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/node-gzip/-/node-gzip-1.1.0.tgz#99a7dfab7c0eec545658f3d736e8d6939ed7161e"
+  integrity sha512-j7cGb6HIOZbDx3sqe9/9VAPeSvyt143yu5k35gzRXE3mxEgK6BOZ6BAiJ3ToXBcJqLzL9Cr53dav21jlp3f9gw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@>=6":
   version "12.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.0.tgz#7f893924970076b20ca0089df50ab9f171088909"
@@ -7840,6 +7847,11 @@ node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-gzip@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/node-gzip/-/node-gzip-1.1.2.tgz#245bd171b31ce7c7f50fc4cd0ca7195534359afb"
+  integrity sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Description
When provided with manifests containing a `locale` attribute, sewing-kit-koa will now attempt to match a user request to a set of assets with that locale's translations embedded into its JavaScript.

This is a companion to the react-i18n PR that supports per-locale builds: https://github.com/Shopify/quilt/pull/1197.  The advantages of this are:
* Bundlers like webpack don't get bloated with metadata about where to find async translations
* Users don't have to download multiple sets of translations

## Type of change

- [x] `@shopify/sewing-kit-koa` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
