### PR TITLE
[dates] exposing memoizedGetDateTimeFormat and adding getIanaTimeZone

### DIFF
--- a/packages/dates/CHANGELOG.md
+++ b/packages/dates/CHANGELOG.md
@@ -5,17 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Added `getIanaTimeZone` and exposed `memoizedGetDateTimeFormat` ([#1367](https://github.com/Shopify/quilt/pull/1367))
 
 ## [0.3.1] - 2020-02-27
 
 ### Fixed
 
-- Allows `hour12: true` to be passed to `formatDate` [#1299](https://github.com/Shopify/quilt/pull/1299)
+- Allows `hour12: true` to be passed to `formatDate` ([#1299](https://github.com/Shopify/quilt/pull/1299))
 
 ## [0.3.0] - 2020-02-19
 
-- Export the `formatDate` function so it can be used by other packages / projects, e.g. in `@shopify/react-i18n`
+- Export the `formatDate` function so it can be used by other packages / projects, e.g. in `@shopify/react-i18n` ([#1286](https://github.com/Shopify/quilt/pull/1286))
 
 ## [0.2.13] - 2020-02-07
 

--- a/packages/dates/src/tests/utilities.test.ts
+++ b/packages/dates/src/tests/utilities.test.ts
@@ -1,4 +1,4 @@
-import {formatDate} from '../utilities/formatDate';
+import {dateTimeFormatCacheKey, formatDate} from '../utilities/formatDate';
 
 describe('formatDate()', () => {
   it('formats dates as expected for various locales', () => {
@@ -35,5 +35,49 @@ describe('formatDate()', () => {
     const expected = '1/1/2018, 12:34:56 PM';
 
     expect(formatDate(date, locale, options)).toBe(expected);
+  });
+});
+
+describe('dateTimeFormatCacheKey()', () => {
+  const locale = 'en-CA';
+  const otherLocale = 'en-US';
+  const options = {timeZone: 'America/Vancouver'};
+  const optionsKey = JSON.stringify(options);
+  it('creates a key for an undefined locale with options', () => {
+    expect(dateTimeFormatCacheKey(undefined, options)).toBe(
+      `undefined-${optionsKey}`,
+    );
+  });
+
+  it('creates a key for an undefined locale without options', () => {
+    expect(dateTimeFormatCacheKey()).toBe(`undefined-{}`);
+  });
+
+  it('creates a key for a single locale with options', () => {
+    expect(dateTimeFormatCacheKey(locale, options)).toBe(
+      `${locale}-${optionsKey}`,
+    );
+  });
+
+  it('creates a key for a single locale without options', () => {
+    expect(dateTimeFormatCacheKey(locale)).toBe(`${locale}-{}`);
+  });
+
+  it('creates a key for a multiple locales with options', () => {
+    expect(dateTimeFormatCacheKey([locale, otherLocale], options)).toBe(
+      `${locale}-${otherLocale}-${optionsKey}`,
+    );
+  });
+
+  it('creates a key for a multiple locales without options', () => {
+    expect(dateTimeFormatCacheKey([locale, otherLocale])).toBe(
+      `${locale}-${otherLocale}-{}`,
+    );
+  });
+
+  it('sorts locales when there are multiple', () => {
+    expect(dateTimeFormatCacheKey([otherLocale, locale])).toBe(
+      `${locale}-${otherLocale}-{}`,
+    );
   });
 });

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -1,13 +1,16 @@
-const intl = new Map();
-const memoizedGetDateTimeFormat = function(locale, options) {
-  const key = dateTimeFormatCacheKey(locale, options);
+const intl = new Map<string, Intl.DateTimeFormat>();
+export function memoizedGetDateTimeFormat(
+  locales?: string | string[],
+  options?: Intl.DateTimeFormatOptions,
+) {
+  const key = dateTimeFormatCacheKey(locales, options);
   if (intl.has(key)) {
-    return intl.get(key);
+    return intl.get(key)!;
   }
-  const i = new Intl.DateTimeFormat(locale, options);
+  const i = new Intl.DateTimeFormat(locales, options);
   intl.set(key, i);
   return i;
-};
+}
 
 const browserFeatureDetectionDate = Intl.DateTimeFormat('en', {
   hour: 'numeric',
@@ -49,9 +52,11 @@ export function formatDate(
   return memoizedGetDateTimeFormat(locales, options).format(date);
 }
 
-function dateTimeFormatCacheKey(
-  locales: string | string[],
-  options?: Intl.DateTimeFormatOptions,
+export function dateTimeFormatCacheKey(
+  locales?: string | string[],
+  options: Intl.DateTimeFormatOptions = {},
 ) {
-  return `${locales}-${JSON.stringify(options)}`;
+  const localeKey = Array.isArray(locales) ? locales.sort().join('-') : locales;
+
+  return `${localeKey}-${JSON.stringify(options)}`;
 }

--- a/packages/dates/src/utilities/index.ts
+++ b/packages/dates/src/utilities/index.ts
@@ -1,1 +1,2 @@
-export {formatDate} from './formatDate';
+export {formatDate, memoizedGetDateTimeFormat} from './formatDate';
+export {getIanaTimeZone} from './timezone';

--- a/packages/dates/src/utilities/tests/timezone.test.ts
+++ b/packages/dates/src/utilities/tests/timezone.test.ts
@@ -1,0 +1,46 @@
+import {getIanaTimeZone} from '../timezone';
+
+jest.mock('../formatDate', () => ({
+  memoizedGetDateTimeFormat: jest.fn(),
+}));
+
+const memoizedGetDateTimeFormatMock: jest.Mock = jest.requireMock(
+  '../formatDate',
+).memoizedGetDateTimeFormat;
+
+describe('getIanaTimeZone()', () => {
+  const resolvedOptionsMock = jest.fn();
+
+  beforeEach(() => {
+    const mockFormatter = {
+      resolvedOptions: resolvedOptionsMock,
+    };
+    memoizedGetDateTimeFormatMock.mockImplementation(() => mockFormatter);
+    resolvedOptionsMock.mockImplementation(() => ({
+      timeZone: 'America/Vancouver',
+    }));
+  });
+
+  afterEach(() => {
+    memoizedGetDateTimeFormatMock.mockReset();
+    resolvedOptionsMock.mockReset();
+  });
+
+  it('uses memoizedGetDateTimeFormat to get a memoized formatter', () => {
+    const locale = 'en';
+    const options = {
+      timeZoneName: 'short',
+    };
+
+    getIanaTimeZone(locale, options);
+    expect(memoizedGetDateTimeFormatMock).toHaveBeenCalledWith(locale, options);
+  });
+
+  it('returns the timeZone from the memoized formatter resolved options', () => {
+    const timeZone = 'testing';
+    resolvedOptionsMock.mockImplementation(() => ({timeZone}));
+
+    expect(getIanaTimeZone('en', {})).toBe(timeZone);
+    expect(resolvedOptionsMock).toHaveBeenCalled();
+  });
+});

--- a/packages/dates/src/utilities/timezone.ts
+++ b/packages/dates/src/utilities/timezone.ts
@@ -1,0 +1,8 @@
+import {memoizedGetDateTimeFormat} from './formatDate';
+
+export function getIanaTimeZone(
+  locale?: string | string[],
+  options?: Intl.DateTimeFormatOptions,
+) {
+  return memoizedGetDateTimeFormat(locale, options).resolvedOptions().timeZone;
+}


### PR DESCRIPTION
## Description

I am exposing `memoizedGetDateTimeFormat()` so that consumers can avoid a memory leak when accessing a `Intl.DateTimeFormat` instance, as well as adding a new `getIanaTimeZone` that will extract the `timeZone` from the formatters `resovedOptions()`. This can be used to get the browser IANA timezone by simply calling without any parameters.

resovles #503

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
