### PR TITLE
add alwaysSendQuery option for PersistedLink

### DIFF
--- a/packages/graphql-persisted/CHANGELOG.md
+++ b/packages/graphql-persisted/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- add alwaysSendQuery option for PersistedLink. ([#1285](https://github.com/Shopify/quilt/pull/1285))
+- Add alwaysIncludeQuery option for PersistedLink. ([#1285](https://github.com/Shopify/quilt/pull/1285))
 
 ## [1.2.0] - 2020-12-18
 

--- a/packages/graphql-persisted/CHANGELOG.md
+++ b/packages/graphql-persisted/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- add alwaysSendQuery option for PersistedLink. ([#1285](https://github.com/Shopify/quilt/pull/1285))
+
 ## [1.2.0] - 2020-12-18
 
 ### Added

--- a/packages/graphql-persisted/README.md
+++ b/packages/graphql-persisted/README.md
@@ -35,9 +35,10 @@ const client = new ApolloClient({
 });
 ```
 
-This function accepts an optional `options` object. The following option is available:
+This function accepts an optional `options` object. The following options are available:
 
 - `idFromOperation?(operation: Operation): string | undefined | null`: calculates the unique ID to use for the persisted query, which will eventually be passed to the server’s `cache#get` method to retrieve the full query body. If omitted, this option will default to pulling the `id` field off of the `operation.query` `DocumentNode`, which works well in combination with documents compiled using [`graphql-mini-transforms`](https://github.com/Shopify/graphql-tools-web/tree/master/packages/graphql-mini-transforms) (used by default in sewing-kit).
+- `alwaysIncludeQuery: boolean`: always include the GraphQL query in a request, instead of the default behavior where the query is only included if the server does not recognize the persisted query ID. This is useful for debugging, and can avoid extra round trips in an SSR environment.
 
 The behavior of this link when a persisted query is not found for a particular ID depends on the `cacheMissBehavior` passed to your server middleware, which is documented below.
 

--- a/packages/graphql-persisted/src/apollo.ts
+++ b/packages/graphql-persisted/src/apollo.ts
@@ -9,6 +9,7 @@ import {
 import {CacheMissBehavior} from './shared';
 
 interface Options {
+  alwaysSendQuery?: boolean;
   idFromOperation?(operation: Operation): string | undefined | null;
 }
 
@@ -32,7 +33,10 @@ export class PersistedLink extends ApolloLink {
     }
 
     return new Observable(observer => {
-      const {idFromOperation = defaultIdFromOperation} = this.options;
+      const {
+        alwaysSendQuery = false,
+        idFromOperation = defaultIdFromOperation,
+      } = this.options;
       const id = idFromOperation(operation);
 
       if (typeof id !== 'string' || this.sendAlwaysIds.has(id)) {
@@ -46,7 +50,7 @@ export class PersistedLink extends ApolloLink {
 
       operation.setContext({
         http: {
-          includeQuery: false,
+          includeQuery: alwaysSendQuery,
           includeExtensions: true,
         },
       });

--- a/packages/graphql-persisted/src/apollo.ts
+++ b/packages/graphql-persisted/src/apollo.ts
@@ -9,7 +9,7 @@ import {
 import {CacheMissBehavior} from './shared';
 
 interface Options {
-  alwaysSendQuery?: boolean;
+  alwaysIncludeQuery?: boolean;
   idFromOperation?(operation: Operation): string | undefined | null;
 }
 
@@ -34,7 +34,7 @@ export class PersistedLink extends ApolloLink {
 
     return new Observable(observer => {
       const {
-        alwaysSendQuery = false,
+        alwaysIncludeQuery = false,
         idFromOperation = defaultIdFromOperation,
       } = this.options;
       const id = idFromOperation(operation);
@@ -50,7 +50,7 @@ export class PersistedLink extends ApolloLink {
 
       operation.setContext({
         http: {
-          includeQuery: alwaysSendQuery,
+          includeQuery: alwaysIncludeQuery,
           includeExtensions: true,
         },
       });


### PR DESCRIPTION
## Description

Adds an option for `createPersistedLink` to always send the query, rather than waiting for the server to ask.

Two motivating use-cases:

### Development

This is useful for development, as it makes debugging easier when the query is visible in requests.

### SSR

It's also useful when doing SSR, as upload link speed isn't a factor there, so always sending the query avoids an extra round-trip with the API server.

### Usage

```javascript
createPersistedLink({
  alwaysSendQuery: process.env.NODE_ENV === 'development' || isServer
})
```

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] @shopify/graphql-persisted - Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
