### PR TITLE
Put minus sign in front of currency symbol formatting negative amounts

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 <!-- ## [Unreleased] -->
 
+### Fixed
+
+- `formatCurrency` will now put the minus sign in front of the currency symbol when the amount is negative ([#1264](https://github.com/Shopify/quilt/pull/1264))
+
 ## [2.3.6] - 2020-02-04
 
 ### Fixed

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -403,9 +403,13 @@ export class I18n {
       ...options,
     }).format(amount);
 
-    return shortSymbol.prefixed
+    const formattedWithSymbol = shortSymbol.prefixed
       ? `${shortSymbol.symbol}${formattedAmount}`
       : `${formattedAmount}${shortSymbol.symbol}`;
+
+    return amount < 0
+      ? `-${formattedWithSymbol.replace('-', '')}`
+      : formattedWithSymbol;
   }
 
   // Intl.NumberFormat sometimes annotates the "currency symbol" with a country code.

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -689,6 +689,36 @@ describe('I18n', () => {
     );
   });
 
+  describe('#formatCurrencyExplicit() with negative amount', () => {
+    it.each`
+      locale     | currency | symbol    | prefixed | expected
+      ${'cs-CZ'} | ${'CZK'} | ${' Kč'}  | ${false} | ${'-1 234,56 Kč CZK'}
+      ${'de-AT'} | ${'EUR'} | ${'€ '}   | ${true}  | ${'-€ 1 234,56 EUR'}
+      ${'de-AT'} | ${'JPY'} | ${'¥ '}   | ${true}  | ${'-¥ 1 235 JPY'}
+      ${'de-AT'} | ${'OMR'} | ${'OMR '} | ${true}  | ${'-OMR 1 234,560'}
+      ${'de-AT'} | ${'USD'} | ${'$ '}   | ${true}  | ${'-$ 1 234,56 USD'}
+      ${'en-US'} | ${'EUR'} | ${'€ '}   | ${true}  | ${'-€ 1,234.56 EUR'}
+      ${'en-US'} | ${'JPY'} | ${'¥ '}   | ${true}  | ${'-¥ 1,235 JPY'}
+      ${'en-US'} | ${'OMR'} | ${'OMR '} | ${true}  | ${'-OMR 1,234.560'}
+      ${'en-US'} | ${'USD'} | ${'$ '}   | ${true}  | ${'-$ 1,234.56 USD'}
+      ${'fr-FR'} | ${'EUR'} | ${' €'}   | ${false} | ${'-1 234,56 € EUR'}
+      ${'fr-FR'} | ${'JPY'} | ${' JPY'} | ${false} | ${'-1 235 JPY'}
+      ${'fr-FR'} | ${'OMR'} | ${' OMR'} | ${false} | ${'-1 234,560 OMR'}
+      ${'fr-FR'} | ${'USD'} | ${' $US'} | ${false} | ${'-1 234,56 $ USD'}
+    `(
+      'formats -1234.56 of $currency in $locale to expected $expected',
+      ({locale, currency, symbol, prefixed, expected}) => {
+        const amount = -1234.56;
+        const mockSymbolResult = {symbol, prefixed};
+
+        getCurrencySymbol.mockReturnValue(mockSymbolResult);
+
+        const i18n = new I18n(defaultTranslations, {locale});
+        expect(i18n.formatCurrencyExplicit(amount, {currency})).toBe(expected);
+      },
+    );
+  });
+
   describe('#formatCurrencyShort()', () => {
     it.each`
       locale     | currency | symbol    | prefixed | expected
@@ -709,6 +739,36 @@ describe('I18n', () => {
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, symbol, prefixed, expected}) => {
         const amount = 1234.56;
+        const mockSymbolResult = {symbol, prefixed};
+
+        getCurrencySymbol.mockReturnValue(mockSymbolResult);
+
+        const i18n = new I18n(defaultTranslations, {locale});
+        expect(i18n.formatCurrencyShort(amount, {currency})).toBe(expected);
+      },
+    );
+  });
+
+  describe('#formatCurrencyShort() with negative amount', () => {
+    it.each`
+      locale     | currency | symbol    | prefixed | expected
+      ${'cs-CZ'} | ${'CZK'} | ${' Kč'}  | ${false} | ${'-1 234,56 Kč'}
+      ${'de-AT'} | ${'EUR'} | ${'€ '}   | ${true}  | ${'-€ 1 234,56'}
+      ${'de-AT'} | ${'JPY'} | ${'¥ '}   | ${true}  | ${'-¥ 1 235'}
+      ${'de-AT'} | ${'OMR'} | ${'OMR '} | ${true}  | ${'-OMR 1 234,560'}
+      ${'de-AT'} | ${'USD'} | ${'$ '}   | ${true}  | ${'-$ 1 234,56'}
+      ${'en-US'} | ${'EUR'} | ${'€ '}   | ${true}  | ${'-€ 1,234.56'}
+      ${'en-US'} | ${'JPY'} | ${'¥ '}   | ${true}  | ${'-¥ 1,235'}
+      ${'en-US'} | ${'OMR'} | ${'OMR '} | ${true}  | ${'-OMR 1,234.560'}
+      ${'en-US'} | ${'USD'} | ${'$ '}   | ${true}  | ${'-$ 1,234.56'}
+      ${'fr-FR'} | ${'EUR'} | ${' €'}   | ${false} | ${'-1 234,56 €'}
+      ${'fr-FR'} | ${'JPY'} | ${' JPY'} | ${false} | ${'-1 235 JPY'}
+      ${'fr-FR'} | ${'OMR'} | ${' OMR'} | ${false} | ${'-1 234,560 OMR'}
+      ${'fr-FR'} | ${'USD'} | ${' $US'} | ${false} | ${'-1 234,56 $'}
+    `(
+      'formats -1234.56 of $currency in $locale to expected $expected',
+      ({locale, currency, symbol, prefixed, expected}) => {
+        const amount = -1234.56;
         const mockSymbolResult = {symbol, prefixed};
 
         getCurrencySymbol.mockReturnValue(mockSymbolResult);


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1234

Changes the output of `i18n.formatCurrency(-3.25)` from `$-3.25` to `-$3.25`, to conform with our new currency formatting guidelines:

https://polaris.shopify.com/foundations/formatting-localized-currency

## Type of change

Changes `react-i18n`'s `i18n.formatCurrency()`.

- [X] `react-i18n` Patch: Minor change in formatting output.  Really too small to be considered "breaking".
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
