### PR TITLE
Update type signature for @shopify/address-consts

### DIFF
--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- [Minor] Add `errors` to `LoadCountriesResponse` and `LoadCountryResponse`. [#1301](https://github.com/Shopify/quilt/pull/1301)
+- [Breaking Change] Update `ResponseError` to match GraphQl specification for Errors. [#1301](https://github.com/Shopify/quilt/pull/1301)
+
 ## [1.0.0] - 2019-08-29
 
 ### Added

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -42,10 +42,12 @@ export interface Zone {
 
 export interface LoadCountriesResponse {
   data: {countries: Country[]};
+  errors?: GraphQlError[];
 }
 
 export interface LoadCountryResponse {
   data: {country: Country};
+  errors?: GraphQlError[];
 }
 
 export interface Country {

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -75,17 +75,7 @@ export interface Country {
 }
 
 export interface ResponseError {
-  errors: {
-    locations: {
-      column: number;
-      line: number;
-    }[];
-    message: string;
-    problems: {
-      explanation: string;
-    }[];
-    value: any;
-  }[];
+  errors: GraphQlError[];
 }
 
 export interface GraphQlError {

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -39,6 +39,7 @@ export interface Zone {
   code: string;
   name: string;
 }
+
 export interface LoadCountriesResponse {
   data: {countries: Country[]};
 }
@@ -46,6 +47,7 @@ export interface LoadCountriesResponse {
 export interface LoadCountryResponse {
   data: {country: Country};
 }
+
 export interface Country {
   name: string;
   code: string;

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -88,6 +88,16 @@ export interface ResponseError {
   }[];
 }
 
+export interface GraphQlError {
+  message: string;
+  locations?: {
+    column: number;
+    line: number;
+  }[];
+  path?: any[];
+  extensions?: object;
+}
+
 export const GRAPHQL_ENDPOINT =
   'https://country-service.shopifycloud.com/graphql';
 export enum GraphqlOperationName {

--- a/packages/address/UNRELEASED.md
+++ b/packages/address/UNRELEASED.md
@@ -1,0 +1,15 @@
+# Unreleased
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+<!-- Released changes should go to CHANGELOG.md -->
+
+---
+
+- [patch] add clearer type check in loadCountry and loadCountries function. The
+  need to add the check was to fix yarn build because `@shopify/address-consts`
+  was updated, although the version was not bumped on `@shopify/address`.
+  [#1313](https://github.com/Shopify/quilt/pull/1313)

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -26,7 +26,9 @@ export const loadCountries: (
     }),
   });
 
-  const countries: LoadCountriesResponse | ResponseError = await response.json();
+  const countries:
+    | LoadCountriesResponse
+    | ResponseError = await response.json();
 
   if (!('data' in countries) && 'errors' in countries) {
     throw new CountryLoaderError(countries);
@@ -53,7 +55,9 @@ export const loadCountry: (
       }),
     });
 
-    const country: LoadCountryResponse | ResponseError = await response.json();
+    const country:
+      | LoadCountryResponse
+      | ResponseError = await response.json();
 
     if (!('data' in country) && 'errors' in country) {
       throw new CountryLoaderError(country);

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -26,11 +26,9 @@ export const loadCountries: (
     }),
   });
 
-  const countries:
-    | LoadCountriesResponse
-    | ResponseError = await response.json();
+  const countries: LoadCountriesResponse | ResponseError = await response.json();
 
-  if ('errors' in countries) {
+  if (!('data' in countries) && 'errors' in countries) {
     throw new CountryLoaderError(countries);
   }
 
@@ -55,9 +53,9 @@ export const loadCountry: (
       }),
     });
 
-    const country: LoadCountryResponse = await response.json();
+    const country: LoadCountryResponse | ResponseError = await response.json();
 
-    if ('errors' in country) {
+    if (!('data' in country) && 'errors' in country) {
       throw new CountryLoaderError(country);
     }
 


### PR DESCRIPTION
## Description

CountryService api has [updated](https://github.com/Shopify/country-service/pull/409) and allow for all locales supported by ShopifyI18n. For locales that is not supported by CountryDb, CountryService will default to english and return a `LOCALE_UNSUPPORTED` error with the data in `en`.

Therefore this PR updates the type signature for `LoadCountriesResponse` and `LoadCountryResponse` to include an optional `errors` field. On the side, this PR also fixes the GraphQl response signature to match [GraphQl specifications](http://spec.graphql.org/June2018/#sec-Errors). 

## Context

The context of why this PR is started is to fix https://github.com/Shopify/intl-china#110, and this PR is extracted and part of https://github.com/Shopify/quilt/pull/1301 because of the [need to release multiple packages in order](https://github.com/Shopify/quilt/pull/1301#issuecomment-596344866).  

## Type of change

- [x] `@shopify/address-consts` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
