### PR TITLE
Fix every tsconfig references

### DIFF
--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/address-mocks/README.md",
   "devDependencies": {
-    "@shopify/address": "^2.8.1",
     "@shopify/jest-dom-mocks": "^2.8.10"
   },
   "sideEffects": false,

--- a/packages/address-mocks/tsconfig.json
+++ b/packages/address-mocks/tsconfig.json
@@ -11,5 +11,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../address"}, {"path": "../jest-dom-mocks"}]
+  "references": [{"path": "../address-consts"}, {"path": "../jest-dom-mocks"}]
 }

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -1,7 +1,7 @@
 import {fetch} from '@shopify/jest-dom-mocks';
 import {Address} from '@shopify/address-consts';
+import {mockCountryRequests} from '@shopify/address-mocks';
 
-import {mockCountryRequests} from '../../../address-mocks/src';
 import AddressFormatter from '../AddressFormatter';
 
 const address: Address = {

--- a/packages/address/src/tests/utilities.test.ts
+++ b/packages/address/src/tests/utilities.test.ts
@@ -1,4 +1,5 @@
-import {fixtures} from '../../../address-mocks/src/fixtures';
+import {fixtures} from '@shopify/address-mocks';
+
 import {renderLineTemplate} from '../utilities';
 
 const Canada = fixtures.country.EN.data.country;

--- a/packages/address/tsconfig.json
+++ b/packages/address/tsconfig.json
@@ -11,5 +11,9 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../address-consts"}]
+  "references": [
+    {"path": "../address-consts"},
+    {"path": "../address-mocks"},
+    {"path": "../jest-dom-mocks"}
+  ]
 }

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/dates/README.md",
   "dependencies": {
     "@shopify/decorators": "^1.1.9",
-    "@shopify/function-enhancers": "^1.0.9",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/dates/tsconfig.json
+++ b/packages/dates/tsconfig.json
@@ -12,8 +12,8 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
-    {"path": "../address"},
     {"path": "../function-enhancers"},
-    {"path": "../decorators"}
+    {"path": "../decorators"},
+    {"path": "../jest-dom-mocks"}
   ]
 }

--- a/packages/dates/tsconfig.json
+++ b/packages/dates/tsconfig.json
@@ -12,7 +12,6 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
-    {"path": "../function-enhancers"},
     {"path": "../decorators"},
     {"path": "../jest-dom-mocks"}
   ]

--- a/packages/decorators/tsconfig.json
+++ b/packages/decorators/tsconfig.json
@@ -11,5 +11,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../address"}, {"path": "../function-enhancers"}]
+  "references": [{"path": "../function-enhancers"}]
 }

--- a/packages/graphql-testing/tsconfig.json
+++ b/packages/graphql-testing/tsconfig.json
@@ -10,5 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "references": [{"path": "../useful-types"}]
 }

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -28,7 +28,6 @@
     "@types/fetch-mock": "^6.0.1",
     "@types/lolex": "^2.1.3",
     "fetch-mock": "^6.3.0",
-    "lodash": ">=4.0.0 <5.0.0",
     "lolex": "^2.7.5",
     "promise": "^8.0.3",
     "tslib": "^1.9.3"

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/koa-metrics/README.md",
   "dependencies": {
     "@shopify/statsd": "^1.2.2",
-    "hot-shots": "^5.9.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/koa-performance/package.json
+++ b/packages/koa-performance/package.json
@@ -30,7 +30,6 @@
     "@types/koa": "^2.0.0",
     "@types/koa-bodyparser": "*",
     "@types/koa-compose": "*",
-    "change-case": "^3.1.0",
     "koa-bodyparser": ">=4.0.0 <5.0.0",
     "koa-compose": ">=3.0.0 <4.0.0"
   },

--- a/packages/koa-performance/tsconfig.json
+++ b/packages/koa-performance/tsconfig.json
@@ -12,5 +12,10 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../performance"}, {"path": "../statsd"}]
+  "references": [
+    {"path": "../network"},
+    {"path": "../performance"},
+    {"path": "../statsd"},
+    {"path": "../with-env"}
+  ]
 }

--- a/packages/koa-shopify-auth/tsconfig.json
+++ b/packages/koa-shopify-auth/tsconfig.json
@@ -11,5 +11,9 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../jest-koa-mocks"}, {"path": "../network"}]
+  "references": [
+    {"path": "../network"},
+    {"path": "../jest-dom-mocks"},
+    {"path": "../jest-koa-mocks"}
+  ]
 }

--- a/packages/koa-shopify-graphql-proxy/tsconfig.json
+++ b/packages/koa-shopify-graphql-proxy/tsconfig.json
@@ -10,6 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../jest-koa-mocks"}]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/koa-shopify-webhooks/tsconfig.json
+++ b/packages/koa-shopify-webhooks/tsconfig.json
@@ -11,5 +11,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../jest-koa-mocks"}, {"path": "../jest-dom-mocks"}]
+  "references": [{"path": "../network"}]
 }

--- a/packages/react-async/tsconfig.json
+++ b/packages/react-async/tsconfig.json
@@ -12,11 +12,12 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
+    {"path": "../async"},
     {"path": "../react-effect"},
     {"path": "../react-hooks"},
-    {"path": "../useful-types"},
+    {"path": "../react-hydrate"},
     {"path": "../react-idle"},
     {"path": "../react-intersection-observer"},
-    {"path": "../react-hydrate"}
+    {"path": "../useful-types"}
   ]
 }

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -10,5 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "references": [{"path": "../useful-types"}]
 }

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -24,9 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-cookie/README.md",
   "dependencies": {
-    "@shopify/react-effect": "^3.2.11",
     "@shopify/react-hooks": "^1.5.0",
-    "@shopify/react-html": "^9.3.0",
     "@shopify/react-network": "^3.3.11",
     "cookie": "^0.4.0",
     "tslib": "^1.9.3"

--- a/packages/react-cookie/tsconfig.json
+++ b/packages/react-cookie/tsconfig.json
@@ -12,5 +12,10 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../react-network"}]
+  "references": [
+    {"path": "../react-effect"},
+    {"path": "../react-hooks"},
+    {"path": "../react-html"},
+    {"path": "../react-network"}
+  ]
 }

--- a/packages/react-cookie/tsconfig.json
+++ b/packages/react-cookie/tsconfig.json
@@ -12,10 +12,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [
-    {"path": "../react-effect"},
-    {"path": "../react-hooks"},
-    {"path": "../react-html"},
-    {"path": "../react-network"}
-  ]
+  "references": [{"path": "../react-hooks"}, {"path": "../react-network"}]
 }

--- a/packages/react-csrf-universal-provider/tsconfig.json
+++ b/packages/react-csrf-universal-provider/tsconfig.json
@@ -12,7 +12,9 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
-    {"path": "../react-universal-provider"},
-    {"path": "../react-csrf"}
+    {"path": "../react-csrf"},
+    {"path": "../react-effect"},
+    {"path": "../react-html"},
+    {"path": "../react-universal-provider"}
   ]
 }

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-effect/README.md",
   "dependencies": {
-    "@shopify/useful-types": "^2.1.4",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/react-effect/tsconfig.json
+++ b/packages/react-effect/tsconfig.json
@@ -10,5 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "references": [{"path": "../useful-types"}]
 }

--- a/packages/react-effect/tsconfig.json
+++ b/packages/react-effect/tsconfig.json
@@ -10,6 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../useful-types"}]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/react-form-state/tsconfig.json
+++ b/packages/react-form-state/tsconfig.json
@@ -10,5 +10,10 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "references": [
+    {"path": "../enzyme-utilities"},
+    {"path": "../predicates"},
+    {"path": "../useful-types"}
+  ]
 }

--- a/packages/react-google-analytics/tsconfig.json
+++ b/packages/react-google-analytics/tsconfig.json
@@ -11,5 +11,8 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../react-import-remote"}]
+  "references": [
+    {"path": "../enzyme-utilities"},
+    {"path": "../react-import-remote"}
+  ]
 }

--- a/packages/react-graphql-universal-provider/tsconfig.json
+++ b/packages/react-graphql-universal-provider/tsconfig.json
@@ -12,8 +12,9 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
-    {"path": "../react-html"},
+    {"path": "../react-effect"},
     {"path": "../react-graphql"},
+    {"path": "../react-html"},
     {"path": "../react-hooks"}
   ]
 }

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -32,12 +32,10 @@
     "@shopify/react-effect": "^3.2.11",
     "@shopify/react-hooks": "^1.5.0",
     "@shopify/react-idle": "^1.0.16",
-    "@shopify/react-network": "^3.3.11",
     "@shopify/useful-types": "^2.1.4",
     "apollo-cache-inmemory": ">=1.0.0 <2.0.0",
     "apollo-client": ">=2.0.0 <3.0.0",
     "apollo-link": ">=1.0.0 <2.0.0",
-    "apollo-link-http": ">=1.0.0 <2.0.0",
     "graphql-typed": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -41,6 +41,7 @@
     "graphql-typed": "^0.4.0"
   },
   "devDependencies": {
+    "@shopify/react-testing": "^2.0.0",
     "@types/graphql": "^14.0.0"
   },
   "files": [

--- a/packages/react-graphql/tsconfig.json
+++ b/packages/react-graphql/tsconfig.json
@@ -12,10 +12,12 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
+    {"path": "../async"},
     {"path": "../react-async"},
+    {"path": "../react-effect"},
     {"path": "../react-hooks"},
-    {"path": "../react-testing"},
     {"path": "../react-idle"},
+    {"path": "../react-testing"},
     {"path": "../useful-types"}
   ]
 }

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -36,6 +36,7 @@
     "react-dom": "^16.3.2"
   },
   "devDependencies": {
+    "@shopify/react-testing": "^2.0.0",
     "@shopify/with-env": "^1.1.6"
   },
   "sideEffects": false,

--- a/packages/react-html/tsconfig.json
+++ b/packages/react-html/tsconfig.json
@@ -11,5 +11,11 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../react-testing"}, {"path": "../react-hydrate"}]
+  "references": [
+    {"path": "../react-effect"},
+    {"path": "../react-hydrate"},
+    {"path": "../react-testing"},
+    {"path": "../useful-types"},
+    {"path": "../with-env"}
+  ]
 }

--- a/packages/react-i18n-universal-provider/tsconfig.json
+++ b/packages/react-i18n-universal-provider/tsconfig.json
@@ -11,5 +11,10 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../react-i18n"}]
+  "references": [
+    {"path": "../react-effect"},
+    {"path": "../react-hooks"},
+    {"path": "../react-html"},
+    {"path": "../react-i18n"}
+  ]
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -46,7 +46,6 @@
     "hoist-non-react-statics": "^3.0.1",
     "lodash.clonedeep": "^4.0.0",
     "lodash.merge": "^4.0.0",
-    "prop-types": "^15.6.2",
     "string-hash": "^1.1.3",
     "tslib": "^1.9.3"
   },

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -12,9 +12,12 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
-    {"path": "../function-enhancers"},
+    {"path": "../dates"},
     {"path": "../decorators"},
+    {"path": "../function-enhancers"},
     {"path": "../i18n"},
-    {"path": "../dates"}
+    {"path": "../react-effect"},
+    {"path": "../react-hooks"},
+    {"path": "../useful-types"}
   ]
 }

--- a/packages/react-import-remote/tsconfig.json
+++ b/packages/react-import-remote/tsconfig.json
@@ -11,5 +11,11 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../react-html"}]
+  "references": [
+    {"path": "../async"},
+    {"path": "../react-hooks"},
+    {"path": "../react-html"},
+    {"path": "../react-intersection-observer"},
+    {"path": "../useful-types"}
+  ]
 }

--- a/packages/react-network/tsconfig.json
+++ b/packages/react-network/tsconfig.json
@@ -10,5 +10,10 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "references": [
+    {"path": "../jest-koa-mocks"},
+    {"path": "../network"},
+    {"path": "../react-effect"}
+  ]
 }

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -24,8 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-performance/README.md",
   "dependencies": {
-    "@shopify/performance": "^1.2.6",
-    "@shopify/react-hooks": "^1.5.0"
+    "@shopify/performance": "^1.2.6"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0"

--- a/packages/react-performance/tsconfig.json
+++ b/packages/react-performance/tsconfig.json
@@ -14,7 +14,6 @@
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
     {"path": "../network"},
-    {"path": "../performance"},
-    {"path": "../react-hooks"}
+    {"path": "../performance"}
   ]
 }

--- a/packages/react-performance/tsconfig.json
+++ b/packages/react-performance/tsconfig.json
@@ -11,5 +11,10 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "references": [
+    {"path": "../network"},
+    {"path": "../performance"},
+    {"path": "../react-hooks"}
+  ]
 }

--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -10,5 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "references": [{"path": "../react-network"}]
 }

--- a/packages/react-server-webpack-plugin/package.json
+++ b/packages/react-server-webpack-plugin/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-server-webpack-plugin/README.md",
   "dependencies": {
     "@babel/types": ">=7.0.0",
-    "@shopify/ast-utilities": "^0.0.11",
     "webpack-virtual-modules": "^0.1.12"
   },
   "devDependencies": {

--- a/packages/react-server-webpack-plugin/tsconfig.json
+++ b/packages/react-server-webpack-plugin/tsconfig.json
@@ -12,5 +12,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../ast-utilities"}, {"path": "../react-server"}]
+  "references": [{"path": "../react-server"}]
 }

--- a/packages/react-server-webpack-plugin/tsconfig.json
+++ b/packages/react-server-webpack-plugin/tsconfig.json
@@ -12,5 +12,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../react-html"}, {"path": "../react-server"}]
+  "references": [{"path": "../ast-utilities"}, {"path": "../react-server"}]
 }

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@shopify/jest-koa-mocks": "^2.2.2",
+    "@shopify/react-testing": "^2.0.0",
     "@shopify/with-env": "^1.1.6",
     "@types/koa": "^2.0.0",
     "@types/supertest": "^2.0.8",

--- a/packages/react-server/tsconfig.json
+++ b/packages/react-server/tsconfig.json
@@ -12,6 +12,7 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
+    {"path": "../jest-koa-mocks"},
     {"path": "../react-async"},
     {"path": "../sewing-kit-koa"},
     {"path": "../network"},
@@ -19,10 +20,10 @@
     {"path": "../react-cookie"},
     {"path": "../react-csrf-universal-provider"},
     {"path": "../with-env"},
-    {"path": "../sewing-kit-koa"},
     {"path": "../react-html"},
     {"path": "../useful-types"},
     {"path": "../react-hydrate"},
-    {"path": "../react-effect"}
+    {"path": "../react-effect"},
+    {"path": "../react-testing"}
   ]
 }

--- a/packages/react-universal-provider/tsconfig.json
+++ b/packages/react-universal-provider/tsconfig.json
@@ -11,5 +11,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../react-html"}]
+  "references": [{"path": "../react-effect"}, {"path": "../react-html"}]
 }

--- a/packages/react-web-worker/tsconfig.json
+++ b/packages/react-web-worker/tsconfig.json
@@ -8,5 +8,9 @@
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../web-worker"}]
+  "references": [
+    {"path": "../react-hooks"},
+    {"path": "../useful-types"},
+    {"path": "../web-worker"}
+  ]
 }

--- a/packages/sewing-kit-koa/tsconfig.json
+++ b/packages/sewing-kit-koa/tsconfig.json
@@ -11,5 +11,9 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
-  "references": [{"path": "../network"}]
+  "references": [
+    {"path": "../jest-koa-mocks"},
+    {"path": "../network"},
+    {"path": "../with-env"}
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,7 +2137,7 @@ apollo-link-http-common@^0.2.15:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
-"apollo-link-http@>=1.0.0 <2.0.0", apollo-link-http@^1.5.5:
+apollo-link-http@^1.5.5:
   version "1.5.16"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.16.tgz#44fe760bcc2803b8a7f57fc9269173afb00f3814"
   integrity sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==
@@ -7247,7 +7247,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=4.0.0 <5.0.0", lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
Fix: #1181 

## Description

This PR adds 2 tests

1. Ensure every internal dependency (dependencies from this package) used in a package are added as references in the `tsconfig.json` file.
2. Ensure every dependency list in the `package.json` of a package is used inside this package. The fail will fail if you have dependency you don't need.

I also fix every failing tests. I did each step in 2 separate commits.
