### PR TITLE
:sparkles: Adding common MimeType base to @shopify/network

### DIFF
--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Minor: Added common mime types base ([#1344](https://github.com/Shopify/quilt/pull/1344))
+
 ## [1.4.0] - 2019-06-27
 
 - Added the following headers: 'X-XSS-Protection', 'X-Frame-Options', 'X-Download-Options', 'X-Content-Type-Options', 'Strict-Transport-Security', 'Referrer-Policy' ([#752](https://github.com/Shopify/quilt/pull/752))

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -176,3 +176,20 @@ export enum CacheControl {
 export const noCache = `${CacheControl.NoCache},${CacheControl.NoStore},${
   CacheControl.MustRevalidate
 },${CacheControl.MaxAge}=0`;
+
+export enum MimeType {
+  Csv = 'text/csv',
+  Gif = 'image/gif',
+  Glb = 'model/gltf-binary',
+  Hls = 'application/x-mpegURL',
+  Html = 'text/html',
+  Jpeg = 'image/jpeg',
+  Js = 'text/javascript',
+  Json = 'application/json',
+  Mov = 'video/quicktime',
+  Mp4 = 'video/mp4',
+  Pdf = 'application/pdf',
+  Png = 'image/png',
+  Text = 'text/plain',
+  Zip = 'application/zip',
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/411

This PR adds an enum of common mime types to `@shopify/network`.  These choices were based off of the most frequently used mime types in `Shopify/web` plus the suggested ones from the issue.

It is not an exhaustive list and more values can be added.

## Type of change

- [ ] `@shopify/network` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
