### PR TITLE
[react-form] allErrors will return an empty array if there are no errors

### DIFF
--- a/packages/react-form/src/hooks/field/reducer.ts
+++ b/packages/react-form/src/hooks/field/reducer.ts
@@ -94,7 +94,8 @@ export function makeFieldReducer<Value>({
           ? action.payload
           : [action.payload];
         const [firstError] = payload;
-        if (shallowArrayComparison(payload, state.allErrors)) {
+        const allErrors = firstError ? payload : [];
+        if (shallowArrayComparison(allErrors, state.allErrors)) {
           return {
             ...state,
             error: firstError,
@@ -103,7 +104,7 @@ export function makeFieldReducer<Value>({
           return {
             ...state,
             error: firstError,
-            allErrors: payload,
+            allErrors,
           };
         }
       }

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -310,8 +310,6 @@ describe('useField', () => {
           );
         }
 
-        const failingValidator = (value: string) => `${value} tastes most foul`;
-
         const fieldConfig = {
           value: 'old title',
           validates: [alwaysPass],
@@ -319,6 +317,8 @@ describe('useField', () => {
 
         const wrapper = mount(<TestField config={fieldConfig} />);
         const newValue = faker.commerce.product();
+
+        expect(wrapper.find('p').props.children).toStrictEqual([]);
 
         wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
         wrapper.find('input')!.trigger('onBlur', blurEvent());
@@ -330,9 +330,7 @@ describe('useField', () => {
 
         const allErrorsSecondValidation = wrapper.find('p').props.children;
 
-        expect(allErrorsFirstValidation).toStrictEqual(
-          allErrorsSecondValidation,
-        );
+        expect(allErrorsFirstValidation).toBe(allErrorsSecondValidation);
       });
     });
   });


### PR DESCRIPTION
Added a check so that if error is undefined, allErrrors  on useField will be an empty array.
