### PR TITLE
Allow hour12 true to be respected by formatDate

### DIFF
--- a/packages/dates/CHANGELOG.md
+++ b/packages/dates/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Allows `hour12: true` to be passed to `formatDate`
+
 ## [0.3.0] - 2020-02-19
 
 - Export the `formatDate` function so it can be used by other packages / projects, e.g. in `@shopify/react-i18n`

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -29,7 +29,7 @@ export function formatDate(
 ) {
   const hourCycleRequired =
     resolvedOptions != null &&
-    options.hour12 != null &&
+    options.hour12 === false &&
     resolvedOptions.hourCycle != null;
 
   if (hourCycleRequired) {


### PR DESCRIPTION
## Description

**Note: a beta version of this change is already being used in web** 

Allows hour12 to be set to true.
Without this change, we were overwriting `hour12` to be false, even when it was set to true. That meant using it to format hours was not working. 

Before:
<img width="386" alt="Screen Shot 2020-02-26 at 4 20 08 PM" src="https://user-images.githubusercontent.com/12213371/75389031-e013b680-58b3-11ea-95d8-f141e7d26f90.png">

After:
<img width="387" alt="Screen Shot 2020-02-26 at 4 19 31 PM" src="https://user-images.githubusercontent.com/12213371/75388967-cf634080-58b3-11ea-8cad-9d930f4d0dae.png">

## Type of change

- [x] Dates Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
