### PR TITLE
Update react-testing readme to link to web-foundation handbook

### DIFF
--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-testing.svg)](https://badge.fury.io/js/%40shopify%2Freact-testing.svg)
 
-A library for testing React components according to [Shopify conventions](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/React/Testing.md).
+A library for testing React components according to [Shopify conventions](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/React/Testing.md).
 
 ## Table of contents
 
@@ -660,7 +660,7 @@ expect(myComponent).toContainHtml('<span>Hello world!</span>');
 Enzyme is a very popular testing library that heavily inspired the approach this library takes. However, our experience with Enzyme has not been ideal:
 
 - It has frequently taken a long time to support new react features.
-- It has a very large API surface area, much of which does not conform to Shopify’s [testing conventions](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/react/Testing.md). For example, Enzyme provides APIs like `setState` which encourage reaching in to implementation details of your components.
+- It has a very large API surface area, much of which does not conform to Shopify’s [testing conventions](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/React/Testing.md). For example, Enzyme provides APIs like `setState` which encourage reaching in to implementation details of your components.
 - Enzyme is unlikely to add features we use or need in a testing library, such as automatic unmounting and a built-in version `trigger()`.
 
 ### Why not use [react-testing-library](https://github.com/testing-library/react-testing-library) instead?


### PR DESCRIPTION
## Description

Fixes a broken link in the [why-not-use-enzyme](https://github.com/Shopify/quilt/tree/master/packages/react-testing#why-not-use-enzyme-instead) section of the FAQ. 

## Type of change

Readme link fix. Points to the new `handbook` section of the `web-foundation` repo. 
Sorry if I got the labels wrong 😬 