### PR TITLE
Allow assetname from context

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Allow `assetName` to take a function for apps which need to serve multiple sub-apps based on path
+
+## [0.9.0]
 
 - Added `assetName` option to allow the `name` to be passed and default to `main`
 

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -77,8 +77,8 @@ interface Options {
   ip?: string;
   // the full base url for the cdn if applicable
   assetPrefix?: string;
-  // the name of the asset on the cdn
-  assetName?: string;
+  // the name of the asset on the cdn, or a function of Koa.Context to a name
+  assetName?: string | (ctx: Context) => string;
   // any additional Koa middleware to mount on the server
   serverMiddleware?: compose.Middleware<Context>[];
   // a function of `(ctx: Context, data: {locale: string}): React.ReactElement<any>`

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -30,6 +30,7 @@ import {
 } from '@shopify/sewing-kit-koa';
 
 import {getLogger} from '../logger';
+import {ValueFromContext} from '../types';
 
 export {Context};
 export interface RenderFunction {
@@ -41,7 +42,7 @@ type Options = Pick<
   'afterEachPass' | 'betweenEachPass'
 > & {
   assetPrefix?: string;
-  assetName?: string;
+  assetName?: string | ValueFromContext<string>;
 };
 
 /**
@@ -51,9 +52,14 @@ type Options = Pick<
  */
 export function createRender(render: RenderFunction, options: Options = {}) {
   const manifestPath = getManifestPath(process.cwd());
-  const {assetPrefix, assetName = 'main'} = options;
+  const {assetPrefix, assetName: assetNameInput = 'main'} = options;
 
   async function renderFunction(ctx: Context) {
+    const assetName =
+      typeof assetNameInput === 'function'
+        ? assetNameInput(ctx)
+        : assetNameInput;
+
     const logger = getLogger(ctx) || console;
     const assets = getAssets(ctx);
 

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -66,8 +66,8 @@ describe('createRender', () => {
   });
 
   it('calls the sewing-kit-koa middleware with the a functional assetName', async () => {
-    const assetName = (ctx: Context) => ctx.location.path;
-    const ctx = createMockContext({url: 'www.hi.com/hello-hi-hello'});
+    const assetName = (ctx: Context) => ctx.path;
+    const ctx = createMockContext({url: 'http://www.hi.com/hello-hi-hello'});
 
     const renderFunction = createRender(() => <></>, {assetName});
     await renderFunction(ctx, noop);

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -4,7 +4,7 @@ import {middleware as sewingKitKoaMiddleware} from '@shopify/sewing-kit-koa';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import withEnv from '@shopify/with-env';
 
-import {createRender} from '../render';
+import {createRender, Context} from '../render';
 import {mockMiddleware} from '../../test/utilities';
 
 const mockAssetsScripts = jest.fn(() => Promise.resolve([]));
@@ -62,6 +62,18 @@ describe('createRender', () => {
 
     expect(mockAssetsScripts).toHaveBeenCalledWith(
       expect.objectContaining({name: assetName}),
+    );
+  });
+
+  it('calls the sewing-kit-koa middleware with the a functional assetName', async () => {
+    const assetName = (ctx: Context) => ctx.location.path;
+    const ctx = createMockContext({url: 'www.hi.com/hello-hi-hello'});
+
+    const renderFunction = createRender(() => <></>, {assetName});
+    await renderFunction(ctx, noop);
+
+    expect(mockAssetsScripts).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'hello-hi-hello'}),
     );
   });
 

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -21,6 +21,11 @@ jest.mock('@shopify/sewing-kit-koa', () => ({
 }));
 
 describe('createRender', () => {
+  beforeEach(() => {
+    mockAssetsScripts.mockClear();
+    mockAssetsStyles.mockClear();
+  });
+
   it('response contains "My cool app"', async () => {
     const myCoolApp = 'My cool app';
     const ctx = createMockContext();
@@ -66,7 +71,7 @@ describe('createRender', () => {
   });
 
   it('calls the sewing-kit-koa middleware with the a functional assetName', async () => {
-    const assetName = (ctx: Context) => ctx.path;
+    const assetName = (ctx: Context) => ctx.path.replace('/', '');
     const ctx = createMockContext({url: 'http://www.hi.com/hello-hi-hello'});
 
     const renderFunction = createRender(() => <></>, {assetName});

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -9,6 +9,7 @@ import {createRender, RenderFunction} from '../render';
 import {requestLogger} from '../logger';
 import {metricsMiddleware as metrics} from '../metrics';
 import {ping} from '../ping';
+import {ValueFromContext} from '../types';
 
 const logger = console;
 
@@ -16,7 +17,7 @@ interface Options {
   port?: number;
   ip?: string;
   assetPrefix?: string;
-  assetName?: string;
+  assetName?: string | ValueFromContext<string>;
   serverMiddleware?: compose.Middleware<Context>[];
   render: RenderFunction;
 }

--- a/packages/react-server/src/types.ts
+++ b/packages/react-server/src/types.ts
@@ -1,3 +1,13 @@
+import {Context} from 'koa';
+
 export interface KoaNextFunction {
   (): Promise<any>;
+}
+
+/**
+ * Takes a koa Context object and returns some value derived from it.
+ * This is useful when a user needs to dynamically define an option for a middlewarebased on the incoming context object for that request.
+ */
+export interface ValueFromContext<T> {
+  (ctx: Context): T;
 }


### PR DESCRIPTION
## What does this do?
This PR addresses some frustrations users have had trying to setup multiple sub-applications using `quilt_rails` and / or `react-server`. It allows the middleware output by `createRender` to accept an `assetName` in the form of a function of the form `(ctx: Koa.context) => string`. This allows serving multiple apps  conditionally without having to build your own render middleware from scratch.