### PR TITLE
[@shopify/react-i18n] Add i18n.formatUnit()

### DIFF
--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -50,23 +50,6 @@ import {
 export interface NumberFormatOptions extends Intl.NumberFormatOptions {
   as?: 'number' | 'currency' | 'percent' | 'unit';
   precision?: number;
-  // At time of writing TS does not have these definitions. They may be removed
-  // once TS adds them onto the type for Intl.NumberFormatOptions.
-  // TS PR: https://github.com/microsoft/TypeScript/pull/38013
-  // Intl.NumberFormatOptions info see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
-  //
-  // Strictly speaking there is a defined set of valid values for unit, however
-  // combinatorial complexity makes it unfeasable to list them all out here.
-  // Valid units are specfied at https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier
-  // In addition to a single units, X-per-Y units are also valid where X and Y
-  // are units from the above list e.g. "acre-per-day". At time of writing there
-  // are 43 simple units, and thus 43*43 X-per-Y units. Ths results in 1892
-  // valid values so lets not try and list all those here.
-  unit?: string;
-  // Strictly speaking this is currently `'long' | 'short' | 'narrow'` but TS
-  // doesn't use a union type for currencyDisplay either, probably to allow
-  // for additional values in the future so follow their lead
-  unitDisplay?: string;
 }
 
 export interface CurrencyFormatOptions extends NumberFormatOptions {

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -48,12 +48,34 @@ import {
 } from './utilities';
 
 export interface NumberFormatOptions extends Intl.NumberFormatOptions {
-  as?: 'number' | 'currency' | 'percent';
+  as?: 'number' | 'currency' | 'percent' | 'unit';
   precision?: number;
+  // At time of writing TS does not have these definitions. They may be removed
+  // once TS adds them onto the type for Intl.NumberFormatOptions.
+  // TS PR: https://github.com/microsoft/TypeScript/pull/38013
+  // Intl.NumberFormatOptions info see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
+  //
+  // Strictly speaking there is a defined set of valid values for unit, however
+  // combinatorial complexity makes it unfeasable to list them all out here.
+  // Valid units are specfied at https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier
+  // In addition to a single units, X-per-Y units are also valid where X and Y
+  // are units from the above list e.g. "acre-per-day". At time of writing there
+  // are 43 simple units, and thus 43*43 X-per-Y units. Ths results in 1892
+  // valid values so lets not try and list all those here.
+  unit?: string;
+  // Strictly speaking this is currently `'long' | 'short' | 'narrow'` but TS
+  // doesn't use a union type for currencyDisplay either, probably to allow
+  // for additional values in the future so follow their lead
+  unitDisplay?: string;
 }
 
 export interface CurrencyFormatOptions extends NumberFormatOptions {
   form?: 'auto' | 'short' | 'explicit' | 'none';
+}
+
+export interface UnitFormatOptions extends NumberFormatOptions {
+  // Unit is required when formating as a number
+  unit: NonNullable<NumberFormatOptions['unit']>;
 }
 
 export interface TranslateOptions {
@@ -291,6 +313,10 @@ export class I18n {
 
   formatPercentage(amount: number, options: Intl.NumberFormatOptions = {}) {
     return this.formatNumber(amount, {as: 'percent', ...options});
+  }
+
+  formatUnit(amount: number, options: UnitFormatOptions) {
+    return this.formatNumber(amount, {as: 'unit', ...options});
   }
 
   formatDate(

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -582,6 +582,30 @@ describe('I18n', () => {
         expect(i18n.formatNumber(50, {as: 'percent'})).toBe(expected);
       });
     });
+
+    describe('unit', () => {
+      // Skipped for now as `formatNumber support for `as:unit` was added in
+      // node 12.11.0 thanks to v8 7.7. Prior to that it crashes
+      // See https://nodejs.org/en/download/releases/ and https://v8.dev/blog/v8-release-77)
+      // Unskip once we update our run tests on at least node 12.11.0
+      // eslint-disable-next-line jest/no-disabled-tests
+      it.skip('formats the number as a unit', () => {
+        const i18n = new I18n(defaultTranslations, defaultDetails);
+        const expected = Intl.NumberFormat(defaultDetails.locale, {
+          style: 'unit',
+          // At time of writing this causes a type warning because the type for
+          // Intl.NumberFormatOptions does not contain `unit`. This ts-ignore
+          // should be removed once we're using a TS version with updated types
+          // https://github.com/microsoft/TypeScript/pull/38013
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignore
+          unit: 'kilometer',
+        }).format(50);
+        expect(i18n.formatNumber(50, {as: 'unit', unit: 'kilometer'})).toBe(
+          expected,
+        );
+      });
+    });
   });
 
   describe('#unformatNumber()', () => {
@@ -1175,6 +1199,28 @@ describe('I18n', () => {
         style: 'percent',
       }).format(50);
       expect(i18n.formatPercentage(50)).toBe(expected);
+    });
+  });
+
+  describe('#formatUnit()', () => {
+    // Skipped for now as `formatNumber support for `as:unit` was added in
+    // node 12.11.0 thanks to v8 7.7. Prior to that it crashes
+    // Unskip once we update our run tests on at least node 12.11.0
+    // See https://nodejs.org/en/download/releases/ and https://v8.dev/blog/v8-release-77)
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('formats the number as a unit', () => {
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      const expected = Intl.NumberFormat(defaultDetails.locale, {
+        style: 'unit',
+        // At time of writing this causes a type warning because the type for
+        // Intl.NumberFormatOptions does not contain `unit`. This ts-ignore
+        // should be removed once we're using a TS version with updated types
+        // https://github.com/microsoft/TypeScript/pull/38013
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        unit: 'kilometer',
+      }).format(50);
+      expect(i18n.formatUnit(50, {unit: 'kilometer'})).toBe(expected);
     });
   });
 

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -584,21 +584,10 @@ describe('I18n', () => {
     });
 
     describe('unit', () => {
-      // Skipped for now as `formatNumber support for `as:unit` was added in
-      // node 12.11.0 thanks to v8 7.7. Prior to that it crashes
-      // See https://nodejs.org/en/download/releases/ and https://v8.dev/blog/v8-release-77)
-      // Unskip once we update our run tests on at least node 12.11.0
-      // eslint-disable-next-line jest/no-disabled-tests
-      it.skip('formats the number as a unit', () => {
+      it('formats the number as a unit', () => {
         const i18n = new I18n(defaultTranslations, defaultDetails);
         const expected = Intl.NumberFormat(defaultDetails.locale, {
           style: 'unit',
-          // At time of writing this causes a type warning because the type for
-          // Intl.NumberFormatOptions does not contain `unit`. This ts-ignore
-          // should be removed once we're using a TS version with updated types
-          // https://github.com/microsoft/TypeScript/pull/38013
-          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-          // @ts-ignore
           unit: 'kilometer',
         }).format(50);
         expect(i18n.formatNumber(50, {as: 'unit', unit: 'kilometer'})).toBe(
@@ -1203,21 +1192,10 @@ describe('I18n', () => {
   });
 
   describe('#formatUnit()', () => {
-    // Skipped for now as `formatNumber support for `as:unit` was added in
-    // node 12.11.0 thanks to v8 7.7. Prior to that it crashes
-    // Unskip once we update our run tests on at least node 12.11.0
-    // See https://nodejs.org/en/download/releases/ and https://v8.dev/blog/v8-release-77)
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('formats the number as a unit', () => {
+    it('formats the number as a unit', () => {
       const i18n = new I18n(defaultTranslations, defaultDetails);
       const expected = Intl.NumberFormat(defaultDetails.locale, {
         style: 'unit',
-        // At time of writing this causes a type warning because the type for
-        // Intl.NumberFormatOptions does not contain `unit`. This ts-ignore
-        // should be removed once we're using a TS version with updated types
-        // https://github.com/microsoft/TypeScript/pull/38013
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
         unit: 'kilometer',
       }).format(50);
       expect(i18n.formatUnit(50, {unit: 'kilometer'})).toBe(expected);


### PR DESCRIPTION
## Description

This PR is mostly a curiosity and a warning to others that head down this path, and is probably something to come back to in the future rather than something we want to merge now (May 2020).

EDIT update Aug 2021: We've now dropped support for node 10 and are using an up-to-date typescript version. That means I've been able to rebase this PR and act upon the "todo in the future" comments. We're just waiting till our browser support matches the browsers this is available in.


[Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat) added the concept of formatting units (see https://v8.dev/features/intl-numberformat#units for an example).

```js
const formatter = new Intl.NumberFormat('en', {
  style: 'unit',
  unit: 'kilobyte',
});
formatter.format(1.234);
// → '1.234 kB'
```

That sounded handy so I added a `i18n.formatUnit()` helper in the same way that we already have a `i18n.formatCurrency()` helper.

This looks like this is supported in all browsers we support with the exception of older safari versions - [it was added in Safaris 14.1 and ios 14.7](https://caniuse.com/mdn-javascript_builtins_intl_numberformat_numberformat_options_unit_parameter) so we probably don't want to merge this till that browser support is fully present so we don't encourage it's usage

## Type of change

- [ ] @shopify/react-i18n Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
