### PR TITLE
Return fallback manifest for nomatch locale

### DIFF
--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- If the requested locale is not found, and only locale-specific manifests exist, return the fallback locale's most polyfilled assets [#1253](https://github.com/Shopify/quilt/pull/1253)
 
 ## 6.2.0 - 2019-11-29
 

--- a/packages/sewing-kit-koa/src/tests/manifests-locales.test.ts
+++ b/packages/sewing-kit-koa/src/tests/manifests-locales.test.ts
@@ -242,4 +242,48 @@ describe('Manifests locales', () => {
       noLocaleScriptOne,
     );
   });
+
+  it('returns the fallbackLocale‘s most polyfilled build when an unknown locale is requested and non-locale builds do not exist', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['fr']},
+          browsers: ['chrome > 50'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(frScriptOne)],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 50'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36',
+      {
+        locale: 'jp',
+      },
+    );
+
+    expect(manifest).toHaveProperty('entrypoints.main.js.0.path', enScriptOne);
+  });
 });


### PR DESCRIPTION
## Description

Fixes (issue #1245) - sewing-kit-koa now returns a manifest when:
* An unknown locale is requested
* _Only_ locale-specific manifests exist

## Type of change
- [x] `@shopify/sewing-kit-koa` - Patch

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
