### PR TITLE
🗒️ docs update

### DIFF
--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -151,6 +151,8 @@ class ReactController < ApplicationController
 end
 ```
 
+🗒️ if you don't have a controller. Follow the [instruction](./docs/manual-installation#add-a-react-controller-and-routes) to setup `quilt_rails` in a controller instead of using the engine.
+
 Headers can be accessed during server-side-rendering with the `useRequestHeader` hook from `@shopify/react-network`.
 
 ```tsx
@@ -183,7 +185,9 @@ class ReactController < ApplicationController
 end
 ```
 
-If using the webpack plugin, this will be automatically passed into your application as the `data` prop.
+🗒️ if you don't have a controller. Follow the [instruction](./docs/manual-installation#add-a-react-controller-and-routes) to setup `quilt_rails` in a controller instead of using the engine.
+
+If using `react-server` without a customized server & client file, this will be automatically passed into your application as the `data` prop. If `react-server` is not being used or a customized server / client file was provided, check out [`react-server/webpack-plugin`](../../packages/react-server/src/webpack-plugin/webpack-plugin.ts) on how to pass the data to React.
 
 ```tsx
 // app/ui/index.tsx
@@ -244,6 +248,10 @@ When a React component sends HTTP requests back to a Rails endpoint (e.g., `/gra
 
 If your API **does not** require session data, the easiest way to deal with this is to use `protect_from_forgery with: :null_session`. This will work for APIs that either have no authentication requirements, or use header based authentication.
 
+While `Can't verify CSRF token authenticity` error will persist, `protect_from_forgery with: :null_session` will keep CSRF protection while ensuring the session is nullified when a token is not sent in to be more secure.
+
+You can also add `self.log_warning_on_csrf_failure = false` to the controller to suppress this error all together.
+
 ##### Example
 
 ```rb
@@ -263,7 +271,7 @@ end
 If your API **does** require session data, you can follow these steps:
 
 - Add an `x-shopify-react-xhr` header to all GraphQL requests with a value of 1 (this is done automatically if you are using `@shopify/react-graphql-universal-provider`)
-- Add a `protect_from_forgery with: Quilt::HeaderCsrfStrategy` override to your controllers
+- Add a `protect_from_forgery with: Quilt::HeaderCsrfStrategy` override to your API controllers
 
 ##### Example
 

--- a/gems/quilt_rails/lib/generators/quilt/rails_setup/templates/Procfile
+++ b/gems/quilt_rails/lib/generators/quilt/rails_setup/templates/Procfile
@@ -1,2 +1,2 @@
-node: node build/server/main.js
-web: bundle exec rails server -p $PORT -e $RAILS_ENV
+node: bin/rails sewing_kit:server:start
+web: bin/rails server -p $PORT -e $RAILS_ENV

--- a/packages/react-graphql-universal-provider/README.md
+++ b/packages/react-graphql-universal-provider/README.md
@@ -63,9 +63,10 @@ The component takes children and a function that can create an Apollo client. Th
 // App.tsx
 
 import {GraphQL} from '../GraphQL';
+const IS_SERVER = typeof window === 'undefined';
 
 function App({server}: {server?: boolean}) {
-  return <GraphQL server={server}>{/* rest of the app */}</GraphQL>;
+  return <GraphQL server={IS_SERVER}>{/* rest of the app */}</GraphQL>;
 }
 ```
 

--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -19,6 +19,8 @@ This library builds on top of [react-apollo](https://github.com/apollographql/re
 
 #### `ApolloProvider`
 
+🗒️ If your application does server side rendering. Skip this step and setup [`@shopify/react-graphql-universal-provider`](../react-graphql-universal-provider/README.md) instead.
+
 Before using the hooks and other utilities provided by this package, you must wrap your application in an `ApolloProvider`. This provider should be used instead of `react-apollo`'s [`ApolloProvider`](https://www.apollographql.com/docs/react/api/react-apollo#ApolloProvider), and it accepts the same props as that component.
 
 ```tsx

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -9,7 +9,8 @@ import {createRender, RenderFunction} from '../render';
 import {requestLogger} from '../logger';
 import {metricsMiddleware as metrics} from '../metrics';
 import {ping} from '../ping';
-import {ValueFromContext} from '../types';
+import {ValueFromContext, KoaNextFunction} from '../types';
+import {fallbackErrorMarkup} from '../render/error';
 
 const logger = console;
 
@@ -41,6 +42,22 @@ export function createServer(options: Options): Server {
   const app = new Koa();
 
   app.use(mount('/services/ping', ping));
+
+  app.use(
+    mount('/webpack/assets/dll/vendor.js', async function middleware(
+      ctx: Context,
+      next: KoaNextFunction,
+    ) {
+      // eslint-disable-next-line no-process-env
+      if (process.env.NODE_ENV === 'development') {
+        console.log('!!! HERE !!!');
+        ctx.body = fallbackErrorMarkup;
+        ctx.set('Content-Type', 'text/html');
+      } else {
+        await next();
+      }
+    }),
+  );
 
   app.use(requestLogger);
   app.use(metrics);


### PR DESCRIPTION
- Note on why user get `Can't verify CSRF token authenticity`
- Note to use controller option if user need to pass data or header from Rails to React
- Note on how to use Rails -> Node data passing if someone is using customized server/client
- Remove `server` from App render in react-graphql-universial-provider example