### PR TITLE
Avoid /u in regex for IE11

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Fixed
+
+- Removed the unicode `RegExp` flag on `getCurrencySymbol` in order to support IE11 ([#1363](https://github.com/Shopify/quilt/pull/1363))
+
 ## [2.5.0] - 2020-04-02
 
 ### Added

--- a/packages/react-i18n/src/utilities/money.ts
+++ b/packages/react-i18n/src/utilities/money.ts
@@ -3,7 +3,7 @@ export function getCurrencySymbol(
   options: Intl.NumberFormatOptions,
 ) {
   const delimiters = ',.';
-  const directionControlCharacters = new RegExp(`[\u{200E}\u{200F}]`, 'u');
+  const directionControlCharacters = /[\u200E\u200F]/;
   const numReg = new RegExp(`0[${delimiters}]*0*`);
 
   const currencyStringRaw = formatCurrency(0, locale, options);


### PR DESCRIPTION
The `u` flag in regular expressions is not supported in IE11. This PR swaps out a usage of that flag in `react-i18n` for the equivalent in a non-unicode regex.