### PR TITLE
@shopify/react-form-state README adds mention of @shopify/react-form

### DIFF
--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -5,7 +5,7 @@
 
 Manage react forms tersely and safely-typed with no magic.
 
-Check out [@shopify/react-form](https://github.com/Shopify/quilt/tree/master/packages/react-form) for our newer form hooks.
+This library is now superseded by [@shopify/react-form](https://github.com/Shopify/quilt/tree/master/packages/react-form) as it allows you to write the preferred, functional, and hooks-driven React components over class-based ones.
 
 ## Installation
 

--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -5,6 +5,8 @@
 
 Manage react forms tersely and safely-typed with no magic.
 
+Check out [@shopify/react-form](https://github.com/Shopify/quilt/tree/master/packages/react-form) for our newer form hooks.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Description

Make the newer react form hook library more visible for those looking for a more functional approach for form state handling.

## Type of change
Documentation update
