### PR TITLE
Fix react-google-analytics when script is blocked

### DIFF
--- a/packages/react-google-analytics/CHANGELOG.md
+++ b/packages/react-google-analytics/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+---
+
+## Unreleased
+
+- Fixes `<Universal />` component from failing when the user’s privacy settings block the analytics script ([1276](https://github.com/Shopify/quilt/pull/1276))

--- a/packages/react-google-analytics/README.md
+++ b/packages/react-google-analytics/README.md
@@ -76,7 +76,7 @@ const UNIVERSAL_GA_ACCOUNT_ID = 'UA-xxxx-xx';
 
 #### Handling Errors
 
-As browser becomes more strict and tracking scripts are blocked more frequently by users, there is a good chance this component will not be able to embed the Google Analytics script as intended. For these cases, you can pass an `onError` callback as follows:
+As browsers become more strict and tracking scripts blocked more frequently by users, there is a good chance this component will not be able to embed the Google Analytics script as intended. For these cases, you can pass an `onError` callback as follows:
 
 ```jsx
 import {Universal} from '@shopify/react-google-analytics';

--- a/packages/react-google-analytics/README.md
+++ b/packages/react-google-analytics/README.md
@@ -74,6 +74,24 @@ const UNIVERSAL_GA_ACCOUNT_ID = 'UA-xxxx-xx';
 </button>;
 ```
 
+#### Handling Errors
+
+As browser becomes more strict and tracking scripts are blocked more frequently by users, there is a good chance this component will not be able to embed the Google Analytics script as intended. For these cases, you can pass an `onError` callback as follows:
+
+```jsx
+import {Universal} from '@shopify/react-google-analytics';
+
+const UNIVERSAL_GA_ACCOUNT_ID = 'UA-xxxx-xx';
+
+<Universal
+  account={UNIVERSAL_GA_ACCOUNT_ID}
+  domain={shopDomain}
+  onError={error => {
+    // do something with error
+  }}
+/>;
+```
+
 For more info on using analytics.js see the [documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/)
 
 ## ga.js example

--- a/packages/react-google-analytics/src/Universal.tsx
+++ b/packages/react-google-analytics/src/Universal.tsx
@@ -38,13 +38,17 @@ export default function UniversalGoogleAnalytics({
   disableTracking,
 }: Props) {
   const setAnalytics = React.useCallback(
-    (googleAnalytics: UniversalAnalytics) => {
+    (googleAnalytics: UniversalAnalytics | Error) => {
       const normalizedDomain = getRootDomain(domain);
       const options = {
         cookieDomain: normalizedDomain,
         legacyCookieDomain: normalizedDomain,
         allowLinker: true,
       };
+
+      if (googleAnalytics instanceof Error) {
+        return null;
+      }
 
       googleAnalytics('create', account, 'auto', options);
 

--- a/packages/react-google-analytics/src/Universal.tsx
+++ b/packages/react-google-analytics/src/Universal.tsx
@@ -12,6 +12,7 @@ export interface Props {
   debug?: boolean;
   disableTracking?: boolean;
   onLoad?(analytics: UniversalAnalytics): void;
+  onError?(error: Error): void;
 }
 
 export const SETUP_SCRIPT = `
@@ -34,6 +35,7 @@ export default function UniversalGoogleAnalytics({
   nonce,
   set: setVariables = {},
   onLoad,
+  onError,
   debug,
   disableTracking,
 }: Props) {
@@ -47,6 +49,10 @@ export default function UniversalGoogleAnalytics({
       };
 
       if (googleAnalytics instanceof Error) {
+        if (onError) {
+          onError(googleAnalytics);
+        }
+
         return null;
       }
 

--- a/packages/react-google-analytics/src/tests/Universal.test.tsx
+++ b/packages/react-google-analytics/src/tests/Universal.test.tsx
@@ -151,6 +151,18 @@ describe('<Universal />', () => {
     });
   });
 
+  describe('onError()', () => {
+    it('is called with the error object', () => {
+      const onError = jest.fn();
+      const error = new Error('Script download error');
+      const universal = mount(<Universal {...mockProps} onError={onError} />);
+
+      universal.find(ImportRemote)!.trigger('onImported', error);
+
+      expect(onError).toHaveBeenCalledWith(error);
+    });
+  });
+
   describe('debug', () => {
     it('loads the GA script without restrictions when debug is not set', () => {
       const analytics = mockAnalytics();


### PR DESCRIPTION
## Description

This PR fixes a bug where the react-google-analytics `<Universal />` component breaks when the analytics script is blocked by the browser.

Note: The default privacy settings in Edge are strict enough to block this script. 

## Type of change

- [x] `react-google-analytics` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
