### PR TITLE
Fix for chrome dates update

### DIFF
--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/dates",
-  "version": "0.2.12",
+  "version": "0.2.13-beta.2.fixchrome80",
   "license": "MIT",
   "description": "Lightweight date operations library.",
   "main": "dist/src/index.js",

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -9,20 +9,27 @@ interface FormatDateOptions extends Intl.DateTimeFormatOptions {
   hourCycle?: string;
 }
 
+interface ResolvedDateOptions extends Intl.ResolvedDateTimeFormatOptions {
+  hourCycle?: string;
+}
+
 export function formatDate(
   date: Date,
   locales: string | string[],
   options: FormatDateOptions = {},
 ) {
+  const formatOptions: ResolvedDateOptions = Intl.DateTimeFormat(locales, {
+    hour: 'numeric',
+  }).resolvedOptions();
+
+  if (options.hour12 != null && formatOptions.hourCycle != null) {
+    options.hour12 = undefined;
+    options.hourCycle = 'h23';
+  }
+
   // Etc/GMT+12 is not supported in most browsers and there is no equivalent fallback
   if (options.timeZone != null && options.timeZone === 'Etc/GMT+12') {
     const adjustedDate = new Date(date.valueOf() - 12 * 60 * 60 * 1000);
-
-    if (options.hour12 != null) {
-      options.hour12 = undefined;
-      options.hourCycle = 'h23';
-    }
-
     return memoizedGetDateTimeFormat(locales, {
       ...options,
       timeZone: 'UTC',


### PR DESCRIPTION
## Description

Chrome 80 has changed its default handling of Intl.DateTimeFormat. We [previously merged a fix for this](https://github.com/Shopify/quilt/pull/1266) but needed to add two fixes:
- Moving where we modify the options so that it's outside of an unrelated if statement
- Ensuring we are modifying the `hourCycle` on a browser that recognizes it. Microsoft Edge and our testing environment do not do anything with the parameter, so we end up with 12-hour formatting if we don't add this check.

See the previous PR for more details about the original fix.

Here is a link to chrome issue
https://bugs.chromium.org/p/chromium/issues/detail?id=1045791&q=Date&can=2&sort=-modified

### Tophat instructions

- `yarn build`
- `yarn tophat dates ../web`
- In web, locally, navigate to `/admin/dashboards` and make sure that when you select a single day in the date picker it only selects that day.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
