### PR TITLE
[react-form] Fix isChangeEvent null check

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Update `isChangeEvent` to check for null [#1288](https://github.com/Shopify/quilt/issues/1288)
 
 ## [0.3.24]
 

--- a/packages/react-form/src/test/utilities.test.ts
+++ b/packages/react-form/src/test/utilities.test.ts
@@ -1,4 +1,4 @@
-import {shallowArrayComparison} from '../utilities';
+import {shallowArrayComparison, isChangeEvent} from '../utilities';
 
 describe('shallowArrayComparison()', () => {
   describe('when the two arrays are the same', () => {
@@ -17,5 +17,11 @@ describe('shallowArrayComparison()', () => {
 
       expect(shallowArrayComparison(array1, array2)).toBe(false);
     });
+  });
+});
+
+describe('isChangeEvent', () => {
+  it('returns false on null', () => {
+    expect(isChangeEvent(null)).toBe(false);
   });
 });

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -43,6 +43,7 @@ export function isChangeEvent(
 ): value is ChangeEvent<HTMLInputElement> {
   return (
     typeof value === 'object' &&
+    value !== null &&
     Reflect.has(value, 'target') &&
     Reflect.has(value.target, 'value')
   );


### PR DESCRIPTION
## Description

Fixes #1288

This should allow the ability to set null values in custom fields rather than throw an error
<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
