### PR TITLE
[Date.Humanize] Humanize future dates

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- modified `I18n#humanizeDate` to humanize future dates, specifically `Tomorrow at {time}` [[#1391](https://github.com/Shopify/quilt/pull/1391)]
 
 ## [2.6.0] - 2020-04-20
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -1,10 +1,12 @@
 import {
   formatDate,
+  isFutureDate,
   isLessThanOneHourAgo,
   isLessThanOneMinuteAgo,
   isLessThanOneWeekAgo,
   isLessThanOneYearAgo,
   isToday,
+  isTomorrow,
   isYesterday,
   TimeUnit,
 } from '@shopify/dates';
@@ -443,6 +445,14 @@ export class I18n {
   }
 
   private humanizeDate(date: Date, options?: Intl.DateTimeFormatOptions) {
+    if (isFutureDate(date)) {
+      return this.humanizeFutureDate(date, options);
+    } else {
+      return this.humanizePastDate(date, options);
+    }
+  }
+
+  private humanizePastDate(date: Date, options?: Intl.DateTimeFormatOptions) {
     if (isLessThanOneMinuteAgo(date)) {
       return this.translate('date.humanize.lessThanOneMinuteAgo');
     }
@@ -492,6 +502,27 @@ export class I18n {
         date: monthDay,
         time,
       });
+    }
+
+    return this.formatDate(date, {
+      ...options,
+      style: DateStyle.Short,
+    });
+  }
+
+  private humanizeFutureDate(date: Date, options?: Intl.DateTimeFormatOptions) {
+    const time = this.formatDate(date, {
+      ...options,
+      hour: 'numeric',
+      minute: '2-digit',
+    }).toLocaleLowerCase();
+
+    if (isToday(date)) {
+      return time;
+    }
+
+    if (isTomorrow(date)) {
+      return this.translate('date.humanize.tomorrow', {time});
     }
 
     return this.formatDate(date, {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1192,151 +1192,173 @@ describe('I18n', () => {
         ).toBe('Dec. 20, 2012');
       });
 
-      it('formats a date less than one minute ago', () => {
-        const today = new Date('2012-12-20T00:00:00-00:00');
-        const lessThanOneMinuteAgo = new Date(today.getTime());
-        lessThanOneMinuteAgo.setSeconds(-5);
-        clock.mock(today);
-        const i18n = new I18n(defaultTranslations, {
-          ...defaultDetails,
-          timezone,
+      describe('past dates', () => {
+        it('formats a date less than one minute ago', () => {
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const lessThanOneMinuteAgo = new Date(today.getTime());
+          lessThanOneMinuteAgo.setSeconds(-5);
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          i18n.formatDate(lessThanOneMinuteAgo, {
+            style: DateStyle.Humanize,
+          });
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.lessThanOneMinuteAgo',
+            {pseudotranslate: false},
+            defaultTranslations,
+            i18n.locale,
+          );
         });
 
-        i18n.formatDate(lessThanOneMinuteAgo, {
-          style: DateStyle.Humanize,
+        it('formats a date less than one hour ago', () => {
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const lessThanOneHourAgo = new Date(today.getTime());
+          const minutesAgo = 5;
+          lessThanOneHourAgo.setMinutes(-minutesAgo);
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          i18n.formatDate(lessThanOneHourAgo, {
+            style: DateStyle.Humanize,
+          });
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.lessThanOneHourAgo',
+            {pseudotranslate: false, replacements: {count: minutesAgo}},
+            defaultTranslations,
+            i18n.locale,
+          );
         });
-        expect(translate).toHaveBeenCalledWith(
-          'date.humanize.lessThanOneMinuteAgo',
-          {pseudotranslate: false},
-          defaultTranslations,
-          i18n.locale,
-        );
+
+        it('formats a date from today', () => {
+          const today = new Date('2012-12-20T23:00:00-00:00');
+          const moreThanOneHourAgo = new Date(today.getTime());
+          const hoursAgo = 5;
+          moreThanOneHourAgo.setHours(today.getHours() - hoursAgo);
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          expect(
+            i18n.formatDate(moreThanOneHourAgo, {style: DateStyle.Humanize}),
+          ).toBe('5:00 a.m.');
+        });
+
+        it('formats a date from yesterday', () => {
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const yesterday = new Date('2012-12-19T00:00:00-00:00');
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          i18n.formatDate(yesterday, {style: DateStyle.Humanize});
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.yesterday',
+            {pseudotranslate: false, replacements: {time: '11:00 a.m.'}},
+            defaultTranslations,
+            i18n.locale,
+          );
+        });
+
+        it('formats a date less than one week ago', () => {
+          const fiveDaysInMilliseconds = 5 * 24 * 60 * 60 * 1000;
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const lessThanOneWeekAgo = new Date(
+            today.getTime() - fiveDaysInMilliseconds,
+          );
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          i18n.formatDate(lessThanOneWeekAgo, {
+            style: DateStyle.Humanize,
+          });
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.lessThanOneWeekAgo',
+            {
+              pseudotranslate: false,
+              replacements: {weekday: 'Saturday', time: '11:00 a.m.'},
+            },
+            defaultTranslations,
+            i18n.locale,
+          );
+        });
+
+        it('formats a date less than one year ago', () => {
+          // Offset from 2012-12-20 to 2012-07-20
+          const fiveMonthsInMilliseconds =
+            (30 + 31 + 30 + 31 + 31) * 24 * 60 * 60 * 1000;
+
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const lessThanOneYearAgo = new Date(
+            today.getTime() - fiveMonthsInMilliseconds,
+          );
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          i18n.formatDate(lessThanOneYearAgo, {
+            style: DateStyle.Humanize,
+          });
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.lessThanOneYearAgo',
+            {
+              pseudotranslate: false,
+              replacements: {date: 'Jul. 20', time: '10:00 a.m.'},
+            },
+            defaultTranslations,
+            i18n.locale,
+          );
+        });
       });
 
-      it('formats a date less than one hour ago', () => {
-        const today = new Date('2012-12-20T00:00:00-00:00');
-        const lessThanOneHourAgo = new Date(today.getTime());
-        const minutesAgo = 5;
-        lessThanOneHourAgo.setMinutes(-minutesAgo);
-        clock.mock(today);
-        const i18n = new I18n(defaultTranslations, {
-          ...defaultDetails,
-          timezone,
+      describe('future dates', () => {
+        it('formats a date from tomorrow', () => {
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const tomorrow = new Date('2012-12-21T00:00:00-00:00');
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          i18n.formatDate(tomorrow, {style: DateStyle.Humanize});
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.tomorrow',
+            {pseudotranslate: false, replacements: {time: '11:00 a.m.'}},
+            defaultTranslations,
+            i18n.locale,
+          );
         });
 
-        i18n.formatDate(lessThanOneHourAgo, {
-          style: DateStyle.Humanize,
+        it('formats a future date', () => {
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const futureDate = new Date(today.getTime());
+          futureDate.setFullYear(today.getFullYear() + 1);
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          expect(i18n.formatDate(futureDate, {style: DateStyle.Humanize})).toBe(
+            'Dec. 20, 2013',
+          );
         });
-        expect(translate).toHaveBeenCalledWith(
-          'date.humanize.lessThanOneHourAgo',
-          {pseudotranslate: false, replacements: {count: minutesAgo}},
-          defaultTranslations,
-          i18n.locale,
-        );
-      });
-
-      it('formats a date from today', () => {
-        const today = new Date('2012-12-20T23:00:00-00:00');
-        const moreThanOneHourAgo = new Date(today.getTime());
-        const hoursAgo = 5;
-        moreThanOneHourAgo.setHours(today.getHours() - hoursAgo);
-        clock.mock(today);
-        const i18n = new I18n(defaultTranslations, {
-          ...defaultDetails,
-          timezone,
-        });
-
-        expect(
-          i18n.formatDate(moreThanOneHourAgo, {style: DateStyle.Humanize}),
-        ).toBe('5:00 a.m.');
-      });
-
-      it('formats a date from yesterday', () => {
-        const today = new Date('2012-12-20T00:00:00-00:00');
-        const yesterday = new Date('2012-12-19T00:00:00-00:00');
-        clock.mock(today);
-        const i18n = new I18n(defaultTranslations, {
-          ...defaultDetails,
-          timezone,
-        });
-
-        i18n.formatDate(yesterday, {style: DateStyle.Humanize});
-        expect(translate).toHaveBeenCalledWith(
-          'date.humanize.yesterday',
-          {pseudotranslate: false, replacements: {time: '11:00 a.m.'}},
-          defaultTranslations,
-          i18n.locale,
-        );
-      });
-
-      it('formats a date less than one week ago', () => {
-        const fiveDaysInMilliseconds = 5 * 24 * 60 * 60 * 1000;
-        const today = new Date('2012-12-20T00:00:00-00:00');
-        const lessThanOneWeekAgo = new Date(
-          today.getTime() - fiveDaysInMilliseconds,
-        );
-        clock.mock(today);
-        const i18n = new I18n(defaultTranslations, {
-          ...defaultDetails,
-          timezone,
-        });
-
-        i18n.formatDate(lessThanOneWeekAgo, {
-          style: DateStyle.Humanize,
-        });
-        expect(translate).toHaveBeenCalledWith(
-          'date.humanize.lessThanOneWeekAgo',
-          {
-            pseudotranslate: false,
-            replacements: {weekday: 'Saturday', time: '11:00 a.m.'},
-          },
-          defaultTranslations,
-          i18n.locale,
-        );
-      });
-
-      it('formats a date less than one year ago', () => {
-        // Offset from 2012-12-20 to 2012-07-20
-        const fiveMonthsInMilliseconds =
-          (30 + 31 + 30 + 31 + 31) * 24 * 60 * 60 * 1000;
-
-        const today = new Date('2012-12-20T00:00:00-00:00');
-        const lessThanOneYearAgo = new Date(
-          today.getTime() - fiveMonthsInMilliseconds,
-        );
-        clock.mock(today);
-        const i18n = new I18n(defaultTranslations, {
-          ...defaultDetails,
-          timezone,
-        });
-
-        i18n.formatDate(lessThanOneYearAgo, {
-          style: DateStyle.Humanize,
-        });
-        expect(translate).toHaveBeenCalledWith(
-          'date.humanize.lessThanOneYearAgo',
-          {
-            pseudotranslate: false,
-            replacements: {date: 'Jul. 20', time: '10:00 a.m.'},
-          },
-          defaultTranslations,
-          i18n.locale,
-        );
-      });
-
-      it('formats a future date', () => {
-        const today = new Date('2012-12-20T00:00:00-00:00');
-        const futureDate = new Date(today.getTime());
-        futureDate.setFullYear(today.getFullYear() + 1);
-        clock.mock(today);
-        const i18n = new I18n(defaultTranslations, {
-          ...defaultDetails,
-          timezone,
-        });
-
-        expect(i18n.formatDate(futureDate, {style: DateStyle.Humanize})).toBe(
-          'Dec. 20, 2013',
-        );
       });
     });
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1327,7 +1327,7 @@ describe('I18n', () => {
       });
 
       describe('future dates', () => {
-        it('formats a date from tomorrow', () => {
+        it('formats a date for tomorrow', () => {
           const today = new Date('2012-12-20T00:00:00-00:00');
           const tomorrow = new Date('2012-12-21T00:00:00-00:00');
           clock.mock(today);
@@ -1343,6 +1343,22 @@ describe('I18n', () => {
             defaultTranslations,
             i18n.locale,
           );
+        });
+
+        it('formats a date for today', () => {
+          const today = new Date('2012-12-20T00:00:00-00:00');
+          const todayInTheFuture = new Date(today.getTime());
+          const hoursInTheFuture = 5;
+          todayInTheFuture.setHours(today.getHours() + hoursInTheFuture);
+          clock.mock(today);
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            timezone,
+          });
+
+          expect(
+            i18n.formatDate(todayInTheFuture, {style: DateStyle.Humanize}),
+          ).toBe('4:00 p.m.');
         });
 
         it('formats a future date', () => {


### PR DESCRIPTION
## Description

Improving `Date.Humanize` to take into consideration future dates (specifically: `Tomorrow at {time}`).

Splits the `humanizeDate` method into `humanizeFutureDate` and `humanizePastDate`. The previous functionality lives in `humanizePastDate` and the new functionality lives in `humanizeFutureDate`.

This change sets up the humanize method(s) to easily add more future date humanization.

Questions:
- Is the `CHANGELOG.md` correct?
- Should we be differentiating between Today (past) & Today (future)?
- Are there other future date considerations that we can add now?

## Type of change

- [x] react-i18n - Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above

cc @patrickkidney @jppellerin 
