### PR TITLE
react-testing / Replace .props() with .props in documentation

### DIFF
--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -58,10 +58,10 @@ describe('<ClickCounter />', () => {
   it('allows us to set props', () => {
     const wrapper = mount(<ClickCounter defaultCount={0} />);
 
-    expect(wrapper.props().count).toBe(0);
+    expect(wrapper.props.count).toBe(0);
     expect(wrapper.text()).toBe('count: 0');
     wrapper.setProps({defaultCount: 1});
-    expect(wrapper.props().count).toBe(1);
+    expect(wrapper.props.count).toBe(1);
     expect(wrapper.text()).toBe('count: 1');
   });
 


### PR DESCRIPTION
## Description

This PR updates `react-testing` documentation.

`.props()` on a `wrapper` is not valid since `props` [is a getter and not a function](https://github.com/Shopify/quilt/blob/153d270592373acc0d835625e2824599480cdbd0/packages/react-testing/src/root.tsx#L44).

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-testing` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
