### PR TITLE
Hooks argument type fixes

### DIFF
--- a/packages/react-async/CHANGELOG.md
+++ b/packages/react-async/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed a type issue with `usePreload`, `usePrefetch`, and `useKeepFresh` hook arguments ([#1404](https://github.com/Shopify/quilt/pull/1404))
 
 ## [3.1.0] - 2019-10-30
 

--- a/packages/react-async/src/hooks.ts
+++ b/packages/react-async/src/hooks.ts
@@ -25,7 +25,7 @@ export type KeepFreshable<KeepFreshOptions extends object> = Pick<
 export function usePreload<PreloadOptions extends object>(
   ...args: IfAllOptionalKeys<
     PreloadOptions,
-    [Preloadable<PreloadOptions>, NoInfer<PreloadOptions>?],
+    [Preloadable<PreloadOptions>, PreloadOptions?],
     [Preloadable<PreloadOptions>, NoInfer<PreloadOptions>]
   >
 ): ReturnType<typeof args[0]['usePreload']> {
@@ -36,7 +36,7 @@ export function usePreload<PreloadOptions extends object>(
 export function usePrefetch<PrefetchOptions extends object>(
   ...args: IfAllOptionalKeys<
     PrefetchOptions,
-    [Prefetchable<PrefetchOptions>, NoInfer<PrefetchOptions>?],
+    [Prefetchable<PrefetchOptions>, PrefetchOptions?],
     [Prefetchable<PrefetchOptions>, NoInfer<PrefetchOptions>]
   >
 ): ReturnType<typeof args[0]['usePrefetch']> {
@@ -47,7 +47,7 @@ export function usePrefetch<PrefetchOptions extends object>(
 export function useKeepFresh<KeepFreshOptions extends object>(
   ...args: IfAllOptionalKeys<
     KeepFreshOptions,
-    [KeepFreshable<KeepFreshOptions>, NoInfer<KeepFreshOptions>?],
+    [KeepFreshable<KeepFreshOptions>, KeepFreshOptions?],
     [KeepFreshable<KeepFreshOptions>, NoInfer<KeepFreshOptions>]
   >
 ): ReturnType<typeof args[0]['useKeepFresh']> {


### PR DESCRIPTION
## Description

Issue noticed in Shopify/web (TypeScript 3.8) when upgrading `react-graphql@6.x` the `usePreload`, `usePrefetch`, and `useKeepFresh` argument types from `react-async` require a second argument:

<img width="1095" alt="Screen Shot 2020-04-26 at 1 07 45 PM" src="https://user-images.githubusercontent.com/3865674/80314449-90703f00-87bf-11ea-85ec-3fe27d5ffea2.png">

In many cases the hook is used by passing through the async/query component w/o additional arguments. If I understand correctly the `NoInfer` type gives the hook options precedence, so the second argument cannot be omitted when calling the hook because it cannot be inferred as undefined.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
