### PR TITLE
✨ Added `gauge` metric support to `statsd` library

### DIFF
--- a/packages/statsd/CHANGELOG.md
+++ b/packages/statsd/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2019-12-24
+
+### Added
+
+- added `gauge` metric support from `hot-spot`
+
 ## [1.1.0] - 2019-10-08
 
 ### Added

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/statsd",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "license": "MIT",
   "description": "An opinionated StatsD client for Shopify Node.js server and other StatsD utilities.",
   "main": "dist/src/index.js",

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -52,6 +52,17 @@ export class StatsDClient {
     });
   }
 
+  gauge(stat: string | string[], value: number, tags?: Tags) {
+    return new Promise<void>(resolve => {
+      this.statsd.gauge(
+        stat,
+        value,
+        this.normalizeTags(tags),
+        this.createCallback(resolve),
+      );
+    });
+  }
+
   increment(stat: string | string[], tags?: Tags) {
     return new Promise<void>(resolve => {
       this.statsd.increment(

--- a/packages/statsd/src/test/client.test.ts
+++ b/packages/statsd/src/test/client.test.ts
@@ -107,6 +107,73 @@ describe('StatsDClient', () => {
     });
   });
 
+  describe('gauge', () => {
+    it('passes gauge metrics to the statsd client', () => {
+      const statsDClient = new StatsDClient(defaultOptions);
+      statsDClient.gauge(stat, value, tags);
+
+      const stats = StatsDMock.mock.instances[0];
+      const gaugeFn = stats.gauge;
+      expect(gaugeFn).toHaveBeenCalledTimes(1);
+      expect(gaugeFn).toHaveBeenCalledWith(
+        stat,
+        value,
+        tags,
+        expect.any(Function),
+      );
+    });
+
+    it('passes gauge metrics with snake case name metrics to the statsd client when snakeCase=true', () => {
+      const statsDClient = new StatsDClient({
+        ...defaultOptions,
+        snakeCase: true,
+      });
+      statsDClient.gauge(stat, value, tags);
+
+      const stats = StatsDMock.mock.instances[0];
+      const gaugeFn = stats.gauge;
+      expect(gaugeFn).toHaveBeenCalledTimes(1);
+      expect(gaugeFn).toHaveBeenCalledWith(
+        stat,
+        value,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        {foo_bar: tagValue},
+        expect.any(Function),
+      );
+    });
+
+    it('calls errorHandler on the promise when the client returns an error', () => {
+      const errorHandler = jest.fn();
+      const statsDClient = new StatsDClient({...defaultOptions, errorHandler});
+      const statsDMock = StatsDMock.mock.instances[0];
+
+      const error = new Error('Something went wrong!');
+      statsDMock.gauge.mockImplementation((_name, _value, _tags, callback) => {
+        callback(error);
+      });
+
+      statsDClient.gauge(stat, value, tags);
+      expect(errorHandler).toHaveBeenCalledWith(error);
+    });
+
+    it("calls logger's log on the promise when the client returns an error and there is no errorHandler in options", () => {
+      function logger() {}
+      logger.log = () => {};
+      const logSpy = jest.spyOn(logger, 'log');
+
+      const statsDClient = new StatsDClient({...defaultOptions, logger});
+      const statsDMock = StatsDMock.mock.instances[0];
+
+      const error = new Error('Something went wrong!');
+      statsDMock.gauge.mockImplementation((_name, _value, _tags, callback) => {
+        callback(error);
+      });
+
+      statsDClient.gauge(name, value, tags);
+      expect(logSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('increment', () => {
     it('passes increment metrics to the statsd client', () => {
       const statsDClient = new StatsDClient(defaultOptions);


### PR DESCRIPTION
## Description

Exposes the hot-spot `gauge` method in our `statsd` library, which can be used [to measure things like memory](https://docs.datadoghq.com/developers/metrics/types/?tab=gauge#metric-type-definition). This will allow us to monitor [Web's Node memory usage](https://github.com/Shopify/web/pull/22136).

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `statsd` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
