### PR TITLE
Prefer variant locale manifests

### DIFF
--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - If the requested locale is not found, and only locale-specific manifests exist, return the fallback locale's most polyfilled assets [#1253](https://github.com/Shopify/quilt/pull/1253)
+- If the requested variant locale is not found, the parent locale's manifest will be returned [#1254](https://github.com/Shopify/quilt/pull/1254)
 
 ## 6.2.0 - 2019-11-29
 

--- a/packages/sewing-kit-koa/src/manifests.ts
+++ b/packages/sewing-kit-koa/src/manifests.ts
@@ -45,12 +45,28 @@ export class Manifests {
     // attribute).
 
     this.resolvedEntry =
-      find(inlineLocaleManifests.get(locale!), userAgent) ||
+      findManifestForLocale(inlineLocaleManifests, locale, userAgent) ||
       find(multiAsyncLanguageManifests, userAgent) ||
       fallbackManifest;
 
     return this.resolvedEntry;
   }
+}
+
+function findManifestForLocale(
+  inlineLocaleManifests: Map<string, Manifest[]>,
+  locale: string | undefined,
+  userAgent: string,
+) {
+  const locales = getPossibleLocales(locale);
+  for (const aLocale of locales) {
+    const result = find(inlineLocaleManifests.get(aLocale), userAgent);
+    if (result) {
+      return result;
+    }
+  }
+
+  return undefined;
 }
 
 let loadPromise: Promise<ReturnType<typeof groupManifests>> | null = null;
@@ -147,4 +163,15 @@ function groupByLocale(
     });
   }
   return acc;
+}
+
+function getPossibleLocales(locale: string | undefined) {
+  if (!locale) {
+    return [];
+  }
+
+  const split = locale.split('-');
+  return split.length > 1
+    ? [`${split[0]}-${split[1].toUpperCase()}`, split[0]]
+    : [locale];
 }

--- a/packages/sewing-kit-koa/src/tests/manifests-locales.test.ts
+++ b/packages/sewing-kit-koa/src/tests/manifests-locales.test.ts
@@ -243,6 +243,79 @@ describe('Manifests locales', () => {
     );
   });
 
+  it('prefers variant locales', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['it']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset('it.js')],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['it-VA']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset('it-va.js')],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71, {
+      locale: 'it-VA',
+    });
+
+    expect(manifest).toHaveProperty('entrypoints.main.js.0.path', 'it-va.js');
+  });
+
+  it('falls back to parent locale if a variant build does not exist', async () => {
+    readJson.mockImplementation(() =>
+      mockConsolidatedManifest([
+        mockManifest({
+          identifier: {locales: ['it']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset('it.js')],
+            }),
+          },
+        }),
+        mockManifest({
+          identifier: {locales: ['en']},
+          browsers: ['chrome > 60'],
+          entrypoints: {
+            main: mockEntrypoint({
+              scripts: [mockAsset(enScriptOne)],
+            }),
+          },
+        }),
+      ]),
+    );
+
+    const manifests = new Manifests();
+    const manifest = await manifests.resolve(chrome71, {
+      locale: 'it-VA',
+    });
+
+    expect(manifest).toHaveProperty('entrypoints.main.js.0.path', 'it.js');
+  });
+
   it('returns the fallbackLocale‘s most polyfilled build when an unknown locale is requested and non-locale builds do not exist', async () => {
     readJson.mockImplementation(() =>
       mockConsolidatedManifest([


### PR DESCRIPTION
## Description
sewing-kit-koa should be more aware of locale variants and their parents.  i.e., if the request is for a `it-VA` manifest:
- Return the `it-VA` assets if they exist
- Otherwise, return the `it` assets if they exist
- Otherwise, return the fallback locale's assets

## Type of change

- [x] `@shopify/sewing-kit-koa` - Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
