### PR TITLE
Removes "window" reference from "useDebouncedValue" hook

### DIFF
--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -27,8 +27,8 @@ function MyComponent() {
     },
   });
 
-  function handleSearchTextChange(value: string) {
-    setSearchValue(value);
+  function handleSearchTextChange(evt: React.KeyboardEvent) {
+    setSearchValue(evt.currentTarget.value);
   }
 
   return (<input onChange={handleSearchTextChange} />);

--- a/packages/react-hooks/src/hooks/debounced.ts
+++ b/packages/react-hooks/src/hooks/debounced.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useRef} from 'react';
 
 interface DebouncedOptions {
   timeoutMs: number;
@@ -11,14 +11,20 @@ export function useDebouncedValue<T>(
   {timeoutMs}: DebouncedOptions = {timeoutMs: DEFAULT_DELAY},
 ) {
   const [state, setState] = useState<T>(value);
+  const stateRef = useRef<T>(state);
 
   useEffect(() => {
-    const timeout = window.setTimeout(() => {
+    if (stateRef.current === value) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      stateRef.current = value;
       setState(value);
     }, timeoutMs);
 
     return () => {
-      window.clearTimeout(timeout);
+      clearTimeout(timeout);
     };
   }, [value, timeoutMs]);
 


### PR DESCRIPTION
## Description

Removes `window` dependency from the hook introduced on https://github.com/Shopify/quilt/pull/1354. Uses a ref to store the value and update it only if different from previous one.

## Type of change

(setting this as a Minor because it will be bundled with the next release so even though this might compromise SSR, nobody's using it yet, hence not being a breaking change)

- [x] react-hooks Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above

