### PR TITLE
Fix memory leak in @shopify/dates when SSR

### DIFF
--- a/packages/dates/CHANGELOG.md
+++ b/packages/dates/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+- Fixes the memory leak that was introduced in v0.1.27 when server-side rendering ([#1277](https://github.com/Shopify/quilt/pull/1277))
+
 ## [0.2.12] - 2020-02-07
 
 - ⚠️ A bug fix because Chrome 80's API change to Intl.DateTimeFormat ([#1266](https://github.com/Shopify/quilt/pull/1266))

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -1,28 +1,45 @@
-import {memoize} from '@shopify/function-enhancers';
+const intl = new Map();
+const memoizedGetDateTimeFormat = function(locale, options) {
+  const key = dateTimeFormatCacheKey(locale, options);
+  if (intl.has(key)) {
+    return intl.get(key);
+  }
+  const i = new Intl.DateTimeFormat(locale, options);
+  intl.set(key, i);
+  return i;
+};
 
-const memoizedGetDateTimeFormat = memoize(
-  getDateTimeFormat,
-  dateTimeFormatCacheKey,
-);
+const browserFeatureDetectionDate = Intl.DateTimeFormat('en', {
+  hour: 'numeric',
+});
 
 interface FormatDateOptions extends Intl.DateTimeFormatOptions {
   hourCycle?: string;
 }
+
+const resolvedOptions: FormatDateOptions | undefined =
+  typeof browserFeatureDetectionDate.resolvedOptions === 'undefined'
+    ? undefined
+    : browserFeatureDetectionDate.resolvedOptions();
 
 export function formatDate(
   date: Date,
   locales: string | string[],
   options: FormatDateOptions = {},
 ) {
+  const hourCycleRequired =
+    resolvedOptions != null &&
+    options.hour12 != null &&
+    resolvedOptions.hourCycle != null;
+
+  if (hourCycleRequired) {
+    options.hour12 = undefined;
+    options.hourCycle = 'h23';
+  }
+
   // Etc/GMT+12 is not supported in most browsers and there is no equivalent fallback
   if (options.timeZone != null && options.timeZone === 'Etc/GMT+12') {
     const adjustedDate = new Date(date.valueOf() - 12 * 60 * 60 * 1000);
-
-    if (options.hour12 != null) {
-      options.hour12 = undefined;
-      options.hourCycle = 'h23';
-    }
-
     return memoizedGetDateTimeFormat(locales, {
       ...options,
       timeZone: 'UTC',
@@ -30,13 +47,6 @@ export function formatDate(
   }
 
   return memoizedGetDateTimeFormat(locales, options).format(date);
-}
-
-function getDateTimeFormat(
-  locales?: string | string[],
-  options?: Intl.DateTimeFormatOptions,
-) {
-  return Intl.DateTimeFormat(locales, options);
 }
 
 function dateTimeFormatCacheKey(


### PR DESCRIPTION
## Description

This fixes the memory leak in the dates package that we were seeing when upgrading to any version after v 0.1.26 in Web.

More info is here: https://github.com/Shopify/web/issues/23454


## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
