### PR TITLE
Export Options from jest-koa-mocks

### DIFF
--- a/packages/jest-koa-mocks/CHANGELOG.md
+++ b/packages/jest-koa-mocks/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] -->
 
+### Added
+
+- `Options` type is now exported for `createMockContext` [#1209](https://github.com/Shopify/quilt/pull/1209)
+
 ## 2.1.7 - 2019-10-23
 
 ### Fixed

--- a/packages/jest-koa-mocks/src/index.ts
+++ b/packages/jest-koa-mocks/src/index.ts
@@ -1,2 +1,2 @@
-export {default as createMockContext} from './create-mock-context';
+export {default as createMockContext, Options} from './create-mock-context';
 export {default as createMockCookies} from './create-mock-cookies';


### PR DESCRIPTION
## Description
This PR simply exports the Options type from jest-koa-mocks

## Type of change
- [x] jest-koa-mocks Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
