### PR TITLE
Add `hasCustomNameFormatter` method

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added 
+
+- Added `hasEasternNameOrderFormatter` method, to determine whether an Eastern name order formatter exists for the locale/language
+
 ## [2.3.10] - 2020-02-27
 
 ### Fixed

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -139,6 +139,7 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
   - `formatName('John', 'Smith')` will return `John` in Germany and `Smith様` in Japan
   - `formatName('John', 'Smith', {full: true})` will return `John Smith` in Germany and `SmithJohn` in Japan
 - `ordinal()`: formats a number as an ordinal according to the locale, e.g. `1st`, `2nd`, `3rd`, `4th`
+- `hasEasternNameOrderFormatter()`: returns true when an eastern name order formatter corresponding to the locale/language exists.
 
 Most notably, you will frequently use `i18n`’s `translate()` method. This method looks up a key in translation files that you supply based on the provided locale. This method is discussed in detail in the next section.
 

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -181,7 +181,7 @@ export {
   DEFAULT_DECIMAL_PLACES,
 } from './currency-decimal-places';
 
-export const CUSTOM_NAME_FORMATTERS = new Map([
+export const EASTERN_NAME_ORDER_FORMATTERS = new Map([
   [
     'ja',
     (firstName: string, lastName: string, full: boolean) =>

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -27,7 +27,7 @@ import {
   Weekday,
   currencyDecimalPlaces,
   DEFAULT_DECIMAL_PLACES,
-  CUSTOM_NAME_FORMATTERS,
+  EASTERN_NAME_ORDER_FORMATTERS,
 } from './constants';
 import {
   MissingCurrencyCodeError,
@@ -345,8 +345,8 @@ export class I18n {
     const isFullName = Boolean(options && options.full);
 
     const customNameFormatter =
-      CUSTOM_NAME_FORMATTERS.get(this.locale) ||
-      CUSTOM_NAME_FORMATTERS.get(this.language);
+      EASTERN_NAME_ORDER_FORMATTERS.get(this.locale) ||
+      EASTERN_NAME_ORDER_FORMATTERS.get(this.language);
 
     if (customNameFormatter) {
       return customNameFormatter(firstName, lastName, isFullName);
@@ -355,6 +355,13 @@ export class I18n {
       return `${firstName} ${lastName}`;
     }
     return firstName;
+  }
+
+  hasEasternNameOrderFormatter() {
+    const easternNameOrderFormatter =
+      EASTERN_NAME_ORDER_FORMATTERS.get(this.locale) ||
+      EASTERN_NAME_ORDER_FORMATTERS.get(this.language);
+    return Boolean(easternNameOrderFormatter);
   }
 
   private formatCurrencyExplicit(

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1556,4 +1556,18 @@ describe('I18n', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('#hasEasternNameOrderFormatter', () => {
+    it('returns true if easternNameOrderFormatter exists', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'ja'});
+
+      expect(i18n.hasEasternNameOrderFormatter()).toStrictEqual(true);
+    });
+
+    it('returns false if custom name formatter does not exist', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.hasEasternNameOrderFormatter()).toStrictEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
## Description
While working on [localizing names](https://github.com/Shopify/pos-channel/pull/1955)  in `pos-channel`, one of the requirements included changing the placement of the name fields in a layout. In particular, the `lastName` field must be placed before `firstName` field when a custom name formatter (with the format `lastName`+`firstName`) exists.

## Type of change
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above