### PR TITLE
[React-i18n] Add defaultLocale option to babel plugin

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -486,6 +486,19 @@ webpack(require(./webpack.config.js));
 
 ```
 
+#### Setting the default locale to something other than `en`
+
+If you want your default locale to be something else than English because it's not your primary locale, you can pass the `defaultLocale` option to the babel plugin:
+
+```
+// webpack.config.js
+{
+  plugins: [
+    ['@shopify/react-i18n/babel', {defaultLocale: 'fr'}],
+  ],
+}
+```
+
 ## FAQ
 
 ### Why another i18n library? Why not just use <[react-intl](https://github.com/yahoo/react-intl) | [react-i18next](https://github.com/i18next/react-i18next)> etc?

--- a/packages/react-i18n/src/babel-plugin/index.ts
+++ b/packages/react-i18n/src/babel-plugin/index.ts
@@ -19,6 +19,7 @@ export const I18N_CALL_NAMES = ['useI18n', 'withI18n'];
 
 export interface Options {
   mode?: 'from-generated-index' | 'from-dictionary-index';
+  defaultLocale?: string;
 }
 
 interface State {
@@ -104,8 +105,10 @@ export default function injectWithI18nArguments({
             return;
           }
 
-          const {mode} = state.opts;
-          const fallbackLocale = DEFAULT_FALLBACK_LOCALE;
+          const {mode, defaultLocale} = state.opts;
+          const fallbackLocale = defaultLocale
+            ? defaultLocale
+            : DEFAULT_FALLBACK_LOCALE;
 
           const fallbackID = nodePath.scope.generateUidIdentifier(
             camelCase(fallbackLocale),

--- a/packages/react-i18n/src/babel-plugin/test/babel-plugin.test.ts
+++ b/packages/react-i18n/src/babel-plugin/test/babel-plugin.test.ts
@@ -322,6 +322,35 @@ describe('babel-pluin-react-i18n', () => {
     );
   });
 
+  it('loads fr.json as default translation when defaultLocale is set to fr', async () => {
+    expect(
+      await transformUsingI18nBabelPlugin(
+        withI18nFixture,
+        optionsForFile('MyComponent.tsx', true),
+        {defaultLocale: 'fr'},
+      ),
+    ).toBe(
+      await normalize(
+        `import _fr from './${TRANSLATION_DIRECTORY_NAME}/fr.json';
+        import React from 'react';
+        import {withI18n} from '@shopify/react-i18n';
+
+        function MyComponent({i18n}) {
+          return i18n.translate('key');
+        }
+
+        export default withI18n({
+          id: 'MyComponent_${defaultHash}',
+          fallback: _fr,
+          ${createExpectedTranslationsOption({
+            translationArrayString: '["de", "en", "zh-TW"]',
+          })}
+        })(MyComponent);
+        `,
+      ),
+    );
+  });
+
   describe('from-dictionary-index', () => {
     it('injects a dictionary import, and returns dictionary values from useI18n', async () => {
       expect(

--- a/packages/react-intersection-observer/CHANGELOG.md
+++ b/packages/react-intersection-observer/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- Add `defaultLocale` option to Babel plugin.
+
 ## [2.0.8] - 2019-10-31
 
 - Change `useIntersection` hook behaviour to set and distribute the `IntersectionObserverEntry` object directly


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1221

Add `defaultLocale` option to the babel plugin to change the default translation language.

## Type of change

- [ ] [React-i18n] Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] [React-i18n] Minor: New feature (non-breaking change which adds functionality)
- [ ] [React-i18n] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
