### PR TITLE
🔥 deprecated package

### DIFF
--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -24,15 +24,16 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/polyfills/README.md",
   "dependencies": {
-    "@babel/polyfill": "^7.0.0",
     "@shopify/useful-types": "^2.1.5",
     "browser-unhandled-rejection": "^1.0.2",
     "caniuse-api": "^3.0.0",
+    "core-js": "^2.6.5",
     "formdata-polyfill": "^3.0.18",
     "intersection-observer": "^0.5.1",
     "intl-pluralrules": "^0.2.1",
     "mutationobserver-shim": "^0.3.3",
     "node-fetch": "^2.3.0",
+    "regenerator-runtime": "^0.13.4",
     "tslib": "^1.9.3",
     "url-polyfill": "^1.1.7",
     "whatwg-fetch": "^3.0.0"

--- a/packages/polyfills/src/base.ts
+++ b/packages/polyfills/src/base.ts
@@ -1,1 +1,2 @@
-require('@babel/polyfill');
+require('core-js/stable');
+require('regenerator-runtime/runtime');

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,14 +808,6 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.6.0"
 
-"@babel/polyfill@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.6.0.tgz#6d89203f8b6cd323e8d946e47774ea35dc0619cc"
-  integrity sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/preset-env@^7.4.3":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.6.3.tgz#9e1bf05a2e2d687036d24c40e4639dc46cef2271"
@@ -10179,7 +10171,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==


### PR DESCRIPTION
closes #1433 

This PR removes the deprecated polyfill package in favour of just using the closest versions of the underlying packages it references. These can be updated normally down the line.