### PR TITLE
[react-form] Bug fix: Use `dirtyStateComparator` from config.

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug in the custom comparator introduced in 0.4.0 [#1305](https://github.com/Shopify/quilt/pull/1305)
+
 ## [0.4.1] - 2020-03-10
 
 ## Fixed

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -105,9 +105,8 @@ export interface FieldConfig<Value> {
 export function useField<Value = string>(
   input: FieldConfig<Value> | Value,
   dependencies: unknown[] = [],
-  dirtyStateComparator?: DirtyStateComparator<Value>,
 ): Field<Value> {
-  const {value, validates} = normalizeFieldConfig(input);
+  const {value, validates, dirtyStateComparator} = normalizeFieldConfig(input);
   const validators = normalizeValidation(validates);
 
   const [state, dispatch] = useFieldReducer(value, dirtyStateComparator);

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -50,6 +50,27 @@ describe('useField', () => {
     });
   });
 
+  it('uses the dirty state comparator from the config', () => {
+    const dirtyStateComparator = jest.fn();
+
+    const wrapper = mount(
+      <TestField
+        config={{
+          value: 'default value',
+          validates: alwaysPass,
+          dirtyStateComparator,
+        }}
+      />,
+    );
+
+    wrapper.find('input')!.trigger('onChange', changeEvent('new value'));
+
+    expect(dirtyStateComparator).toHaveBeenCalledWith(
+      'default value',
+      'new value',
+    );
+  });
+
   describe('handlers', () => {
     describe('#onChange', () => {
       it('updates the value of the field when called with only a value', () => {


### PR DESCRIPTION
## Description

My previous pull request (#1296) to add the `dirtyStateComparator` option had a problem that snuck in while addressing a review comment. I made the mistake of adding the `dirtyStateComparator` as a function argument, which meant it didn't actually use the value with the same name from the field configuration, and then somehow didn't notice this during tophatting. 😕 

It meant that you had to use the flag like this:

```
  const myField = useField(
    originalValue, 
    undefined, //dependencies
    (first, second) => compare(first, second) // comparator
  );
```

... instead of inside the config block as intended:

```
  const myField = useField({
    value: originalValue,
    validates: () => undefined,
    dirtyStateComparator: (first, second) => compare(first, second),
  });
```

## Type of change

- [x] `react-form` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
