### PR TITLE
[react-form] add allErrors property to Field

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Add optional `allErrors` property to `Field` type definition that stores all error messages resulting from `runValidation` [#1383](https://github.com/Shopify/quilt/pull/1383)
 
 ## [0.5.4] - 2020-04-13
 

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -123,13 +123,13 @@ export function useField<Value = string>(
 
   const runValidation = useCallback(
     (value: Value = state.value) => {
-      const error = validators
+      const errors = validators
         .map(check => check(value, {}))
         .filter(value => value != null);
 
-      if (error && error.length > 0) {
-        const [firstError] = error;
-        dispatch(updateErrorAction(firstError));
+      if (errors && errors.length > 0) {
+        const [firstError] = errors;
+        dispatch(updateErrorAction(errors));
         return firstError;
       }
 

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -191,6 +191,149 @@ describe('useField', () => {
           children: firstFailingValidator(newValue),
         });
       });
+
+      it('updates the allErrors property with all failing validation messages', () => {
+        function TestField({config}: {config: string | FieldConfig<string>}) {
+          const field = useField(config);
+          const text = 'Test field';
+
+          return (
+            <>
+              <label htmlFor="test-field">
+                {text}
+                <input
+                  id="test-field"
+                  name="test-field"
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+              </label>
+              {field.allErrors && <p>{field.allErrors}</p>}
+            </>
+          );
+        }
+
+        const firstFailingValidator = (value: string) =>
+          `${value} tastes most foul`;
+        const secondFailingValidator = (value: string) => `${value} is horrid`;
+
+        const fieldConfig = {
+          value: 'old title',
+          validates: [
+            alwaysPass,
+            firstFailingValidator,
+            alwaysPass,
+            secondFailingValidator,
+          ],
+        };
+        const wrapper = mount(<TestField config={fieldConfig} />);
+        const newValue = faker.commerce.product();
+
+        wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
+        wrapper.find('input')!.trigger('onBlur', blurEvent());
+
+        expect(wrapper).toContainReactComponent('p', {
+          children: [
+            firstFailingValidator(newValue),
+            secondFailingValidator(newValue),
+          ],
+        });
+      });
+
+      it('only updates the allErrors property if validation errors have changed', () => {
+        function TestField({config}: {config: string | FieldConfig<string>}) {
+          const field = useField(config);
+          const text = 'Test field';
+
+          return (
+            <>
+              <label htmlFor="test-field">
+                {text}
+                <input
+                  id="test-field"
+                  name="test-field"
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+              </label>
+              {field.allErrors && <p>{field.allErrors}</p>}
+            </>
+          );
+        }
+
+        const failingValidator = (value: string) => `${value} tastes most foul`;
+
+        const fieldConfig = {
+          value: 'old title',
+          validates: [failingValidator],
+        };
+
+        const wrapper = mount(<TestField config={fieldConfig} />);
+        const newValue = faker.commerce.product();
+
+        wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
+        wrapper.find('input')!.trigger('onBlur', blurEvent());
+
+        const allErrorsFirstValidation = wrapper.find('p').props.children;
+
+        wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
+        wrapper.find('input')!.trigger('onBlur', blurEvent());
+
+        const allErrorsSecondValidation = wrapper.find('p').props.children;
+
+        expect(allErrorsFirstValidation).toStrictEqual(
+          allErrorsSecondValidation,
+        );
+      });
+
+      it('does not update allErrors if there are no failing validations', () => {
+        function TestField({config}: {config: string | FieldConfig<string>}) {
+          const field = useField(config);
+          const text = 'Test field';
+
+          return (
+            <>
+              <label htmlFor="test-field">
+                {text}
+                <input
+                  id="test-field"
+                  name="test-field"
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+              </label>
+              {field.allErrors && <p>{field.allErrors}</p>}
+            </>
+          );
+        }
+
+        const failingValidator = (value: string) => `${value} tastes most foul`;
+
+        const fieldConfig = {
+          value: 'old title',
+          validates: [alwaysPass],
+        };
+
+        const wrapper = mount(<TestField config={fieldConfig} />);
+        const newValue = faker.commerce.product();
+
+        wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
+        wrapper.find('input')!.trigger('onBlur', blurEvent());
+
+        const allErrorsFirstValidation = wrapper.find('p').props.children;
+
+        wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
+        wrapper.find('input')!.trigger('onBlur', blurEvent());
+
+        const allErrorsSecondValidation = wrapper.find('p').props.children;
+
+        expect(allErrorsFirstValidation).toStrictEqual(
+          allErrorsSecondValidation,
+        );
+      });
     });
   });
 

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -35,6 +35,7 @@ export interface FieldState<Value> {
   value: Value;
   defaultValue: Value;
   error: ErrorValue;
+  allErrors?: ErrorValue[];
   touched: boolean;
   dirty: boolean;
 }
@@ -46,6 +47,7 @@ export type FieldStates<Record extends object> = {
 export interface Field<Value> {
   value: Value;
   error: ErrorValue;
+  allErrors?: ErrorValue[];
   defaultValue: Value;
   touched: boolean;
   dirty: boolean;


### PR DESCRIPTION
## Description

This PR adds an optional 'allErrors' property returned by useField in react-form.

The purpose of this change is to allow access to all error messages resulting from runValidation() if multiple validations fail for a single field. The format of this property is `allErrors: ['error msg 1', 'error msg 2']`

I modified the updateErrorAction to accept the whole array of validation error messages, and set the allErrors property in the reducer function. The runValidation function still returns the error message from the first failing validator.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->
- [x] react-form Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
