### PR TITLE
upgrade typescript to 3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^23.10.4",
     "tslib": "^1.9.3",
-    "typescript": "^3.6.2"
+    "typescript": "^3.7.5"
   },
   "dependencies": {},
   "resolutions": {

--- a/packages/react-intersection-observer/src/hooks.ts
+++ b/packages/react-intersection-observer/src/hooks.ts
@@ -20,6 +20,9 @@ const emptyBoundingClientRect = {
   right: 0,
   top: 0,
   width: 0,
+  x: 0,
+  y: 0,
+  toJSON: () => {},
 };
 
 export function useIntersection({

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -298,7 +298,7 @@ function flatten(
     return [node.memoizedProps as string];
   }
 
-  const props = {...(node.memoizedProps || {})};
+  const props = {...((node.memoizedProps as any) || {})};
   const {children, descendants} = childrenToTree(node.child, root);
 
   return [

--- a/yarn.lock
+++ b/yarn.lock
@@ -10586,10 +10586,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
## Description
Upgrades typescript from `3.6.2` to `3.7.5`.

- Dom Changes. [Types in lib.dom.d.ts have been updated.](https://github.com/microsoft/TypeScript/pull/33627) These changes are largely correctness changes related to nullability, but impact will ultimately depend on your codebase.
- [Assertion Functions](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#assertion-functions).
- [Nullish Coalescing](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#nullish-coalescing)
- [Optional Chaining](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#optional-chaining)

[Changelog](https://github.com/microsoft/TypeScript/releases/tag/v3.7.5)
[Blog](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
