### PR TITLE
[react-i18n] fixing memoizedNumberFormatter signature

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- updated `memoizedNumberFormatter` to support all `Intl.NumberFormat` constructor inputs ([#1366](https://github.com/Shopify/quilt/pull/1366))
 
 ## [2.5.4] - 2020-04-09
 

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -125,6 +125,16 @@ describe('memoizedNumberFormatter', () => {
     expect(numberFormatterB).toBe(numberFormatterA);
   });
 
+  it('returns the same object when passed multiple locales as an array', () => {
+    const locales = ['en-US', 'en-CA'];
+    const numberFormatterA = memoizedNumberFormatter(locales);
+    expect(numberFormatterA).toBeInstanceOf(Intl.NumberFormat);
+
+    const numberFormatterB = memoizedNumberFormatter(locales);
+    expect(numberFormatterB).toBeInstanceOf(Intl.NumberFormat);
+    expect(numberFormatterB).toBe(numberFormatterA);
+  });
+
   it('returns different object when passed different arguments', () => {
     const numberFormatterA = memoizedNumberFormatter(locale);
     expect(numberFormatterA).toBeInstanceOf(Intl.NumberFormat);

--- a/packages/react-i18n/src/utilities/tests/money.test.ts
+++ b/packages/react-i18n/src/utilities/tests/money.test.ts
@@ -38,10 +38,6 @@ describe('formatCurrency()', () => {
 
   it('calls format on the memoized formatter', () => {
     const amount = 123;
-    const locale = 'en';
-    const options = {
-      currency: 'USD',
-    };
     const result = 'result';
     mockFormat.mockImplementation(() => result);
 

--- a/packages/react-i18n/src/utilities/tests/translate.test.ts
+++ b/packages/react-i18n/src/utilities/tests/translate.test.ts
@@ -1,0 +1,46 @@
+import {numberFormatCacheKey} from '../translate';
+
+describe('numberFormatCacheKey()', () => {
+  const locale = 'en-CA';
+  const otherLocale = 'en-US';
+  const options = {currency: 'USD'};
+  const optionsKey = JSON.stringify(options);
+
+  it('creates a key for an undefined locale with options', () => {
+    expect(numberFormatCacheKey(undefined, options)).toBe(
+      `undefined-${optionsKey}`,
+    );
+  });
+
+  it('creates a key for an undefined locale without options', () => {
+    expect(numberFormatCacheKey()).toBe(`undefined-{}`);
+  });
+
+  it('creates a key for a single locale with options', () => {
+    expect(numberFormatCacheKey(locale, options)).toBe(
+      `${locale}-${optionsKey}`,
+    );
+  });
+
+  it('creates a key for a single locale without options', () => {
+    expect(numberFormatCacheKey(locale)).toBe(`${locale}-{}`);
+  });
+
+  it('creates a key for a multiple locales with options', () => {
+    expect(numberFormatCacheKey([locale, otherLocale], options)).toBe(
+      `${locale}-${otherLocale}-${optionsKey}`,
+    );
+  });
+
+  it('creates a key for a multiple locales without options', () => {
+    expect(numberFormatCacheKey([locale, otherLocale])).toBe(
+      `${locale}-${otherLocale}-{}`,
+    );
+  });
+
+  it('sorts locales when there are multiple', () => {
+    expect(numberFormatCacheKey([otherLocale, locale])).toBe(
+      `${locale}-${otherLocale}-{}`,
+    );
+  });
+});

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -19,14 +19,14 @@ const SEPARATOR = '.';
 
 const numberFormats = new Map<string, Intl.NumberFormat>();
 export function memoizedNumberFormatter(
-  locale: string,
-  options: Intl.NumberFormatOptions = {},
+  locales?: string | string[],
+  options?: Intl.NumberFormatOptions,
 ) {
-  const key = numberFormatCacheKey(locale, options);
+  const key = numberFormatCacheKey(locales, options);
   if (numberFormats.has(key)) {
     return numberFormats.get(key)!;
   }
-  const i = new Intl.NumberFormat(locale, options);
+  const i = new Intl.NumberFormat(locales, options);
   numberFormats.set(key, i);
   return i;
 }
@@ -44,11 +44,13 @@ export interface TranslateOptions<Replacements = {}> {
   pseudotranslate?: boolean | string;
 }
 
-function numberFormatCacheKey(
-  locale: string,
+export function numberFormatCacheKey(
+  locales?: string | string[],
   options: Intl.NumberFormatOptions = {},
 ) {
-  return `${locale}${JSON.stringify(options)}`;
+  const localeKey = Array.isArray(locales) ? locales.sort().join('-') : locales;
+
+  return `${localeKey}-${JSON.stringify(options)}`;
 }
 
 function pluralRules(locale: string, options: Intl.PluralRulesOptions = {}) {


### PR DESCRIPTION
## Description

It is reasonable to want to create an `Intl.NumberFormat` instance with an `undefined` locale. This PR is patching `memoizedNumberFormatter` to support this use case. We can also support the case of a `string[]` of locales.

related to #1310

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
