### PR TITLE
add condition where result.data is undefined.

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.0.7] - 2019-??-??
+
+### Fixed
+
+- Fixed when using `no-cache` fetch policy and data is undefined ([#1244](https://github.com/Shopify/quilt/pull/1244)).
+
 ## [6.0.0] - 2019-10-30
 
 ### Added

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -168,7 +168,7 @@ export default function useQuery<
       data = (queryObservable.getLastResult() || {}).data;
     } else if (
       fetchPolicy === 'no-cache' &&
-      Object.keys(result.data).length === 0
+      (!result.data || Object.keys(result.data).length === 0)
     ) {
       data = previousData.current;
     } else {

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -153,6 +153,26 @@ describe('useQuery', () => {
 
       expect(watchQuerySpy).not.toHaveBeenCalled();
     });
+
+    it('returns previous data if the fetchPolicy=no-cache and the current query has error', async () => {
+      function MockQuery({children}) {
+        const results = useQuery(petQuery, {fetchPolicy: 'no-cache'});
+        return children(results);
+      }
+
+      const graphQL = createGraphQL({PetQuery: new Error()});
+      const renderPropSpy = jest.fn(() => null);
+
+      await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
+        graphQL,
+      });
+
+      expect(renderPropSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: undefined,
+        }),
+      );
+    });
   });
 
   describe('async query component', () => {


### PR DESCRIPTION
## Description

Original issue was raised by @felipenvaz on [Discourse](https://discourse.shopify.io/t/issue-when-testing-graphql-error-flows-and-fetchpolicy-is-set-to-no-cache/6070)

The type for `result.data` can actually be undefined so it make sense to check it and include it in the condition for the no-cached policy.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
