### PR TITLE
✨ Add type aliases for constructor arguemnts

### DIFF
--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Added the `ConstructorArguments` type alias
+- Added the `ConstructorArgumentAtIndex` type alias
+- Added the `FirstConstructorArgument` type alias
 
 ## [2.1.4] - 2019-01-27
 

--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -9,9 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added the `ConstructorArguments` type alias
-- Added the `ConstructorArgumentAtIndex` type alias
-- Added the `FirstConstructorArgument` type alias
+- Added the `ConstructorArguments`, `ConstructorArgumentAtIndex`, and `FirstConstructorArgument` type aliases
 
 ## [2.1.4] - 2019-01-27
 

--- a/packages/useful-types/README.md
+++ b/packages/useful-types/README.md
@@ -41,6 +41,30 @@ The following type aliases are provided by this library:
   type Arg = FirstArgument<typeof func>; // Promise<any>
   ```
 
+- `ConstructorArgumentAtIndex<T, Index>`: Resolves to the type of the argument of the passed class's constructor at the passed index. Useful for cases where you wish to extract the type of arguments without actually exporting the argument types, and is a nice complement to TypeScript’s built-in `ReturnType`.
+
+  ```tsx
+  class SomeClass {
+    constructor(floop: string, doop: number) {
+      console.log(floop);
+    }
+  }
+
+  type DoopType = ConstructorArgument<typeof SomeClass, 1>; // number
+  ```
+
+- `FirstConstructorArgument<T>`: Resolves to the type of the first argument to the passed class's constructor. This is shorthand for `ConstructorArgumentAtIndex<T, 0>`.
+
+  ```ts
+  class SomeClass {
+    constructor(floop: string) {
+      console.log(floop);
+    }
+  }
+
+  type DoopType = FirstConstructorArgument<typeof SomeClass>; // string
+  ```
+
 - `ArrayElement<T>`: When `T` is an array, resolves to the type contained within the array.
 
   ```ts

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -66,3 +66,16 @@ type ReactStatics =
 export type NonReactStatics<T> = Pick<T, Exclude<keyof T, ReactStatics>>;
 
 export type ExtendedWindow<T> = Window & typeof globalThis & T;
+
+export type ConstructorArguments<T> = T extends {
+  new (...args: infer U): any;
+}
+  ? U
+  : never;
+
+export type ConstructorArgumentAtIndex<
+  T,
+  I extends keyof ConstructorArguments<T>
+> = ConstructorArguments<T>[I];
+
+export type FirstConstructorArgument<T> = ConstructorArgumentAtIndex<T, 0>;


### PR DESCRIPTION
This PR just adds some handy type aliases around constructor arguments to `@shopify/useful-types`. I was needing them for some stuff in sewing-kit.

Check the added docs for details and examples