### PR TITLE
[enzyme-utilities] Trigger now always return the value

### DIFF
--- a/packages/enzyme-utilities/CHANGELOG.md
+++ b/packages/enzyme-utilities/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- `trigger` now return the return value when the callback is a promise. [[#1434](https://github.com/Shopify/quilt/pull/1434)]
 
 ## [2.0.0] - 2019-03-28
 

--- a/packages/enzyme-utilities/src/index.ts
+++ b/packages/enzyme-utilities/src/index.ts
@@ -45,19 +45,20 @@ export function trigger(wrapper: AnyWrapper, keypath: string, ...args: any[]) {
     // This condition checks the returned value is an actual Promise and returns it
     // to React’s `act()` call, otherwise we just want to return `undefined`
     if (isPromise(returnValue)) {
-      return (returnValue as unknown) as Promise<void>;
+      return returnValue;
     }
   });
 
   if (isPromise(returnValue)) {
-    return Promise.resolve(promise as Promise<any>).then(ret => {
+    // `promise` here refer to the the `act` promise above.
+    // Resolving this promise will never return the resolved value because how `act` is design.
+    return Promise.resolve(promise).then(() => {
       updateRoot(wrapper);
-      return ret;
+      return returnValue;
     });
   }
 
   updateRoot(wrapper);
-
   return returnValue;
 }
 

--- a/packages/enzyme-utilities/src/test/fixtures/Toggle.tsx
+++ b/packages/enzyme-utilities/src/test/fixtures/Toggle.tsx
@@ -20,14 +20,12 @@ export function Toggle({onToggle, deferred}: Props) {
       return new Promise(resolve => {
         setTimeout(() => {
           setActive(!active);
-          onToggle();
-          resolve();
+          resolve(onToggle());
         }, DEFERRED_TIMEOUT);
       });
     }
     setActive(!active);
-    onToggle();
-    return Promise.resolve();
+    return onToggle();
   }, [active, deferred, onToggle]);
 
   return (

--- a/packages/enzyme-utilities/src/test/index.test.tsx
+++ b/packages/enzyme-utilities/src/test/index.test.tsx
@@ -42,6 +42,24 @@ describe('enzyme-utilities', () => {
       expect(spy).toHaveBeenCalledWith('hello', 1, 2, 3);
     });
 
+    it('returns the value when the callback is not a promise', () => {
+      const mockReturnValue = 'foo';
+      const spy = jest.fn(() => mockReturnValue);
+      const toggle = mount(<Toggle onToggle={spy} />);
+
+      const returnValue = trigger(toggle.find('button'), 'onClick');
+      expect(returnValue).toBe(mockReturnValue);
+    });
+
+    it('returns the value when the callback is a promise', async () => {
+      const mockReturnValue = 'foo';
+      const spy = jest.fn(() => mockReturnValue);
+      const toggle = mount(<Toggle onToggle={spy} deferred />);
+
+      const returnValue = await trigger(toggle.find('button'), 'onClick');
+      expect(returnValue).toBe(mockReturnValue);
+    });
+
     it('calls the callback in an act block', () => {
       const toggle = mount(<Toggle onToggle={() => {}} />);
       trigger(toggle.find('button'), 'onClick');

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -19,8 +19,6 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Removed the providers that were previously exported. To our knowledge nothing used them and they offered little value. If cookie context is needed users can manually use `CookieUniversalProvider` from `@shopify/react-cookie`, and `CSRFProvider` should not be necessary with the new strategies provided by `quilt_rails`.
 
-## [0.11.0] - 2020-05-04
-
 - Add: Serialize `x-quilt-data` received from the Rails server for use on the client ([#1411](https://github.com/Shopify/quilt/pull/1411))
 
 ## [0.10.0] - 2020-03-23


### PR DESCRIPTION
## Description
`trigger` doesn't return the value returned by the promise. We now return the value even if it's a promise.

## Type of change

- [x]  Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
