### PR TITLE
Fix type for react-csrf CsrfTokenContext to work properly with JSON encoded serialization

### DIFF
--- a/packages/react-csrf-universal-provider/CHANGELOG.md
+++ b/packages/react-csrf-universal-provider/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Changed context type to take { csrfToken: string | undefined; } to work properly with newest serialize-javascript version 3.0.0 and JSON.parse enforcement
 
 ## [1.1.0] - 2019-12-19
 

--- a/packages/react-csrf-universal-provider/README.md
+++ b/packages/react-csrf-universal-provider/README.md
@@ -20,7 +20,7 @@ import {CsrfUniversalProvider} from '@shopify/react-csrf-universal-provider';
 
 function App({token}: {token?: string}) {
   return (
-    <CsrfUniversalProvider value={token}>
+    <CsrfUniversalProvider value={{csrfToken: token}}>
       {/* rest of the app */}
     </CsrfUniversalProvider>
   );

--- a/packages/react-csrf-universal-provider/src/CsrfUniversalProvider.ts
+++ b/packages/react-csrf-universal-provider/src/CsrfUniversalProvider.ts
@@ -1,6 +1,7 @@
-import {CsrfTokenContext} from '@shopify/react-csrf';
+import {CsrfTokenContext, CsrfTokenData} from '@shopify/react-csrf';
 import {createUniversalProvider} from '@shopify/react-universal-provider';
 
-export const CsrfUniversalProvider = createUniversalProvider<
-  string | undefined
->('csrf-token', CsrfTokenContext);
+export const CsrfUniversalProvider = createUniversalProvider<CsrfTokenData>(
+  'csrf-token',
+  CsrfTokenContext,
+);

--- a/packages/react-csrf-universal-provider/src/test/CsrfUniversalProvider.test.tsx
+++ b/packages/react-csrf-universal-provider/src/test/CsrfUniversalProvider.test.tsx
@@ -9,7 +9,7 @@ import {CsrfUniversalProvider} from '../CsrfUniversalProvider';
 
 describe('<CsrfUniversalProvider />', () => {
   it('renders a CsrfTokenContext.Provider with token value from the prop', () => {
-    const token = faker.lorem.word();
+    const token = {csrfToken: faker.lorem.word()};
     const csrf = mount(<CsrfUniversalProvider value={token} />);
 
     expect(csrf).toContainReactComponent(CsrfTokenContext.Provider, {
@@ -19,7 +19,7 @@ describe('<CsrfUniversalProvider />', () => {
 
   it('renders a CsrfTokenContext.Provider with token value from the serializes csrf token', async () => {
     const htmlManager = new HtmlManager();
-    const token = faker.lorem.word();
+    const token = {csrfToken: faker.lorem.word()};
 
     // Simulated server render
     await extract(<CsrfUniversalProvider value={token} />, {
@@ -43,8 +43,8 @@ describe('<CsrfUniversalProvider />', () => {
 
   it('renders a CsrfTokenContext.Provider with value from server when value are provided on both server and client', async () => {
     const htmlManager = new HtmlManager();
-    const serverToken = faker.lorem.word();
-    const clientToken = faker.lorem.word();
+    const serverToken = {csrfToken: faker.lorem.word()};
+    const clientToken = {csrfToken: faker.lorem.word()};
 
     // Simulated server render
     await extract(<CsrfUniversalProvider value={serverToken} />, {

--- a/packages/react-csrf/CHANGELOG.md
+++ b/packages/react-csrf/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Changed context type to take { csrfToken: string | undefined; } to work properly with newest serialize-javascript version 3.0.0 and JSON.parse enforcement
 
 ## [1.0.8] - 2020-10-15
 

--- a/packages/react-csrf/README.md
+++ b/packages/react-csrf/README.md
@@ -22,7 +22,7 @@ import {CsrfTokenContext} from '@shopify/react-csrf';
 
 function App({token}: {token?: string}) {
   return (
-    <CsrfTokenContext.Provider value={token}>
+    <CsrfTokenContext.Provider value={{csrfToken: token}}>
       {/* rest of the app */}
     </CsrfTokenContext.Provider>
   );

--- a/packages/react-csrf/src/context.ts
+++ b/packages/react-csrf/src/context.ts
@@ -1,3 +1,9 @@
 import {createContext} from 'react';
 
-export const CsrfTokenContext = createContext<string | undefined>(undefined);
+export interface CsrfTokenData {
+  csrfToken: string | undefined;
+}
+
+export const CsrfTokenContext = createContext<CsrfTokenData>({
+  csrfToken: undefined,
+});

--- a/packages/react-csrf/src/hooks.ts
+++ b/packages/react-csrf/src/hooks.ts
@@ -5,9 +5,9 @@ import {CsrfTokenContext} from './context';
 export function useCsrfToken() {
   const csrf = useContext(CsrfTokenContext);
 
-  if (csrf == null) {
+  if (!csrf || csrf.csrfToken === undefined) {
     throw new Error('No CSRF token found in context.');
   }
 
-  return csrf;
+  return csrf.csrfToken;
 }

--- a/packages/react-csrf/src/index.ts
+++ b/packages/react-csrf/src/index.ts
@@ -1,2 +1,2 @@
-export {CsrfTokenContext} from './context';
+export {CsrfTokenContext, CsrfTokenData} from './context';
 export {useCsrfToken} from './hooks';

--- a/packages/react-csrf/src/test/hooks.test.tsx
+++ b/packages/react-csrf/src/test/hooks.test.tsx
@@ -14,7 +14,7 @@ describe('<CsrfProvider />', () => {
   it('renders a csrfToken with value from the context', () => {
     const token = faker.lorem.word();
     const csrf = mount(
-      <CsrfTokenContext.Provider value={token}>
+      <CsrfTokenContext.Provider value={{csrfToken: token}}>
         <CsrfToken />
       </CsrfTokenContext.Provider>,
     );

--- a/packages/react-server/src/providers/providers.tsx
+++ b/packages/react-server/src/providers/providers.tsx
@@ -24,7 +24,7 @@ export function createCombinedProvider(options?: Options) {
         <ConditionalProvider
           provider={CsrfUniversalProvider}
           condition={csrf}
-          props={{value: csrfToken}}
+          props={{value: {csrfToken}}}
         >
           {children}
         </ConditionalProvider>


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1356

This changes the type for `CsrfTokenContext` in react-csrf so that it can be properly JSON serialized and used with newest serialize-javascript@^3.0.0 which enforces JSON.parse for our universal providers. 

## Type of change

- [x] react-csrf Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] react-csrf-universal-provider Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
