### PR TITLE
:pencil2: [react-graphql] Minor doc markdown fix

### DIFF
--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -272,7 +272,7 @@ const MyQuery = createAsyncQueryComponent({
 </MyQuery>;
 ```
 
-As with components created by `createAsyncQuery()`, these queries also have static `usePreload`, `usePrefetch`, and `useKeepFresh` hooks. Like components create with ``@shopify/react-async`, these components also have static`Preload`,`Prefetch`, and`KeepFresh` components.
+As with components created by `createAsyncQuery()`, these queries also have static `usePreload`, `usePrefetch`, and `useKeepFresh` hooks. Like components create with `@shopify/react-async`, these components also have static `Preload`,`Prefetch`, and`KeepFresh` components.
 
 ```tsx
 import {usePrefetch} from '@shopify/react-async';


### PR DESCRIPTION
## Description

Fixing a minor markdown error I noticed when reading the docs for `react-graphql`.

| Before  | After|
|---|---|
| <img width="981" alt="Screen Shot 2020-05-29 at 9 23 25 AM" src="https://user-images.githubusercontent.com/5506721/83267130-c4110100-a191-11ea-90ce-9bd19bf166da.png">  | <img width="919" alt="Screen Shot 2020-05-29 at 9 52 56 AM" src="https://user-images.githubusercontent.com/5506721/83267422-3255c380-a192-11ea-94ab-fce490106a7f.png"> |

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `react-graphql` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
