### PR TITLE
Allow passing a `fetchPolicy` to `useBackgroundQuery`

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve typings for `useBackgroundQuery` by allowing the `fetchPolicy` option. ([#1293](https://github.com/Shopify/quilt/pull/1293)).
+
 ## [6.0.7] - 2020-01-24
 
 ### Fixed

--- a/packages/react-graphql/src/hooks/background-query.ts
+++ b/packages/react-graphql/src/hooks/background-query.ts
@@ -13,7 +13,7 @@ type Subscription = ReturnType<
 
 export function useBackgroundQuery(
   load: () => Promise<DocumentNode | null | Error>,
-  options?: Omit<WatchQueryOptions, 'query' | 'fetchPolicy'>,
+  options?: Omit<WatchQueryOptions, 'query'>,
 ) {
   const client = useApolloClient();
   const lastClient = useRef(client);


### PR DESCRIPTION
`useBackgroundQuery` doesn't currently allow passing a custom `fetchPolicy`, but it will still forward the options to `client.watchQuery()`.

So I've decided to allow it as it might be useful for some people (like me) which would like to trigger a cache-first query instead of the default network-only query.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-graphql` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above