### PR TITLE
Adding function to get localized currency names

### DIFF
--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -337,6 +337,19 @@ export class I18n {
     return getCurrencySymbol(locale, {currency});
   }
 
+  getCurrencyName(currencyCode: string) {
+    return this.getCurrencyNameLocalized(this.locale, currencyCode);
+  }
+
+  getCurrencyNameLocalized(locale: string, currencyCode: string) {
+    const currencyDetails = getCurrencySymbol(locale, {
+      style: 'currency',
+      currency: currencyCode,
+      currencyDisplay: 'name',
+    });
+    return currencyDetails.symbol.trim();
+  }
+
   formatName(firstName: string, lastName?: string, options?: {full?: boolean}) {
     if (!firstName) {
       return lastName || '';

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1448,6 +1448,20 @@ describe('I18n', () => {
     });
   });
 
+  describe('#getCurrencyName()', () => {
+    it('returns the locale-specific currency name', () => {
+      const mockResult = {
+        symbol: 'euros',
+        prefixed: true,
+      };
+      getCurrencySymbol.mockReturnValue(mockResult);
+
+      const i18n = new I18n(defaultTranslations, {locale: 'en'});
+
+      expect(i18n.getCurrencySymbol('euros')).toStrictEqual(mockResult);
+    });
+  });
+
   describe('#formatName()', () => {
     it('returns only the firstName when lastName is missing', () => {
       const i18n = new I18n(defaultTranslations, {locale: 'en'});

--- a/packages/react-i18n/src/utilities/tests/money.test.ts
+++ b/packages/react-i18n/src/utilities/tests/money.test.ts
@@ -36,6 +36,20 @@ describe('formatCurrency()', () => {
     });
   });
 
+  it('memoizedNumberFormatter will be called with all given options', () => {
+    const locale = 'en';
+    const options = {
+      currency: 'USD',
+      currencyDisplay: 'name',
+    };
+
+    formatCurrency(123, locale, options);
+    expect(memoizedNumberFormatterMock).toHaveBeenCalledWith(locale, {
+      ...options,
+      style: 'currency',
+    });
+  });
+
   it('calls format on the memoized formatter', () => {
     const amount = 123;
     const result = 'result';


### PR DESCRIPTION
## Description

There currently isn't a way to get the full name of a currency through i18n.  There are instances where we would need to have the name of the currency, ie: currency selector.  A new function has been added to get the full name of a currency.

Examples:
'USD' -> US Dollars
'EUR' -> euros

I have put together what currency names would look like based on different inputs - using `CurrencyCode` enum from this library or `CurrencyCode` from `types/graphql/core-types` in `Shopify/web`.  

https://docs.google.com/spreadsheets/d/1b2lG7NF8T-vkfqnGXr2uQVlub3vYCdLrRFRB9Uy9j04/edit?usp=sharing

cc: @gabyap123 with regards to https://vault.shopify.io/projects/10343
cc: @winterweix with regards to https://vault.shopify.io/projects/8347

This technique is currently used to populate the `CurrencySelector` in `Shopify/web` here: https://github.com/Shopify/web/blob/master/app/components/CurrencySelector/CurrencySelector.tsx

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

This adds a new function in the i18n class (from `react-i18n` package) to `getCurrencyName` with it's localized version (same pattern as `getCurrencySymbol`.

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
