### PR TITLE
[Proof of concept] Speed up build/type-check CI job with a cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,19 @@ shared:
       - export PATH="$HOME/.yarn/bin:$PATH"
     install:
       - yarn install --production=false --frozen-lockfile
-    cache: yarn
+    cache:
+      directories:
+        - node_modules
+        - tsbuildcache
+    before_cache:
+      - node ./scripts/save-typescript-cache.js
 
 matrix:
   include:
     - <<: *node_container
       name: 'Node - build, type-check, and end-to-end tests'
       script:
+        - node ./scripts/restore-typescript-cache.js
         - yarn build --verbose
         - yarn test:ci --testPathPattern react-server-webpack-plugin address
     - <<: *node_container

--- a/scripts/restore-typescript-cache.js
+++ b/scripts/restore-typescript-cache.js
@@ -1,0 +1,87 @@
+const {execSync} = require('child_process');
+const fs = require('fs-extra');
+
+const {exec, gracefulExit} = require('./utilities');
+
+process.on('uncaughtException', gracefulExit);
+process.on('unhandledRejection', gracefulExit);
+
+const resetModifiedTimesCommand = 'touch -m -t 201001010000';
+
+/*
+ * This script is an ugly hack to speed up CI time :/  It is necessary because:
+ * - TypeScript's incremental build caching is based on file modification dates
+ * - Git always clones repos using the current date/time for all files
+ * - So in CI, TypeScript will always view a cache as 100% "stale"
+ *
+ * To work around this, the script:
+ * - Resets the modification dates of all config / src files to a time in the
+ *   far past
+ * - Grabs all changed paths for the branch
+ * - Tweaks the modification date of all changed paths
+ *
+ * This gets the cache / git in sync, albeit in a very gross manner 🤭
+ */
+
+async function run() {
+  const branchName = process.env.TRAVIS_PULL_REQUEST_BRANCH;
+  if (!branchName || branchName === 'master') {
+    console.log('Skipping build cache for master');
+    return;
+  }
+
+  await resetConfigModifiedDates();
+  await resetSourceModifiedDates();
+  await restoreDistFiles();
+  await touchModifiedFiles(await findBranchChanges());
+}
+
+run();
+
+async function restoreDistFiles() {
+  await fs.mkdirp('./tsbuildcache');
+
+  if (await fs.pathExists('./tsbuildcache/cache.tar')) {
+    await exec('tar -xf ./tsbuildcache/cache.tar');
+  }
+}
+
+async function resetConfigModifiedDates() {
+  await exec(`${resetModifiedTimesCommand} ./packages/tsconfig_base.json`);
+  await exec(
+    `find ./packages/*/tsconfig.json -exec ${resetModifiedTimesCommand} {} +`,
+  );
+  await exec(`find ./config -exec ${resetModifiedTimesCommand} {} +`);
+}
+
+async function resetSourceModifiedDates() {
+  await exec(`find ./packages/*/src -exec ${resetModifiedTimesCommand} {} +`);
+}
+
+async function fetchMasterCommits() {
+  await exec(`git remote set-branches origin 'master'`);
+  await exec(`git fetch -v`);
+}
+
+async function findBranchChanges() {
+  await fetchMasterCommits();
+
+  // Inspired by:
+  // - https://stackoverflow.com/a/50521039
+  // - https://stackoverflow.com/a/4991675
+  return execSync(
+    'git --no-pager diff  --name-only --diff-filter=AM $(git rev-list --first-parent origin/master | head -1) HEAD',
+  )
+    .toString()
+    .trim()
+    .split('\n');
+}
+
+async function touchModifiedFiles(files) {
+  console.log('Invalidating build cache for changed files:');
+  const touches = files.map(async file => {
+    console.log(`  ∙ ${file}`);
+    await exec(`touch ${file}`);
+  });
+  await Promise.all(touches);
+}

--- a/scripts/save-typescript-cache.js
+++ b/scripts/save-typescript-cache.js
@@ -1,0 +1,10 @@
+const {exec, gracefulExit} = require('./utilities');
+
+process.on('uncaughtException', gracefulExit);
+process.on('unhandledRejection', gracefulExit);
+
+async function run() {
+  await exec(`tar -cf tsbuildcache/cache.tar packages/*/dist`);
+}
+
+run();

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,0 +1,27 @@
+const {exec: rawExec, execSync} = require('child_process');
+const {promisify} = require('util');
+
+const fs = require('fs-extra');
+
+function gracefulExit(err) {
+  // eslint-disable-next-line no-console
+  console.log('Error setting up build cache', err);
+  process.stdout.write('\n', () => {
+    process.exit(1);
+  });
+}
+
+async function exec(command) {
+  const {stdout, stderr} = await promisify(rawExec);
+  if (stdout) {
+    console.log(stdout);
+  }
+  if (stderr) {
+    console.log(stderr);
+  }
+}
+
+module.exports = {
+  gracefulExit,
+  exec,
+};


### PR DESCRIPTION
## Description
Speed up CI using one weird file timestamp workaround.  vs the usual 10m+, this is pretty good:

<img width="867" alt="quilt - Travis CI 2019-12-03 18-36-22" src="https://user-images.githubusercontent.com/673655/70099061-d1429e00-15fb-11ea-8c87-9f46ea088e61.png">

## Can you prove that this works, yo?
In the [Github diff for a test commit](https://github.com/Shopify/quilt/compare/ci-test-2), you can see changes to:
* `packages/csrf-token-fetcher/src/index.ts`
* `packages/koa-performance/src/index.ts`
* `packages/koa-performance/tsconfig.json`
* `packages/react-google-analytics/package.json`
* `packages/semaphore/src/Semaphore.ts`

In [the Travis build output for that commit](https://travis-ci.org/Shopify/quilt/jobs/620359665), you can see most projects building in 0 seconds, but touched projects taking a few seconds.  Selected highlights:

```
22:36:39 - Building project '/home/travis/build/Shopify/quilt/packages/csrf-token-fetcher/tsconfig.json'...

22:36:51 - Building project '/home/travis/build/Shopify/quilt/packages/koa-performance/tsconfig.json'...

22:36:59 - Building project '/home/travis/build/Shopify/quilt/packages/react-google-analytics/tsconfig.json'...

22:37:06 - Building project '/home/travis/build/Shopify/quilt/packages/semaphore/tsconfig.json'...
```

## Why not do this on master?
Ehhh, I'd like to try it out on branches for a while.  If the cache invalidation logic isn't right, it'll be caught by the master build.

Releases will still be painful, but branch work / rebasing will be much faster.

## Checklist

- [ ] ~~I have added a changelog entry, prefixed by the type of change noted above~~
