### PR TITLE
 [react-form] Fixed getValue on empty array

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,11 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Fixed
+
+- Fixed a bug where onSubmit fieldValues doesn't return empty arrays [#1353](https://github.com/Shopify/quilt/pull/1353)
+- Fixed a bug where useDirty does not update dirty state properly on lists [#1353](https://github.com/Shopify/quilt/pull/1353)
+
 ## [0.5.1] - 2020-04-02
 
 ### Fixed

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -856,11 +856,12 @@ function reduceFields<V>(
 
 - `fieldBag` is the collection of fields returned from `useForm`.
 - `reduceFn` is the reducer function to operate on each field. The return value will be passed onto the next iteration.
-- `initialValues` the starting value passed to the first iteration of the reducerFn.
+- `initialValues` (optional) the starting value passed to the first iteration of the reducerFn.
+- `reduceEmptyFn` (optional) is a reducer function that acts on non-field values such as empty array, empty object, and primitives.
 
 ###### Return value:
 
-A value returned by the `reduceFn` iterating through all the fields in the form.
+A value returned by `reduceFn` iterating through all the fields in the form, and `reduceEmptyFn` for all empty or primitive values.
 
 ##### Examples
 

--- a/packages/react-form/src/hooks/dirty.ts
+++ b/packages/react-form/src/hooks/dirty.ts
@@ -1,14 +1,6 @@
-import {useMemo} from 'react';
-
 import {FieldBag} from '../types';
-import {fieldsToArray} from '../utilities';
+import {reduceFields} from '../utilities';
 
 export function useDirty(fieldBag: FieldBag) {
-  const fields = fieldsToArray(fieldBag);
-
-  return useMemo(
-    () => fields.some(field => field.dirty),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    fields,
-  );
+  return reduceFields(fieldBag, (dirty, field) => dirty || field.dirty, false);
 }

--- a/packages/react-form/src/test/utilities.test.ts
+++ b/packages/react-form/src/test/utilities.test.ts
@@ -82,6 +82,17 @@ describe('getValues()', () => {
 
     expect(getValues(fieldBag)).toStrictEqual(formValue);
   });
+
+  it('returns empty arrays', () => {
+    const formValue = {
+      emails: [],
+    };
+    const fieldBag = {
+      emails: [],
+    };
+
+    expect(getValues(fieldBag)).toStrictEqual(formValue);
+  });
 });
 
 describe('validateAll', () => {


### PR DESCRIPTION
- reduceField takes 4th argument to deal with non-field primitive/empty values
 - useDirty no longer uses useMemo

## Description

Fixes https://github.com/Shopify/web/pull/25308

`reduceFields` was previously unable to parse empty arrays and objects, making `getValue` not return the entire fieldValue since they do not loop over a field (empty arrays are not fields). A new argument `reduceEmptyFn` allows `getValue` to handle empty arrays.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
