### PR TITLE
Upgrade webpack-virtual-modules

### DIFF
--- a/packages/magic-entries-webpack-plugin/package.json
+++ b/packages/magic-entries-webpack-plugin/package.json
@@ -33,5 +33,9 @@
   "files": [
     "dist/*",
     "!tsconfig.tsbuildinfo"
-  ]
+  ],
+  "devDependencies": {
+    "@types/webpack-virtual-modules": "^0.1.0",
+    "webpack-virtual-modules": "^0.2.2"
+  }
 }

--- a/packages/react-server-webpack-plugin/CHANGELOG.md
+++ b/packages/react-server-webpack-plugin/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Bump `webpack-virtual-modules` to `v0.2.2` [[#1484]](https://github.com/Shopify/quilt/pull/1484)
 
 ## [3.0.0] - 2020-05-12
 

--- a/packages/react-server-webpack-plugin/package.json
+++ b/packages/react-server-webpack-plugin/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-server-webpack-plugin/README.md",
   "dependencies": {
     "@babel/types": ">=7.0.0",
-    "webpack-virtual-modules": "^0.1.12"
+    "webpack-virtual-modules": "^0.2.2"
   },
   "devDependencies": {
     "@shopify/react-server": "^0.12.1",

--- a/packages/web-worker/CHANGELOG.md
+++ b/packages/web-worker/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Bump `webpack-virtual-modules` to `v0.2.2` [[#1484]](https://github.com/Shopify/quilt/pull/1484)
 
 ## [1.3.1] - 2019-11-12
 

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@shopify/rpc": "^1.0.6",
     "loader-utils": "^1.0.0",
-    "webpack-virtual-modules": "^0.1.12"
+    "webpack-virtual-modules": "^0.2.2"
   },
   "devDependencies": {
     "@babel/types": ">=7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,7 +1699,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@16.9.5", "@types/react-dom@^16.0.11", "@types/react-dom@^16.9.5":
+"@types/react-dom@^16.0.11", "@types/react-dom@^16.9.5":
   version "16.9.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.5.tgz#5de610b04a35d07ffd8f44edad93a71032d9aaa7"
   integrity sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==
@@ -11890,10 +11890,10 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-virtual-modules@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.1.12.tgz#ff6430c1d6f514eff12bae773ec03e5043a81943"
-  integrity sha512-uwVhcpmh7WykpP2fD4T//5DLdMuanPHGXQHCnIrKoRg10GgVNy5z2oAcn26HLF67a6HCSzgc9xar+SMtZhOnXw==
+webpack-virtual-modules@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz#20863dc3cb6bb2104729fff951fbe14b18bd0299"
+  integrity sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
   dependencies:
     debug "^3.0.0"
 


### PR DESCRIPTION
## Description

This PR upgrades `webpack-virtual-modules` and also adds a test the `magic-entries-webpack-plugin` to verify that it creates magic entries from virtual modules. This ability was provided free by upgrading the `webpack-virutual-modules` plugin

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
