### PR TITLE
Introduce `useInterval` React Hook

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Added `useInterval` hook ([#1241](https://github.com/Shopify/quilt/pull/1241))
 
 ## [1.4.0] - 2019-12-19
 

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -41,6 +41,32 @@ function MyComponent() {
 }
 ```
 
+### `useInterval()`
+
+This hook provides a declarative version of [`setInterval`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval). The first argument is a callback that will be invoked successively after the given delay (number of milliseconds) as the second argument. Optionally, the interval can be disabled by passing `null` as the delay.
+
+```tsx
+function MyComponent() {
+  const [counter, setCounter] = React.useState(0);
+  const [enabled, setEnabled] = React.useState(true);
+
+  const delay = enabled ? 1000 : null;
+  const label = enabled ? 'Disable' : 'Enable';
+  const toggle = () => setEnabled(!enabled);
+
+  useInterval(() => setCounter(counter + 1), delay);
+
+  return (
+    <div>
+      <div>{counter}</div>
+      <button onClick={toggle}>{label}</button>
+    </div>
+  );
+}
+```
+
+This is a TypeScript implementation of @gaeron's `useInterval` hook from the [Overreacted blog post](https://overreacted.io/making-setinterval-declarative-with-react-hooks/#just-show-me-the-code).
+
 ### `useLazyRef()`
 
 This hook creates a ref object like React’s `useRef`, but instead of providing it the value directly, you provide a function that returns the value. The first time the hook is run, it will call the function and use the returned value as the initial `ref.current` value. Afterwards, the function is never invoked. You can use this for creating refs to values that are expensive to initialize.

--- a/packages/react-hooks/src/hooks/index.ts
+++ b/packages/react-hooks/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export {useInterval} from './interval';
 export {useLazyRef} from './lazy-ref';
 export {useMountedRef} from './mounted-ref';
 export {useOnValueChange} from './on-value-change';

--- a/packages/react-hooks/src/hooks/interval.ts
+++ b/packages/react-hooks/src/hooks/interval.ts
@@ -1,0 +1,27 @@
+import {useEffect, useRef} from 'react';
+
+type IntervalCallback = () => void;
+type IntervalDelay = number | null;
+
+// Adapted from https://overreacted.io/making-setinterval-declarative-with-react-hooks
+// Also available at https://github.com/gaearon/overreacted.io/blob/master/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+//
+// Copyright (c) 2020 Dan Abramov and the contributors.
+//
+export function useInterval(callback: IntervalCallback, delay: IntervalDelay) {
+  const savedCallback = useRef(callback);
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}

--- a/packages/react-hooks/src/hooks/tests/interval.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/interval.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {timer} from '@shopify/jest-dom-mocks';
+
+import {useInterval} from '../interval';
+
+const ONE_SECOND = 1000;
+const HALF_A_SECOND = ONE_SECOND / 2;
+
+describe('useInterval', () => {
+  beforeEach(() => {
+    timer.mock();
+  });
+
+  afterEach(() => {
+    timer.restore();
+  });
+
+  it('does not call the callback immediately', () => {
+    const {callback} = setup({delay: ONE_SECOND});
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('repeately calls the callback after the delay', () => {
+    const {callback} = setup({delay: ONE_SECOND});
+
+    timer.runTimersToTime(ONE_SECOND);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    timer.runTimersToTime(ONE_SECOND);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates the callback when it changes', () => {
+    const {callback, wrapper} = setup({delay: ONE_SECOND});
+
+    const newCallback = jest.fn();
+    wrapper.setProps({callback: newCallback});
+
+    timer.runTimersToTime(ONE_SECOND);
+    expect(newCallback).toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('sets no interval if the delay provided is null', () => {
+    const {callback} = setup({delay: null});
+
+    timer.runTimersToTime(ONE_SECOND);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('clears existing interval if the new delay is null', () => {
+    const {callback, wrapper} = setup({delay: ONE_SECOND});
+
+    wrapper.setProps({delay: null});
+
+    timer.runTimersToTime(ONE_SECOND);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('continues to respect the delay after the callback changes', () => {
+    const {callback, wrapper} = setup({delay: ONE_SECOND});
+
+    timer.runTimersToTime(HALF_A_SECOND);
+    expect(callback).not.toHaveBeenCalled();
+
+    const newCallback = jest.fn();
+    wrapper.setProps({callback: newCallback});
+
+    timer.runTimersToTime(HALF_A_SECOND);
+    expect(newCallback).toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('resets the interval when the delay changes', () => {
+    const {callback, wrapper} = setup({delay: HALF_A_SECOND});
+
+    timer.runTimersToTime(HALF_A_SECOND);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    wrapper.setProps({delay: ONE_SECOND});
+
+    timer.runTimersToTime(HALF_A_SECOND);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    timer.runTimersToTime(HALF_A_SECOND);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});
+
+function setup({delay}) {
+  const callback = jest.fn();
+  const wrapper = mount(<MockComponent delay={delay} callback={callback} />);
+
+  return {callback, wrapper};
+}
+function MockComponent({callback, delay}) {
+  useInterval(callback, delay);
+  return null;
+}


### PR DESCRIPTION
## Description

**This adds a `useInterval` hook to `@shopify/react-hooks`.**

It wraps `setInterval` in a `useEffect`, similarly to the existing `useTimeout` hook, which wraps `setTimeout`.

## Type of change

- [x] `@shopify/react-hooks` Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have squashed this PR into meaningful commits
- [ ] I have answered the questions about licensing
