### PR TITLE
Locale perf tracking

### DIFF
--- a/packages/koa-performance/CHANGELOG.md
+++ b/packages/koa-performance/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Middleware now adds a `locale` tag to distributions (if provided) [#1260](https://github.com/Shopify/quilt/pull/1260)
+
 ## [1.1.0] 2019-10-25
 
 ### Added

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -37,6 +37,7 @@ export interface Metrics {
   pathname: string;
   connection: Partial<BrowserConnection>;
   events: LifecycleEvent[];
+  locale?: string;
   navigations: {
     details: NavigationDefinition;
     metadata: NavigationMetadata;
@@ -75,7 +76,7 @@ export function clientPerformanceMetrics({
       });
 
       const userAgent = ctx.get(Header.UserAgent);
-      const {connection, events, navigations} = body;
+      const {connection, events, navigations, locale} = body;
 
       const metrics: {
         name: string;
@@ -89,6 +90,7 @@ export function clientPerformanceMetrics({
 
       const tags = {
         browserConnectionType: connection.effectiveType,
+        ...(locale ? {locale} : {}),
         ...additionalTags,
       };
 

--- a/packages/koa-performance/src/test/middleware.test.ts
+++ b/packages/koa-performance/src/test/middleware.test.ts
@@ -176,6 +176,54 @@ describe('client metrics middleware', () => {
         expect.objectContaining(additionalTags),
       );
     });
+
+    it('includes locale in distributions', async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          connection: {
+            effectiveType: '3G',
+          },
+          locale: 'es',
+          events: [createLifecycleEvent()],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Number),
+        expect.objectContaining({
+          locale: 'es',
+        }),
+      );
+    });
+
+    it('omits undefined locales from distributions', async () => {
+      const context = createMockContext({
+        method: Method.Post,
+        requestBody: createBody({
+          connection: {
+            effectiveType: '3G',
+          },
+          locale: undefined,
+          events: [createLifecycleEvent()],
+        }),
+      });
+
+      await withEnv('production', async () => {
+        await clientPerformanceMetrics(config)(context);
+      });
+
+      expect(StatsDClient.distributionSpy).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Number),
+        expect.objectContaining({locale: expect.anything()}),
+      );
+    });
   });
 
   describe('events', () => {
@@ -493,6 +541,7 @@ type DeepPartial<T> = {
 function createBody({
   connection,
   events = [],
+  locale,
   navigations = [],
   pathname = '/some-path',
 }: DeepPartial<Metrics> = {}): Metrics {
@@ -503,6 +552,7 @@ function createBody({
       ...connection,
     },
     events,
+    locale,
     navigations,
     pathname,
   };

--- a/packages/react-performance/CHANGELOG.md
+++ b/packages/react-performance/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Performance report hook and component now accepts a `locale` attribute [#1260](https://github.com/Shopify/quilt/pull/1260)
+
 ## [1.2.0] - 2019-10-25
 
 ### Added

--- a/packages/react-performance/src/PerformanceReport.tsx
+++ b/packages/react-performance/src/PerformanceReport.tsx
@@ -3,10 +3,11 @@ import {usePerformanceReport, ErrorHandler} from './performance-report';
 interface Props {
   url: string;
   onError?: ErrorHandler;
+  locale?: string;
 }
 
-export function PerformanceReport({url, onError}: Props) {
-  usePerformanceReport(url, {onError});
+export function PerformanceReport({url, onError, locale}: Props) {
+  usePerformanceReport(url, {onError, locale});
 
   return null;
 }

--- a/packages/react-performance/src/performance-report.ts
+++ b/packages/react-performance/src/performance-report.ts
@@ -11,7 +11,10 @@ export interface ErrorHandler {
 
 export function usePerformanceReport(
   url: string,
-  {onError = noop}: {onError?: ErrorHandler} = {},
+  {
+    locale = undefined,
+    onError = noop,
+  }: {locale?: string; onError?: ErrorHandler} = {},
 ) {
   const navigations = useRef<Navigation[]>([]);
   const events = useRef<LifecycleEvent[]>([]);
@@ -42,6 +45,7 @@ export function usePerformanceReport(
               metadata: navigation.metadata,
             })),
             pathname: window.location.pathname,
+            locale,
           }),
         });
       } catch (error) {
@@ -53,7 +57,7 @@ export function usePerformanceReport(
         navigations.current = [];
       }
     }, 1000);
-  }, [onError, url]);
+  }, [locale, onError, url]);
 
   const onNavigation = useCallback(
     (navigation: Navigation) => {

--- a/packages/react-performance/src/test/PerformanceReport.test.tsx
+++ b/packages/react-performance/src/test/PerformanceReport.test.tsx
@@ -121,4 +121,24 @@ describe('<PerformanceReport />', () => {
       connection: mockConnection,
     });
   });
+
+  it('includes locale in reports', () => {
+    const performance = mockPerformance();
+    const mockConnection = randomConnection();
+    connection.mock(mockConnection);
+
+    mount(
+      <PerformanceContext.Provider value={performance}>
+        <PerformanceReport url={faker.internet.url()} locale="zh-CN" />
+      </PerformanceContext.Provider>,
+    );
+
+    performance.simulateNavigation();
+    timer.runAllTimers();
+
+    const [, {body}] = fetch.lastCall();
+    expect(JSON.parse(body!.toString())).toMatchObject({
+      locale: 'zh-CN',
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes (issue #1246)

Client-side code can now pass a `locale` to our performance libs.  Server-middleware now sends on locale to stats trackers.

## Type of change

- [x] `@shopify/koa-performance` Minor: New feature (non-breaking change which adds functionality)
- [x] `@shopify/react-performance` - Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
