### PR TITLE
update interface for LoadCountriesResponse and LoadCountryResponse

### DIFF
--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -11,8 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Update `LoadCountryResponse` to match new CountryService response signature
-- Update `LoadCountriesResponse` to match new CountryService response signature
+- Update `ResponseError` to allow for more custom errors from CountryService
 
 ## [1.0.0] - 2019-08-29
 

--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.1.5] - 2020-03-03
+## [2.0.0] - 2020-03-03
 
 ### Added
 

--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -7,6 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.5] - 2020-03-03
+
+### Added
+
+- Update `LoadCountryResponse` to match new CountryService response signature
+- Update `LoadCountriesResponse` to match new CountryService response signature
+
 ## [1.0.0] - 2019-08-29
 
 ### Added

--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -11,7 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Update `ResponseError` to allow for more custom errors from CountryService
+- Update `ResponseError` to allow for more custom errors from CountryService [#1302](https://github.com/Shopify/quilt/pull/1302)
 
 ## [1.0.0] - 2019-08-29
 

--- a/packages/address-consts/package.json
+++ b/packages/address-consts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/address-consts",
-  "version": "1.0.5",
+  "version": "1.1.5",
   "license": "MIT",
   "description": "Constants and types relating to @shopify/address",
   "main": "dist/src/index.js",

--- a/packages/address-consts/package.json
+++ b/packages/address-consts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/address-consts",
-  "version": "1.1.5",
+  "version": "1.0.5",
   "license": "MIT",
   "description": "Constants and types relating to @shopify/address",
   "main": "dist/src/index.js",

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -39,13 +39,27 @@ export interface Zone {
   code: string;
   name: string;
 }
+
 export interface LoadCountriesResponse {
   data: {countries: Country[]};
+  errors?: {
+    message: string;
+    locations?: object[];
+    path?: any[];
+    extensions?: object;
+  }[];
 }
 
 export interface LoadCountryResponse {
   data: {country: Country};
+  errors?: {
+    message: string;
+    locations?: object[];
+    path?: any[];
+    extensions?: object;
+  }[];
 }
+
 export interface Country {
   name: string;
   code: string;

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -41,10 +41,12 @@ export interface Zone {
 }
 export interface LoadCountriesResponse {
   data: {countries: Country[]};
+  errors?: [any]
 }
 
 export interface LoadCountryResponse {
   data: {country: Country};
+  errors?: [any]
 }
 export interface Country {
   name: string;

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -41,12 +41,10 @@ export interface Zone {
 }
 export interface LoadCountriesResponse {
   data: {countries: Country[]};
-  errors?: any[];
 }
 
 export interface LoadCountryResponse {
   data: {country: Country};
-  errors?: any[];
 }
 export interface Country {
   name: string;
@@ -76,15 +74,9 @@ export interface Country {
 
 export interface ResponseError {
   errors: {
-    locations: {
-      column: number;
-      line: number;
-    }[];
     message: string;
-    problems: {
-      explanation: string;
-    }[];
-    value: any;
+    locations?: object;
+    extensions?: object;
   }[];
 }
 

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -41,12 +41,12 @@ export interface Zone {
 }
 export interface LoadCountriesResponse {
   data: {countries: Country[]};
-  errors?: [any];
+  errors?: any[];
 }
 
 export interface LoadCountryResponse {
   data: {country: Country};
-  errors?: [any];
+  errors?: any[];
 }
 export interface Country {
   name: string;

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -75,7 +75,8 @@ export interface Country {
 export interface ResponseError {
   errors: {
     message: string;
-    locations?: object;
+    locations?: object[];
+    path?: any[];
     extensions?: object;
   }[];
 }

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -54,7 +54,10 @@ export interface LoadCountryResponse {
   data: {country: Country};
   errors?: {
     message: string;
-    locations?: object[];
+    locations?: {
+      column: number;
+      line: number;
+    }[];
     path?: any[];
     extensions?: object;
   }[];

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -41,12 +41,12 @@ export interface Zone {
 }
 export interface LoadCountriesResponse {
   data: {countries: Country[]};
-  errors?: [any]
+  errors?: [any];
 }
 
 export interface LoadCountryResponse {
   data: {country: Country};
-  errors?: [any]
+  errors?: [any];
 }
 export interface Country {
   name: string;


### PR DESCRIPTION
## Description

CountryService response signature has changed slightly. (https://github.com/Shopify/country-service/pull/409). CountryService now returns data in `en` but with an error message for locales that are supported by ShopifyI18n but not CountryDb. 

#### Example of new type of response, `data` with `errors`
```graphql
# query
query country {
  country(countryCode: "CA", locale: AF) {
    name
  }
}

# response 
{
  "data": {
    "country": {
      "name": "Canada"
    }
  },
  "errors": [
    {
      "message": "Translations for `af` is currently not supported.",
      "extensions": {
        "code": "LOCALE_UNSUPPORTED",
        "attribute": "locale"
      }
    }
  ]
}
```

# Update ResponseError
Update Error signature to include new `extensions` key. Update the ResponseError at the same time to match the GraphQl Specifications. https://spec.graphql.org/June2018/#sec-Errors

**Example of a GraphQl thrown error**
```graphql
{
  "errors": [
    {
      "message": "Argument 'locale' on Field 'country' has an invalid value (XX). Expected type 'SupportedLocale!'.",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "query country",
        "country",
        "locale"
      ],
      "extensions": {
        "code": "argumentLiteralsIncompatible",
        "typeName": "Field",
        "argumentName": "locale"
      }
    }
  ]
}
```

## Type of change

- [x] `@shopify/address-consts` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
