### PR TITLE
Updates usePrefetch options

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Improve typings for `usePrefetch` to accept a `fetchPolicy` in `options` ([#1437](https://github.com/Shopify/quilt/pull/1437))
+
 ## [6.1.0] - 2020-03-13
 
 - Update dependencies from `react-apollo` to `@apollo/react-common`, `@apollo/react-components`, and `@apollo/react-hooks` ([#1321](https://github.com/Shopify/quilt/pull/1321))

--- a/packages/react-graphql/src/async/query.ts
+++ b/packages/react-graphql/src/async/query.ts
@@ -22,7 +22,9 @@ export function createAsyncQuery<Data, Variables, DeepPartial>({
     return useAsync(resolver, {assets: AssetTiming.NextPage}).load;
   }
 
-  function usePrefetch(options: VariableOptions<Variables>) {
+  function usePrefetch(
+    options: VariableOptions<Variables> & Pick<QueryProps, 'fetchPolicy'>,
+  ) {
     const load = usePreload();
     return useBackgroundQuery(load, options);
   }


### PR DESCRIPTION
## Description

This pr updates the generic for `usePrefetch` to allow `fetchPolicy` to be passed in `options`.

This is done to support a web pr that introduced a `cache-first fetch policy` for prefetch rather than using the `network-only` default: https://github.com/Shopify/web/pull/26887. 

## Type of change

- [x] `react-graphql` [Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
