### PR TITLE
Move @shopify/browser into Quilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Each package has its own `README` and documentation describing usage.
 | admin-graphql-api-utilities | [directory](packages/admin-graphql-api-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities) |
 | ast-utilities | [directory](packages/ast-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fast-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fast-utilities) |
 | async | [directory](packages/async) | [![npm version](https://badge.fury.io/js/%40shopify%2Fasync.svg)](https://badge.fury.io/js/%40shopify%2Fasync) |
+| browser | [directory](packages/browser) | [![npm version](https://badge.fury.io/js/%40shopify%2Fbrowser.svg)](https://badge.fury.io/js/%40shopify%2Fbrowser) |
 | csrf-token-fetcher | [directory](packages/csrf-token-fetcher) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg)](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher) |
 | css-utilities | [directory](packages/css-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fcss-utilities) |
 | dates | [directory](packages/dates) | [![npm version](https://badge.fury.io/js/%40shopify%2Fdates.svg)](https://badge.fury.io/js/%40shopify%2Fdates) |

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/browser` package

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,0 +1,253 @@
+# `@shopify/browser`
+
+A package providing a simple wrapper around [`ua-parser-js`](https://www.npmjs.com/package/ua-parser-js) to make extracting browser information from user-agents less cumbersome.
+
+## Installation
+
+```bash
+$ yarn add @shopify/browser
+```
+
+## You probably don't need this
+
+Generally speaking, browser-sniffing can be an unreliable practice. Many words have been written about why it is a [bad idea](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Considerations_before_using_browser_detection).
+
+However, there are some cases where it is the best tool for the job. It can provide better user-experience by allowing you to differentially serve javascript bundles at varying levels of transpilation to different browsers. It can also aid in collecting and categorizing metrics to allow you to understand when error spikes or performance degradations are isolated to a single browser.
+
+Regardless of the usecase for browser-sniffing, always keep in mind the limitations and spoofability of user-agents. If providing different bundles based on browser, be sure to always have a sane (and preferably as compatible as possible) default for unknown or otherwise unparseable user-agents. If collecting metrics, be on the lookout for data that does not make sense, or spikes of browsers marked as unknown. Providing different features based on browser-sniffing should almost always be avoided in favour of [feature-detection](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection).
+
+## Basic Usage
+
+This library can be used both in a browser and in a NodeJS environment.
+
+### Browser usage
+
+You can find the user-agent of the current browser by accessing `navigator.userAgent`. Passing this value to the constructor of `Browser` will allow you to use all of the class's convenience methods.
+
+```tsx
+import {Browser} from '@shopify/browser';
+const browser = new Browser({userAgent: navigator.userAgent});
+document.body.innerHTML = `
+  your browser is: ${browser.name} v${browser.version}
+  ${browser.isMobile ? 'on a mobile device'}
+`;
+```
+
+### Node usage
+
+You can find the user-agent of incoming requests by accessing the `user-agent` header. Many web frameworks also provide convenience methods for accessing it.
+
+Passing this value to the constructor of `Browser` will allow you to use all of the class's convenience methods.
+
+```tsx
+import Koa from 'koa';
+import {Browser} from '@shopify/browser';
+const app = new Koa();
+app.use(ctx => {
+  const userAgent = ctx.get('user-agent');
+  const browser = new Browser({userAgent});
+  ctx.body = `
+    your browser is: ${browser.name} v${browser.version}
+    ${browser.isMobile ? 'on a mobile device'}
+  `;
+});
+```
+
+## API
+
+### The `Browser` class
+
+The primary API of this package is the `Browser` class. This class represents information about an individual browser as gleaned from it's user-agent.
+
+```tsx
+import {Browser} from '@shopify/browser';
+const chromeUA =
+  'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+const browser = new Browser({userAgent: chromeUA});
+```
+
+The class provides a number of convenience methods and properties for categorizing the browser, detailed below.
+
+#### name
+
+The name of the browser.
+
+```tsx
+const chromeUA =
+  'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+const browser = new Browser({userAgent: chromeUA}).name;
+=>  'Chrome'
+```
+
+#### version
+
+The (semver) version of the browser.
+
+```tsx
+const chromeUA =
+  'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+const browser = new Browser({userAgent: chromeUA}).version;
+=>  '69.0.3497.100'
+```
+
+#### majorVersion
+
+The current major version of the browser.
+
+```tsx
+const chromeUA =
+  'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+const browser = new Browser({userAgent: chromeUA}).majorVersion;
+=>  '69'
+```
+
+#### unknown
+
+Whether the browser is unknown to the parser.
+
+```tsx
+const fakeUA = 'totally not real';
+const browser = new Browser({userAgent: fakeUA}).unknown;
+=>  true
+```
+
+#### isMobile
+
+Whether the browser is a mobile browser.
+
+```tsx
+const iOSUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+const browser = new Browser({userAgent: iOSUA}).isMobile;
+=>  true
+```
+
+#### isDesktop
+
+Whether the browser is a desktop (not mobile) browser.
+
+```tsx
+const iOSUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+const browser = new Browser({userAgent: iOSUA}).isDesktop;
+=>  false
+```
+
+#### os
+
+The operating system the browser runs on.
+
+```tsx
+const iOSUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+const browser = new Browser({userAgent: iOSUA}).os;
+=>  'iOS'
+```
+
+#### isWindows
+
+Whether the operating system of the browser is any version of windows.
+
+```tsx
+const iOSUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+const browser = new Browser({userAgent: iOSUA}).isWindows;
+=>  false
+```
+
+#### isMac
+
+Whether the operating system of the browser is any version of macOS.
+
+```tsx
+const iOSUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+const browser = new Browser({userAgent: iOSUA}).isMac;
+=>  false
+```
+
+#### isSafari
+
+Whether the operating system of the browser is any version of macOS.
+
+```tsx
+const iOSUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+const browser = new Browser({userAgent: iOSUA}).isMac;
+=>  true
+```
+
+#### isChrome
+
+Whether the browser is any version of chrome.
+
+```tsx
+const chromeUA =
+  'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+const browser = new Browser({userAgent: chromeUA}).isChrome;
+=>  true
+```
+
+#### isAndroidChrome
+
+Whether the browser is specifically an Android build of Chrome.
+
+```tsx
+const chromeUA =
+  'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+const browser = new Browser({userAgent: chromeUA}).majorVersion;
+=> true
+```
+
+#### isFirefox
+
+Whether the browser is any version of Firefox.
+
+```tsx
+const firefoxUA =
+  'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0';
+const browser = new Browser({userAgent: firefoxUA}).isFirefox;
+=>  true
+```
+
+#### isIE
+
+Whether the browser is any version of Internet Explorer.
+
+```tsx
+const ieUA =
+  'Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)';
+const browser = new Browser({userAgent: ieUA}).isIE;
+=>  true
+```
+
+#### isEdge
+
+Whether the browser is any version of edge.
+
+```tsx
+const edgeUA = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136';
+const browser = new Browser({userAgent: edgeUA}).isEdge;
+=>  true
+```
+
+#### isNativeApp
+
+Whether the browser is a Shopify Mobile web-view
+
+```tsx
+const nativeAppUA = 'Shopify Mobile/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/10.1.2)';
+const browser = new Browser({userAgent: nativeAppUA}).isNativeApp;
+=>  true
+```
+
+#### asPlainObject()
+
+Returns basic information about the browser as a readily serializable plain object.
+
+```tsx
+const userAgent =
+  'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+new Browser({userAgent}).asPlainObject();
+=> {
+  name: 'Chrome',
+  version: '69.0.3497.100',
+  isMobile: true,
+  isNativeApp: false,
+  isDesktop: false,
+}
+```

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@shopify/browser",
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "Utilities for extracting browser information from user-agents",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc --p tsconfig.json"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git",
+    "directory": "packages/browser"
+  },
+  "bugs": {
+    "url": "https://github.com/Shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/master/packages/browser/README.md",
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "ua-parser-js": "^0.7.17"
+  }
+}

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -86,10 +86,10 @@ export class Browser {
 
   get isIOS() {
     const os = this.ua.getOS();
-    const isStandardiOS = os.name && os.name.search('iOS') !== -1;
+    const isStandardiOS = os.name && os.name.includes('iOS');
     const isShopifyiOS =
-      this.userAgent.search(/Shopify Mobile|Shopify POS|Shopify Ping/g) !==
-        -1 && this.userAgent.search('iOS') !== -1;
+      /Shopify Mobile|Shopify POS|Shopify Ping/.test(this.userAgent) &&
+      this.userAgent.includes('iOS');
     return isStandardiOS || isShopifyiOS;
   }
 

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -1,0 +1,115 @@
+import {UAParser} from 'ua-parser-js';
+
+const MOBILE_DEVICE_TYPES = ['mobile', 'tablet'];
+
+export interface Options {
+  userAgent: string;
+  supported?: boolean;
+  bypass?: boolean;
+}
+
+export class Browser {
+  userAgent: string;
+  supported: boolean;
+  private ua: UAParser;
+
+  get name() {
+    return this.ua.getBrowser().name || '';
+  }
+
+  get version() {
+    return this.ua.getBrowser().version || '';
+  }
+
+  get majorVersion() {
+    const {version} = this;
+
+    if (version === '') {
+      return undefined;
+    }
+
+    const majorVersion = parseInt(version.split('.')[0], 10);
+    return Number.isNaN(majorVersion) ? undefined : majorVersion;
+  }
+
+  get unknown() {
+    return this.name === '';
+  }
+
+  get isMobile() {
+    return MOBILE_DEVICE_TYPES.includes(this.ua.getDevice().type);
+  }
+
+  get isDesktop() {
+    return !this.isMobile;
+  }
+
+  get isNativeApp() {
+    return this.ua.getUA().includes('Shopify Mobile/', 0);
+  }
+
+  get os() {
+    return this.ua.getOS().name || '';
+  }
+
+  get isWindows() {
+    return this.os.includes('Windows');
+  }
+
+  get isMac() {
+    return this.os.includes('Mac OS');
+  }
+
+  get isSafari() {
+    return this.name.includes('Safari');
+  }
+
+  get isChrome() {
+    return this.name.includes('Chrome');
+  }
+
+  get isAndroidChrome() {
+    return this.ua.getUA().includes('Android') && this.name.includes('Chrome');
+  }
+
+  get isFirefox() {
+    return this.name === 'Firefox';
+  }
+
+  get isIE() {
+    return this.name.includes('IE');
+  }
+
+  get isEdge() {
+    return this.name === 'Edge';
+  }
+
+  get isIOS() {
+    const os = this.ua.getOS();
+    const isStandardiOS = os.name && os.name.search('iOS') !== -1;
+    const isShopifyiOS =
+      this.userAgent.search(/Shopify Mobile|Shopify POS|Shopify Ping/g) !==
+        -1 && this.userAgent.search('iOS') !== -1;
+    return isStandardiOS || isShopifyiOS;
+  }
+
+  constructor({userAgent, supported = true}: Options) {
+    this.userAgent = userAgent;
+    this.supported = supported;
+    this.ua = new UAParser(userAgent);
+  }
+}
+
+export function asPlainObject(browser?: Browser) {
+  if (browser == null) {
+    return {};
+  }
+
+  return {
+    name: browser.name,
+    version: browser.version,
+    isMobile: browser.isMobile,
+    isNativeApp: browser.isNativeApp,
+    isDesktop: browser.isDesktop,
+  };
+}

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,0 +1,2 @@
+export {Browser, asPlainObject} from './browser';
+export {BrowserDetails} from './types';

--- a/packages/browser/src/test/browser.test.ts
+++ b/packages/browser/src/test/browser.test.ts
@@ -1,0 +1,199 @@
+import {Browser, asPlainObject} from '../browser';
+
+describe('Browser', () => {
+  describe('supported', () => {
+    it('uses the value supplied by the user', () => {
+      expect(new Browser({userAgent: 'fake', supported: false}).supported).toBe(
+        false,
+      );
+      expect(new Browser({userAgent: 'fake', supported: true}).supported).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('majorVersion', () => {
+    it('returns the major version of the browser if present', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+
+      expect(new Browser({userAgent}).majorVersion).toBe(69);
+    });
+
+    it('returns undefined if a major version cannot be found', () => {
+      const userAgent = 'Shopify Mobile/';
+
+      expect(new Browser({userAgent}).majorVersion).toBeUndefined();
+    });
+  });
+
+  describe('isNativeApp', () => {
+    it('returns true for Shopify Mobile', () => {
+      const userAgent =
+        'Shopify Mobile/Android/8.12.0 (Build 12005 with API 28 on Google Android SDK built for x86) MobileMiddlewareSupported Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv)  AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36';
+
+      expect(new Browser({userAgent}).isNativeApp).toBe(true);
+    });
+
+    it('returns false for other UA strings', () => {
+      [
+        'some-fake-UI/3.0.1 (nonsense) Apple Microsoft (XML like salamander)',
+        'completely bogus UA',
+        'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36',
+      ].forEach(userAgent => {
+        expect(new Browser({userAgent}).isNativeApp).toBe(false);
+      });
+    });
+  });
+
+  describe('isAndroidChrome', () => {
+    it('returns true for Chrome on Android', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+
+      expect(new Browser({userAgent}).isAndroidChrome).toBe(true);
+    });
+
+    it('returns false when using a non-Chrome browser on Android', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; U; Android 4.4.2; es-es; SM-T210R Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30';
+
+      expect(new Browser({userAgent}).isAndroidChrome).toBe(false);
+    });
+
+    it('returns false for iOS userAgents', () => {
+      const userAgent =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+
+      expect(new Browser({userAgent}).isAndroidChrome).toBe(false);
+    });
+  });
+
+  describe('os', () => {
+    it('returns the os name', () => {
+      const userAgent =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+
+      expect(new Browser({userAgent}).os).toBe('iOS');
+    });
+  });
+
+  describe('isMobile', () => {
+    it('returns true when device type is mobile', () => {
+      const userAgent =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+
+      expect(new Browser({userAgent}).isMobile).toStrictEqual(true);
+    });
+
+    it('returns true when device type is tablet', () => {
+      const userAgent =
+        'Mozilla/5.0 (iPad; CPU OS 9_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13E230 Safari/601.1';
+
+      expect(new Browser({userAgent}).isMobile).toStrictEqual(true);
+    });
+
+    it('returns false when device is a desktop', () => {
+      const userAgent =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0';
+
+      expect(new Browser({userAgent}).isMobile).toStrictEqual(false);
+    });
+  });
+
+  describe('isIOS', () => {
+    it('returns true with standard iOS 9 userAgent', () => {
+      const userAgent =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns true on Mobile Shopify when iOS version is 9 and app version is not 9', () => {
+      const userAgent =
+        'Shopify Mobile/iOS/5.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns true on Mobile Shopify when iOS version is 9 and app version is 9', () => {
+      const userAgent =
+        'Shopify Mobile/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns false on Mobile Shopify when iOS version is not 9 but app version is 9', () => {
+      const userAgent =
+        'Shopify Mobile/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/10.1.2)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns true on POS when iOS version is 9 and app version is not 9', () => {
+      const userAgent =
+        'com.jadedpixel.pos Shopify POS/5.11.0 (iPad; iOS 9.3; Scale/2.00)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns true on POS when iOS version is 9 and app version is 9', () => {
+      const userAgent =
+        'com.jadedpixel.pos Shopify POS/9.11.0 (iPad; iOS 9.3; Scale/2.00)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns false on POS when iOS version is not 9 but app version is 9', () => {
+      const userAgent =
+        'com.jadedpixel.pos Shopify POS/9.11.0 (iPad; iOS 10.3; Scale/2.00)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns true on Shopify Ping when iOS version is 9 and app version is not 9', () => {
+      const userAgent =
+        'Shopify Ping/iOS/5.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns true on Shopify Ping when iOS version is 9 and app version is 9', () => {
+      const userAgent =
+        'Shopify Ping/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns false on Shopify Ping when iOS version is not 9 but app version is 9', () => {
+      const userAgent =
+        'Shopify Ping/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/10.1.2)';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(true);
+    });
+
+    it('returns false for an Android browser', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; Android 7.0; SM-G892A Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36';
+
+      expect(new Browser({userAgent}).isIOS).toStrictEqual(false);
+    });
+  });
+
+  describe('asPlainObject', () => {
+    it('outputs userAgent details as a plain object', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
+
+      const browser = asPlainObject(new Browser({userAgent}));
+
+      expect(browser).toMatchObject({
+        name: 'Chrome',
+        version: '69.0.3497.100',
+        isMobile: true,
+        isNativeApp: false,
+        isDesktop: false,
+      });
+    });
+  });
+});

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -1,0 +1,4 @@
+export interface BrowserDetails {
+  height: number;
+  width: number;
+}

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig_base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "rootDir": "."
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -8,6 +8,7 @@
     {"path": "./admin-graphql-api-utilities"},
     {"path": "./ast-utilities"},
     {"path": "./async"},
+    {"path": "./browser"},
     {"path": "./csrf-token-fetcher"},
     {"path": "./css-utilities"},
     {"path": "./dates"},


### PR DESCRIPTION
## Description

Fixes #1446 

This PR moves the `@shopify/browser` package from `web` into Quilt. Basically all of the code, tests, and documentation were copied from [its original location](https://github.com/Shopify/web/tree/master/packages/%40shopify/browser). PR-related changes include:
- Reorganization of file structure to better match those of other Quilt packages
- Addition of `package.json`, `CHANGELOG.md`
- Updating repo/parent-level files (`README.md`, `tsconfig.json`)

After this PR is merged into `master`, we also need to:
- [Publish](https://github.com/Shopify/quilt/blob/master/documentation/guides/release-and-deploy.md)
- Remove `@shopify/browser` from `web` (and other places where it is being consumed/pasted into) and have those projects consume the Quilt package instead

Tophatted by consuming the local Quilt package in local `web` using the following steps:
1. `dev cd` into `web` (may need to `dev clone` if you don't already have it)
2. Delete the `packages/@shopify/browser` folder
3. Pull down this branch in Quilt
3. `yarn add file:<path_to_local_quilt_@shopify/browser>` in `web`
4. `dev up && dev server` (optionally `dev server --focus <section>` to speed up the build
5. Click around and make sure nothing breaks. Since we're just moving code from the repo to an external package there should be no change in behaviour