### PR TITLE
Allow the assetName to be passed in options to react-server

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- Added `assetName` option to allow the `name` to be passed and default to `main`
+
 ## [0.8.5] - 2019-11-29
 
 - Updated dependency: `@shopify/sewing-kit-koa@6.2.0`

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -68,6 +68,8 @@ interface Options {
   ip?: string;
   // the full base url for the cdn if applicable
   assetPrefix?: string;
+  // the name of the asset on the cdn
+  assetName?: string;
   // any additional Koa middleware to mount on the server
   serverMiddleware?: compose.Middleware<Context>[];
   // a function of `(ctx: Context, data: {locale: string}): React.ReactElement<any>`

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -41,6 +41,7 @@ type Options = Pick<
   'afterEachPass' | 'betweenEachPass'
 > & {
   assetPrefix?: string;
+  assetName?: string;
 };
 
 /**
@@ -50,7 +51,7 @@ type Options = Pick<
  */
 export function createRender(render: RenderFunction, options: Options = {}) {
   const manifestPath = getManifestPath(process.cwd());
-  const {assetPrefix} = options;
+  const {assetPrefix, assetName = 'main'} = options;
 
   async function renderFunction(ctx: Context) {
     const logger = getLogger(ctx) || console;
@@ -105,8 +106,8 @@ export function createRender(render: RenderFunction, options: Options = {}) {
         AssetTiming.Immediate,
       );
       const [styles, scripts] = await Promise.all([
-        assets.styles({name: 'main', asyncAssets: immediateAsyncAssets}),
-        assets.scripts({name: 'main', asyncAssets: immediateAsyncAssets}),
+        assets.styles({name: assetName, asyncAssets: immediateAsyncAssets}),
+        assets.scripts({name: assetName, asyncAssets: immediateAsyncAssets}),
       ]);
 
       const response = stream(

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -7,12 +7,15 @@ import withEnv from '@shopify/with-env';
 import {createRender} from '../render';
 import {mockMiddleware} from '../../test/utilities';
 
+const mockAssetsScripts = jest.fn(() => Promise.resolve([]));
+const mockAssetsStyles = jest.fn(() => Promise.resolve([]));
+
 jest.mock('@shopify/sewing-kit-koa', () => ({
   middleware: jest.fn(() => mockMiddleware),
   getAssets() {
     return {
-      styles: () => Promise.resolve([]),
-      scripts: () => Promise.resolve([]),
+      styles: mockAssetsStyles,
+      scripts: mockAssetsScripts,
     };
   },
 }));
@@ -47,6 +50,18 @@ describe('createRender', () => {
 
     expect(sewingKitKoaMiddleware).toHaveBeenCalledWith(
       expect.objectContaining({assetPrefix}),
+    );
+  });
+
+  it('calls the sewing-kit-koa middleware with the passed in assetName', async () => {
+    const assetName = 'alternate';
+    const ctx = createMockContext();
+
+    const renderFunction = createRender(() => <></>, {assetName});
+    await renderFunction(ctx, noop);
+
+    expect(mockAssetsScripts).toHaveBeenCalledWith(
+      expect.objectContaining({name: assetName}),
     );
   });
 

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -16,6 +16,7 @@ interface Options {
   port?: number;
   ip?: string;
   assetPrefix?: string;
+  assetName?: string;
   serverMiddleware?: compose.Middleware<Context>[];
   render: RenderFunction;
 }
@@ -26,7 +27,7 @@ interface Options {
  * @returns a Server instance
  */
 export function createServer(options: Options): Server {
-  const {port, assetPrefix, render, serverMiddleware, ip} = options;
+  const {port, assetPrefix, render, serverMiddleware, ip, assetName} = options;
   const app = new Koa();
 
   app.use(mount('/services/ping', ping));
@@ -38,7 +39,7 @@ export function createServer(options: Options): Server {
     app.use(compose(serverMiddleware));
   }
 
-  app.use(createRender(render, {assetPrefix}));
+  app.use(createRender(render, {assetPrefix, assetName}));
 
   return app.listen(port || 3000, () => {
     logger.log(`started react-server on ${ip}:${port}`);


### PR DESCRIPTION
## Description
Currently, the react-server asset name is hardcoded to main. This PR updates the options to include an `assetName` option that defaults to `main` but can be changed.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] react-html Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
