### PR TITLE
Use @shopify/dates formatDate function and memoize Intl.NumberFormat

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed memory leaks when server-side rendering for `Intl.DateTimeFormat.format()` and `Intl.NumberFormat.format()` ([#1287](https://github.com/Shopify/quilt/pull/1287))
+
+---
 
 ### Fixed
 

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -17,6 +17,17 @@ const MISSING_TRANSLATION = Symbol('Missing translation');
 const PLURALIZATION_KEY_NAME = 'count';
 const SEPARATOR = '.';
 
+const numberFormats = new Map();
+export const memoizedNumberFormatter = function(locale, options = {}) {
+  const key = numberFormatCacheKey(locale, options);
+  if (numberFormats.has(key)) {
+    return numberFormats.get(key);
+  }
+  const i = new Intl.NumberFormat(locale, options);
+  numberFormats.set(key, i);
+  return i;
+};
+
 export const PSEUDOTRANSLATE_OPTIONS: PseudotranslateOptions = {
   startDelimiter: '{',
   endDelimiter: '}',
@@ -30,18 +41,12 @@ export interface TranslateOptions<Replacements = {}> {
   pseudotranslate?: boolean | string;
 }
 
-function numberFormatter(
+function numberFormatCacheKey(
   locale: string,
   options: Intl.NumberFormatOptions = {},
 ) {
-  return new Intl.NumberFormat(locale, options);
+  return `${locale}${JSON.stringify(options)}`;
 }
-
-export const memoizedNumberFormatter = memoizeFn(
-  numberFormatter,
-  (locale: string, options: Intl.NumberFormatOptions = {}) =>
-    `${locale}${JSON.stringify(options)}`,
-);
 
 function pluralRules(locale: string, options: Intl.PluralRulesOptions = {}) {
   return new Intl.PluralRules(locale, options);


### PR DESCRIPTION
## Description

Previous PRs: https://github.com/Shopify/quilt/pull/1277, https://github.com/Shopify/quilt/pull/1286

This makes use of the now exported `formatDate` function from the `@shopify/dates` package.

It also changes `Intl.NumberFormat.format()` to be memoized on SSR. This is because it is, same as `Intl.DateTimeFormat.format()`, leaking memory.

You can test this by doing `node --inspect leak.js` using node v10 or v12

```js
// leak.js

setInterval(() => {
  var b;
  for (let i = 0; i < 100; i++) {
    b = new Intl.NumberFormat("ja-JP", {
      style: "currency",
      currency: "JPY"
    }).format(Math.floor(Math.random() * Math.floor(1000000)));
  }
}, 1);

```

Right after start
![image](https://user-images.githubusercontent.com/6950534/74864657-e63aed80-531d-11ea-9115-c57e1263d6c1.png)

After a minute
![image](https://user-images.githubusercontent.com/6950534/74864749-05397f80-531e-11ea-8a48-ff31d3ae3c53.png)

I opened an [issue in the node bug tracker](https://github.com/nodejs/node/issues/31914) to hopefully get the V8 fix backported to node v10/v12.


## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
