### PR TITLE
🐛 [react-form] Update reduceField() to check array equality when determining if a field is dirty

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [0.3.24]
+
+### Fixed
+
+- Update reduceField() to check array equality when determining if a field is dirty [#1222](https://github.com/Shopify/quilt/pull/1222)
+
 ## [0.3.23]
 
 ### Added

--- a/packages/react-form/src/hooks/field/reducer.ts
+++ b/packages/react-form/src/hooks/field/reducer.ts
@@ -1,6 +1,7 @@
 import {useReducer, Reducer} from 'react';
 
 import {FieldState, ErrorValue} from '../../types';
+import {shallowArrayComparison} from '../../utilities';
 
 interface UpdateErrorAction {
   type: 'updateError';
@@ -62,10 +63,13 @@ export function reduceField<Value>(
     case 'update': {
       const newValue = action.payload;
       const {defaultValue} = state;
+      const isDirty = Array.isArray(defaultValue)
+        ? !shallowArrayComparison(defaultValue, newValue)
+        : defaultValue !== newValue;
 
       return {
         ...state,
-        dirty: defaultValue !== newValue,
+        dirty: isDirty,
         value: newValue,
         touched: true,
       };

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -3,6 +3,8 @@ import faker from 'faker';
 import {mount} from '@shopify/react-testing';
 
 import {asChoiceField, useChoiceField, useField, FieldConfig} from '../field';
+import {FieldState} from '../../../types';
+import {FieldAction, reduceField} from '../reducer';
 
 describe('useField', () => {
   function TestField({config}: {config: string | FieldConfig<string>}) {
@@ -288,6 +290,86 @@ describe('useField', () => {
 
       expect(wrapper).toContainReactComponent('p', {
         children: fieldConfig.validates('pants'),
+      });
+    });
+  });
+
+  describe('#reduceField', () => {
+    function buildState<Value>({
+      value,
+      defaultValue,
+      dirty = false,
+    }): FieldState<Value> {
+      return {
+        value,
+        defaultValue,
+        error: undefined,
+        touched: true,
+        dirty,
+      };
+    }
+
+    describe('when the new value is the same as the default value', () => {
+      describe('when the default value is an array', () => {
+        it('identifies that the state is not dirty', () => {
+          const originalState = buildState({value: [], defaultValue: []});
+          const action: FieldAction<string[]> = {
+            type: 'update',
+            payload: [],
+          };
+
+          const newState = reduceField(originalState, action);
+
+          expect(originalState).toStrictEqual(newState);
+        });
+
+        it('identifies that the state is dirty', () => {
+          const originalState = buildState({value: [], defaultValue: []});
+          const action: FieldAction<string[]> = {
+            type: 'update',
+            payload: ['new value'],
+          };
+          const expectedNewState = buildState({
+            value: action.payload,
+            defaultValue: [],
+            dirty: true,
+          });
+
+          const newState = reduceField(originalState, action);
+
+          expect(newState).toStrictEqual(expectedNewState);
+        });
+      });
+
+      describe('when the default value is not an array', () => {
+        it('identifies that the state is not dirty', () => {
+          const originalState = buildState({value: '', defaultValue: ''});
+          const action: FieldAction<string> = {
+            type: 'update',
+            payload: '',
+          };
+
+          const newState = reduceField(originalState, action);
+
+          expect(originalState).toStrictEqual(newState);
+        });
+
+        it('identifies that the state is dirty', () => {
+          const originalState = buildState({value: '', defaultValue: ''});
+          const action: FieldAction<string> = {
+            type: 'update',
+            payload: 'new value',
+          };
+          const expectedNewState = buildState({
+            value: action.payload,
+            defaultValue: '',
+            dirty: true,
+          });
+
+          const newState = reduceField(originalState, action);
+
+          expect(newState).toStrictEqual(expectedNewState);
+        });
       });
     });
   });

--- a/packages/react-form/src/test/utilities.test.ts
+++ b/packages/react-form/src/test/utilities.test.ts
@@ -1,0 +1,21 @@
+import {shallowArrayComparison} from '../utilities';
+
+describe('shallowArrayComparison()', () => {
+  describe('when the two arrays are the same', () => {
+    it('returns true', () => {
+      const array1 = [1, 'a', 2, 'b'];
+      const array2 = [1, 'a', 2, 'b'];
+
+      expect(shallowArrayComparison(array1, array2)).toBe(true);
+    });
+  });
+
+  describe('when the two arrays are not the same', () => {
+    it('returns true', () => {
+      const array1 = [1, 'a', 2, 'b'];
+      const array2 = ['other', 'stuff', 'in', 'here'];
+
+      expect(shallowArrayComparison(array1, array2)).toBe(false);
+    });
+  });
+});

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -96,3 +96,27 @@ export function validateAll(fieldBag: {[key: string]: FieldOutput<any>}) {
 }
 
 export function noop() {}
+
+export function shallowArrayComparison(arrA: unknown[], arrB: any) {
+  if (arrA === arrB) {
+    return true;
+  }
+
+  if (!arrA || !arrB) {
+    return false;
+  }
+
+  const len = arrA.length;
+
+  if (arrB.length !== len) {
+    return false;
+  }
+
+  for (let i = 0; i < len; i++) {
+    if (arrA[i] !== arrB[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Description

In react-form, dirty tracking doesn't work when a field's initial value is an array. This is because we compare arrays with `===`, which always returns `false` regardless of the arrays' contents. So after the field's value has changed once, comparing the changes always fails.

You can see this bug in action in [this codepen](https://codesandbox.io/s/optimistic-archimedes-78tjo). Follow the instructions in the output pane.

## Questions

1. I've fixed this with a naive solution: if a field's default value is an array, use `JSON.stringify` to compare it to the current value. This only works if all of the elements in the default value are scalars. Is this okay, or is there a better approach that we should use?

2. How can I test this? I didn't see any tests related to dirty tracking, so I'm not sure where to start.

## Type of change

- [x] react-form Patch: Bug fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above