### PR TITLE
✨ magic-entries-webpack-plugin

### DIFF
--- a/packages/magic-entries-webpack-plugin/CHANGELOG.md
+++ b/packages/magic-entries-webpack-plugin/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0]
 
 ### Added
 
-- `@shopify/magic-entries-webpack-plugin` package
+- `@shopify/magic-entries-webpack-plugin` package [[#1412](https://github.com/Shopify/quilt/pull/1412)]

--- a/packages/magic-entries-webpack-plugin/CHANGELOG.md
+++ b/packages/magic-entries-webpack-plugin/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/magic-entries-webpack-plugin` package

--- a/packages/magic-entries-webpack-plugin/README.md
+++ b/packages/magic-entries-webpack-plugin/README.md
@@ -1,0 +1,115 @@
+# `@shopify/magic-entries-webpack-plugin`
+
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin.svg)
+
+A webpack plugin that automatically sets up webpack entrypoints using filename conventions
+
+## Installation
+
+```bash
+$ yarn add @shopify/magic-entries-webpack-plugin
+```
+
+## Motivation
+
+Setting up entrypoints in webpack works well enough, but large applications, repos containing multiple logical sub-applications, or tools and meta-frameworks attempting to automate front end tooling may want to be able to automate it.
+
+When to use this:
+
+- Your projects has developed highly complex webpack configurations that are maintained by a small portion of the team and fully understood by fewer.
+- Your project frequently adds/removes/changes entrypoint configuration.
+- Your project is a tool or metaframework attempting to automate configuration of webpack.
+- Your project is large enough or has enough entrypoints that it is difficult to tell what files are an entrypoint and what files are regular old modules
+
+When not to use this:
+
+- Your build tool or metaframework already does something like this for you
+- Your app is small and only has a single entrypoint anyway
+- Your app rarely needs to add, remove, or change entrypoints
+- Your team tend to all be comfortable editing webpack configurations and your app is simple enough that it is low risk to do so
+
+## Usage
+
+### Default behaviour
+
+The default behaviour of the plugin is to populate the `entry` option of your webpack config with an entry for every file in the root of your project that matches the glob `*.entry.server.{jsx,js,ts,tsx}`. Thus a file named `main.entry.js` would be picked up as the `main` entrypoint. This behaviour can be configured via the [options](#options) object passed to the plugin.
+
+### Quick-start
+
+To setup the plugin first import it into your webpack config
+
+```js
+import {MagicEntriesPlugin} from '@shopify/magic-entries-plugin';
+```
+
+and then pass an instance of it to the plugin array.
+
+```js
+plugins: [new MagicEntriesPlugin()],
+```
+
+### Example
+
+A minimal webpack config with the default settings of the plugin might look like:
+
+```javascript
+// webpack.config.js
+// this webpack config is just an example, it's not meant to be production ready or anything
+const MagicEntriesPlugin = require('@shopify/magic-entries-webpack-plugin');
+
+exports = {
+  mode: 'production',
+  optimization: {
+    minimize: true,
+  },
+  output: {
+    filename: '[name].js',
+  },
+  plugins: [new MagicEntriesPlugin()],
+};
+```
+
+### Server and client presets
+
+Some universal applications (such as react applications using server-side-rendering) may need to have a different set of entrypoints for the client and server environments.
+
+To provide for this common usecase, the plugin comes with presets for client and server accessible via the `.client` and `.server` static methods.
+
+```js
+// the same as the default behaviour except it looks for files matching '*.entry.server.{jsx,js,ts,tsx}'
+plugins: [new MagicEntriesPlugin.server()],
+```
+
+```js
+// the same as the default behaviour except it looks for files matching '*.entry.client.{jsx,js,ts,tsx}'
+plugins: [new MagicEntriesPlugin.client()],
+```
+
+Using these in the appropriate webpack builds allows convention based entrypoints in both cases without accidentally compiling your client code on the server or vice-versa.
+
+### Customization
+
+By default this plugin has opinions about how entrypoints should look (specifically ending in `.entry.{js,ts}` and in the root of the application). If a different convention is better suited to your codebase it also accepts a configuration object with the following interface:
+
+```tsx
+interface Options {
+  // The pattern passed to `glob` to find all the entrypoints
+  // default: '*.entry.{jsx,js,ts,tsx}'
+  pattern: string;
+  // the folder or folders to run the glob in (relative to the webpack context)
+  // default: '.'
+  folder: string | string[];
+  // how to derive the name of the entrypoint from it's file path
+  // default: the file's basename stripped of it's extensions
+  nameFromFile: (file: string) => string;
+}
+```
+
+#### Example
+
+In this example the plugin is configured to use all js files in the `/entrypoints` folder as entrypoints.
+
+```ts
+new MagicEntriesPlugin({pattern: '*.js', folder: 'entrypoints'});
+```

--- a/packages/magic-entries-webpack-plugin/README.md
+++ b/packages/magic-entries-webpack-plugin/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin.svg)
 
-A webpack plugin that automatically sets up webpack entrypoints using filename conventions
+A webpack plugin which automatically sets up webpack entrypoints using filename conventions.
 
 ## Installation
 

--- a/packages/magic-entries-webpack-plugin/package.json
+++ b/packages/magic-entries-webpack-plugin/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@shopify/magic-entries-webpack-plugin",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A webpack plugin that automatically sets up entrypoints from filename conventions",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc --p tsconfig.json"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git",
+    "directory": "packages/magic-entries-webpack-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/Shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/magic-entries-webpack-plugin/README.md",
+  "dependencies": {
+    "glob": "^7.1.6",
+    "webpack": "^4.43.0"
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
+}

--- a/packages/magic-entries-webpack-plugin/package.json
+++ b/packages/magic-entries-webpack-plugin/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/magic-entries-webpack-plugin/README.md",
   "dependencies": {
     "glob": "^7.1.6",
+    "glob-to-regexp": "^0.4.1",
     "webpack": "^4.43.0"
   },
   "files": [

--- a/packages/magic-entries-webpack-plugin/src/index.ts
+++ b/packages/magic-entries-webpack-plugin/src/index.ts
@@ -1,0 +1,3 @@
+import {MagicEntriesPlugin} from './magic-entries-webpack-plugin';
+
+export {MagicEntriesPlugin};

--- a/packages/magic-entries-webpack-plugin/src/magic-entries-webpack-plugin.ts
+++ b/packages/magic-entries-webpack-plugin/src/magic-entries-webpack-plugin.ts
@@ -1,0 +1,116 @@
+import {resolve, basename} from 'path';
+import {promisify} from 'util';
+
+import cbGlob from 'glob';
+import {Compiler, Entry} from 'webpack';
+
+const glob = promisify(cbGlob);
+
+export interface Options {
+  pattern: string;
+  folder: string | string[];
+  nameFromFile: (file: string) => string;
+}
+
+type EntryOption = Compiler['options']['entry'];
+
+/**
+ * A webpack plugin that automatically configures webpack entries by checking the filesystem
+ * @param config
+ * @returns a customized webpack plugin
+ */
+export class MagicEntriesPlugin {
+  static server({folder = '.'}: Partial<Pick<Options, 'folder'>> = {}) {
+    return new MagicEntriesPlugin({
+      folder,
+      pattern: '*.entry.server.{jsx,js,ts,tsx}',
+      nameFromFile(file: string) {
+        return defaultNameFromFile(file).replace('.server', '');
+      },
+    });
+  }
+
+  static client({folder = '.'}: Partial<Pick<Options, 'folder'>> = {}) {
+    return new MagicEntriesPlugin({
+      folder,
+      pattern: '*.entry.client.{jsx,js,ts,tsx}',
+      nameFromFile(file: string) {
+        return defaultNameFromFile(file).replace('.client', '');
+      },
+    });
+  }
+
+  private options: Options;
+
+  constructor({
+    pattern = '*.entry.{jsx,js,ts,tsx}',
+    folder = '.',
+    nameFromFile = defaultNameFromFile,
+  }: Partial<Options> = {}) {
+    this.options = {
+      folder,
+      pattern,
+      nameFromFile,
+    };
+  }
+
+  apply(compiler: Compiler) {
+    const originalEntries = compiler.options.entry;
+
+    compiler.options.entry = async () => {
+      const defaultEntries = await normalizedEntries(originalEntries);
+
+      const entries = {
+        ...(await defaultEntries),
+        ...(await this.autodetectEntries(compiler.context)),
+      };
+
+      return entries;
+    };
+  }
+
+  async autodetectEntries(context: string) {
+    const {pattern, folder, nameFromFile} = this.options;
+    const folders = typeof folder === 'string' ? [folder] : folder;
+    const entries: Entry = {};
+
+    for (const folder of folders) {
+      const entryPattern = resolve(context, folder, pattern);
+      const entryFiles = await glob(entryPattern);
+
+      for (const entry of entryFiles) {
+        entries[nameFromFile(entry)] = entry;
+      }
+
+      return entries;
+    }
+  }
+}
+
+function defaultNameFromFile(filename: string) {
+  return basename(filename)
+    .replace(/\.[tj]sx?/, '')
+    .replace('.entry', '');
+}
+
+async function normalizedEntries(entry: EntryOption): Promise<Entry> {
+  const rawEntry = typeof entry === 'function' ? await entry() : entry;
+
+  if (rawEntry == null) {
+    return {};
+  }
+
+  if (typeof rawEntry === 'string') {
+    return {
+      main: [rawEntry],
+    };
+  }
+
+  if (Array.isArray(rawEntry)) {
+    return {
+      main: rawEntry,
+    };
+  }
+
+  return rawEntry;
+}

--- a/packages/magic-entries-webpack-plugin/src/test/magic-entries-webpack-plugin.test.ts
+++ b/packages/magic-entries-webpack-plugin/src/test/magic-entries-webpack-plugin.test.ts
@@ -217,31 +217,31 @@ describe('magic-entries-webpack-plugin', () => {
       },
       BUILD_TIMEOUT,
     );
-  });
 
-  it(
-    'adds entrypoints from a custom sub-folder',
-    async () => {
-      const name = 'node-custom-folder-entrypoints';
-      const content = 'console.log("hi")';
-      await withWorkspace(name, async ({workspace}) => {
-        await workspace.write('entrypoints/main.entry.js', content);
-        await workspace.write('entrypoints/floop.entry.js', content);
-        const result = await runBuild(workspace, {
-          ...BASIC_WEBPACK_CONFIG,
-          plugins: [new MagicEntriesPlugin({folder: 'entrypoints'})],
+    it(
+      'adds entrypoints from a custom sub-folder',
+      async () => {
+        const name = 'node-custom-folder-entrypoints';
+        const content = 'console.log("hi")';
+        await withWorkspace(name, async ({workspace}) => {
+          await workspace.write('entrypoints/main.entry.js', content);
+          await workspace.write('entrypoints/floop.entry.js', content);
+          const result = await runBuild(workspace, {
+            ...BASIC_WEBPACK_CONFIG,
+            plugins: [new MagicEntriesPlugin({folder: 'entrypoints'})],
+          });
+
+          const mainJs = getModule(result.modules, 'entrypoints/main').source;
+          expect(mainJs).toBeDefined();
+          expect(mainJs).toMatch(content);
+          const floopJs = getModule(result.modules, 'entrypoints/floop').source;
+          expect(floopJs).toBeDefined();
+          expect(floopJs).toMatch(content);
         });
-
-        const mainJs = getModule(result.modules, 'entrypoints/main').source;
-        expect(mainJs).toBeDefined();
-        expect(mainJs).toMatch(content);
-        const floopJs = getModule(result.modules, 'entrypoints/floop').source;
-        expect(floopJs).toBeDefined();
-        expect(floopJs).toMatch(content);
-      });
-    },
-    BUILD_TIMEOUT,
-  );
+      },
+      BUILD_TIMEOUT,
+    );
+  });
 });
 
 function runBuild(

--- a/packages/magic-entries-webpack-plugin/src/test/magic-entries-webpack-plugin.test.ts
+++ b/packages/magic-entries-webpack-plugin/src/test/magic-entries-webpack-plugin.test.ts
@@ -1,0 +1,299 @@
+import webpack, {Compiler, Configuration, Stats} from 'webpack';
+
+import {MagicEntriesPlugin} from '../magic-entries-webpack-plugin';
+
+import {withWorkspace, Workspace} from './utilities';
+
+const BUILD_TIMEOUT = 10000;
+const ENTRY_A = `
+import cats from './cats';
+console.log('I am the default entry');
+`;
+const ENTRY_B = `
+import cats from './cats';
+console.log('I am a conventional entrypoint');
+`;
+const CATS_MODULE = `
+const cats = ['kokusho', 'toki', 'cosmo', 'rika', 'rena'];
+export default cats;
+`;
+
+const BASIC_WEBPACK_CONFIG: Configuration = {
+  mode: 'production',
+  optimization: {
+    minimize: false,
+  },
+  entry: './index.js',
+  output: {
+    filename: '[name].js',
+  },
+  plugins: [new MagicEntriesPlugin()],
+};
+
+describe('magic-entries-webpack-plugin', () => {
+  describe('with default settings', () => {
+    it(
+      'does nothing when no extra entries are present',
+      async () => {
+        const name = 'node-no-extra-entrypoints';
+
+        await withWorkspace(name, async ({workspace}) => {
+          await workspace.write('index.js', ENTRY_A);
+          await workspace.write('cats.js', CATS_MODULE);
+
+          const result = await runBuild(workspace, BASIC_WEBPACK_CONFIG);
+          const main = getModule(result.modules, 'index').source;
+
+          expect(main).toBeDefined();
+          expect(main).toMatch(ENTRY_A);
+        });
+      },
+      BUILD_TIMEOUT,
+    );
+
+    it(
+      'adds entrypoints which match the default pattern (*.entry.{ts,js,tsx,jsx})',
+      async () => {
+        const name = 'node-default-extra-entrypoints';
+
+        await withWorkspace(name, async ({workspace}) => {
+          await workspace.write('index.js', ENTRY_A);
+          await workspace.write('cats.js', CATS_MODULE);
+          await workspace.write('basic-js.entry.js', ENTRY_B);
+          await workspace.write('basic-jsx.entry.jsx', ENTRY_B);
+          await workspace.write('basic-ts.entry.ts', ENTRY_B);
+          await workspace.write('basic-tsx.entry.tsx', ENTRY_B);
+          const result = await runBuild(workspace, BASIC_WEBPACK_CONFIG);
+
+          const main = getModule(result.modules, 'index').source;
+          expect(main).toBeDefined();
+          expect(main).toMatch(ENTRY_A);
+
+          const js = getModule(result.modules, 'basic-js').source;
+          expect(js).toBeDefined();
+          expect(js).toMatch(ENTRY_B);
+          const jsx = getModule(result.modules, 'basic-jsx').source;
+          expect(jsx).toBeDefined();
+          expect(jsx).toMatch(ENTRY_B);
+          const ts = getModule(result.modules, 'basic-ts').source;
+          expect(ts).toBeDefined();
+          expect(ts).toMatch(ENTRY_B);
+          const tsx = getModule(result.modules, 'basic-tsx').source;
+          expect(tsx).toBeDefined();
+          expect(tsx).toMatch(ENTRY_B);
+        });
+      },
+      BUILD_TIMEOUT,
+    );
+
+    it(
+      'works when used to implicitly set the main entry',
+      async () => {
+        const name = 'node-no-extra-entrypoints';
+
+        await withWorkspace(name, async ({workspace}) => {
+          await workspace.write('main.entry.js', ENTRY_A);
+          await workspace.write('cats.js', CATS_MODULE);
+
+          const result = await runBuild(workspace, {
+            ...BASIC_WEBPACK_CONFIG,
+            entry: undefined,
+          });
+          const main = getModule(result.modules, 'main').source;
+
+          expect(main).toBeDefined();
+          expect(main).toMatch(ENTRY_A);
+        });
+      },
+      BUILD_TIMEOUT,
+    );
+  });
+
+  describe('with client preset', () => {
+    const clientWebpackConfig = {
+      ...BASIC_WEBPACK_CONFIG,
+      plugins: [MagicEntriesPlugin.client()],
+    };
+
+    it(
+      'adds entrypoints which match the client pattern (*.entry.client.{ts,js,tsx,jsx})',
+      async () => {
+        const name = 'node-client-extra-entrypoints';
+
+        await withWorkspace(name, async ({workspace}) => {
+          await workspace.write('index.js', ENTRY_A);
+          await workspace.write('cats.js', CATS_MODULE);
+          await workspace.write('basic-js.entry.client.js', ENTRY_B);
+          await workspace.write('basic-jsx.entry.client.jsx', ENTRY_B);
+          await workspace.write('basic-ts.entry.client.ts', ENTRY_B);
+          await workspace.write('basic-tsx.entry.client.tsx', ENTRY_B);
+          const result = await runBuild(workspace, clientWebpackConfig);
+
+          const main = getModule(result.modules, 'index').source;
+          expect(main).toBeDefined();
+          expect(main).toMatch(ENTRY_A);
+
+          const js = getModule(result.modules, 'basic-js').source;
+          expect(js).toBeDefined();
+          expect(js).toMatch(ENTRY_B);
+          const jsx = getModule(result.modules, 'basic-jsx').source;
+          expect(jsx).toBeDefined();
+          expect(jsx).toMatch(ENTRY_B);
+          const ts = getModule(result.modules, 'basic-ts').source;
+          expect(ts).toBeDefined();
+          expect(ts).toMatch(ENTRY_B);
+          const tsx = getModule(result.modules, 'basic-tsx').source;
+          expect(tsx).toBeDefined();
+          expect(tsx).toMatch(ENTRY_B);
+        });
+      },
+      BUILD_TIMEOUT,
+    );
+  });
+
+  describe('with server preset', () => {
+    const serverWebpackConfig = {
+      ...BASIC_WEBPACK_CONFIG,
+      plugins: [MagicEntriesPlugin.server()],
+    };
+
+    it(
+      'adds entrypoints which match the server pattern (*.entry.server.{ts,js,tsx,jsx})',
+      async () => {
+        const name = 'node-server-extra-entrypoints';
+
+        await withWorkspace(name, async ({workspace}) => {
+          await workspace.write('index.js', ENTRY_A);
+          await workspace.write('cats.js', CATS_MODULE);
+          await workspace.write('basic-js.entry.server.js', ENTRY_B);
+          await workspace.write('basic-jsx.entry.server.jsx', ENTRY_B);
+          await workspace.write('basic-ts.entry.server.ts', ENTRY_B);
+          await workspace.write('basic-tsx.entry.server.tsx', ENTRY_B);
+          const result = await runBuild(workspace, serverWebpackConfig);
+
+          const main = getModule(result.modules, 'index').source;
+          expect(main).toBeDefined();
+          expect(main).toMatch(ENTRY_A);
+
+          const js = getModule(result.modules, 'basic-js').source;
+          expect(js).toBeDefined();
+          expect(js).toMatch(ENTRY_B);
+          const jsx = getModule(result.modules, 'basic-jsx').source;
+          expect(jsx).toBeDefined();
+          expect(jsx).toMatch(ENTRY_B);
+          const ts = getModule(result.modules, 'basic-ts').source;
+          expect(ts).toBeDefined();
+          expect(ts).toMatch(ENTRY_B);
+          const tsx = getModule(result.modules, 'basic-tsx').source;
+          expect(tsx).toBeDefined();
+          expect(tsx).toMatch(ENTRY_B);
+        });
+      },
+      BUILD_TIMEOUT,
+    );
+  });
+
+  describe('with custom configuration', () => {
+    it(
+      'adds entrypoints which match a custom pattern',
+      async () => {
+        const name = 'node-custom-pattern-entrypoints';
+        const content = 'console.log("hi")';
+        await withWorkspace(name, async ({workspace}) => {
+          await workspace.write('main.js', content);
+          await workspace.write('floop.js', content);
+          const result = await runBuild(workspace, {
+            ...BASIC_WEBPACK_CONFIG,
+            plugins: [new MagicEntriesPlugin({pattern: '*.js'})],
+          });
+
+          const mainJs = getModule(result.modules, 'main').source;
+          expect(mainJs).toBeDefined();
+          expect(mainJs).toMatch(content);
+          const floopJs = getModule(result.modules, 'floop').source;
+          expect(floopJs).toBeDefined();
+          expect(floopJs).toMatch(content);
+        });
+      },
+      BUILD_TIMEOUT,
+    );
+  });
+
+  it(
+    'adds entrypoints from a custom sub-folder',
+    async () => {
+      const name = 'node-custom-folder-entrypoints';
+      const content = 'console.log("hi")';
+      await withWorkspace(name, async ({workspace}) => {
+        await workspace.write('entrypoints/main.entry.js', content);
+        await workspace.write('entrypoints/floop.entry.js', content);
+        const result = await runBuild(workspace, {
+          ...BASIC_WEBPACK_CONFIG,
+          plugins: [new MagicEntriesPlugin({folder: 'entrypoints'})],
+        });
+
+        const mainJs = getModule(result.modules, 'entrypoints/main').source;
+        expect(mainJs).toBeDefined();
+        expect(mainJs).toMatch(content);
+        const floopJs = getModule(result.modules, 'entrypoints/floop').source;
+        expect(floopJs).toBeDefined();
+        expect(floopJs).toMatch(content);
+      });
+    },
+    BUILD_TIMEOUT,
+  );
+});
+
+function runBuild(
+  workspace: Workspace,
+  config: Configuration,
+): Promise<Stats.ToJsonOutput> {
+  return new Promise((resolve, reject) => {
+    const pathFromRoot = workspace.resolvePath('.');
+
+    const contextConfig = {
+      ...config,
+      context: pathFromRoot,
+    };
+
+    // We use MemoryOutputFileSystem to prevent webpack from outputting to our actual FS
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const MemoryOutputFileSystem = require('webpack/lib/MemoryOutputFileSystem');
+
+    const compiler: Compiler = webpack(contextConfig);
+    compiler.outputFileSystem = new MemoryOutputFileSystem({});
+
+    compiler.run((err, stats) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      if (stats.hasErrors()) {
+        reject(stats.toString());
+        return;
+      }
+
+      const statsObject = stats.toJson();
+      resolve(statsObject);
+    });
+  });
+}
+
+function getModule(results: Stats.FnModules[], basePath: string) {
+  const newResults = Array.from(results).find(({name, source}) => {
+    return (
+      (name.includes(`./${basePath}.`) ||
+        name.includes(`./${basePath}/index.js`)) &&
+      source != null
+    );
+  });
+
+  if (newResults == null) {
+    throw new Error(
+      `Could not find a module for ${basePath} in output from webpack`,
+    );
+  }
+
+  return newResults;
+}

--- a/packages/magic-entries-webpack-plugin/src/test/utilities.ts
+++ b/packages/magic-entries-webpack-plugin/src/test/utilities.ts
@@ -1,12 +1,12 @@
-import * as path from 'path';
+import {resolve, dirname, join} from 'path';
 
-import * as fs from 'fs-extra';
+import {writeFile, mkdirp, emptyDir, remove} from 'fs-extra';
 
 export class Workspace {
   constructor(public readonly root: string) {}
 
   resolvePath(...parts: string[]) {
-    return path.resolve(this.root, ...parts);
+    return resolve(this.root, ...parts);
   }
 
   buildPath(...parts: string[]) {
@@ -15,22 +15,22 @@ export class Workspace {
 
   async write(file: string, contents: string) {
     const filePath = this.resolvePath(file);
-    await fs.mkdirp(path.dirname(filePath));
-    await fs.writeFile(filePath, contents);
+    await mkdirp(dirname(filePath));
+    await writeFile(filePath, contents);
   }
 
   async cleanup() {
-    await fs.emptyDir(this.root);
-    await fs.remove(this.root);
+    await emptyDir(this.root);
+    await remove(this.root);
   }
 }
 
-const rootFixtureDirectory = path.resolve(__dirname, '../fixtures');
+const rootFixtureDirectory = resolve(__dirname, '../fixtures');
 
 export async function createWorkspace({name}: {name: string}) {
-  const fixtureDirectory = path.join(rootFixtureDirectory, name);
-  await fs.mkdirp(fixtureDirectory);
-  await fs.writeFile(path.join(fixtureDirectory, '.gitignore'), '*');
+  const fixtureDirectory = join(rootFixtureDirectory, name);
+  await mkdirp(fixtureDirectory);
+  await writeFile(join(fixtureDirectory, '.gitignore'), '*');
   return new Workspace(fixtureDirectory);
 }
 

--- a/packages/magic-entries-webpack-plugin/src/test/utilities.ts
+++ b/packages/magic-entries-webpack-plugin/src/test/utilities.ts
@@ -1,0 +1,48 @@
+import * as path from 'path';
+
+import * as fs from 'fs-extra';
+
+export class Workspace {
+  constructor(public readonly root: string) {}
+
+  resolvePath(...parts: string[]) {
+    return path.resolve(this.root, ...parts);
+  }
+
+  buildPath(...parts: string[]) {
+    return this.resolvePath('build', ...parts);
+  }
+
+  async write(file: string, contents: string) {
+    const filePath = this.resolvePath(file);
+    await fs.mkdirp(path.dirname(filePath));
+    await fs.writeFile(filePath, contents);
+  }
+
+  async cleanup() {
+    await fs.emptyDir(this.root);
+    await fs.remove(this.root);
+  }
+}
+
+const rootFixtureDirectory = path.resolve(__dirname, '../fixtures');
+
+export async function createWorkspace({name}: {name: string}) {
+  const fixtureDirectory = path.join(rootFixtureDirectory, name);
+  await fs.mkdirp(fixtureDirectory);
+  await fs.writeFile(path.join(fixtureDirectory, '.gitignore'), '*');
+  return new Workspace(fixtureDirectory);
+}
+
+export async function withWorkspace(
+  name: string,
+  runner: (context: {workspace: Workspace}) => any,
+) {
+  const workspace = await createWorkspace({name});
+
+  try {
+    await runner({workspace});
+  } finally {
+    await workspace.cleanup();
+  }
+}

--- a/packages/magic-entries-webpack-plugin/tsconfig.json
+++ b/packages/magic-entries-webpack-plugin/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig_base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "rootDir": "."
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -28,6 +28,7 @@
     {"path": "./koa-shopify-graphql-proxy"},
     {"path": "./koa-shopify-webhooks"},
     {"path": "./logger"},
+    {"path": "./magic-entries-webpack-plugin"},
     {"path": "./mime-types"},
     {"path": "./network"},
     {"path": "./performance"},


### PR DESCRIPTION
## Description
closes [sewing-kit#2009](https://github.com/Shopify/sewing-kit/issues/2009)

This PR adds a webpack plugin to quilt that allows convention based "magic" webpack entrypoints. The README and the tests should be sufficient to understand how it works.

## Stuff that should happen after
- See if there's a way we can get virtual modules in react-server to work with this
- Add to sewing-kit
- Pull out common workspace utilities that are in 3 tests now into a shared utility
