### PR TITLE
Update dom mocks setup docs

### DIFF
--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [2.9.1] - 2020-05-05
+
+### Added
+
+- Fixed setup instructions instructions for `ensureMocksReset`
+
 ## [2.9.0] - 2020-04-23
 
 - Added mock for `innerWidth` to dimensions ([#1399](https://github.com/Shopify/quilt/pull/1399))

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -20,12 +20,12 @@ This package provides two methods that should be included in the jest setup file
 
 ### `ensureMocksReset`
 
-Should be called in the `beforeEach` method of the jest `each-test` setup file. For example:
+Should be called in the `afterEach` method of the jest `each-test` setup file. For example:
 
 ```ts
 import {ensureMocksReset} from '@shopify/jest-dom-mocks';
 
-beforeEach(() => {
+afterEach(() => {
   ensureMocksReset();
 });
 ```


### PR DESCRIPTION
## Description

Fixes documentation

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Documentation change: Updating the setup instructions for our jest mocking utilities. Currently, we recommend invoking `ensureMocksReset` in the `beforeEach` setup. Instead, let's instruct developers to use it in the `afterEach` setup.

**Why?**
Based on the `mock` in before, `clean up` after testing principle.

Our implementation even [hints](https://github.com/Shopify/quilt/blob/master/packages/jest-dom-mocks/src/index.ts#L69) at resetting after tests.

**Notes**

Open for discussion! 😇

**Affected package**: `jest-dom-mocks`

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
