### PR TITLE
[quilt_rails] Parse plaintext data as JSON

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## [Unreleased] -->
 
-## [1.12.1] - 2020-05-13
+## [1.12.1] - 2020-05-14
 
 - Fixed: Performance endpoint now accepts data that lacks a `connection` parameter, replacing it with a stand-in value
 

--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## [Unreleased] -->
 
+- Fixed: Performance endpoint now parses `text/plain` report data as JSON
+
 ## [1.12.1] - 2020-05-14
 
 - Fixed: Performance endpoint now accepts data that lacks a `connection` parameter, replacing it with a stand-in value

--- a/gems/quilt_rails/CONTRIBUTING.md
+++ b/gems/quilt_rails/CONTRIBUTING.md
@@ -19,7 +19,7 @@ All notable changes should be included in the [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Releasing
 
-**Note:** Gem releases will _not_ publish Node packages. If the gem depends on changes in the Node library, you _must_ [publish a Node release first](.github/contributing.md#releasing).
+**Note:** Gem releases will _not_ publish Node packages. If the gem depends on changes in the Node library, you _must_ [publish a Node release first](documentation/guides/release-and-deploy.md).
 
 1. `cd gems/quilt_rails`
 1. Update `version.rb` and `CHANGELOG.md` to your new desired version

--- a/gems/quilt_rails/CONTRIBUTING.md
+++ b/gems/quilt_rails/CONTRIBUTING.md
@@ -19,7 +19,7 @@ All notable changes should be included in the [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Releasing
 
-**Note:** Gem releases will _not_ publish Node packages. If the gem depends on changes in the Node library, you _must_ [publish a Node release first](documentation/guides/release-and-deploy.md).
+**Note:** Gem releases will _not_ publish Node packages. If the gem depends on changes in the Node library, you _must_ [publish a Node release first](../../documentation/guides/release-and-deploy.md).
 
 1. `cd gems/quilt_rails`
 1. Update `version.rb` and `CHANGELOG.md` to your new desired version

--- a/gems/quilt_rails/CONTRIBUTING.md
+++ b/gems/quilt_rails/CONTRIBUTING.md
@@ -19,7 +19,7 @@ All notable changes should be included in the [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Releasing
 
-**Note:** Gem releases will _not_ publish Node packages. If the gem depends on changes in the Node library, you _must_ [publish a Node release first](../../documentation/guides/release-and-deploy.md).
+**Note:** Gem releases will _not_ publish Node packages. If the gem depends on changes in the Node library, you _must_ [publish a Node release first](../../.github/CONTRIBUTING.md#releasing).
 
 1. `cd gems/quilt_rails`
 1. Update `version.rb` and `CHANGELOG.md` to your new desired version

--- a/gems/quilt_rails/lib/quilt_rails/performance/reportable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/performance/reportable.rb
@@ -4,7 +4,9 @@ module Quilt
   module Performance
     module Reportable
       def process_report(&block)
-        params.transform_keys! { |key| key.underscore.to_sym }
+        if request.content_type == 'text/plain'
+          self.params = ActionController::Parameters.new(JSON.parse(request.body.read))
+        end
         Client.send!(Report.from_params(params), &block)
       end
     end

--- a/gems/quilt_rails/lib/quilt_rails/performance/reportable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/performance/reportable.rb
@@ -4,10 +4,12 @@ module Quilt
   module Performance
     module Reportable
       def process_report(&block)
-        if request.content_type == 'text/plain'
-          self.params = ActionController::Parameters.new(JSON.parse(request.body.read))
+        report_params = if request.content_type == 'text/plain'
+          ActionController::Parameters.new(JSON.parse(request.body.read))
+        else
+          params
         end
-        Client.send!(Report.from_params(params), &block)
+        Client.send!(Report.from_params(report_params), &block)
       end
     end
   end

--- a/gems/quilt_rails/lib/quilt_rails/performance/reportable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/performance/reportable.rb
@@ -4,12 +4,15 @@ module Quilt
   module Performance
     module Reportable
       def process_report(&block)
-        report_params = if request.content_type == 'text/plain'
-          ActionController::Parameters.new(JSON.parse(request.body.read))
-        else
-          params
-        end
-        Client.send!(Report.from_params(report_params), &block)
+        Client.send!(Report.from_params(normalized_params), &block)
+      end
+
+      private
+
+      def normalized_params
+        return params unless request.content_type == 'text/plain'
+
+        ActionController::Parameters.new(JSON.parse(request.body.read))
       end
     end
   end

--- a/gems/quilt_rails/test/quilt_rails/performance_reportable_test.rb
+++ b/gems/quilt_rails/test/quilt_rails/performance_reportable_test.rb
@@ -472,10 +472,6 @@ module Quilt
       @params
     end
 
-    def params=(params)
-      @params = params
-    end
-
     def request
       @request
     end

--- a/gems/quilt_rails/test/quilt_rails/performance_reportable_test.rb
+++ b/gems/quilt_rails/test/quilt_rails/performance_reportable_test.rb
@@ -7,6 +7,7 @@ module Quilt
     include Quilt::Performance::Reportable
 
     def setup
+      @request = ActionDispatch::TestRequest.create('CONTENT_TYPE' => 'application/json')
       @params = ActionController::Parameters.new
     end
 
@@ -433,11 +434,50 @@ module Quilt
       process_report
     end
 
+    def test_parses_plaintext_to_json
+      @request = ActionDispatch::TestRequest.create(
+        'CONTENT_TYPE' => 'text/plain',
+        'RAW_POST_DATA' => JSON.generate(
+          'navigations' => [],
+          'events' => [{
+            'type' => 'ttfb',
+            'start' => 2,
+            'duration' => 1000,
+          }, {
+            'type' => 'kitty-cat cuddle',
+            'start' => 100,
+            'duration' => 999999,
+          }],
+        )
+      )
+
+      StatsD
+        .expects(:distribution)
+        .with('time_to_first_byte', 2, tags: {
+          browser_connection_type: 'unknown',
+        })
+      StatsD
+        .expects(:distribution)
+        .with('kitty-cat cuddle', 100, tags: {
+          browser_connection_type: 'unknown',
+        })
+
+      process_report
+    end
+
     private
 
     # rubocop:disable Style/TrivialAccessors
     def params
       @params
+    end
+
+    def params=(params)
+      @params = params
+    end
+
+    def request
+      @request
     end
     # rubocop:enable Style/TrivialAccessors
   end


### PR DESCRIPTION
## Description

Fixes #1431 

When using certain APIs, Firefox will send data to the performance endpoint with `Content-Type: text/plain`. This PR makes it so we parse any incoming plaintext data as JSON.

**Minor fix:** fixed the changelog date from the previous `quilt_rails` release
**Minor fix:** fixed a link in one of the docs

Tophatted with the following steps:
1. Check out this branch in `quilt`
1. `dev cd shrink-ray`
2. In `Gemfile`, replace `quilt_rails` entry with `gem "quilt_rails", path: <relative_path_to_local_quilt_rails>`
3. `dev up && dev run`
4. Install Firefox if you don't already have it (you could use Chrome but it's a lot easier in Firefox)
5. Navigate to `https://shrink-ray.myshopify.io/repos/generated/` in Firefox
6. Open the network tab in the console and find the request to the performance endpoint
7. Right-click the request to "Edit and Resend", change `Content-Type` from `application/json` to `text/plain`, and resend the request
7. Verify that you get a successful response
8. In the terminal, verify that the distributions are properly logged

## Screenshots
| | Before | After |
| --- | --- | --- |
| cURL commands (`text/plain` and `application/json`) | <img width="1508" alt="Screen Shot 2020-05-19 at 10 47 31 AM" src="https://user-images.githubusercontent.com/46533681/82342457-a4beea80-99bf-11ea-8eee-9ee9dc5fa063.png"> | <img width="1513" alt="Screen Shot 2020-05-19 at 11 04 54 AM" src="https://user-images.githubusercontent.com/46533681/82343309-ae951d80-99c0-11ea-9a2c-53d1f9cb0939.png"> |
| Distribution logs (`text/plain`) | <img width="747" alt="Screen Shot 2020-05-19 at 10 58 54 AM" src="https://user-images.githubusercontent.com/46533681/82342559-c15b2280-99bf-11ea-9fa8-d22d2db972eb.png"> | <img width="819" alt="Screen Shot 2020-05-19 at 11 03 14 AM" src="https://user-images.githubusercontent.com/46533681/82343341-b654c200-99c0-11ea-8f3c-da64d487f0df.png"> |

## Type of change

- [x] `quilt_rails` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
