### PR TITLE
Adds ruby deps to manual install instructions

### DIFF
--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -91,6 +91,9 @@ An application can also be setup manually using the following steps.
 #### Install dependencies
 
 ```sh
+# Add ruby dependencies
+bundle add sewing_kit quilt_rails
+
 # Add core Node dependencies
 yarn add @shopify/sewing-kit @shopify/react-server
 


### PR DESCRIPTION
When going through the instructions for manual installation it wasn't completely clear to me I still had to install the gems.