### PR TITLE
Use deep repo links

### DIFF
--- a/packages/address-consts/package.json
+++ b/packages/address-consts/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/address-consts",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/address-mocks",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/address",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/admin-graphql-api-utilities",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/ast-utilities/package.json
+++ b/packages/ast-utilities/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/ast-utilities",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/async",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/csrf-token-fetcher/package.json
+++ b/packages/csrf-token-fetcher/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/csrf-token-fetcher",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/css-utilities/package.json
+++ b/packages/css-utilities/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/css-utilities",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/dates",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/decorators",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/enzyme-utilities",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/function-enhancers/package.json
+++ b/packages/function-enhancers/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/function-enhancers",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/graphql-persisted/package.json
+++ b/packages/graphql-persisted/package.json
@@ -12,10 +12,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/graphql-persisted",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/graphql-testing",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/i18n",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/jest-dom-mocks",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/jest-koa-mocks",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/jest-mock-apollo",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/jest-mock-router",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/koa-liveness-ping",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/koa-metrics",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/koa-performance/package.json
+++ b/packages/koa-performance/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/koa-performance",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/koa-shopify-auth",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/koa-shopify-graphql-proxy",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/koa-shopify-webhooks/package.json
+++ b/packages/koa-shopify-webhooks/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/koa-shopify-webhooks",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/logger",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/network",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/performance",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -14,10 +14,7 @@
     "build": "tsc --p tsconfig.json"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/polyfills",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/predicates/package.json
+++ b/packages/predicates/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/predicates",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-app-bridge-universal-provider/package.json
+++ b/packages/react-app-bridge-universal-provider/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-app-bridge-universal-provider",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-async",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-compose",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-cookie",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-csrf-universal-provider/package.json
+++ b/packages/react-csrf-universal-provider/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-csrf-universal-provider",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-csrf/package.json
+++ b/packages/react-csrf/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-csrf",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-effect-apollo/package.json
+++ b/packages/react-effect-apollo/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-effect-apollo",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-effect",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-form-state",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-form",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-google-analytics",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-graphql-universal-provider",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-graphql",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-hooks",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-html",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-hydrate/package.json
+++ b/packages/react-hydrate/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-hydrate",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-i18n-universal-provider",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-i18n",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-idle/package.json
+++ b/packages/react-idle/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-idle",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-import-remote",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-intersection-observer",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-network",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-performance",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-router",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-serialize",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-server-webpack-plugin/package.json
+++ b/packages/react-server-webpack-plugin/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-server-webpack-plugin",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-server",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-shopify-app-route-propagator",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-shortcuts",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-testing",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-tracking-pixel",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-universal-provider/package.json
+++ b/packages/react-universal-provider/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-universal-provider",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/react-web-worker/package.json
+++ b/packages/react-web-worker/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/react-web-worker",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/rpc",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/semaphore/package.json
+++ b/packages/semaphore/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/semaphore",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/sewing-kit-koa/package.json
+++ b/packages/sewing-kit-koa/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/sewing-kit-koa",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/statsd",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/useful-types/package.json
+++ b/packages/useful-types/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/useful-types",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/web-worker",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -13,10 +13,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/with-env",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -14,10 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Shopify/quilt.git"
-  },
+  "repository": "https://github.com/shopify/quilt/tree/master/packages/{{name}}",
   "bugs": {
     "url": "https://github.com/shopify/quilt/issues"
   },


### PR DESCRIPTION
## Description

This changes how we link each package to a repository. Rather than link to the top-level mono-repo, we deep link.

Based on seeing how @babel/plugin-transform-flow-comments does it:

```json
  {
    "name": "@babel/plugin-transform-flow-comments",
    [...]
    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments",
```

This originated from a discussion in Slack, about how some tooling doesn't handle packages in Quilt very well (e.g. Dependabot). @GoodForOneFare suggested we may be able to use this approach.

This affects **every** package.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
