### PR TITLE
Change date.humanize.today to 'Today at {time}'

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+<!-- ## [Unreleased] -->
+
+### Changed
+
+- Updated `I18n#humanizeDate` to humanize today's date as `Today at {time}` [[#1459](https://github.com/Shopify/quilt/pull/1459)]
+
+  Please see the [migration guide](./migration-guide.md) for more information.
+
 ## [3.0.0] - 2020-04-23
 
 ### Changed

--- a/packages/react-i18n/migration-guide.md
+++ b/packages/react-i18n/migration-guide.md
@@ -2,6 +2,19 @@
 
 This is a concise summary of changes and recommendations around updating `@shopify/react-i18n` in consuming projects. For a more detailed list of changes, see [the changelog](./CHANGELOG.md).
 
+## [Unreleased]
+
+🛑Breaking change - New translation key is needed for future 'today' date formatted with `DateStyle.Humanize`. Consumers will need to add the translation key as outlined below.
+
+```json
+"date": {
+  "humanize": {
+    ...
+    "today": "Today at {time}"
+  }
+},
+```
+
 ## [3.0.0] - 2020-04-23
 
 🛑Breaking change - New translation key is needed for future dates formatted with `DateStyle.Humanize`. Consumers will need to add the translation key as outlined below.

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -518,7 +518,7 @@ export class I18n {
     }).toLocaleLowerCase();
 
     if (isToday(date)) {
-      return time;
+      return this.translate('date.humanize.today', {time});
     }
 
     if (isTomorrow(date)) {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1356,9 +1356,13 @@ describe('I18n', () => {
             timezone,
           });
 
-          expect(
-            i18n.formatDate(todayInTheFuture, {style: DateStyle.Humanize}),
-          ).toBe('4:00 p.m.');
+          i18n.formatDate(todayInTheFuture, {style: DateStyle.Humanize});
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.today',
+            {pseudotranslate: false, replacements: {time: '4:00 p.m.'}},
+            defaultTranslations,
+            i18n.locale,
+          );
         });
 
         it('formats a future date', () => {


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Humanize future 'today' date as `Today at {time}`

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] **react-i18n** - Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
