### PR TITLE
Use memoized number format for currency symbol

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Updated `formatCurrency` to use `memoizedNumberFormatter` to eliminate memory leak ([#1310](https://github.com/Shopify/quilt/pull/1310))
 
 ## [2.5.3] - 2020-04-09
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -333,7 +333,6 @@ export class I18n {
     return this.getCurrencySymbolLocalized(this.locale, currency);
   };
 
-  @memoize((currency: string, locale: string) => `${locale}${currency}`)
   getCurrencySymbolLocalized(locale: string, currency: string) {
     return getCurrencySymbol(locale, {currency});
   }

--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -3,7 +3,7 @@ export {I18nContext} from './context';
 export {I18n} from './i18n';
 export {useI18n} from './hooks';
 export {withI18n, WithI18nProps} from './decorator';
-export {translate} from './utilities';
+export {memoizedNumberFormatter, translate} from './utilities';
 export {
   I18nDetails,
   LanguageDirection,

--- a/packages/react-i18n/src/utilities/money.ts
+++ b/packages/react-i18n/src/utilities/money.ts
@@ -1,3 +1,5 @@
+import {memoizedNumberFormatter} from './translate';
+
 export function getCurrencySymbol(
   locale: string,
   options: Intl.NumberFormatOptions,
@@ -29,12 +31,12 @@ export function getCurrencySymbol(
   return elements;
 }
 
-function formatCurrency(
+export function formatCurrency(
   amount: number,
   locale: string,
   options: Intl.NumberFormatOptions,
 ) {
-  return new Intl.NumberFormat(locale, {
+  return memoizedNumberFormatter(locale, {
     style: 'currency',
     ...options,
   }).format(amount);

--- a/packages/react-i18n/src/utilities/tests/money.test.ts
+++ b/packages/react-i18n/src/utilities/tests/money.test.ts
@@ -1,0 +1,51 @@
+import {formatCurrency} from '../money';
+
+jest.mock('../translate', () => ({
+  memoizedNumberFormatter: jest.fn(),
+}));
+
+const memoizedNumberFormatterMock: jest.Mock = jest.requireMock('../translate')
+  .memoizedNumberFormatter;
+
+describe('formatCurrency()', () => {
+  const mockFormat = jest.fn();
+
+  beforeEach(() => {
+    const mockFormatter = {
+      format: mockFormat,
+    };
+    memoizedNumberFormatterMock.mockImplementation(() => mockFormatter);
+    mockFormat.mockImplementation(() => 'test');
+  });
+
+  afterEach(() => {
+    memoizedNumberFormatterMock.mockReset();
+    mockFormat.mockReset();
+  });
+
+  it('uses memoizedNumberFormatter to get a memoized formatter with currency style', () => {
+    const locale = 'en';
+    const options = {
+      currency: 'USD',
+    };
+
+    formatCurrency(123, locale, options);
+    expect(memoizedNumberFormatterMock).toHaveBeenCalledWith(locale, {
+      ...options,
+      style: 'currency',
+    });
+  });
+
+  it('calls format on the memoized formatter', () => {
+    const amount = 123;
+    const locale = 'en';
+    const options = {
+      currency: 'USD',
+    };
+    const result = 'result';
+    mockFormat.mockImplementation(() => result);
+
+    expect(formatCurrency(amount, 'en', {})).toBe(result);
+    expect(mockFormat).toHaveBeenCalledWith(amount);
+  });
+});

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -17,16 +17,19 @@ const MISSING_TRANSLATION = Symbol('Missing translation');
 const PLURALIZATION_KEY_NAME = 'count';
 const SEPARATOR = '.';
 
-const numberFormats = new Map();
-export const memoizedNumberFormatter = function(locale, options = {}) {
+const numberFormats = new Map<string, Intl.NumberFormat>();
+export function memoizedNumberFormatter(
+  locale: string,
+  options: Intl.NumberFormatOptions = {},
+) {
   const key = numberFormatCacheKey(locale, options);
   if (numberFormats.has(key)) {
-    return numberFormats.get(key);
+    return numberFormats.get(key)!;
   }
   const i = new Intl.NumberFormat(locale, options);
   numberFormats.set(key, i);
   return i;
-};
+}
 
 export const PSEUDOTRANSLATE_OPTIONS: PseudotranslateOptions = {
   startDelimiter: '{',


### PR DESCRIPTION
## Description

Fixes (issue #)

This should be the last step of eliminating memory leaks through the creation of new `Intl.DateTimeFormat` and `Intl.NumberFormat` and calling `format()` on them. There are no more case of a new `NumberFormat` instance being created in `quilt`.

I added some really basic tests to confirm that `formatCurrency()` is relying on `memoizedNumberFormatter()` (and `memoizedNumberFormatter` is already asserted to memoize correctly).

related to #1277 and #1287
related to https://github.com/nodejs/node/issues/31914

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
