### PR TITLE
[react-form]: types to allow deep nesting

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## Changed
+
+- `FormMapping` and `FieldOutput` are recursively typed to allow deeply nested forms.
+
 ## [0.6.0] - 2020-04-23
 
 ### Added


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1479

- FieldOutput and FormMapping now recursively typed for deep nesting

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
## Checklist
- [x] I have added a changelog entry, prefixed by the type of change noted above
