### PR TITLE
Add basename to react-router

### DIFF
--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Adds `basename` attribute to router to set the base URL for all locations.
 
 ## [0.0.15] - 2019-10-30
 

--- a/packages/react-router/src/components/Router/Router.tsx
+++ b/packages/react-router/src/components/Router/Router.tsx
@@ -5,15 +5,16 @@ import {isClient} from './utilities';
 
 interface Props {
   location?: string;
+  basename?: string;
   children?: React.ReactNode;
 }
 
 export const NO_LOCATION_ERROR =
   'A location must be passed to <Router /> on the server.';
 
-export default function Router({location, children}: Props) {
+export default function Router({location, basename, children}: Props) {
   if (isClient()) {
-    return <BrowserRouter>{children}</BrowserRouter>;
+    return <BrowserRouter basename={basename}>{children}</BrowserRouter>;
   }
 
   if (location == null) {
@@ -21,7 +22,7 @@ export default function Router({location, children}: Props) {
   }
 
   return (
-    <StaticRouter location={location} context={{}}>
+    <StaticRouter basename={basename} location={location} context={{}}>
       {children}
     </StaticRouter>
   );

--- a/packages/react-router/src/components/Router/test/Router.test.tsx
+++ b/packages/react-router/src/components/Router/test/Router.test.tsx
@@ -40,6 +40,23 @@ describe('Router', () => {
     expect(wrapper).toContainReactComponent(StaticRouter, {location});
   });
 
+  it('mounts a BrowserRouter with basename', () => {
+    const basename = '/something';
+    const wrapper = mount(<Router basename={basename} />);
+
+    expect(wrapper).toContainReactComponent(BrowserRouter, {basename});
+  });
+
+  it('mounts a StaticRouter on the server with basename', () => {
+    isClient.mockReturnValue(false);
+
+    const location = 'http://www.shopify.com';
+    const basename = '/something';
+    const wrapper = mount(<Router location={location} basename={basename} />);
+
+    expect(wrapper).toContainReactComponent(StaticRouter, {location, basename});
+  });
+
   it('throws a useful error when location is omitted on the server', () => {
     isClient.mockReturnValue(false);
 


### PR DESCRIPTION
## Description

This adds the `basename` attribute to `@shopify/react-router` which is supported by the underlying Static and Browser routers that are used.

## Type of change
- [x] @shopify/react-router Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
