### PR TITLE
Move changelog entry from i18n to react-i18n

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -5,11 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- Fixed `DateStyle.Short` zero-padding days ([#1468](https://github.com/Shopify/quilt/pull/1468))
+<!-- ## [Unreleased] -->
 
 ## [0.1.3] - 2019-01-09
 

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -13,6 +13,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
   Please see the [migration guide](./migration-guide.md) for more information.
 
+### Fixed
+
+- Fixed `DateStyle.Short` zero-padding days ([#1468](https://github.com/Shopify/quilt/pull/1468))
+
 ## [3.0.0] - 2020-04-23
 
 ### Changed


### PR DESCRIPTION
## Description

A CHANGELOG entry was erroneously added to the i18n package instead of react-i18n.

## Type of change

- [x] i18n Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] react-i18n Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
