### PR TITLE
[several packages] Update jest matcher types

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `jest.Matchers` type updated to match `@types/jest` version `25` [[#1239](https://github.com/Shopify/quilt/pull/1239)]
 - Update `jest-matcher-utils` to `25` [[#1375](https://github.com/Shopify/quilt/pull/1375)]
 
 ## [0.0.3] - 2019-09-18

--- a/packages/ast-utilities/src/matchers.ts
+++ b/packages/ast-utilities/src/matchers.ts
@@ -7,7 +7,7 @@ import {
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R, T> {
+    interface Matchers<R, T = {}> {
       toBeFormated(expected: string): void;
     }
   }

--- a/packages/ast-utilities/src/matchers.ts
+++ b/packages/ast-utilities/src/matchers.ts
@@ -7,7 +7,7 @@ import {
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toBeFormated(expected: string): void;
     }
   }

--- a/packages/graphql-testing/CHANGELOG.md
+++ b/packages/graphql-testing/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Update `graphql` dependencies [[#1379](https://github.com/Shopify/quilt/pull/1379)]
+- `jest.Matchers` type updated to match `@types/jest` version `25` [[#1239](https://github.com/Shopify/quilt/pull/1239)]
 - Update `jest-matcher-utils` to `25` [[#1375](https://github.com/Shopify/quilt/pull/1375)]
 
 ## [4.0.9] - 2019-12-04

--- a/packages/graphql-testing/src/matchers/index.ts
+++ b/packages/graphql-testing/src/matchers/index.ts
@@ -5,7 +5,7 @@ import {toHavePerformedGraphQLOperation} from './operations';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R, T> {
+    interface Matchers<R, T = {}> {
       toHavePerformedGraphQLOperation<Variables>(
         document: GraphQLOperation<any, Variables, any>,
         variables?: Partial<Variables>,

--- a/packages/graphql-testing/src/matchers/index.ts
+++ b/packages/graphql-testing/src/matchers/index.ts
@@ -5,7 +5,7 @@ import {toHavePerformedGraphQLOperation} from './operations';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toHavePerformedGraphQLOperation<Variables>(
         document: GraphQLOperation<any, Variables, any>,
         variables?: Partial<Variables>,

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- `jest.Matchers` type updated to match `@types/jest` version `25` [[#1239](https://github.com/Shopify/quilt/pull/1239)]
 
 ## [2.5.5] - 2020-04-13
 

--- a/packages/react-i18n/src/test/matchers.ts
+++ b/packages/react-i18n/src/test/matchers.ts
@@ -1,7 +1,7 @@
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R, T> {
+    interface Matchers<R, T = {}> {
       toBeArrayOfUniqueItems(): void;
     }
   }

--- a/packages/react-i18n/src/test/matchers.ts
+++ b/packages/react-i18n/src/test/matchers.ts
@@ -1,7 +1,7 @@
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toBeArrayOfUniqueItems(): void;
     }
   }

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `jest.Matchers` type updated to match `@types/jest` version `25` [[#1239](https://github.com/Shopify/quilt/pull/1239)]
 - Update `jest-matcher-utils` to `25` [[#1375](https://github.com/Shopify/quilt/pull/1375)]
 
 ## [2.0.0] - 2020-02-27

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -15,7 +15,7 @@ type PropsFromNode<T> = T extends Node<infer U> ? U : never;
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R, T> {
+    interface Matchers<R, T = {}> {
       toHaveReactProps(props: Partial<PropsFromNode<T>>): void;
       toHaveReactDataProps(data: {[key: string]: string}): void;
       toContainReactComponent<Type extends string | ComponentType<any>>(

--- a/test/matchers/index.ts
+++ b/test/matchers/index.ts
@@ -3,7 +3,7 @@ import 'jest-enzyme';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toBeArrayOfUniqueItems(): void;
     }
   }

--- a/test/matchers/index.ts
+++ b/test/matchers/index.ts
@@ -3,7 +3,7 @@ import 'jest-enzyme';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R, T> {
+    interface Matchers<R, T = {}> {
       toBeArrayOfUniqueItems(): void;
     }
   }


### PR DESCRIPTION
## Description

When working on https://github.com/Shopify/web/pull/22447, I ran into issues when using `toHaveReactProps`. For some reason it was no longer inferring the typescript types of the React Components. I believe it was due to [this change](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39243/files) and due to the namespace no longer implementing the same interface it cause these issues.

This PR updates the `@types/jest` package and the `Matcher` interface in all packages to match.


<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change
I'm not sure what type of change this should be. It's a breaking change for Typescript projects, but the update to the types package is the real reason, not these packages themselves 

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->
- [ ]  `ast-utilities` Minor: `jest.Matchers` type updated to match `@types/jest` version `25`
- [ ]  `graphql-testing` Minor: `jest.Matchers` type updated to match `@types/jest` version `25`
- [ ]  `react-i18n` Minor: `jest.Matchers` type updated to match `@types/jest` version `25`
- [ ]  `react-testing` Minor: `jest.Matchers` type updated to match `@types/jest` version `25`

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
