### PR TITLE
Short date style should use numeric instead of 2-digit for day

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed `DateStyle.Short` zero-padding days ([#1468](https://github.com/Shopify/quilt/pull/1468))
 
 ## [0.1.3] - 2019-01-09
 

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -14,7 +14,7 @@ export const dateStyle = {
   },
   [DateStyle.Short]: {
     month: 'short',
-    day: '2-digit',
+    day: 'numeric',
     year: 'numeric',
   },
   [DateStyle.Humanize]: {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1156,14 +1156,14 @@ describe('I18n', () => {
     });
 
     it('formats a date using DateStyle.Short', () => {
-      const date = new Date('2012-12-20T00:00:00-00:00');
+      const date = new Date('2012-12-09T00:00:00-00:00');
       const i18n = new I18n(defaultTranslations, {
         ...defaultDetails,
         timezone,
       });
 
       expect(i18n.formatDate(date, {style: DateStyle.Short})).toBe(
-        'Dec. 20, 2012',
+        'Dec. 9, 2012',
       );
     });
 


### PR DESCRIPTION
## Description

Fixes #1467

react-i18n's `DateStyle.Short` uses zero padding in day values. It should actually be just a single digit when the day number has a single digit.

## Type of change

- [x] react-i18n Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
