### PR TITLE
Chrome 80 fix off @shopify/dates@0.1.23

### DIFF
--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/dates",
-  "version": "0.1.23",
+  "version": "0.1.23-fixchrome80",
   "license": "MIT",
   "description": "Lightweight date operations library.",
   "main": "dist/index.js",

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -5,11 +5,27 @@ const memoizedGetDateTimeFormat = memoize(
   dateTimeFormatCacheKey,
 );
 
+interface FormatDateOptions extends Intl.DateTimeFormatOptions {
+  hourCycle?: string;
+}
+interface ResolvedDateOptions extends Intl.ResolvedDateTimeFormatOptions {
+  hourCycle?: string;
+}
+
 export function formatDate(
   date: Date,
   locales: string | string[],
-  options: Intl.DateTimeFormatOptions = {},
+  options: FormatDateOptions = {},
 ) {
+  const formatOptions: ResolvedDateOptions = Intl.DateTimeFormat(locales, {
+    hour: 'numeric',
+  }).resolvedOptions();
+
+  if (options.hour12 != null && formatOptions.hourCycle != null) {
+    options.hour12 = undefined;
+    options.hourCycle = 'h23';
+  }
+
   // Etc/GMT+12 is not supported in most browsers and there is no equivalent fallback
   if (options.timeZone != null && options.timeZone === 'Etc/GMT+12') {
     const adjustedDate = new Date(date.valueOf() - 12 * 60 * 60 * 1000);


### PR DESCRIPTION
This PR applies the Chrome 80 fixed mentioned in https://github.com/Shopify/quilt/pull/1270 but off `@shopify/dates@0.1.23`.  Web is quite behind the latest release of `@shopify/dates`, which caused o.o.m issues. 