### PR TITLE
Adds GIP currency code to CurrencyCode enum

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 - Fixed `unformatNumber` for numbers using a period as the thousand separator ([#1215](https://github.com/Shopify/quilt/pull/1215))
+- Added `Gip` currency code value ([#1235](https://github.com/Shopify/quilt/pull/1235))
 
 ## [2.3.0] - 2019-11-29
 

--- a/packages/react-i18n/src/currencyCode.ts
+++ b/packages/react-i18n/src/currencyCode.ts
@@ -139,4 +139,5 @@ export enum CurrencyCode {
   Xof = 'XOF',
   Yer = 'YER',
   Zmw = 'ZMW',
+  Gip = 'GIP',
 }


### PR DESCRIPTION
## Description

Adds the missing currency code value for `GIP` that is also present in [billing_graph_api/schema.graphql](https://github.com/Shopify/shopify/blob/32052207a433f679ad453b0de34925f1d815f61a/components/billing/app/graph_clients/billing_graph_api/schema.graphql#L389). This change is necessary in order to fix the following bug reported. 

Bugsnag: https://app.bugsnag.com/shopify/shopify-production/timeline?filters[error][0]=5e14e89ba14aea0018358f98

## Type of change

Updating the `CurrencyCode` enum to include the value `GIP`

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
