### PR TITLE
[Bugfix] Fix getQueuingTime header extraction

### DIFF
--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/koa-metrics",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "license": "MIT",
   "description": "Aims to provide standard middlewares and instrumentation tooling for metrics in Koa.",
   "main": "dist/src/index.js",

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/koa-metrics",
-  "version": "0.3.13",
+  "version": "0.3.12",
   "license": "MIT",
   "description": "Aims to provide standard middlewares and instrumentation tooling for metrics in Koa.",
   "main": "dist/src/index.js",

--- a/packages/koa-metrics/src/test/middleware.test.ts
+++ b/packages/koa-metrics/src/test/middleware.test.ts
@@ -173,7 +173,7 @@ describe('koa-metrics', () => {
 
       const ctx = createMockContext({
         headers: {
-          'X-Request-Start': String(queuingTime),
+          'X-Request-Start': `t=${queuingTime}`,
         },
       });
 

--- a/packages/koa-metrics/src/timing.ts
+++ b/packages/koa-metrics/src/timing.ts
@@ -1,10 +1,10 @@
 import {Context} from 'koa';
 
 export function getQueuingTime(ctx: Context): number | null {
-  const requestQueuingTime = ctx.request.get('X-Request-Start');
-  if (requestQueuingTime) {
+  const requestStartHeader = ctx.request.get('X-Request-Start');
+  if (requestStartHeader) {
     try {
-      return parseInt(requestQueuingTime, 10);
+      return parseInt(requestStartHeader.replace('t=', ''), 10);
     } catch (err) {
       // this is a non-critical error, so we can continue execution.
     }


### PR DESCRIPTION
## Description

Fixes the extraction of `X-Rrequest-Start` header as the header comes from Nginx in a format  `X-Rrequest-Start t=1585939545.844`.
This will fix the emission to Datadog for Request Queuing Time.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
