### PR TITLE
✨add package deprecation document, and update current quilt according…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Each package has its own `README` and documentation describing usage.
 | react-csrf | [directory](packages/react-csrf) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-csrf.svg)](https://badge.fury.io/js/%40shopify%2Freact-csrf) |
 | react-csrf-universal-provider | [directory](packages/react-csrf-universal-provider) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider) |
 | react-effect | [directory](packages/react-effect) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect) |
-| react-effect-apollo | [directory](packages/react-effect-apollo) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect-apollo.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect-apollo) |
 | react-form | [directory](packages/react-form) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form.svg)](https://badge.fury.io/js/%40shopify%2Freact-form) |
 | react-form-state | [directory](packages/react-form-state) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
 | react-google-analytics | [directory](packages/react-google-analytics) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg)](https://badge.fury.io/js/%40shopify%2Freact-google-analytics) |
@@ -77,7 +76,6 @@ Each package has its own `README` and documentation describing usage.
 | react-serialize | [directory](packages/react-serialize) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-serialize.svg)](https://badge.fury.io/js/%40shopify%2Freact-serialize) |
 | react-server | [directory](packages/react-server) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-server.svg)](https://badge.fury.io/js/%40shopify%2Freact-server) |
 | react-server-webpack-plugin | [directory](packages/react-server-webpack-plugin) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-server-webpack-plugin.svg)](https://badge.fury.io/js/%40shopify%2Freact-server-webpack-plugin) |
-| react-shopify-app-route-propagator | [directory](packages/react-shopify-app-route-propagator) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator.svg)](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator) |
 | react-shortcuts | [directory](packages/react-shortcuts) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-shortcuts.svg)](https://badge.fury.io/js/%40shopify%2Freact-shortcuts) |
 | react-testing | [directory](packages/react-testing) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-testing.svg)](https://badge.fury.io/js/%40shopify%2Freact-testing) |
 | react-tracking-pixel | [directory](packages/react-tracking-pixel) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel.svg)](https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel) |

--- a/documentation/guides/package-deprecation.md
+++ b/documentation/guides/package-deprecation.md
@@ -1,0 +1,42 @@
+# Deprecating a package
+
+## 1. Update `packages/{deprecate-package-name}/README.md` and `packages/{deprecate-package-name}/CHANGELOG.md`
+
+A note should be added to both of those files.
+
+Showing prominently
+
+- The last version supported.
+- Alternate to the deprecate package.
+
+## 2. Delete most files in `packages/{deprecate-package-name}`
+
+Leaving only `README.md` and `CHANGELOG.md`
+(It is important to delete `package.json` so lerna will no longer pick it up for future release.)
+
+## 3. Delete TS package project reference
+
+Delete the line referencing the deprecate package from [`packages/tsconfig.json`](../../packages/tsconfig.json)
+
+## 4. Global search deprecate package in quilt
+
+Do a global search in quilt for
+
+- Any package with `{deprecate-package-name}` listed as dependency
+- Any documentation that reference `{deprecate-package-name}`
+
+and update those accordingly.
+
+## 5.Update quilt README
+
+run `yarn plop docs` to remove `{deprecate-package-name}` from the main README
+
+## 6. Create your deprecation PR
+
+Create your PR with all the above changes and follow the normal PR review protocol to merge into master.
+
+## 7. Deprecate the package on npm
+
+While your PR is being review, follow [npm doc](https://docs.npmjs.com/cli/deprecate) to construct and run the deprecation command.
+
+(**Note** Your will need npm permission to run this command, Shopifolk should follow the instructions from this [Discourse issue](https://discourse.shopify.io/t/how-can-i-deprecate-an-npm-package-version/6652) or ping @Shopify/web-foundation team to do so.)

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -84,15 +84,19 @@ You may optionally pass an options object that contains the following keys (all 
   ```tsx
   import {renderToString} from 'react-dom/server';
   import {extract} from '@shopify/react-effect/server';
-  import {createApolloBridge} from '@shopify/react-effect-apollo';
+  import {HtmlContext, HtmlManager} from '@shopify/react-html/server';
 
   async function app(ctx) {
-    const ApolloBridge = createApolloBridge();
+    const htmlManager = new HtmlManager();
     const app = <App />;
 
     await extract(app, {
       decorate(element) {
-        return <ApolloBridge>{element}</ApolloBridge>;
+        return (
+          <HtmlContext.Provider value={htmlManager}>
+            {element}
+          </HtmlContext.Provider>
+        );
       },
     });
 

--- a/packages/react-effect/documentation/migrating-version-1-to-2.md
+++ b/packages/react-effect/documentation/migrating-version-1-to-2.md
@@ -52,4 +52,4 @@ extract(<App />, {
 });
 ```
 
-If you are also using Apollo for GraphQL data, we recommend you use [`@shopify/react-effect-apollo`](../../react-effect-apollo), which can collapse the tree passes performed by Apollo and this library into a single set. Instructions for doing so are in the documentation for `@shopify/react-effect-apollo`.
+If you are also using Apollo for GraphQL data, we recommend you use the `GraphQLUniversalProvider` from [`@shopify/react-graphql-universal-provider`](../../react-graphql-universal-provider/README.md) to wait for GraphQL queries to resolve on the server, and to perform automatic serialization.

--- a/packages/react-graphql-universal-provider/README.md
+++ b/packages/react-graphql-universal-provider/README.md
@@ -3,13 +3,53 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-graphql-universal-provider.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-graphql-universal-provider.svg)
 
-A self-serializing/deserializing GraphQL provider for universal applications. In order to understand how this package works you should be fimiliar with [React self-serializers](https://github.com/Shopify/quilt/tree/master/packages/react-self-serializers#self-serializers).
-
 ## Installation
 
 ```bash
 $ yarn add @shopify/react-graphql-universal-provider
 ```
+
+## Self serializers
+
+A self-serializer is a React component that leverages the `useSerialized()` hook from `@shopify/react-html` to handle both serializing data during server rendering, and deserializing it on the client. The components often render `React.context()` providers to make their serialized state available to the rest of the app they're rendered in.
+
+### Comparison with traditional serialization techniques
+
+Consider the `I18n` self-serializer. In the server you may want to set the locale based on the `Accept-Language` header. The client needs to be informed of this somehow to make sure React can render consistently. Traditionally you might do something like:
+
+#### On the server
+
+- get the locale from the `Accept-Language` header in your node server
+- create an instance of `I18nManager` with that locale
+- pass the instance into your app
+- render a `<Serialize name="locale" />` component in the DOM you send to the client
+
+#### On the client
+
+- call `getSerialized('locale')` in your client entrypoint for your locale
+- create an instance of `I18nManager` with that locale
+- pass the instance into your app
+
+#### In your react app's universal code
+
+- have your app render an `<I18nProvider />` with the manager from props
+
+With self-serializers you would instead:
+
+#### On the server
+
+- get the locale from the `Accept-Language` header in your node server
+- pass the locale into your app directly
+
+#### On the client
+
+- render your app without passing in the locale
+
+#### In your react app's universal code
+
+- have your app render an `<I18n />` with the locale from props
+
+Since self-serializers handle the details of serialization they allow you to remove code from your client/server entrypoints and instead let the react app itself handle those concerns.
 
 ## Usage
 

--- a/test/typescript-project-references.test.ts
+++ b/test/typescript-project-references.test.ts
@@ -3,14 +3,7 @@ import {resolve} from 'path';
 import {readJSONSync} from 'fs-extra';
 import glob from 'glob';
 
-const IGNORE_REGEX = [
-  /tsconfig\.json/,
-  /tsconfig_base\.json/,
-  /react-self-serializer/,
-  /react-preconnect/,
-  /react-effect-apollo/,
-  /react-shopify-app-route-propagator/,
-];
+const IGNORE_REGEX = [/tsconfig\.json/, /tsconfig_base\.json/];
 
 const ROOT = resolve(__dirname, '..');
 const projectReferencesConfig = resolve(ROOT, 'packages', 'tsconfig.json');
@@ -23,10 +16,15 @@ describe('typescript project references', () => {
     );
 
     const packages = glob
-      .sync(resolve(ROOT, 'packages', '*'))
+      .sync(resolve(ROOT, 'packages', '*/package.json'))
       .filter(filePath => !IGNORE_REGEX.some(regex => regex.test(filePath)))
-      .map(packagePath => packagePath.split('quilt/packages/')[1]);
+      .map(
+        packageJsonPath =>
+          /quilt\/packages\/(?<packageName>[\w._-]+)\/package\.json$/i.exec(
+            packageJsonPath,
+          ).groups.packageName,
+      );
 
-    expect(packages).toStrictEqual(references);
+    expect(packages.sort()).toStrictEqual(references.sort());
   });
 });


### PR DESCRIPTION
* Added doc on how to deprecate package
* Fix project reference test so it will ignore any package without package.json (deprecated)
* Remove any reference to `react-effect-apollo` or `react-shopify-app-route-propagator`