### PR TITLE
[quilt/dates] Fix for chrome date 'bug'

### DIFF
--- a/config/typescript/itnl.d.ts
+++ b/config/typescript/itnl.d.ts
@@ -1,0 +1,5 @@
+declare namespace Intl {
+  interface DateTimeFormatOptions {
+    hourCycle?: string;
+  }
+}

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -14,6 +14,11 @@ export function formatDate(
   if (options.timeZone != null && options.timeZone === 'Etc/GMT+12') {
     const adjustedDate = new Date(date.valueOf() - 12 * 60 * 60 * 1000);
 
+    if (options.hour12 != null) {
+      options.hour12 = undefined;
+      options.hourCycle = 'h23';
+    }
+
     return memoizedGetDateTimeFormat(locales, {
       ...options,
       timeZone: 'UTC',


### PR DESCRIPTION
## Description

Chrome 80 has changed its default handling of Intl.DateTimeFormat.

We now need to set the `hourCycle` in Chrome to `h23,` and ensure `hour12` is set to `undefined` so it doesn’t overwrite the `hourCycle` property, to bring it inline with more browsers. See [Chrome bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=1045791&q=Date&can=2&sort=-modified) for more details. Setting the `hourCycle` property to 23 means that we continue to use a time system with hours 0–23 and with midnight starting at 0:00.
The bug manifested itself on overview dashboard as the user not being able to select a single date in the date picker and dates being wrong throughout reports, the home section and likely throughout other places in the admin that have yet to be found.

Here is a link to chrome issue
https://bugs.chromium.org/p/chromium/issues/detail?id=1045791&q=Date&can=2&sort=-modified
 
Fixes https://github.com/Shopify/store/issues/12993 

### Tophat instructions

- `yarn build`
- `yarn tophat dates ../web`
- In web, locally, navigate to `/admin/dashboards` and make sure that when you select a single day in the date picker it only selects that day.

## Type of change

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] Dates<!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
