### PR TITLE
[react-form] useList list as arg

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+
+- Overloaded `useList` to accept list as argument ([#1308](https://github.com/Shopify/quilt/issues/1308))
+
 ## [0.4.0] - 2020-03-04
 
 ### Added

--- a/packages/react-form/src/hooks/list/list.ts
+++ b/packages/react-form/src/hooks/list/list.ts
@@ -33,13 +33,13 @@ export interface FieldListConfig<Item extends object> {
  * In it's simplest form `useList` can be called with a single parameter with the list to derive default values and structure from.
  *
  * ```typescript
- * const field = useList([{title: '', description: ''}, {title: '', description: ''}]);
+ * const list = useList([{title: '', description: ''}, {title: '', description: ''}]);
  * ```
  *
  * You can also pass a more complex configuration object specifying a validation dictionary.
  *
  * ```tsx
- *const field = useField({
+ *const list = useList({
  *  list: [{title: '', description: ''}, {title: '', description: ''}],
  *  validates: {
  *    title:(title) => {
@@ -59,7 +59,7 @@ export interface FieldListConfig<Item extends object> {
  * Generally, you will want to use the list returned from useList by looping over it in your JSX.
  * ```tsx
  *function MyComponent() {
- *  const title = useField([{title: '', description: ''}, {title: '', description: ''}]);
+ *  const variants = useList([{title: '', description: ''}, {title: '', description: ''}]);
  *
  *  return (
  *    <ul>
@@ -99,7 +99,7 @@ export interface FieldListConfig<Item extends object> {
  *
  * ```tsx
  * function MyComponent() {
- *  const title = useField([{title: '', description: ''}, {title: '', description: ''}]);
+ *  const variants = useList([{title: '', description: ''}, {title: '', description: ''}]);
  *
  *  return (
  *    <ul>
@@ -131,9 +131,16 @@ export interface FieldListConfig<Item extends object> {
  * or to build new abstractions in the same vein as `useForm`, `useSubmit` and friends.
  */
 export function useList<Item extends object>(
-  {list, validates = {}}: FieldListConfig<Item>,
+  listOrConfig: FieldListConfig<Item> | Item[],
   validationDependencies: unknown[] = [],
 ): FieldDictionary<Item>[] {
+  const list = Array.isArray(listOrConfig) ? listOrConfig : listOrConfig.list;
+  const validates: FieldListConfig<Item>['validates'] = Array.isArray(
+    listOrConfig,
+  )
+    ? {}
+    : listOrConfig.validates || {};
+
   const [state, dispatch] = useListReducer(list);
 
   useEffect(() => {

--- a/packages/react-form/src/hooks/list/test/list.test.tsx
+++ b/packages/react-form/src/hooks/list/test/list.test.tsx
@@ -60,6 +60,57 @@ describe('useList', () => {
     });
   });
 
+  it('accepts a list as argument', () => {
+    function ListArgTestList({list}: {list: Variant[]}) {
+      const variants = useList<Variant>(list);
+
+      return (
+        <ul>
+          {variants.map((fields, index) => (
+            <li key={index}>
+              <TextField
+                label="price"
+                name={`price${index}`}
+                {...fields.price}
+              />
+              <TextField
+                label="option"
+                name={`option${index}`}
+                {...fields.optionName}
+              />
+              <TextField
+                label="value"
+                name={`value${index}`}
+                {...fields.optionValue}
+              />
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    const variants = randomVariants(4);
+    const wrapper = mount(<ListArgTestList list={variants} />);
+
+    variants.forEach(({price, optionName, optionValue}) => {
+      expect(wrapper).toContainReactComponent(TextField, {
+        value: price,
+        onChange: expect.any(Function),
+        onBlur: expect.any(Function),
+      });
+      expect(wrapper).toContainReactComponent(TextField, {
+        value: optionName,
+        onChange: expect.any(Function),
+        onBlur: expect.any(Function),
+      });
+      expect(wrapper).toContainReactComponent(TextField, {
+        value: optionValue,
+        onChange: expect.any(Function),
+        onBlur: expect.any(Function),
+      });
+    });
+  });
+
   describe('handlers', () => {
     describe('#onChange', () => {
       it('updates the value of the specific field and item when called with a value', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1308

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

`useList` errors when passing list as argument

## Type of change

Overloaded the function to allow for list passing as first argument.

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
