### PR TITLE
Cookies must be `SameSite=None`

### DIFF
--- a/packages/koa-shopify-auth/README.md
+++ b/packages/koa-shopify-auth/README.md
@@ -95,7 +95,7 @@ app.keys = [SHOPIFY_SECRET];
 
 app
   // sets up secure session data on each request
-  .use(session({ sameSite: 'none' }, app))
+  .use(session({ secure: true, sameSite: 'none' }, app))
 
   // sets up shopify auth
   .use(

--- a/packages/koa-shopify-auth/README.md
+++ b/packages/koa-shopify-auth/README.md
@@ -95,7 +95,7 @@ app.keys = [SHOPIFY_SECRET];
 
 app
   // sets up secure session data on each request
-  .use(session(app))
+  .use(session({ sameSite: 'none' }, app))
 
   // sets up shopify auth
   .use(


### PR DESCRIPTION
## Description

Chrome requires `SameSite=None` for third-party cookies starting in February. Updates documentation accordingly.

## Type of change

- [x] koa-shopify-auth Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [ ] ~I have added a changelog entry, prefixed by the type of change noted above~ I did not add a changelog entry since this is a change to the README, has no functionality implications and is already very visible.
