### PR TITLE
[@shopify/react-testing, @shopify/enzyme-utilities] Remove cast

### DIFF
--- a/packages/enzyme-utilities/CHANGELOG.md
+++ b/packages/enzyme-utilities/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Remove cast for `act` following update to `@types/react-dom`
 
 ## [2.1.11] - 2020-05-13
 

--- a/packages/enzyme-utilities/src/index.ts
+++ b/packages/enzyme-utilities/src/index.ts
@@ -1,4 +1,4 @@
-import {act as reactAct} from 'react-dom/test-utils';
+import {act} from 'react-dom/test-utils';
 import {ReactWrapper, CommonWrapper} from 'enzyme';
 import {get} from 'lodash';
 
@@ -7,11 +7,6 @@ export type AnyWrapper =
   | ReactWrapper<any, never>
   | CommonWrapper<any, any>
   | CommonWrapper<any, never>;
-
-// Manually casting `act()` until @types/react-dom is updated to include
-// the Promise types for async act introduced in version 16.9.0-alpha.0
-// https://github.com/Shopify/quilt/issues/692
-const act = reactAct as (func: () => void | Promise<void>) => Promise<void>;
 
 export function trigger(wrapper: AnyWrapper, keypath: string, ...args: any[]) {
   if (wrapper.length === 0) {
@@ -41,12 +36,13 @@ export function trigger(wrapper: AnyWrapper, keypath: string, ...args: any[]) {
   const promise = act(() => {
     returnValue = callback(...args);
 
-    // The return type of non-async `act()`, DebugPromiseLike, contains a `then` method
     // This condition checks the returned value is an actual Promise and returns it
     // to React’s `act()` call, otherwise we just want to return `undefined`
     if (isPromise(returnValue)) {
       return returnValue;
     }
+
+    return (undefined as unknown) as Promise<void>;
   });
 
   updateRoot(wrapper);

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Remove cast for `act` following update to `@types/react-dom`
 
 ## [2.1.0] - 2020-04-20
 

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render, unmountComponentAtNode} from 'react-dom';
-import {act as reactAct} from 'react-dom/test-utils';
+import {act} from 'react-dom/test-utils';
 import {
   Arguments,
   MaybeFunctionReturnType as ReturnType,
@@ -19,11 +19,6 @@ import {
   PropsFor,
   DebugOptions,
 } from './types';
-
-// Manually casting `act()` until @types/react is updated to include
-// the Promise types for async act introduced in version 16.9.0-alpha.0
-// https://github.com/Shopify/quilt/issues/692
-const act = reactAct as (func: () => void | Promise<void>) => Promise<void>;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const {findCurrentFiberUsingSlowPath} = require('react-reconciler/reflection');
@@ -115,12 +110,13 @@ export class Root<Props> implements Node<Props> {
     const promise = act(() => {
       result = action();
 
-      // The return type of non-async `act()`, DebugPromiseLike, contains a `then` method
       // This condition checks the returned value is an actual Promise and returns it
       // to React’s `act()` call, otherwise we just want to return `undefined`
       if (isPromise(result)) {
         return (result as unknown) as Promise<void>;
       }
+
+      return (undefined as unknown) as Promise<void>;
     });
 
     if (isPromise(result)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11410,6 +11410,11 @@ typescript@^3.7.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
+ua-parser-js@^0.7.17:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
+  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+
 ua-parser-js@^0.7.18:
   version "0.7.20"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"


### PR DESCRIPTION
## Description

Fixes #692 

Due to an out-of-date type in `@types/react-dom` we had to cast `act` in `@shopify/react-testing` and `@shopify/enzyme-utilities`. This PR removes that cast. There should be no change in functionality/return behaviour, we are just manipulating types.

**Minor fix:** Update `yarn.lock` (holdover from [this PR](https://github.com/Shopify/quilt/pull/1447) I believe)

## Type of change

- [x] `@shopify/react-testing, @shopify/enzyme-utilities` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
