### PR TITLE
Accept Firefox params

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## [Unreleased] -->
 
+## [1.12.1] - 2020-05-13
+
+- Fixed: Performance endpoint now accepts data that lacks a `connection` parameter, replacing it with a stand-in value
+
 ## [1.12.0] - 2020-05-07
 
-- Add: Expose a `data` arugment on `render_react` to share data to the React server using the `X-Quilt-Data` header ([#1411](https://github.com/Shopify/quilt/pull/1411))
+- Add: Expose a `data` argument on `render_react` to share data to the React server using the `X-Quilt-Data` header ([#1411](https://github.com/Shopify/quilt/pull/1411))
 
 ## [1.11.1] - 2020-03-24
 

--- a/gems/quilt_rails/lib/quilt_rails/performance/report.rb
+++ b/gems/quilt_rails/lib/quilt_rails/performance/report.rb
@@ -9,7 +9,7 @@ module Quilt
 
       def self.from_params(params)
         params.transform_keys! { |key| key.underscore.to_sym }
-        params[:connection] = {effectiveType: 'unknown'} if params[:connection].blank?
+        params[:connection] = { effectiveType: 'unknown' } if params[:connection].blank?
 
         connection = Connection.from_params(params[:connection])
 

--- a/gems/quilt_rails/lib/quilt_rails/performance/report.rb
+++ b/gems/quilt_rails/lib/quilt_rails/performance/report.rb
@@ -9,7 +9,7 @@ module Quilt
 
       def self.from_params(params)
         params.transform_keys! { |key| key.underscore.to_sym }
-        params.require(:connection)
+        params[:connection] = {effectiveType: 'unknown'} if params[:connection].blank?
 
         connection = Connection.from_params(params[:connection])
 


### PR DESCRIPTION
## Description

Fixes #1430 

Firefox doesn't attach `connection` parameters to performance data by default, causing the endpoint to reject the request, since `connection` is a required param.

Changed it so that `connection` is no longer a required param, and the value defaults to `{effectiveType: 'unknown'}`.

Updated tests and changelog. Tophatted changes with the following steps:

1. Check out this branch in `quilt`
1. `dev cd shrink-ray`
2. In `Gemfile`, replace `quilt_rails` entry with `gem "quilt_rails", path: <relative_path_to_local_quilt_rails>`
3. `dev up && dev run`
4. Install Firefox if you don't already have it
5. Navigate to `https://shrink-ray.myshopify.io/repos/generated/` in Firefox
6. Open the network tab in the console and verify that the performance report request is a `success`, and that your request body had an empty `connection` parameter (see screenshots)
7. Verify that, in the terminal, you can see the logged distributions and that `browser_connection_type` is `unknown`

## Screenshots

| Before | After |
| --- | --- |
| <img width="1023" alt="Screen Shot 2020-05-14 at 12 31 53 PM" src="https://user-images.githubusercontent.com/46533681/81964401-85e9de00-95e4-11ea-89b7-7263aab756e0.png"> |  <img width="990" alt="Screen Shot 2020-05-14 at 1 04 49 PM" src="https://user-images.githubusercontent.com/46533681/81964416-8bdfbf00-95e4-11ea-8b81-1e5a88b32bb6.png"> |

In development Shrink-Ray, you can also verify the distributions logged to the terminal:

<img width="832" alt="Screen Shot 2020-05-14 at 1 39 05 PM" src="https://user-images.githubusercontent.com/46533681/81967253-a9af2300-95e8-11ea-9253-b8b7992656c1.png">
 


<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
