### PR TITLE
React hooks - add useMedia

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Added `useInterval` hook ([#1241](https://github.com/Shopify/quilt/pull/1241))
+- Added a `useMedia` hook ([#1338](https://github.com/Shopify/quilt/pull/1338))
 
 ## [1.4.0] - 2019-12-19
 

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -83,6 +83,22 @@ function MyComponent() {
 }
 ```
 
+### `useMedia()`
+
+This hook will return the value that matches the associated media query string. If no media query is matching then it will return the default value.
+
+```tsx
+function Message() {
+  const message = useMedia(
+    ['(max-width: 640px)', '(max-width: 748px)'],
+    ['You are using a small screen', 'You are using a medium screen'],
+    'Default message',
+  );
+
+  return <p>{message}</p>;
+}
+```
+
 ### `useMountedRef()`
 
 This hook keeps track of a component's mounted / un-mounted status and returns a ref object like React’s [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) with a boolean value representing said status. This is often used when a component contains an async task that sets state after the task has resolved.

--- a/packages/react-hooks/src/hooks/index.ts
+++ b/packages/react-hooks/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export {useInterval} from './interval';
 export {useLazyRef} from './lazy-ref';
+export {useMedia} from './media';
 export {useMountedRef} from './mounted-ref';
 export {useOnValueChange} from './on-value-change';
 export {usePrevious} from './previous';

--- a/packages/react-hooks/src/hooks/media.ts
+++ b/packages/react-hooks/src/hooks/media.ts
@@ -1,0 +1,36 @@
+import {useState, useEffect} from 'react';
+
+export function useMedia<ValueType>(
+  queries: string[],
+  values: ValueType[],
+  defaultValue: ValueType,
+) {
+  const mediaQueryLists = queries.map(query => {
+    return window.matchMedia(query);
+  });
+
+  const getValue = () => {
+    const index = mediaQueryLists.findIndex(mediaQueryList => {
+      return mediaQueryList.matches;
+    });
+    return typeof values[index] === 'undefined' ? defaultValue : values[index];
+  };
+
+  const [value, setValue] = useState(getValue);
+
+  useEffect(() => {
+    const handler = () => {
+      setValue(getValue);
+    };
+    mediaQueryLists.forEach(mediaQueryList => {
+      mediaQueryList.addListener(handler);
+    });
+    return () => {
+      mediaQueryLists.forEach(mediaQueryList => {
+        mediaQueryList.removeListener(handler);
+      });
+    };
+  }, []);
+
+  return value;
+}

--- a/packages/react-hooks/src/hooks/tests/media.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/media.test.tsx
@@ -1,0 +1,43 @@
+import React, {useState} from 'react';
+import {mount} from '@shopify/react-testing';
+import {matchMedia} from '@shopify/jest-dom-mocks';
+
+import {useMedia} from '../media';
+
+describe('useMedia', () => {
+  beforeEach(() => {
+    matchMedia.mock();
+  });
+
+  afterEach(() => {
+    matchMedia.restore();
+  });
+
+  function Message() {
+    const message = useMedia(
+      ['(max-width: 748px)'],
+      ['You are using a small screen'],
+      'Default message',
+    );
+
+    return <p>{message}</p>;
+  }
+
+  it('shows labels when media does not match', () => {
+    matchMedia.setMedia(() => ({matches: false}));
+    const message = mount(<Message />);
+
+    expect(message).toContainReactComponent('p', {
+      children: 'Default message',
+    });
+  });
+
+  it('hides labels when media matches', () => {
+    matchMedia.setMedia(() => ({matches: true}));
+    const message = mount(<Message />);
+
+    expect(message).toContainReactComponent('p', {
+      children: 'You are using a small screen',
+    });
+  });
+});


### PR DESCRIPTION
## Description

When using a design system such as [Polaris](https://polaris.shopify.com/), you might want to change props values based on a media query instead of doing custom css that could break if the design system changes its implementation. E.g. Imagine I might want to hide a [TextField](https://polaris.shopify.com/components/forms/text-field) label via its `labelHidden` prop. This is not meant to replace CSS media queries, it's really meant for specific scenarios.

I've adapted the code from https://usehooks.com/useMedia/

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] react-hooks Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
