### PR TITLE
Export formatDate function

### DIFF
--- a/packages/dates/CHANGELOG.md
+++ b/packages/dates/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+- Export the `formatDate` function so it can be used by other packages / projects, e.g. in `@shopify/react-i18n`
+
 ## [0.2.13] - 2020-02-07
 
 - Fixes the memory leak that was introduced in v0.1.27 when server-side rendering ([#1277](https://github.com/Shopify/quilt/pull/1277))

--- a/packages/dates/README.md
+++ b/packages/dates/README.md
@@ -30,6 +30,23 @@ const timeZone2 = 'America/Toronto';
 const newDate = applyTimeZoneOffset(date, timeZone1, timeZone2);
 ```
 
+### `formatDate`
+
+Takes in a date object and two additional parameters, the locale and an optional options object. Returns a new date string with the applied locale and options.
+
+```ts
+import {formatDate} from '@shopify/dates';
+
+const date = new Date('2020-02-18Z14:00');
+const locales = 'en';
+const options = {
+  timeZone: 'America/New_York',
+  hour: 'numeric',
+};
+
+const newDate = formatDate(date, locales, options); // 9 AM
+```
+
 ### `getDateTimeParts`
 
 Takes in a date object and an optional time zone string parameter. Returns an object with functions to get the year, month, day, weekday, hour, minute and second of the provided date.

--- a/packages/dates/src/get-date-time-parts.ts
+++ b/packages/dates/src/get-date-time-parts.ts
@@ -1,6 +1,6 @@
 import {memoize} from '@shopify/decorators';
 
-import {formatDate} from './utilities/formatDate';
+import {formatDate} from './utilities';
 import {sanitiseDateString} from './sanitise-date-string';
 
 const TWO_DIGIT_REGEX = /(\d{2})/;

--- a/packages/dates/src/index.ts
+++ b/packages/dates/src/index.ts
@@ -19,3 +19,4 @@ export * from './parse-date-string-parts';
 export * from './sanitise-date-string';
 export * from './unapply-time-zone-offset';
 export * from './map-deprecated-timezones';
+export * from './utilities';

--- a/packages/dates/src/utilities/index.ts
+++ b/packages/dates/src/utilities/index.ts
@@ -1,0 +1,1 @@
+export {formatDate} from './formatDate';

--- a/packages/dates/tsconfig.json
+++ b/packages/dates/tsconfig.json
@@ -11,5 +11,9 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../address"}, {"path": "../function-enhancers"}, {"path": "../decorators"}]
+  "references": [
+    {"path": "../address"},
+    {"path": "../function-enhancers"},
+    {"path": "../decorators"}
+  ]
 }


### PR DESCRIPTION
## Description

This exports the `formatDate` function so we can reuse it in [`@shopify/react-i18n`](https://github.com/Shopify/quilt/blob/master/packages/react-i18n/src/i18n.ts#L314-L317) and in shopify web directly. This will reduce code duplication and hopefully also eliminate more memory leaks once we use it.

I'll put up a follow-up PR for the `@shopify/react-i18n` package that makes use of this function.
Follow up PR: https://github.com/Shopify/quilt/pull/1287

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
