### PR TITLE
[enzyme-utilities] trigger now update the wrapper even if you don't await the promise

### DIFF
--- a/packages/enzyme-utilities/CHANGELOG.md
+++ b/packages/enzyme-utilities/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- `trigger` update the wrapper even if the promise is not resolved. [[#1439](https://github.com/Shopify/quilt/pull/1439)]
 
 ## [2.1.10] - 2020-05-13
 

--- a/packages/enzyme-utilities/src/index.ts
+++ b/packages/enzyme-utilities/src/index.ts
@@ -49,6 +49,8 @@ export function trigger(wrapper: AnyWrapper, keypath: string, ...args: any[]) {
     }
   });
 
+  updateRoot(wrapper);
+
   if (isPromise(returnValue)) {
     // `promise` here refer to the the `act` promise above.
     // Resolving this promise will never return the resolved value because how `act` is design.
@@ -58,7 +60,6 @@ export function trigger(wrapper: AnyWrapper, keypath: string, ...args: any[]) {
     });
   }
 
-  updateRoot(wrapper);
   return returnValue;
 }
 

--- a/packages/enzyme-utilities/src/test/fixtures/Toggle.tsx
+++ b/packages/enzyme-utilities/src/test/fixtures/Toggle.tsx
@@ -5,6 +5,12 @@ export interface Props {
   deferred?: boolean;
 }
 
+export enum Status {
+  Active,
+  Inactive,
+  InTransition,
+}
+
 export interface State {
   active: boolean;
 }
@@ -12,25 +18,33 @@ export interface State {
 const DEFERRED_TIMEOUT = 100;
 
 export function Toggle({onToggle, deferred}: Props) {
-  const [active, setActive] = React.useState(true);
-  const statusMarkup = active ? 'active' : 'inactive';
+  const [status, setStatus] = React.useState(Status.Active);
 
   const handleClick = React.useCallback(() => {
+    setStatus(Status.InTransition);
+
     if (deferred) {
       return new Promise(resolve => {
         setTimeout(() => {
-          setActive(!active);
           resolve(onToggle());
+          setStatus(Status.Inactive);
         }, DEFERRED_TIMEOUT);
       });
     }
-    setActive(!active);
-    return onToggle();
-  }, [active, deferred, onToggle]);
 
+    setStatus(Status.Inactive);
+    return onToggle();
+  }, [deferred, onToggle]);
+
+  return <Button onClick={handleClick} status={status} />;
+}
+
+export function Button({onClick, status}) {
   return (
-    <button type="button" onClick={handleClick}>
-      {statusMarkup}
-    </button>
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={status === Status.Inactive}
+    />
   );
 }

--- a/packages/enzyme-utilities/src/test/index.test.tsx
+++ b/packages/enzyme-utilities/src/test/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import {Toggle} from './fixtures/Toggle';
+import {Toggle, Button, Status} from './fixtures/Toggle';
 import {ActionList, Action} from './fixtures/Actions';
 
 import {trigger, findById} from '..';
@@ -60,6 +60,31 @@ describe('enzyme-utilities', () => {
       expect(returnValue).toBe(mockReturnValue);
     });
 
+    it('updates root with synchronous functions', () => {
+      const spy = jest.fn();
+      const toggle = mount(<Toggle onToggle={spy} />);
+
+      expect(toggle.find(Button).prop('status')).toBe(Status.Active);
+      trigger(toggle.find(Button), 'onClick');
+
+      expect(toggle.find(Button).prop('status')).toBe(Status.Inactive);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('updates root with asynchronous functions', async () => {
+      const spy = jest.fn();
+      const toggle = mount(<Toggle onToggle={spy} deferred />);
+
+      expect(toggle.find(Button).prop('status')).toBe(Status.Active);
+      const promise = trigger(toggle.find(Button), 'onClick');
+
+      expect(toggle.find(Button).prop('status')).toBe(Status.InTransition);
+      await promise;
+
+      expect(toggle.find(Button).prop('status')).toBe(Status.Inactive);
+      expect(spy).toHaveBeenCalled();
+    });
+
     it('calls the callback in an act block', () => {
       const toggle = mount(<Toggle onToggle={() => {}} />);
       trigger(toggle.find('button'), 'onClick');
@@ -72,18 +97,6 @@ describe('enzyme-utilities', () => {
         trigger(toggle.find('button'), 'onClick'),
       );
       expect(errors).toHaveLength(0);
-    });
-
-    it('updates root after asynchronous functions resolve', async () => {
-      const spy = jest.fn();
-      const toggle = mount(<Toggle onToggle={spy} deferred />);
-
-      const promise = trigger(toggle.find('button'), 'onClick');
-      expect(toggle.find('button').text()).toBe('active');
-
-      await promise;
-      expect(toggle.find('button').text()).toBe('inactive');
-      expect(spy).toHaveBeenCalled();
     });
 
     it('throws an error if wrapper has no matching nodes', () => {


### PR DESCRIPTION
## Description
`trigger` doesn't update the wrapper if the callback returns a promise and you don't resolve this promise. Now `trigger` update the wrapper before the promise is resolved and after the promise is resolved.

## Type of change

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
