### PR TITLE
using normalizedId when creating a MissingTranslationError

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- `MissingTranslationError` now uses the `normalizedId` which includes the `scope` ([#0](https://github.com/Shopify/quilt/pull/0))
+- `MissingTranslationError` now uses the `normalizedId` which includes the `scope` ([#1258](https://github.com/Shopify/quilt/pull/1258))
 
 ## [2.3.4] - 2020-01-20
 


### PR DESCRIPTION
## Description

Adding to [a change](https://github.com/Shopify/quilt/commit/68d11e9047a459799fcd2942ed5e45d291adc7b7) that was merged directly to `master` in error. this PR will serve as a historical record of the changes that were made (as well as to adjust the `CHANGELOG.md`).

This change is intending to add visibility to missing translations where the `scope` option is used. Prior to this PR only the `id` is used which can often be too terse to uniquely identify which translation is actually missing. By using the `normalizedId` we get a full picture of the key path that is missing.

when translating with scope: `i18n.translate('foo', {scope: 'bar'});`

Instead of seeing an error like `Missing translation for key: foo`, we will see the fully qualified key error like `Missing translation for key: bar.foo`.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
