### PR TITLE
:sparkles: Adding base package for mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Each package has its own `README` and documentation describing usage.
 | koa-shopify-graphql-proxy | [directory](packages/koa-shopify-graphql-proxy) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy) |
 | koa-shopify-webhooks | [directory](packages/koa-shopify-webhooks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks) |
 | logger | [directory](packages/logger) | [![npm version](https://badge.fury.io/js/%40shopify%2Flogger.svg)](https://badge.fury.io/js/%40shopify%2Flogger) |
+| mime-types | [directory](packages/mime-types) | [![npm version](https://badge.fury.io/js/%40shopify%2Fmime-types.svg)](https://badge.fury.io/js/%40shopify%2Fmime-types) |
 | network | [directory](packages/network) | [![npm version](https://badge.fury.io/js/%40shopify%2Fnetwork.svg)](https://badge.fury.io/js/%40shopify%2Fnetwork) |
 | performance | [directory](packages/performance) | [![npm version](https://badge.fury.io/js/%40shopify%2Fperformance.svg)](https://badge.fury.io/js/%40shopify%2Fperformance) |
 | polyfills | [directory](packages/polyfills) | [![npm version](https://badge.fury.io/js/%40shopify%2Fpolyfills.svg)](https://badge.fury.io/js/%40shopify%2Fpolyfills) |

--- a/packages/mime-types/CHANGELOG.md
+++ b/packages/mime-types/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/mime-types` package

--- a/packages/mime-types/README.md
+++ b/packages/mime-types/README.md
@@ -1,0 +1,51 @@
+# `@shopify/mime-types`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fmime-types.svg)](https://badge.fury.io/js/%40shopify%2Fmime-types.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/mime-types.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/mime-types.svg)
+
+Mime type consistency
+
+## Installation
+
+```bash
+$ yarn add @shopify/mime-types
+```
+
+## Usage
+
+This package exposes utilities to dynamically get MIME types from file names and/or get file extensions based on common MIME types.
+
+The types of files currently supported are:
+
+```
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'application/pdf',
+  'video/mp4',
+  'video/quicktime',
+  'model/gltf-binary',
+  'application/x-mpegURL',
+```
+
+This helps keeping MIME types and file extensions consistent.
+
+### `getMimeTypeFromFilename`
+
+Takes in a file name string and returns a `MimeType`.
+
+```ts
+import {getMimeTypeFromFilename} from '@shopify/files';
+
+getMimeTypeFromFilename('image.jpg'); // image/jpeg
+```
+
+### `getExtensionFromMimeType`
+
+Takes in a `MimeType` and returns a string filename extension that matches the inputted `MimeType`.
+
+```ts
+import {getExtensionFromMimeType, MimeType} from '@shopify/files';
+
+getExtensionFromMimeType(MimeType.Pdf); // .pdf
+```

--- a/packages/mime-types/package.json
+++ b/packages/mime-types/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@shopify/mime-types",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Mime type consistency",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc --p tsconfig.json"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git",
+    "directory": "packages/mime-types"
+  },
+  "bugs": {
+    "url": "https://github.com/Shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/mime-types/README.md",
+  "files": ["dist/*", "!tsconfig.tsbuildinfo"]
+}

--- a/packages/mime-types/src/get-extension-from-mime-type.ts
+++ b/packages/mime-types/src/get-extension-from-mime-type.ts
@@ -1,0 +1,25 @@
+import {MimeType} from './types';
+
+export function getExtensionFromMimeType(mimeType: MimeType) {
+  switch (mimeType) {
+    case MimeType.Gif:
+      return '.gif';
+    case MimeType.Glb:
+      return '.glb';
+    case MimeType.Hls:
+      return '.m3u8';
+    case MimeType.Jpeg:
+      return '.jpg';
+    case MimeType.Mov:
+      return '.mov';
+    case MimeType.Mp4:
+      return '.mp4';
+    case MimeType.Pdf:
+      return '.pdf';
+    case MimeType.Png:
+      return '.png';
+  }
+
+  const nope: never = mimeType;
+  return nope;
+}

--- a/packages/mime-types/src/get-mime-type-from-filename.ts
+++ b/packages/mime-types/src/get-mime-type-from-filename.ts
@@ -1,0 +1,33 @@
+import {MimeType} from './types';
+
+export function getMimeTypeFromFilename(filename: string) {
+  const extension = getFileExtension(filename.toLowerCase());
+
+  switch (extension) {
+    case 'gif':
+      return MimeType.Gif;
+    case 'glb':
+      return MimeType.Glb;
+    case 'm3u8':
+      return MimeType.Hls;
+    case 'jpg':
+    case 'jpeg':
+      return MimeType.Jpeg;
+    case 'mov':
+      return MimeType.Mov;
+    case 'mp4':
+      return MimeType.Mp4;
+    case 'pdf':
+      return MimeType.Pdf;
+    case 'png':
+      return MimeType.Png;
+  }
+}
+
+function getFileExtension(filename: string) {
+  const match = /(?:\.([^.]+))?$/.exec(filename);
+
+  if (match) {
+    return match[1];
+  }
+}

--- a/packages/mime-types/src/index.ts
+++ b/packages/mime-types/src/index.ts
@@ -1,0 +1,3 @@
+export {getExtensionFromMimeType} from './get-extension-from-mime-type';
+export {getMimeTypeFromFilename} from './get-mime-type-from-filename';
+export {MimeType} from './types';

--- a/packages/mime-types/src/test/get-extension-from-mime-type.test.ts
+++ b/packages/mime-types/src/test/get-extension-from-mime-type.test.ts
@@ -1,0 +1,21 @@
+import {MimeType} from '../types';
+import {getExtensionFromMimeType} from '../get-extension-from-mime-type';
+
+describe('getExtensionFromMimeType', () => {
+  assertExtensionForMimeType('.gif', MimeType.Gif);
+  assertExtensionForMimeType('.glb', MimeType.Glb);
+  assertExtensionForMimeType('.jpg', MimeType.Jpeg);
+  assertExtensionForMimeType('.mov', MimeType.Mov);
+  assertExtensionForMimeType('.mp4', MimeType.Mp4);
+  assertExtensionForMimeType('.pdf', MimeType.Pdf);
+  assertExtensionForMimeType('.png', MimeType.Png);
+});
+
+function assertExtensionForMimeType(extension: string, mimeType: MimeType) {
+  // eslint-disable-next-line jest/require-top-level-describe
+  test(`returns ${extension} for ${mimeType}`, () => {
+    const actualExtension = getExtensionFromMimeType(mimeType);
+
+    expect(extension).toBe(actualExtension);
+  });
+}

--- a/packages/mime-types/src/test/get-mime-type-from-filename.test.ts
+++ b/packages/mime-types/src/test/get-mime-type-from-filename.test.ts
@@ -1,0 +1,26 @@
+import {MimeType} from '../types';
+import {getMimeTypeFromFilename} from '../get-mime-type-from-filename';
+
+describe('getMimeTypeFromFilename', () => {
+  it.each([
+    [MimeType.Gif, 'animated-image.gif'],
+    [MimeType.Glb, 'sunglasses.glb'],
+    [MimeType.Jpeg, 'image.jpeg'],
+    [MimeType.Jpeg, 'image.jpg'],
+    [MimeType.Mov, 'collection.mov'],
+    [MimeType.Mp4, 'movie.mp4'],
+    [MimeType.Pdf, 'document.pdf'],
+    [MimeType.Png, 'image.png'],
+    [MimeType.Hls, 'video.m3u8'],
+  ])('returns %s for %s', (mimeType, filename) => {
+    const actualMimeType = getMimeTypeFromFilename(filename);
+
+    expect(mimeType).toBe(actualMimeType);
+  });
+
+  it('returns undefined when the filename extension is not recognized', () => {
+    const mimeType = getMimeTypeFromFilename('nope.abc');
+
+    expect(mimeType).toBeUndefined();
+  });
+});

--- a/packages/mime-types/src/types.ts
+++ b/packages/mime-types/src/types.ts
@@ -1,0 +1,10 @@
+export enum MimeType {
+  Jpeg = 'image/jpeg',
+  Png = 'image/png',
+  Gif = 'image/gif',
+  Pdf = 'application/pdf',
+  Mp4 = 'video/mp4',
+  Mov = 'video/quicktime',
+  Glb = 'model/gltf-binary',
+  Hls = 'application/x-mpegURL',
+}

--- a/packages/mime-types/tsconfig.json
+++ b/packages/mime-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig_base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "rootDir": "."
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -28,6 +28,7 @@
     {"path": "./koa-shopify-graphql-proxy"},
     {"path": "./koa-shopify-webhooks"},
     {"path": "./logger"},
+    {"path": "./mime-types"},
     {"path": "./network"},
     {"path": "./performance"},
     {"path": "./polyfills"},


### PR DESCRIPTION
## Description

First part to help fix https://github.com/Shopify/quilt/issues/411

Follow-up PR to add common mime types will be: https://github.com/Shopify/quilt/pull/1372

Based off a comment on https://github.com/Shopify/quilt/pull/1344 [here](https://github.com/Shopify/quilt/pull/1344#pullrequestreview-388275429).

We take the `@shopify/files` [package](https://github.com/Shopify/web/tree/master/packages/%40shopify/files) that exists in `@shopify/web`, and expose it as a new package in quilt.

This enables consumers to grab the common mime types it exposes, and two helpers to dynamically grab file extensions/mime types.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
