### PR TITLE
fixing typo in useMountedRef docs

### DIFF
--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -59,7 +59,7 @@ function MyComponent() {
 
 ### `useMountedRef()`
 
-This hook keep track of a component's mounted / un-mounted status and returns a ref object like React’s [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) with a boolean value representing said status. This is often use when a component contains async task that set state after the task resolved.
+This hook keeps track of a component's mounted / un-mounted status and returns a ref object like React’s [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) with a boolean value representing said status. This is often used when a component contains an async task that sets state after the task has resolved.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
## Description
fixes some typos in the react-hooks `useMountedRef` docs
Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] react-hooks Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
