### PR TITLE
[react-form] Add value parameter to runValidation type definition

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Fixed
+
+- [Patch] Add optional `value` parameter to `runValidation` type definition [#1362](https://github.com/Shopify/quilt/pull/1362)
+
 ## [0.5.2] - 2020-04-07
 
 ### Fixed

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -51,7 +51,7 @@ export interface Field<Value> {
   dirty: boolean;
   onBlur(): void;
   onChange(value: Value | ChangeEvent<HTMLInputElement>): void;
-  runValidation(): ErrorValue;
+  runValidation(value?: Value): ErrorValue;
   setError(value: ErrorValue): void;
   newDefaultValue(value: Value): void;
   reset(): void;


### PR DESCRIPTION
## Description

Adding the value parameter to the runValidation type definition to be able to call the function with updated values.

## Type of change

Extending type definition. 

- [x] react-form Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
