### PR TITLE
✨💥  pass data, url to app component by default in react-server-webpack-plugin

### DIFF
--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -345,7 +345,7 @@ class ReactController < ApplicationController
 end
 ```
 
-The React server will serialize the provided quilt data using `x-quilt-data` as the ID. You can then get this serialized data on the client with `getSerialized` from `@shopify/react-html`.
+The React server will serialize the provided quilt data using `quilt-data` as the ID. You can then get this serialized data on the client with `getSerialized` from `@shopify/react-html`. If using the webpack plugin, this will be done automatically and the data will be passed into your application as the `data` prop.
 
 ```tsx
 // app/ui/index.tsx
@@ -356,8 +356,8 @@ import {getSerialized} from '@shopify/react-html';
 const IS_CLIENT = typeof window !== 'undefined';
 
 function App() {
-  // get `x-quilt-data` from the request that was sent through Rails ReactController
-  const quiltData = IS_CLIENT ? getSerialized<{[key: string]: any}>('x-quilt-data') : null;
+  // get the serialized data from the request that was sent through Rails ReactController
+  const quiltData = IS_CLIENT ? getSerialized<Record<string, any>>('quilt-data') : null;
 
   // Logs {"x-custom-header":"header-value-a","some_id":123}
   console.log(quiltData);

--- a/packages/react-router/src/components/Router/Router.tsx
+++ b/packages/react-router/src/components/Router/Router.tsx
@@ -4,7 +4,7 @@ import {StaticRouter, BrowserRouter} from 'react-router-dom';
 import {isClient} from './utilities';
 
 interface Props {
-  location?: string;
+  location?: string | URL;
   children?: React.ReactNode;
 }
 

--- a/packages/react-server-webpack-plugin/CHANGELOG.md
+++ b/packages/react-server-webpack-plugin/CHANGELOG.md
@@ -9,8 +9,40 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Generated entrypoints no longer render the App component with a `location` prop. Apps can instead get the same data from the new `url` prop's `href` attribute.
-- Generated entrypoints no longer render the `App` component with a `server` prop. Whether an app is rendered on the server can instead be trivially inferred from `typeof window === 'undefined'`
+- ⚠️ Generated entrypoints no longer render the App component with a `location` prop. Apps can instead get the same data from the new `url` prop's `href` attribute.
+- ⚠️ Generated entrypoints no longer render the `App` component with a `server` prop. Whether an app is rendered on the server can instead be trivially inferred from `typeof window === 'undefined'`
+
+Apps which were using the `location` prop will need to use the `url` prop instead. Where before an app component might look like this
+
+```tsx
+export function App({location}: {location: string}) {
+  return (
+    <div className={styles.App}>
+      <Router location={location}>
+        <Frame>
+          <Routes />
+        </Frame>
+      </Router>
+    </div>
+  );
+}
+```
+
+It would now look like this
+
+```tsx
+export function App({url}: {url: URL}) {
+  return (
+    <div className={styles.App}>
+      <Router location={url}>
+        <Frame>
+          <Routes />
+        </Frame>
+      </Router>
+    </div>
+  );
+}
+```
 
 ### Added
 

--- a/packages/react-server-webpack-plugin/CHANGELOG.md
+++ b/packages/react-server-webpack-plugin/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Generated entrypoints no longer render the App component with a `location` prop. Apps can instead get the same data from the new `url` prop's `href` attribute.
+- Generated entrypoints no longer render the `App` component with a `server` prop. Whether an app is rendered on the server can instead be trivially inferred from `typeof window === 'undefined'`
+
+### Added
+
+- Generated entrypoints now pass a `data` prop to the `App`. This prop contains the deserialized data from the `x-quilt-data` header which is used by `quilt_rails` to pass data directly to React
+- Generated entrypoints now pass a `url` prop to the `App`. This prop is a full WHATWG compliant `URL` object representing the url for the request that react-server responded to.
 
 ## [2.2.17] - 2019-11-29
 

--- a/packages/react-server-webpack-plugin/README.md
+++ b/packages/react-server-webpack-plugin/README.md
@@ -95,7 +95,7 @@ The plugin passes some props to your application automatically.
 ```typescript
 interface DefaultProps {
   /*
-   The full WHATWG URL object for the initial request
+   The full WHATWG URL object for the initial request. On the client this will *not* update reactively. It is always the URL for the initial request.
   */
   url: URL;
 

--- a/packages/react-server-webpack-plugin/README.md
+++ b/packages/react-server-webpack-plugin/README.md
@@ -15,7 +15,7 @@ $ yarn add @shopify/react-server-webpack-plugin
 
 ### With sewing-kit
 
-As of version [0.102.0](https://github.com/Shopify/sewing-kit/blob/big-docs-update/CHANGELOG.md#L35) `sewing-kit` consumes this plugin by default if you have `@shopify/react-server` in your `package.json`. 
+As of version [0.102.0](https://github.com/Shopify/sewing-kit/blob/big-docs-update/CHANGELOG.md#L35) `sewing-kit` consumes this plugin by default if you have `@shopify/react-server` in your `package.json`.
 
 For detailed instructions on usage with Rails and sewing-kit see the documentation for [quilt_rails](/gems/quilt_rails/README.md).
 
@@ -87,6 +87,52 @@ started react-server on localhost:PORT
 ```
 
 If you point your browser at `localhost:PORT` you should see "I am an app". :)
+
+### Automatic Props
+
+The plugin passes some props to your application automatically.
+
+```typescript
+interface DefaultProps {
+  /*
+   The full WHATWG URL object for the initial request
+  */
+  url: URL;
+
+  /*
+   An object containing any data sent via the `x-quilt-data` header.
+   This header is used by `quilt_rails` for sending data directly from ruby to React.
+  */
+  data: Record<string, any>;
+}
+```
+
+These props are provided during both server-side and client-side rendering, so they can be used without any special logic around what environment your app is in.
+
+These props can be used to feed initial data into your application for use with libraries such as `react-router`, as well as for simple app logic.
+
+```tsx
+// index.jsx
+import React from 'react';
+
+export default function App({url, data}: {url: Url, data: Record<string, any>}) {
+  const {href} = url;
+  if (href.endsWith('/about')) {
+    return <div>this is an about page</div>;
+  }
+
+  return (
+    <div>
+      I am an app, here are some items:
+      <ul>
+        {data.items.forEach(({content, id}) => (
+          <li key={id}>{content}</li>;
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
 
 ### API
 

--- a/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
+++ b/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
@@ -118,7 +118,7 @@ function clientSource() {
     import ReactDOM from 'react-dom';
     import {showPage, getSerialized} from '@shopify/react-html';
 
-    import App from './index';
+    import App from 'index';
 
     const appContainer = document.getElementById('app');
     const data = getSerialized('quilt-data');

--- a/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
+++ b/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
@@ -82,7 +82,9 @@ function serverSource(options: Options) {
     ${HEADER}
     import React from 'react';
     import {createServer} from '@shopify/react-server';
+
     import App from 'index';
+
     process.on('uncaughtException', logError);
     process.on('unhandledRejection', logError);
     function logError(error) {
@@ -90,17 +92,21 @@ function serverSource(options: Options) {
       console.log(\`React Server failed to start.\n\${errorLog}\`);
       process.exit(1);
     }
-    const render = (ctx) =>
-    React.createElement(App, {
-      server: true,
-      location: ctx.request.url,
-    });
+
+    const render = (ctx) => {
+      return React.createElement(App, {
+        url: ctx.request.URL,
+        data: ctx.state.quiltData,
+      });
+    }
+
     const app = createServer({
       port: ${serverPort},
       ip: ${serverIp},
       assetPrefix: ${serverAssetPrefix},
       render,
     });
+
     export default app;
   `;
 }
@@ -110,10 +116,15 @@ function clientSource() {
     ${HEADER}
     import React from 'react';
     import ReactDOM from 'react-dom';
-    import {showPage} from '@shopify/react-html';
-    import App from 'index';
+    import {showPage, getSerialized} from '@shopify/react-html';
+
+    import App from './index';
+
     const appContainer = document.getElementById('app');
-    ReactDOM.hydrate(React.createElement(App), appContainer);
+    const data = getSerialized('quilt-data');
+    const url = new URL(window.location.href);
+
+    ReactDOM.hydrate(React.createElement(App, {data, url: url}), appContainer);
     showPage();
   `;
 }

--- a/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
+++ b/packages/react-server-webpack-plugin/src/react-server-webpack-plugin.ts
@@ -124,7 +124,7 @@ function clientSource() {
     const data = getSerialized('quilt-data');
     const url = new URL(window.location.href);
 
-    ReactDOM.hydrate(React.createElement(App, {data, url: url}), appContainer);
+    ReactDOM.hydrate(React.createElement(App, {data, url}), appContainer);
     showPage();
   `;
 }

--- a/packages/react-server/src/quilt-data/index.ts
+++ b/packages/react-server/src/quilt-data/index.ts
@@ -1,0 +1,1 @@
+export {quiltDataMiddleware} from './middleware';

--- a/packages/react-server/src/quilt-data/middleware.ts
+++ b/packages/react-server/src/quilt-data/middleware.ts
@@ -1,0 +1,10 @@
+import {Context, Next} from 'koa';
+
+export const HEADER = 'x-quilt-data';
+
+export async function quiltDataMiddleware(ctx: Context, next: Next) {
+  if (ctx.headers[HEADER]) {
+    ctx.state.quiltData = JSON.parse(ctx.headers[HEADER]);
+  }
+  await next();
+}

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -30,6 +30,7 @@ import {
   middleware as sewingKitMiddleware,
 } from '@shopify/sewing-kit-koa';
 
+import {quiltDataMiddleware} from '../quilt-data';
 import {getLogger} from '../logger';
 import {ValueFromContext} from '../types';
 
@@ -77,14 +78,14 @@ export function createRender(render: RenderFunction, options: Options = {}) {
     const hydrationManager = new HydrationManager();
 
     function Providers({children}: {children: React.ReactElement<any>}) {
-      const [, Serialize] = useSerialized<Data>('x-quilt-data');
+      const [, Serialize] = useSerialized<Data>('quilt-data');
 
       return (
         <AsyncAssetContext.Provider value={asyncAssetManager}>
           <HydrationContext.Provider value={hydrationManager}>
             <NetworkContext.Provider value={networkManager}>
               {children}
-              <Serialize data={() => ctx.headers['x-quilt-data']} />
+              <Serialize data={() => ctx.state.quiltData} />
             </NetworkContext.Provider>
           </HydrationContext.Provider>
         </AsyncAssetContext.Provider>
@@ -150,6 +151,7 @@ export function createRender(render: RenderFunction, options: Options = {}) {
   }
 
   return compose([
+    quiltDataMiddleware,
     sewingKitMiddleware({assetPrefix, manifestPath}),
     renderFunction,
   ]);

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -38,17 +38,17 @@ describe('createRender', () => {
 
   it('response contains x-quilt-data from headers', async () => {
     const myCoolApp = 'My cool app';
-    const customHeader = {'X-foo': 'bar'};
+    const data = {foo: 'bar'};
     const ctx = createMockContext({
-      headers: {'x-quilt-data': JSON.stringify(customHeader)},
+      headers: {'x-quilt-data': JSON.stringify({foo: 'bar'})},
     });
 
     const renderFunction = createRender(() => <>{myCoolApp}</>);
     await renderFunction(ctx, noop);
 
     const response = await readStream(ctx.body);
-    expect(response).toContain('x-quilt-data');
-    expect(response).toContain('X-foo');
+    expect(response).toContain('quilt-data');
+    expect(response).toContain(JSON.stringify(data));
   });
 
   it('does not clobber proxies in the context object', async () => {

--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -33,7 +33,7 @@ describe('createServer()', () => {
     const response = await wrapper.request();
 
     expect(await response.text()).toStrictEqual(
-      `<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="referrer" content="never"/></head><body><div id="app"><div>markup</div></div><script type="text/json" data-serialized-id="x-quilt-data">undefined</script></body></html>`,
+      `<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="referrer" content="never"/></head><body><div id="app"><div>markup</div></div><script type="text/json" data-serialized-id="quilt-data">undefined</script></body></html>`,
     );
   });
 


### PR DESCRIPTION
Closes #1115

### What do

This PR revamps what we pass into the user's app in our react-server plugin.  It is a breaking change, and since we 

In detail it:
- Moves `x-quilt-data` header parsing into it's own middleware
- Changes the name of the `x-quilt-data` serialization key to just `quilt-data` (no need for x when it is no longer a header)
- Passes the full WHATWG `URL` object into the app component in `@shopify/react-server-webpack-plugin` as an automatic prop
- Deserializes and passes `quilt-data` into the app component as well
- Updates relevant documentation


### Tophatting 🎩

It's tough to write sane tests for this, but I tophatted this pretty thoroughly using `hydrox-again` following this method:
- checkout this branch
- `yarn build`
- `cp ./packages/react-server ../hydrox-again/node_modules/@shopify`
- `cp ./packages/react-server-webpack-plugin ../hydrox-again/node_modules/@shopify`
- `cp ./packages/react-server-webpack-plugin ../hydrox-again/node_modules/@shopify/sewing-kit/node_modules`
- change the `App.tsx` to use the new props
- run the app

I also prepared this [branch](https://github.com/Shopify/hydrox-again/pull/15) that makes all the changes necessary to get this working and also removes some cruft. Once this is actually released we can use this branch to actually install the new version.
