### PR TITLE
[react-i18n] adding some additional exports

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- adding additional exports: `RegisterOptions`, `CurrencyFormatOptions`, `NumberFormatOptions`, `TranslateOptions`, `RootTranslateOptions`, `Replacements` ([#1365](https://github.com/Shopify/quilt/pull/1365))
+
 ### Fixed
 
 - Updated `formatCurrency` to use `memoizedNumberFormatter` to eliminate memory leak ([#1310](https://github.com/Shopify/quilt/pull/1310))

--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -1,13 +1,23 @@
-export {I18nManager, ExtractedTranslations} from './manager';
+export {I18nManager, ExtractedTranslations, RegisterOptions} from './manager';
 export {I18nContext} from './context';
-export {I18n} from './i18n';
+export {
+  CurrencyFormatOptions,
+  I18n,
+  NumberFormatOptions,
+  TranslateOptions,
+} from './i18n';
 export {useI18n} from './hooks';
 export {withI18n, WithI18nProps} from './decorator';
-export {memoizedNumberFormatter, translate} from './utilities';
+export {
+  memoizedNumberFormatter,
+  translate,
+  TranslateOptions as RootTranslateOptions,
+} from './utilities';
 export {
   I18nDetails,
   LanguageDirection,
   CurrencyCode,
+  Replacements,
   TranslationDictionary,
 } from './types';
 export {


### PR DESCRIPTION
## Description

There are some parts of `react-i18n` that would benefit from being exported, this PR is adding some additional exports to the API surface.

- `RegisterOptions` - used primarily by `useI18n()`
- `CurrencyFormatOptions` - used by `formatCurrency()`
- `NumberFormatOptions` - used by `formatNumber()`
- `TranslateOptions` - used by `I18n.translate()`
- `RootTranslateOptions` - used by the static `translate()`
- `Replacements` - union of `PrimitiveReplacementDictionary` and `ComplexReplacementDictionary` for use with `I18n.translate()`

This shouldn't affect any existing consumers as this is only supplementing the already existing API surface.

I picked these new exports by objectively looking at their usages and inferring whether or not they would be useful to consumers. All of these new type exports can be reproduced using complex typing constructs, so they are not _required_ by any means, only simplifying usage of other function abstractions. Some of these I have already run into annoyances from their absence in other projects (typically with testing or mocks).

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-i18n` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
