### PR TITLE
Ensure the serialized data is an object

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Fixes an issue where passing a string to Serialize component would break serialization as it fails to properly JSON.parse
 
 ## [9.3.0] - 2020-03-13
 

--- a/packages/react-html/src/server/components/Serialize.tsx
+++ b/packages/react-html/src/server/components/Serialize.tsx
@@ -12,7 +12,7 @@ export default function Serialize({id, data}: Props) {
   return (
     <script
       type="text/json"
-      dangerouslySetInnerHTML={{__html: serialize(data, {isJSON: true})}}
+      dangerouslySetInnerHTML={{__html: serialize({data}, {isJSON: true})}}
       {...{[SERIALIZE_ATTRIBUTE]: id}}
     />
   );

--- a/packages/react-html/src/server/components/tests/Serialize.test.tsx
+++ b/packages/react-html/src/server/components/tests/Serialize.test.tsx
@@ -30,7 +30,7 @@ describe('<Serialize />', () => {
 
       expect(serialize).toContainReactComponent('script', {
         dangerouslySetInnerHTML: {
-          __html: serializeJavaScript(data, {isJSON: true}),
+          __html: serializeJavaScript({data}, {isJSON: true}),
         },
       });
     });

--- a/packages/react-html/src/tests/serializer.test.tsx
+++ b/packages/react-html/src/tests/serializer.test.tsx
@@ -8,8 +8,8 @@ import {useSerialized, HtmlContext, HtmlManager} from '..';
 describe('useSerialized', () => {
   it('serializes promise results', async () => {
     function MockComponent() {
-      const [foo, Serialize] = useSerialized('foo');
-      return <Serialize data={() => foo || Promise.resolve('foo_value')} />;
+      const [, Serialize] = useSerialized('foo');
+      return <Serialize data={() => Promise.resolve({result: 'foo_value'})} />;
     }
 
     const manager = new HtmlManager();
@@ -21,7 +21,26 @@ describe('useSerialized', () => {
     });
 
     expect(render(<Html manager={manager}>{app}</Html>)).toContain(
-      `<script type="text/json" data-serialized-id="foo">"foo_value"</script>`,
+      `<script type="text/json" data-serialized-id="foo">{"data":{"result":"foo_value"}}</script>`,
+    );
+  });
+
+  it('serializes string values with data wrapper', async () => {
+    function MockComponent() {
+      const [, Serialize] = useSerialized('foo');
+      return <Serialize data={() => 'my-value'} />;
+    }
+
+    const manager = new HtmlManager();
+    const app = <MockComponent />;
+    await extract(app, {
+      decorate: element => (
+        <HtmlContext.Provider value={manager}>{element}</HtmlContext.Provider>
+      ),
+    });
+
+    expect(render(<Html manager={manager}>{app}</Html>)).toContain(
+      `<script type="text/json" data-serialized-id="foo">{"data":"my-value"}</script>`,
     );
   });
 });

--- a/packages/react-html/src/tests/utilities.test.tsx
+++ b/packages/react-html/src/tests/utilities.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {getSerialized} from '../utilities';
+
+describe('getSerialized', () => {
+  it('gets proper value from serialized script', async () => {
+    await mount(
+      <div>
+        <script type="text/json" data-serialized-id="foo">
+          {JSON.stringify({data: 'foo_value'})}
+        </script>
+      </div>,
+    );
+
+    expect(getSerialized('foo')).toBe('foo_value');
+  });
+
+  it('throws error when nothing is found', async () => {
+    await mount(<div />);
+
+    expect(() => getSerialized('foo')).toThrow(
+      'No serializations found for id "foo"',
+    );
+  });
+});

--- a/packages/react-html/src/utilities.ts
+++ b/packages/react-html/src/utilities.ts
@@ -22,7 +22,7 @@ function getSerializedFromNode<Data>(node: Element): Data | undefined {
   const value = node.textContent;
 
   try {
-    return value ? JSON.parse(value) : undefined;
+    return value ? JSON.parse(value).data : undefined;
   } catch {
     return undefined;
   }

--- a/packages/react-universal-provider/src/test/create-universal-provider.test.tsx
+++ b/packages/react-universal-provider/src/test/create-universal-provider.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import faker from 'faker';
 import {extract} from '@shopify/react-effect/server';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';
+import {render, Html} from '@shopify/react-html/server';
 import {mount} from '@shopify/react-testing';
 
 import {createUniversalProvider} from '../create-universal-provider';
@@ -24,9 +25,10 @@ describe('createUniversalProvider()', () => {
   it('renders a RandomContext.Provider with value from the serializer', async () => {
     const htmlManager = new HtmlManager();
     const randomValue = faker.lorem.word();
+    const app = <RandomProvider value={randomValue} />;
 
     // Simulated server render
-    await extract(<RandomProvider value={randomValue} />, {
+    await extract(app, {
       decorate: (element: React.ReactNode) => (
         <HtmlContext.Provider value={htmlManager}>
           {element}
@@ -44,15 +46,20 @@ describe('createUniversalProvider()', () => {
       RandomContext,
       randomValue,
     );
+
+    expect(render(<Html manager={htmlManager}>{app}</Html>)).toContain(
+      `<script type="text/json" data-serialized-id="${id}">{"data":"${randomValue}"}</script>`,
+    );
   });
 
   it('renders a RandomContext.Provider with value from server when value are provided on both server and client', async () => {
     const htmlManager = new HtmlManager();
     const serverRandomValue = faker.lorem.word();
     const clientRandomValue = faker.lorem.word();
+    const app = <RandomProvider value={serverRandomValue} />;
 
     // Simulated server render
-    await extract(<RandomProvider value={serverRandomValue} />, {
+    await extract(app, {
       decorate: (element: React.ReactNode) => (
         <HtmlContext.Provider value={htmlManager}>
           {element}
@@ -69,6 +76,10 @@ describe('createUniversalProvider()', () => {
     expect(randomProvider).toProvideReactContext<string | undefined>(
       RandomContext,
       serverRandomValue,
+    );
+
+    expect(render(<Html manager={htmlManager}>{app}</Html>)).toContain(
+      `<script type="text/json" data-serialized-id="${id}">{"data":"${serverRandomValue}"}</script>`,
     );
   });
 });


### PR DESCRIPTION
## Description
Fixes https://github.com/Shopify/quilt/issues/1356
This makes sure setting value of the Serialized component to a plain string or number won't break the JSON.parse enforcing.

## Type of change

- [x] react-html Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
