### PR TITLE
Fix typo in jest-dom-mocks Readme

### DIFF
--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -224,7 +224,7 @@ The storage mocks are a bit different than the other mocks, because they serve p
 
 - `getItem`
 - `setItem`
-- `removeItrem`
+- `removeItem`
 - `clear`
 
 Each of these are wrapped in a jest spy, which is automatically restored at the end of the test run.


### PR DESCRIPTION
## Description
Noticed a typo in `packages/jest-dom-mocks/README.md`

`removeItrem` => `removeItem`
