### PR TITLE
Update dev release dist-tag to use beta

### DIFF
--- a/documentation/guides/release-and-deploy.md
+++ b/documentation/guides/release-and-deploy.md
@@ -52,16 +52,16 @@ git push origin master --follow-tags
 
 # Releases for 🎩ing changes?
 
-### Step 1 - Publish a `dev` release for testing
+### Step 1 - Publish a `beta` release for testing
 
-- In your branch, run `yarn run release-dev`. Lerna will launch it's CLI to select a version for the changed packages. Select the `Custom` option and enter a version with an appended `-dev.X` (eg. `0.29.10-my-feature-dev.1`). Many quilt packages reference others. If your are prompted to version other packages, it is safe to do so.
+- In your branch, run `yarn run release-beta`. Lerna will launch it's CLI to select a version for the changed packages. Select the `Custom` option and enter a version with an appended `-beta.X` (eg. `0.29.10-my-feature-beta.1`). Many quilt packages reference others. If your are prompted to version other packages, it is safe to do so.
 - Push your branch to Github with the newly created tags using `git push origin <branch> --follow-tags`
 - Create a temporary stack in Shipit that points to your deb branch. Set the Branch to your PR/feature branch and update the Environment to something specific to your feature (eg. test-cool-feature)
   ![Create Shipit Stack](../images/shipit-stack.png)
 
-- Hit the deploy button on your Publish commit in Shipit to publish your dev release to npm
+- Hit the deploy button on your Publish commit in Shipit to publish your beta release to npm
 
 ### Step 2 - Consume the release
 
 - Add your release to a repository that uses the package your testing
-  - `yarn add --dev @shopify/my-package@0.29.10-my-feature-dev.1`
+  - `yarn add --dev @shopify/my-package@0.29.10-my-feature-beta.1`

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:ci": "yarn _test --maxWorkers=3 --coverage",
     "check": "lerna run check",
     "release": "lerna publish",
-    "release-dev": "lerna publish --dist-tag dev",
+    "release-beta": "lerna publish --dist-tag beta",
     "clean": "rimraf './packages/*/dist'",
     "generate": "plop",
     "generate:package": "plop package && yarn plop docs",


### PR DESCRIPTION
## Description

We got reports of our [dev release](https://github.com/Shopify/quilt/blob/master/documentation/guides/release-and-deploy.md#releases-for-ing-changes) workflow publishing to the `latest` tag instead of `dev`. shipit [doesn't support](https://github.com/Shopify/shipit-engine/blob/master/lib/snippets/publish-lerna-independent-packages#L7-L12) the `dev` dist-tag. This PR updates the dist-tag to use `beta`.