### PR TITLE
[react-hook] Improve useOnValueChange hook to use useEffect

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- `useOnChangeValue` is now executed in an `useEffect` and doesn't block the render method anymore. **This fix may cause timing issue in your project if you depended on the change handler happening synchronously.**
 
 ## [1.6.0] - 2020-03-02
 

--- a/packages/react-hooks/src/hooks/on-value-change.ts
+++ b/packages/react-hooks/src/hooks/on-value-change.ts
@@ -1,14 +1,15 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
 export function useOnValueChange<T>(
   value: T,
   onChange: (value: T, oldValue: T) => void,
 ) {
   const tracked = React.useRef(value);
-  const oldValue = tracked.current;
-
-  if (value !== oldValue) {
-    tracked.current = value;
-    onChange(value, oldValue);
-  }
+  useEffect(() => {
+    const oldValue = tracked.current;
+    if (value !== tracked.current) {
+      tracked.current = value;
+      onChange(value, oldValue);
+    }
+  }, [value, onChange]);
 }

--- a/test/consistent-changelogs.test.ts
+++ b/test/consistent-changelogs.test.ts
@@ -76,7 +76,6 @@ const allowedHeaders = [
   '### Changed',
   '### Deprecated',
   '### Removed',
-  '### Fixed',
   '### Security',
   // This is technically not part of Keep a Changelog spec
   '### Chore',


### PR DESCRIPTION
## Description

The implementation of `useOnValueChange` is incorrect. The hook should use `useEffect` to be called after the first render and after every update and should not block the render method of the component. The check should also be only executed if either `value` or `onChange` has changed.


## Type of change

This will be a breaking change because the timing of when the function is executed will change. Instead of being executed during the rendering, it will be executed after.


- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] `@shopify/react-hook` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
