### PR TITLE
Add support for useMediaEffect

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Added `useMediaLayout` hook ([#1396](https://github.com/Shopify/quilt/pull/1396))
 
 ## [1.8.0] - 2020-04-14
 

--- a/packages/react-hooks/src/hooks/media.ts
+++ b/packages/react-hooks/src/hooks/media.ts
@@ -1,23 +1,31 @@
-import {useState, useEffect} from 'react';
+import {useState, useEffect, useLayoutEffect} from 'react';
 
-export function useMedia(query: string) {
-  const [match, setMatch] = useState(false);
+type EffectHook = typeof useEffect | typeof useLayoutEffect;
 
-  useEffect(() => {
-    if (!window || !window.matchMedia) {
-      return;
-    }
+function createUseMediaFactory(useEffectHook: EffectHook) {
+  return (query: string) => {
+    const [match, setMatch] = useState(false);
 
-    const matchMedia = window.matchMedia(query);
-    const updateMatch = (event: MediaQueryListEvent) => setMatch(event.matches);
+    useEffectHook(() => {
+      if (!window || !window.matchMedia) {
+        return;
+      }
 
-    setMatch(matchMedia.matches);
+      const matchMedia = window.matchMedia(query);
+      const updateMatch = (event: MediaQueryListEvent) =>
+        setMatch(event.matches);
 
-    matchMedia.addListener(updateMatch);
-    return () => {
-      matchMedia.removeListener(updateMatch);
-    };
-  }, [query]);
+      setMatch(matchMedia.matches);
 
-  return match;
+      matchMedia.addListener(updateMatch);
+      return () => {
+        matchMedia.removeListener(updateMatch);
+      };
+    }, [query]);
+
+    return match;
+  };
 }
+
+export const useMedia = createUseMediaFactory(useEffect);
+export const useMediaLayout = createUseMediaFactory(useLayoutEffect);

--- a/packages/react-hooks/src/hooks/tests/media.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/media.test.tsx
@@ -2,15 +2,9 @@ import React from 'react';
 import {matchMedia, mediaQueryList} from '@shopify/jest-dom-mocks';
 import {mount} from '@shopify/react-testing';
 
-import {useMedia} from '../media';
+import {useMedia, useMediaLayout} from '../media';
 
-function MockComponent({mediaQuery}: {mediaQuery: string}) {
-  const matchedQuery = useMedia(mediaQuery);
-  const message = matchedQuery ? 'matched' : 'did not match';
-  return <div>{message}</div>;
-}
-
-describe('useMedia', () => {
+describe('useMedia and useMediaLayout', () => {
   beforeEach(() => {
     matchMedia.mock();
   });
@@ -19,86 +13,97 @@ describe('useMedia', () => {
     matchMedia.restore();
   });
 
-  it('installs/uninstalls listeners', () => {
-    const media = mediaQueryList({
-      matches: true,
-    });
-    const mediaAddSpy = jest.spyOn(media, 'addListener');
-    const mediaRemoveSpy = jest.spyOn(media, 'removeListener');
+  describe.each([
+    ['useMedia', useMedia],
+    ['useMediaLayout', useMediaLayout],
+  ])('%s', (_, useEffectHook) => {
+    function MockComponent({mediaQuery}: {mediaQuery: string}) {
+      const matchedQuery = useEffectHook(mediaQuery);
+      const message = matchedQuery ? 'matched' : 'did not match';
+      return <div>{message}</div>;
+    }
 
-    matchMedia.setMedia(() => media);
-
-    const mockComponent = mount(<MockComponent mediaQuery="print" />);
-    expect(mediaAddSpy).toHaveBeenCalled();
-
-    mockComponent.unmount();
-    expect(mediaRemoveSpy).toHaveBeenCalled();
-  });
-
-  it('installs new listeners when mediaQuery used by hook changes', () => {
-    const media = mediaQueryList({
-      matches: true,
-    });
-    const mediaAddSpy = jest.spyOn(media, 'addListener');
-    const mediaRemoveSpy = jest.spyOn(media, 'removeListener');
-
-    matchMedia.setMedia(() => media);
-
-    const mockComponent = mount(<MockComponent mediaQuery="print" />);
-    expect(mediaAddSpy).toHaveBeenCalled();
-    expect(mediaRemoveSpy).not.toHaveBeenCalled();
-
-    mockComponent.setProps({mediaQuery: 'screen'});
-
-    expect(mediaRemoveSpy).toHaveBeenCalled();
-    expect(mediaAddSpy).toHaveBeenCalledTimes(2);
-  });
-
-  it('initial render when matches', () => {
-    matchMedia.setMedia(() =>
-      mediaQueryList({
+    it('installs/uninstalls listeners', () => {
+      const media = mediaQueryList({
         matches: true,
-      }),
-    );
+      });
+      const mediaAddSpy = jest.spyOn(media, 'addListener');
+      const mediaRemoveSpy = jest.spyOn(media, 'removeListener');
 
-    const mockComponent = mount(<MockComponent mediaQuery="print" />);
-    expect(mockComponent.text()).toContain('matched');
-  });
+      matchMedia.setMedia(() => media);
 
-  it('initial render when does not match', () => {
-    matchMedia.setMedia(() =>
-      mediaQueryList({
-        matches: false,
-      }),
-    );
+      const mockComponent = mount(<MockComponent mediaQuery="print" />);
+      expect(mediaAddSpy).toHaveBeenCalled();
 
-    const mockComponent = mount(<MockComponent mediaQuery="print" />);
-    expect(mockComponent.text()).toContain('did not match');
-  });
-
-  it('rerenders when the media changes from !match=>match', () => {
-    const media = mediaQueryList({
-      matches: false,
+      mockComponent.unmount();
+      expect(mediaRemoveSpy).toHaveBeenCalled();
     });
-    const addListenerSpy = jest.spyOn(media, 'addListener');
-    matchMedia.setMedia(() => media);
 
-    const mockComponent = mount(<MockComponent mediaQuery="print" />);
-    expect(mockComponent.text()).toContain('did not match');
+    it('installs new listeners when mediaQuery used by hook changes', () => {
+      const media = mediaQueryList({
+        matches: true,
+      });
+      const mediaAddSpy = jest.spyOn(media, 'addListener');
+      const mediaRemoveSpy = jest.spyOn(media, 'removeListener');
 
-    expect(addListenerSpy).toHaveBeenCalled();
-    mockComponent.act(() => {
+      matchMedia.setMedia(() => media);
+
+      const mockComponent = mount(<MockComponent mediaQuery="print" />);
+      expect(mediaAddSpy).toHaveBeenCalled();
+      expect(mediaRemoveSpy).not.toHaveBeenCalled();
+
+      mockComponent.setProps({mediaQuery: 'screen'});
+
+      expect(mediaRemoveSpy).toHaveBeenCalled();
+      expect(mediaAddSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('initial render when matches', () => {
       matchMedia.setMedia(() =>
         mediaQueryList({
           matches: true,
         }),
       );
 
-      // setMedia API does not actually invoke the listeners registered by the hook, so we must invoke manually
-      const [listener] = addListenerSpy.mock.calls[0];
-      (listener as any)({...media, matches: true});
+      const mockComponent = mount(<MockComponent mediaQuery="print" />);
+      expect(mockComponent.text()).toContain('matched');
     });
 
-    expect(mockComponent.text()).toContain('matched');
+    it('initial render when does not match', () => {
+      matchMedia.setMedia(() =>
+        mediaQueryList({
+          matches: false,
+        }),
+      );
+
+      const mockComponent = mount(<MockComponent mediaQuery="print" />);
+      expect(mockComponent.text()).toContain('did not match');
+    });
+
+    it('rerenders when the media changes from !match=>match', () => {
+      const media = mediaQueryList({
+        matches: false,
+      });
+      const addListenerSpy = jest.spyOn(media, 'addListener');
+      matchMedia.setMedia(() => media);
+
+      const mockComponent = mount(<MockComponent mediaQuery="print" />);
+      expect(mockComponent.text()).toContain('did not match');
+
+      expect(addListenerSpy).toHaveBeenCalled();
+      mockComponent.act(() => {
+        matchMedia.setMedia(() =>
+          mediaQueryList({
+            matches: true,
+          }),
+        );
+
+        // setMedia API does not actually invoke the listeners registered by the hook, so we must invoke manually
+        const [listener] = addListenerSpy.mock.calls[0];
+        (listener as any)({...media, matches: true});
+      });
+
+      expect(mockComponent.text()).toContain('matched');
+    });
   });
 });


### PR DESCRIPTION
## Description

In our project, we prefer using `useLayoutEffect` to prevent the the user from seeing the UI flashing from one state to another. This is done because `useLayoutEffect` will rerender synchronously.

It's easier to review if you hide the whitespace changes.

## Type of change

- [x] `react-hooks` Minor

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
