### PR TITLE
Fix available permits in Semaphore

### DIFF
--- a/packages/semaphore/CHANGELOG.md
+++ b/packages/semaphore/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue with incorrect number of permits when the semaphore has multiple tries to be acquired, then released [[#1394](https://github.com/Shopify/quilt/pull/1394)]
 
 ## [1.0.0] - 2019-07-25
 

--- a/packages/semaphore/src/Semaphore.ts
+++ b/packages/semaphore/src/Semaphore.ts
@@ -31,7 +31,6 @@ export class Semaphore {
 
   acquire(): Promise<Permit> {
     if (this.availablePermits > 0) {
-      this.availablePermits--;
       return Promise.resolve(this.createPermit());
     } else {
       const deferred: Deferred = {};
@@ -44,11 +43,13 @@ export class Semaphore {
   }
 
   private createPermit(): Permit {
+    this.availablePermits--;
+
     return new Permit(
       async (): Promise<any> => {
         this.availablePermits++;
 
-        if (this.deferreds.length) {
+        if (this.deferreds.length > 0) {
           const deferred = this.deferreds.shift()!;
           deferred.resolve!(this.createPermit());
           await deferred.promise;

--- a/packages/semaphore/src/test/Semaphore.test.ts
+++ b/packages/semaphore/src/test/Semaphore.test.ts
@@ -89,6 +89,33 @@ describe('Semaphore', () => {
 
       expect(spy4).toHaveBeenCalledWith(expect.any(Permit));
     });
+
+    it('does not allow acquiring more permits than initially allowed', async () => {
+      const semaphore = new Semaphore(1);
+
+      const promise1 = semaphore.acquire();
+      const promise2 = semaphore.acquire();
+
+      (await promise1).release();
+      (await promise2).release();
+
+      const spy3 = jest.fn();
+      const spy4 = jest.fn();
+
+      semaphore
+        .acquire()
+        .then(spy3)
+        .catch(() => {});
+      semaphore
+        .acquire()
+        .then(spy4)
+        .catch(() => {});
+
+      await endOfPollPhase;
+
+      expect(spy3).toHaveBeenCalledWith(expect.any(Permit));
+      expect(spy4).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
## Description

While debugging an issue with a mutex (Semaphore(1)), I noticed it was possible to increase the number of available permits when the consumer calls `acquire()` several times before they get released.

## Type of change
- [x] `@shopify/semaphore` Patch: Fixed an issue with incorrect number of permits when the semaphore has multiple tries to be acquired, then released

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
