### PR TITLE
[@shopify/react-network] Get rid of unused function

### DIFF
--- a/packages/react-network/CHANGELOG.md
+++ b/packages/react-network/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Removed
+
+- Got rid of unused function `hasDocumentCookie`
 
 ## [3.3.0]
 

--- a/packages/react-network/src/utilities.ts
+++ b/packages/react-network/src/utilities.ts
@@ -1,5 +1,0 @@
-export function hasDocumentCookie() {
-  return Boolean(
-    typeof document === 'object' && typeof document.cookie === 'string',
-  );
-}


### PR DESCRIPTION
## Description

This PR gets rid of an unused/unexported function `hasDocumentCookie` (there seems to be an identical function in [`@shopify/react-cookie`](https://github.com/Shopify/quilt/blob/master/packages/react-cookie/src/utilities.ts), but the one in this package isn't being used anywhere).

## Type of change

- [x] `@shopify/react-network` Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
