### PR TITLE
Dont publish packages with tsconfig.tsbuildinfo

### DIFF
--- a/packages/address-consts/package.json
+++ b/packages/address-consts/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/address-consts/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -27,5 +27,9 @@
     "@shopify/address-consts": "^1.0.3",
     "@shopify/jest-dom-mocks": "^2.8.7",
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -26,5 +26,9 @@
   "dependencies": {
     "@shopify/address-consts": "^1.0.3",
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -21,5 +21,9 @@
   "sideEffects": false,
   "dependencies": {
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/ast-utilities/package.json
+++ b/packages/ast-utilities/package.json
@@ -28,7 +28,8 @@
     "@types/unist": "^2.0.3"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "@babel/template": "^7.6.0",

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "babel.d.ts",
     "babel.js"
   ]

--- a/packages/csrf-token-fetcher/package.json
+++ b/packages/csrf-token-fetcher/package.json
@@ -19,7 +19,8 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/csrf-token-fetcher/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "tslib": "^1.9.3"

--- a/packages/css-utilities/package.json
+++ b/packages/css-utilities/package.json
@@ -24,6 +24,7 @@
     "classnames": "^2.2.6"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -27,6 +27,7 @@
     "@shopify/jest-dom-mocks": "^2.8.7"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/decorators/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "@shopify/function-enhancers": "^1.0.7"

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -27,5 +27,9 @@
     "enzyme": "^3.10.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/function-enhancers/package.json
+++ b/packages/function-enhancers/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/function-enhancers/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/graphql-persisted/package.json
+++ b/packages/graphql-persisted/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "apollo.js",
     "apollo.d.ts",
     "koa.js",

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -33,6 +33,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "matchers.d.ts",
     "matchers.js"
   ]

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -21,5 +21,9 @@
   "sideEffects": false,
   "dependencies": {
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -29,5 +29,9 @@
     "promise": "^8.0.3",
     "tslib": "^1.9.3"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -27,5 +27,9 @@
     "@types/express": "^4.11.1",
     "@types/koa": "^2.0.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -35,5 +35,9 @@
     "apollo-cache-inmemory": "^1.3.6",
     "apollo-client": "^2.3.8"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -33,5 +33,9 @@
   "sideEffects": false,
   "dependencies": {
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -28,5 +28,9 @@
   "sideEffects": false,
   "dependencies": {
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -29,5 +29,9 @@
     "@types/koa": "^2.0.0",
     "koa": "^2.5.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/koa-performance/package.json
+++ b/packages/koa-performance/package.json
@@ -37,6 +37,7 @@
     "@shopify/with-env": "^1.1.4"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -33,5 +33,9 @@
     "@types/safe-compare": "^1.1.0",
     "koa": "^2.5.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -26,5 +26,9 @@
   "peerDependencies": {
     "koa": ">=2.0.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/koa-shopify-webhooks/package.json
+++ b/packages/koa-shopify-webhooks/package.json
@@ -35,6 +35,7 @@
     "koa": ">=2.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -24,5 +24,9 @@
     "pretty-ms": "^3.2.0",
     "tslib": "^1.9.3"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/network/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "tslib": "^1.9.3"

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/performance/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/predicates/package.json
+++ b/packages/predicates/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/predicates/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-app-bridge-universal-provider/package.json
+++ b/packages/react-app-bridge-universal-provider/package.json
@@ -30,6 +30,7 @@
     "faker": "^4.1.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -33,6 +33,7 @@
     "react": ">=16.8.0 <17.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -26,5 +26,9 @@
   "peerDependencies": {
     "react": "^16.3.2"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^16.3.2"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-csrf-universal-provider/package.json
+++ b/packages/react-csrf-universal-provider/package.json
@@ -32,6 +32,7 @@
     "faker": "^4.1.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-csrf/package.json
+++ b/packages/react-csrf/package.json
@@ -23,6 +23,7 @@
     "react": ">=16.8.0 <17.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-effect-apollo/package.json
+++ b/packages/react-effect-apollo/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-effect-apollo/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "server.js",
     "server.d.ts"
   ],

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -31,5 +31,9 @@
     "@shopify/useful-types": "^1.3.0",
     "faker": "^4.1.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -27,7 +27,8 @@
     "faker": "^4.1.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "@shopify/predicates": "^1.2.3",

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -27,5 +27,9 @@
   },
   "devDependencies": {
     "@shopify/enzyme-utilities": "^2.1.7"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -34,6 +34,7 @@
     "apollo-link": "^1.2.3"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -38,7 +38,8 @@
     "@types/graphql": "^14.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0"

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-hooks/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -35,5 +35,9 @@
   "devDependencies": {
     "@shopify/with-env": "^1.1.4"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-hydrate/package.json
+++ b/packages/react-hydrate/package.json
@@ -30,6 +30,7 @@
     "react": "^16.8.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -32,6 +32,7 @@
     "faker": "^4.1.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -57,6 +57,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "babel.d.ts",
     "babel.js",
     "generate-index.d.ts",

--- a/packages/react-idle/package.json
+++ b/packages/react-idle/package.json
@@ -27,6 +27,7 @@
     "react": "^16.8.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -29,5 +29,9 @@
   "peerDependencies": {
     "react": "^16.4.1"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-intersection-observer/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0"

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -38,6 +38,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "server.js",
     "server.d.ts"
   ]

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -30,6 +30,7 @@
     "@shopify/network": "^1.4.4"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8.0 <17.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-serialize/package.json
+++ b/packages/react-serialize/package.json
@@ -25,5 +25,9 @@
   "peerDependencies": {
     "react": "^16.0.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-server-webpack-plugin/package.json
+++ b/packages/react-server-webpack-plugin/package.json
@@ -30,6 +30,7 @@
     "webpack": "^4.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -51,6 +51,7 @@
     "react-dom": ">=16.8.0 <17.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-shopify-app-route-propagator/package.json
+++ b/packages/react-shopify-app-route-propagator/package.json
@@ -26,5 +26,9 @@
   "sideEffects": false,
   "dependencies": {
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -24,5 +24,9 @@
   "dependencies": {
     "tslib": "^1.9.3"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -29,6 +29,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "matchers.js",
     "matchers.d.ts"
   ],

--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -26,7 +26,8 @@
     "react": "^16.4.1"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "sideEffects": false
 }

--- a/packages/react-universal-provider/package.json
+++ b/packages/react-universal-provider/package.json
@@ -30,6 +30,7 @@
     "faker": "^4.1.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/react-web-worker/package.json
+++ b/packages/react-web-worker/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8.0 <17.0.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/rpc/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ],
   "devDependencies": {
     "@types/uuid": "^3.4.6",

--- a/packages/semaphore/package.json
+++ b/packages/semaphore/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/semaphore/README.md",
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/sewing-kit-koa/package.json
+++ b/packages/sewing-kit-koa/package.json
@@ -41,6 +41,7 @@
     "@types/node-gzip": "^1.1.0"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -24,6 +24,7 @@
     "hot-shots": "^5.9.1"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -55,7 +55,6 @@
     {"path": "./react-intersection-observer"},
     {"path": "./react-network"},
     {"path": "./react-performance"},
-    {"path": "./react-preconnect"},
     {"path": "./react-router"},
     {"path": "./react-serialize"},
     {"path": "./react-server"},

--- a/packages/useful-types/package.json
+++ b/packages/useful-types/package.json
@@ -22,6 +22,7 @@
     "tslib": "^1.9.3"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
   ]
 }

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/*",
+    "!tsconfig.tsbuildinfo",
     "babel.js",
     "babel.d.ts",
     "webpack.js",

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -21,5 +21,9 @@
   "sideEffects": false,
   "dependencies": {
     "tslib": "^1.9.3"
-  }
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
 }

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -20,5 +20,5 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/{{name}}/README.md",
   "dependencies": {},
-  "files": ["dist/*"]
+  "files": ["dist/*", "!tsconfig.tsbuildinfo"]
 }

--- a/test/typescript-project-references.test.ts
+++ b/test/typescript-project-references.test.ts
@@ -7,6 +7,7 @@ const IGNORE_REGEX = [
   /tsconfig\.json/,
   /tsconfig_base\.json/,
   /react-self-serializer/,
+  /react-preconnect/,
 ];
 
 const ROOT = resolve(__dirname, '..');


### PR DESCRIPTION
## Description

`tsconfig.tsbuildinfo` for packages are sneaking into [published packages](https://unpkg.com/browse/@shopify/react-i18n@2.3.0/dist/). This PR prevents that from happening. Ideally, adding this file to a `.npmignore` would be nice but since we have `package.json#files` already listed, it takes precedence. 
