### PR TITLE
Add option to use a custom comparator for dirty state checking

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -13,6 +13,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Update `isChangeEvent` to check for null ([#1288](https://github.com/Shopify/quilt/issues/1288))
 
+### Added
+
+- Add option to use a custom comparator for determining if a field is dirty [#1296](https://github.com/Shopify/quilt/pull/1296/)
+
 ## [0.3.24]
 
 ### Fixed

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -2,11 +2,7 @@ import {useCallback, useEffect, useMemo, ChangeEvent} from 'react';
 import isEqual from 'fast-deep-equal';
 
 import {Validates, Field, DirtyStateComparator} from '../../types';
-import {
-  normalizeValidation,
-  isChangeEvent,
-  defaultDirtyComparator,
-} from '../../utilities';
+import {normalizeValidation, isChangeEvent} from '../../utilities';
 
 import {
   updateAction,
@@ -109,12 +105,9 @@ export interface FieldConfig<Value> {
 export function useField<Value = string>(
   input: FieldConfig<Value> | Value,
   dependencies: unknown[] = [],
+  dirtyStateComparator?: DirtyStateComparator<Value>,
 ): Field<Value> {
-  const {
-    value,
-    validates,
-    dirtyStateComparator = defaultDirtyComparator,
-  } = normalizeFieldConfig(input);
+  const {value, validates} = normalizeFieldConfig(input);
   const validators = normalizeValidation(validates);
 
   const [state, dispatch] = useFieldReducer(value, dirtyStateComparator);
@@ -247,13 +240,12 @@ export function useChoiceField(
 
 function normalizeFieldConfig<Value>(
   input: FieldConfig<Value> | Value,
-  dirtyStateComparator?: DirtyStateComparator<Value>,
 ): FieldConfig<Value> {
   if (isFieldConfig(input)) {
     return input;
   }
 
-  return {value: input, validates: () => undefined, dirtyStateComparator};
+  return {value: input, validates: () => undefined};
 }
 
 function isFieldConfig<Value>(input: unknown): input is FieldConfig<Value> {

--- a/packages/react-form/src/hooks/field/index.ts
+++ b/packages/react-form/src/hooks/field/index.ts
@@ -7,6 +7,7 @@ export {
 } from './field';
 export {
   reduceField,
+  makeFieldReducer,
   FieldAction,
   updateErrorAction,
   initialFieldState,

--- a/packages/react-form/src/hooks/field/index.ts
+++ b/packages/react-form/src/hooks/field/index.ts
@@ -6,9 +6,8 @@ export {
   FieldConfig,
 } from './field';
 export {
-  reduceField,
-  makeFieldReducer,
   FieldAction,
+  reduceField,
   updateErrorAction,
   initialFieldState,
 } from './reducer';

--- a/packages/react-form/src/hooks/field/reducer.ts
+++ b/packages/react-form/src/hooks/field/reducer.ts
@@ -3,6 +3,9 @@ import {useReducer, Reducer} from 'react';
 import {FieldState, ErrorValue, DirtyStateComparator} from '../../types';
 import {defaultDirtyComparator} from '../../utilities';
 
+export interface ReducerOptions<Value> {
+  dirtyStateComparator?: DirtyStateComparator<Value>;
+}
 interface UpdateErrorAction {
   type: 'updateError';
   payload: ErrorValue;
@@ -55,11 +58,20 @@ export type FieldAction<Value> =
   | UpdateAction<Value>
   | NewDefaultAction<Value>;
 
+const shallowFieldReducer = makeFieldReducer({
+  dirtyStateComparator: defaultDirtyComparator,
+});
+
+export function reduceField<Value>(
+  prevState: FieldState<Value>,
+  action: FieldAction<Value>,
+): FieldState<Value> {
+  return shallowFieldReducer(prevState, action) as FieldState<Value>;
+}
+
 export function makeFieldReducer<Value>({
-  dirtyStateComparator,
-}: {
-  dirtyStateComparator: DirtyStateComparator<Value>;
-}): Reducer<FieldState<Value>, FieldAction<Value>> {
+  dirtyStateComparator = defaultDirtyComparator,
+}: ReducerOptions<Value>): Reducer<FieldState<Value>, FieldAction<Value>> {
   return (state: FieldState<Value>, action: FieldAction<Value>) => {
     switch (action.type) {
       case 'update': {
@@ -109,20 +121,9 @@ export function makeFieldReducer<Value>({
   };
 }
 
-const shallowFieldReducer = makeFieldReducer({
-  dirtyStateComparator: defaultDirtyComparator,
-});
-
-export function reduceField<Value>(
-  prevState: FieldState<Value>,
-  action: FieldAction<Value>,
-): FieldState<Value> {
-  return shallowFieldReducer(prevState, action) as FieldState<Value>;
-}
-
 export function useFieldReducer<Value>(
   value: Value,
-  dirtyStateComparator: DirtyStateComparator<Value>,
+  dirtyStateComparator?: DirtyStateComparator<Value>,
 ) {
   return useReducer(
     makeFieldReducer<Value>({dirtyStateComparator}),

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -4,7 +4,7 @@ import {mount} from '@shopify/react-testing';
 
 import {asChoiceField, useChoiceField, useField, FieldConfig} from '../field';
 import {FieldState} from '../../../types';
-import {FieldAction, reduceField} from '../reducer';
+import {FieldAction, reduceField, makeFieldReducer} from '../reducer';
 
 describe('useField', () => {
   function TestField({config}: {config: string | FieldConfig<string>}) {
@@ -370,6 +370,52 @@ describe('useField', () => {
 
           expect(newState).toStrictEqual(expectedNewState);
         });
+      });
+    });
+
+    describe('when using a custom comparator', () => {
+      it("marks as dirty if the comparator says it's dirty", () => {
+        const dirtyStateComparator = () => true;
+        const reducer = makeFieldReducer({dirtyStateComparator});
+        const originalState = buildState({
+          value: 'original value',
+          defaultValue: 'default value',
+        });
+        const action: FieldAction<string> = {
+          type: 'update',
+          payload: 'updated value',
+        };
+        const expectedNewState = buildState({
+          value: 'updated value',
+          defaultValue: 'default value',
+          dirty: true,
+        });
+
+        const newState = reducer(originalState, action);
+
+        expect(newState).toStrictEqual(expectedNewState);
+      });
+
+      it("marks as clean if the comparator says it's not dirty", () => {
+        const dirtyStateComparator = () => false;
+        const reducer = makeFieldReducer({dirtyStateComparator});
+        const originalState = buildState({
+          value: 'original value',
+          defaultValue: 'default value',
+        });
+        const action: FieldAction<string> = {
+          type: 'update',
+          payload: 'updated value',
+        };
+        const expectedNewState = buildState({
+          value: 'updated value',
+          defaultValue: 'default value',
+          dirty: false,
+        });
+
+        const newState = reducer(originalState, action);
+
+        expect(newState).toStrictEqual(expectedNewState);
       });
     });
   });

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -1,6 +1,10 @@
 import {ChangeEvent} from 'react';
 
 export type ErrorValue = string | undefined;
+export type DirtyStateComparator<Value> = (
+  defaultValue: Value,
+  value: Value,
+) => boolean;
 
 export interface Validator<Value, Context> {
   (value: Value, context: Context): ErrorValue;

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -121,3 +121,12 @@ export function shallowArrayComparison(arrA: unknown[], arrB: any) {
 
   return true;
 }
+
+export function defaultDirtyComparator<Value>(
+  defaultValue: Value,
+  newValue: Value,
+): boolean {
+  return Array.isArray(defaultValue)
+    ? !shallowArrayComparison(defaultValue, newValue)
+    : defaultValue !== newValue;
+}


### PR DESCRIPTION
## Description

This change adds an option to the `useField` hook in `react-form` to use a custom comparator for checking whether a field is dirty. This allows you to, for example, apply a deep equals function for deep equality checking if you field requires it:

```
  const myField = useField<Type>({
    value: initialValue,
    validates: () => false,
    dirtyStateComparator: _.isEqual
  });
```

This is required to resolve a bug we have an in upcoming Web feature (Slack me for more details) where we are storing a list of objects in a field, and currently we remain in the dirty state if the user manually resets the form to its default state. With this feature, we correctly detect that the form is again in its default state, and report that it's now clean.

**Note:** I recommend turning on "Hide whitespace changes" when reviewing this feature to make the diff readable.

## Type of change

- [x] `react-form` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
