### PR TITLE
✨ make csrf less of with quilt_rails and graphql when needed

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Custom CSRF strategy to allow requests containing an `x-shopify-react-xhr: 1` header, deprecating the old custom CSRF strategy which was intended for use only in server rendering in favour of one for use both on the server and client.
 
 ## [1.10.0] - 2019-01-30
 

--- a/gems/quilt_rails/lib/quilt_rails.rb
+++ b/gems/quilt_rails/lib/quilt_rails.rb
@@ -9,4 +9,5 @@ require "quilt_rails/configuration"
 require "quilt_rails/react_renderable"
 require "quilt_rails/performance"
 require "quilt_rails/trusted_ui_server_csrf_strategy"
+require "quilt_rails/header_csrf_strategy"
 require "quilt_rails/monkey_patches/active_support_reloader" if Rails.env.development?

--- a/gems/quilt_rails/lib/quilt_rails/header_csrf_strategy.rb
+++ b/gems/quilt_rails/lib/quilt_rails/header_csrf_strategy.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Quilt
+  class HeaderCsrfStrategy
+    HEADER = "x-shopify-react-xhr"
+    HEADER_VALUE = "1"
+
+    def initialize(controller)
+      @controller = controller
+    end
+
+    def handle_unverified_request
+      raise NoSameSiteHeaderError unless same_site?
+    end
+
+    private
+
+    def same_site?
+      @controller.request.headers[HEADER] == HEADER_VALUE
+    end
+
+    def fallback_handler
+      ActionController::RequestForgeryProtection::ProtectionMethods::Exception.new(@controller)
+    end
+
+    class NoSameSiteHeaderError < StandardError
+      def initialize
+        # rubocop:disable LineLength
+        super "CSRF verification failed. This request is missing the `x-shopify-react-xhr` header, or it does not have the expected value."
+        # rubocop:enable LineLength
+      end
+    end
+  end
+end

--- a/gems/quilt_rails/test/quilt_rails/header_csrf_strategy_test.rb
+++ b/gems/quilt_rails/test/quilt_rails/header_csrf_strategy_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Quilt
+  class HeaderCsrfStrategyTest < Minitest::Test
+    def test_raises_an_exception_if_the_samesite_header_is_missing
+      DummyRequest.any_instance.stubs(:headers).returns({})
+      strategy = HeaderCsrfStrategy.new(DummyController.new)
+
+      assert_raises HeaderCsrfStrategy::NoSameSiteHeaderError do
+        strategy.handle_unverified_request
+      end
+    end
+
+    def test_raises_an_exception_if_the_samesite_header_has_an_unexpected_value
+      headers = {}
+      headers[HeaderCsrfStrategy::HEADER] = 'hi hello this is not the value you are looking for'
+      DummyRequest.any_instance.stubs(:headers).returns(headers)
+      strategy = HeaderCsrfStrategy.new(DummyController.new)
+
+      assert_raises HeaderCsrfStrategy::NoSameSiteHeaderError do
+        strategy.handle_unverified_request
+      end
+    end
+
+    def test_noops_if_the_samesite_header_is_present
+      headers = {}
+      headers[HeaderCsrfStrategy::HEADER] = HeaderCsrfStrategy::HEADER_VALUE
+      DummyRequest.any_instance.stubs(:headers).returns(headers)
+      strategy = HeaderCsrfStrategy.new(DummyController.new)
+
+      strategy.handle_unverified_request
+    end
+  end
+end
+
+class DummyController
+  def request
+    DummyRequest.new
+  end
+end
+
+class DummyRequest
+end

--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- The generated `ApolloClient` now automatically includes a `x-shopify-react-xhr: 1` header.
+
 ## [3.0.2] - 2020-02-27
 
 - Specify package has no `sideEffects` ([#1233](https://github.com/Shopify/quilt/pull/1233))

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -27,7 +27,8 @@
     "@shopify/react-graphql": "^6.1.1",
     "@shopify/react-hooks": "^1.5.0",
     "@shopify/react-html": "^9.3.1",
-    "apollo-client": "^2.3.8"
+    "apollo-client": "^2.3.8",
+    "apollo-link-context": "^1.0.19"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0"

--- a/packages/react-graphql-universal-provider/src/csrf-link.tsx
+++ b/packages/react-graphql-universal-provider/src/csrf-link.tsx
@@ -1,0 +1,13 @@
+import {setContext} from 'apollo-link-context';
+
+export const SAME_SITE_HEADER = 'x-shopify-react-xhr';
+export const SAME_SITE_VALUE = '1';
+
+export const csrfLink = setContext((_, {headers}) => {
+  return {
+    headers: {
+      ...headers,
+      [SAME_SITE_HEADER]: SAME_SITE_VALUE,
+    },
+  };
+});

--- a/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
@@ -77,7 +77,7 @@ describe('<GraphQLUniversalProvider />', () => {
     expect(restoreSpy).toHaveBeenCalledWith(initialData);
   });
 
-  it('includes createSsrExtractableLink if a link is not present', () => {
+  it('includes a link if none are given', () => {
     const clientOptions = {
       cache: new InMemoryCache(),
     };
@@ -87,7 +87,7 @@ describe('<GraphQLUniversalProvider />', () => {
     );
 
     expect(graphQL).toContainReactComponent(ApolloProvider, {
-      client: expect.objectContaining({link: expect.any(SsrExtractableLink)}),
+      client: expect.objectContaining({link: expect.any(ApolloLink)}),
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,7 +2111,7 @@ apollo-language-server@1.15.0:
     vscode-languageserver "^5.1.0"
     vscode-uri "1.0.6"
 
-apollo-link-context@^1.0.9:
+apollo-link-context@^1.0.19, apollo-link-context@^1.0.9:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.19.tgz#3c9ba5bf75ed5428567ce057b8837ef874a58987"
   integrity sha512-TUi5TyufU84hEiGkpt+5gdH5HkB3Gx46npNfoxR4of3DKBCMuItGERt36RCaryGcU/C3u2zsICU3tJ+Z9LjFoQ==


### PR DESCRIPTION
closes #1297 

## Description
This PR adds a new simplified CSRF workaround strategy to `quilt_rails` for use with `@shopify/react-universal-graphql-provider` and other API setups. This strategy simple checks for the presence of an `x-shopify-react-xhr` header and throws if it is not found. It also updates the universal provider to automagically append this header to all requests.

We also update the documentation to first point users to use `null_session` if applicable and otherwise use the custom strategy if required.

## Why
After speaking with some folks who had trouble getting around CSRF errors adding GraphQL to their applications I was dissatisfied with our current APIs and documentation. Further, upon discussion with some users and @JackMc it seems like the weird setup we had with CSRF tokens on the client and a header on the server is unnecessary, and we can simply use a custom header since browsers do not allow them cross origin.

It is also clear that `null_session` is the ideal protection strategy and is generally what APIs should use if they are going to be external facing in any fashion or if they use token based authentication of some kind. As such I opted to update the docs to spell this out as the first option.