### PR TITLE
Doing a minimal change to force a release beacuse 0.0.24 is missing f…

### DIFF
--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+## [0.0.25] - 2020-05-27
+
+- Change the Router location prop to accept URL as well as string. [1423](https://github.com/Shopify/quilt/pull/1423)
 
 ## [0.0.15] - 2019-10-30
 

--- a/packages/react-router/src/components/Router/Router.tsx
+++ b/packages/react-router/src/components/Router/Router.tsx
@@ -4,8 +4,8 @@ import {StaticRouter, BrowserRouter} from 'react-router-dom';
 import {isClient} from './utilities';
 
 interface Props {
-  location?: string | URL;
   children?: React.ReactNode;
+  location?: string | URL;
 }
 
 export const NO_LOCATION_ERROR =


### PR DESCRIPTION
…rom [npm](https://www.npmjs.com/package/@shopify/react-router) even thought the [tag](https://github.com/Shopify/quilt/releases/tag/%40shopify%2Freact-router%400.0.24) exist

## Description

Also added the missing changlog item for the type change.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
