### PR TITLE
Use bundler v2.0.2 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ matrix:
     - language: ruby
       name: 'Gem - test and lint'
       before_install:
+        - gem install bundler -v 2.0.2
         - cd gems/quilt_rails
-        - gem install bundler
         - bundle config path /tmp/bundle
       install:
         - bundle install --clean
@@ -44,5 +44,4 @@ matrix:
 notifications:
   slack:
     on_pull_requests: false
-    secure:
-      1dRk1kc3vEav6ut7FG5hj8Gowx99B/M4hEXf0b9RDHGEhaWVoDbDGZEqGUn1fdltPLNPmlGp4tM9b00ISu1MMflYkJl3l/8Czp/xGSbzD7FZYACJB2IujHms1xhIijSFkD5+EG3hcwmleWqvySjSQ42z5saaNHlM/mO5kUMIuTgaqqQV2wZC8mN0eZva85Y8HzYIeT0a5DvrTOupUiXKxk8M+y5k9HCuRYTLbgDcdjRR0u0RbGak6PVRFlSEBV4hEjdKS1aQyjXutKWfZxdgWiQbpdC0RmTNTePN0p53pt7oPFHv+BSN7eWzLkeMquIu02r2EEAb9tnYRpChuuFOphguSI5BDYtS1/zOx+VZhkXzoo4nq5iEbh8vYEXI+mj5op9Lz+v38I9j3haCjzjz/PeI7W8/DUIPHhO3t9fqKXqySm/2bx0ZSdSyW8Em63v+8LudkxEcBVLtn1ZPvOCOCfRt+FvzlwJZThzTJ92efxPuFiL5AZoeU4RQGpV/3A7W/wnHt830nNgiUAjMMXhuznF1Fnn4rsGh+Ntr8m18P0DUx+XPflp/r1EfPnkapwSM02tUwF3xunT6i++xg8tuTcVOjWLmq3CBgZ+Q/7g3Ff6Ykcfupqgm5bDgzkQ9bNZM/jAN0cDavzK9i0AELqZkqFcrQclEarL9NgAeCvsl0yk=
+    secure: 1dRk1kc3vEav6ut7FG5hj8Gowx99B/M4hEXf0b9RDHGEhaWVoDbDGZEqGUn1fdltPLNPmlGp4tM9b00ISu1MMflYkJl3l/8Czp/xGSbzD7FZYACJB2IujHms1xhIijSFkD5+EG3hcwmleWqvySjSQ42z5saaNHlM/mO5kUMIuTgaqqQV2wZC8mN0eZva85Y8HzYIeT0a5DvrTOupUiXKxk8M+y5k9HCuRYTLbgDcdjRR0u0RbGak6PVRFlSEBV4hEjdKS1aQyjXutKWfZxdgWiQbpdC0RmTNTePN0p53pt7oPFHv+BSN7eWzLkeMquIu02r2EEAb9tnYRpChuuFOphguSI5BDYtS1/zOx+VZhkXzoo4nq5iEbh8vYEXI+mj5op9Lz+v38I9j3haCjzjz/PeI7W8/DUIPHhO3t9fqKXqySm/2bx0ZSdSyW8Em63v+8LudkxEcBVLtn1ZPvOCOCfRt+FvzlwJZThzTJ92efxPuFiL5AZoeU4RQGpV/3A7W/wnHt830nNgiUAjMMXhuznF1Fnn4rsGh+Ntr8m18P0DUx+XPflp/r1EfPnkapwSM02tUwF3xunT6i++xg8tuTcVOjWLmq3CBgZ+Q/7g3Ff6Ykcfupqgm5bDgzkQ9bNZM/jAN0cDavzK9i0AELqZkqFcrQclEarL9NgAeCvsl0yk=

--- a/packages/web-worker/src/test/e2e.test.ts
+++ b/packages/web-worker/src/test/e2e.test.ts
@@ -16,7 +16,7 @@ const mainFile = 'src/main.js';
 const workerFile = 'src/worker.js';
 const secondWorkerFile = 'src/worker2.js';
 
-jest.setTimeout(10_000);
+jest.setTimeout(30_000);
 
 describe('web-worker', () => {
   it('creates a worker factory that can produce workers that act like the original module', async () => {


### PR DESCRIPTION
## Description

Fixes CI

There were a bunch of new [bundler releases](https://rubygems.org/gems/bundler/versions) releases this past month. In CI we install the latest version of bundler, but quilt_rails requires the version specified in under [`BUNDLED WITH`](https://github.com/Shopify/quilt/blob/master/gems/quilt_rails/Gemfile.lock#L170)


