### PR TITLE
🐛Fix unformat number in react-i18n

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Fixed `unformatNumber` for numbers using a period as the thousand separator ([#1215](https://github.com/Shopify/quilt/pull/1215))
 
 ## [2.3.0] - 2019-11-29
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -500,7 +500,7 @@ export class I18n {
   }
 
   private numberSymbols() {
-    const formattedNumber = this.formatNumber(123456.789, {
+    const formattedNumber = this.formatNumber(123456.7, {
       maximumFractionDigits: 1,
       minimumFractionDigits: 1,
     });

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -499,6 +499,7 @@ export class I18n {
     return decimal.length === 0 ? DECIMAL_NOT_SUPPORTED : decimal;
   }
 
+  @memoize()
   private numberSymbols() {
     const formattedNumber = this.formatNumber(123456.7, {
       maximumFractionDigits: 1,

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -238,12 +238,12 @@ export class I18n {
   }
 
   unformatNumber(input: string): string {
-    const {thousandSeparator, decimalSeparator} = this.numberSymbols();
+    const {thousandSymbol, decimalSymbol} = this.numberSymbols();
 
     const normalizedValue = normalizedNumber(
       input,
-      decimalSeparator,
-      thousandSeparator === PERIOD,
+      decimalSymbol,
+      thousandSymbol === PERIOD,
     );
 
     return normalizedValue === '' ? '' : parseFloat(normalizedValue).toString();
@@ -504,14 +504,22 @@ export class I18n {
       maximumFractionDigits: 1,
       minimumFractionDigits: 1,
     });
-    return getSeparators(formattedNumber);
+    let thousandSymbol;
+    let decimalSymbol;
+    for (const char of formattedNumber) {
+      if (isNaN(parseInt(char, 10))) {
+        if (thousandSymbol) decimalSymbol = char;
+        else thousandSymbol = char;
+      }
+    }
+    return {thousandSymbol, decimalSymbol};
   }
 }
 
 function normalizedNumber(
   input: string,
   expectedDecimal: string,
-  usesPeriodThousandSeparator?: boolean,
+  usesPeriodThousandSymbol?: boolean,
 ) {
   const nonDigits = /\D/g;
 
@@ -520,7 +528,7 @@ function normalizedNumber(
   const hasExpectedDecimalSymbol = input.lastIndexOf(expectedDecimal) !== -1;
   const hasPeriodAsDecimal = input.lastIndexOf(PERIOD) !== -1;
   const usesPeriodDecimal =
-    !usesPeriodThousandSeparator &&
+    !usesPeriodThousandSymbol &&
     !hasExpectedDecimalSymbol &&
     hasPeriodAsDecimal;
   const decimalSymbolToUse = usesPeriodDecimal ? PERIOD : expectedDecimal;
@@ -559,16 +567,4 @@ function dateTimeFormatter(
   options: Intl.DateTimeFormatOptions = {},
 ) {
   return new Intl.DateTimeFormat(locale, options);
-}
-
-function getSeparators(str: string) {
-  let thousandSeparator;
-  let decimalSeparator;
-  for (const char of str) {
-    if (isNaN(parseInt(char, 10))) {
-      if (thousandSeparator) decimalSeparator = char;
-      else thousandSeparator = char;
-    }
-  }
-  return {thousandSeparator, decimalSeparator};
 }

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -605,7 +605,7 @@ describe('I18n', () => {
     const input = 123456.7891;
 
     it('handles number with period decimal symbol', () => {
-      formatNumber.mockImplementationOnce(() => '1.1');
+      formatNumber.mockImplementationOnce(() => '123,456.7');
 
       const formatted = '123,456.7891';
 
@@ -613,15 +613,23 @@ describe('I18n', () => {
     });
 
     it('handles number with comma decimal symbol', () => {
-      formatNumber.mockImplementationOnce(() => '1,1');
+      formatNumber.mockImplementationOnce(() => '123.456,7');
 
       const formatted = '123.456,7891';
 
       expect(i18n.unformatNumber(formatted)).toBe(input.toString());
     });
 
+    it('handles number with space as the thousand symbol', () => {
+      formatNumber.mockImplementationOnce(() => '123 456,7');
+
+      const formatted = '123 456,7891';
+
+      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+    });
+
     it('handles number with unusual comma separators and period decimal symbol', () => {
-      formatNumber.mockImplementationOnce(() => '1.1');
+      formatNumber.mockImplementationOnce(() => '123,456.7');
 
       const formatted = '1,23,456.7891';
 
@@ -629,7 +637,7 @@ describe('I18n', () => {
     });
 
     it('handles invalid value', () => {
-      formatNumber.mockImplementationOnce(() => '1.1');
+      formatNumber.mockImplementationOnce(() => '123,456.7');
 
       const formatted = 'foobar';
 


### PR DESCRIPTION
## Description

Issue: https://github.com/Shopify/intl-new-commerce-patterns/issues/916

Fixes an issue with `unformatNumber` when the thousand separator symbol is a period.
Ideally, we would use the [formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts) method to fix the issue but that is still experimental.

Before:

![out](https://user-images.githubusercontent.com/6954038/70478012-148f8780-1aa8-11ea-9af8-c110956c646d.gif)

After: 

![out](https://user-images.githubusercontent.com/6954038/70478024-1c4f2c00-1aa8-11ea-91a9-f7c001fadf5a.gif)

## Type of change

- [x] react-i18n Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
