### PR TITLE
[quilt] Polish repo README and package descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,100 @@
 [comment]: # (NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead)
-# quilt
+# Quilt
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![codecov](https://codecov.io/gh/Shopify/quilt/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/quilt)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Shopify/quilt.svg)](https://greenkeeper.io/)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
-A loosely related set of packages for JavaScript / TypeScript projects at Shopify.
+A loosely related set of packages for JavaScript/TypeScript projects at Shopify.
 
 These libraries compose together to help you create performant modern JS apps that you love to develop and test. These packages are developed primarily to be used on top of the stack we like best for our JS apps; Typescript for the flavor, Koa for the server, React for UI, Apollo for data fetching, and Jest for tests. That said, you can mix and match as you like.
 
 ## Usage
 
-The Quilt repo is managed as a monorepo that is composed of many npm packages.
-Each package has its own `README` and documentation describing usage.
+The Quilt repo is managed as a monorepo that is composed of 70 npm packages and one Ruby gem.
+Each package/gem has its own `README.md` and documentation describing usage.
 
 ### Package Index
 
-| package |     |     |
-| ------- | --- | --- |
-| address | [directory](packages/address) | [![npm version](https://badge.fury.io/js/%40shopify%2Faddress.svg)](https://badge.fury.io/js/%40shopify%2Faddress) |
-| address-consts | [directory](packages/address-consts) | [![npm version](https://badge.fury.io/js/%40shopify%2Faddress-consts.svg)](https://badge.fury.io/js/%40shopify%2Faddress-consts) |
-| address-mocks | [directory](packages/address-mocks) | [![npm version](https://badge.fury.io/js/%40shopify%2Faddress-mocks.svg)](https://badge.fury.io/js/%40shopify%2Faddress-mocks) |
-| admin-graphql-api-utilities | [directory](packages/admin-graphql-api-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities) |
-| ast-utilities | [directory](packages/ast-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fast-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fast-utilities) |
-| async | [directory](packages/async) | [![npm version](https://badge.fury.io/js/%40shopify%2Fasync.svg)](https://badge.fury.io/js/%40shopify%2Fasync) |
-| browser | [directory](packages/browser) | [![npm version](https://badge.fury.io/js/%40shopify%2Fbrowser.svg)](https://badge.fury.io/js/%40shopify%2Fbrowser) |
-| csrf-token-fetcher | [directory](packages/csrf-token-fetcher) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg)](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher) |
-| css-utilities | [directory](packages/css-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fcss-utilities) |
-| dates | [directory](packages/dates) | [![npm version](https://badge.fury.io/js/%40shopify%2Fdates.svg)](https://badge.fury.io/js/%40shopify%2Fdates) |
-| decorators | [directory](packages/decorators) | [![npm version](https://badge.fury.io/js/%40shopify%2Fdecorators.svg)](https://badge.fury.io/js/%40shopify%2Fdecorators) |
-| enzyme-utilities | [directory](packages/enzyme-utilities) | [![npm version](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fenzyme-utilities) |
-| function-enhancers | [directory](packages/function-enhancers) | [![npm version](https://badge.fury.io/js/%40shopify%2Ffunction-enhancers.svg)](https://badge.fury.io/js/%40shopify%2Ffunction-enhancers) |
-| graphql-persisted | [directory](packages/graphql-persisted) | [![npm version](https://badge.fury.io/js/%40shopify%2Fgraphql-persisted.svg)](https://badge.fury.io/js/%40shopify%2Fgraphql-persisted) |
-| graphql-testing | [directory](packages/graphql-testing) | [![npm version](https://badge.fury.io/js/%40shopify%2Fgraphql-testing.svg)](https://badge.fury.io/js/%40shopify%2Fgraphql-testing) |
-| i18n | [directory](packages/i18n) | [![npm version](https://badge.fury.io/js/%40shopify%2Fi18n.svg)](https://badge.fury.io/js/%40shopify%2Fi18n) |
-| jest-dom-mocks | [directory](packages/jest-dom-mocks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks) |
-| jest-koa-mocks | [directory](packages/jest-koa-mocks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks) |
-| jest-mock-apollo | [directory](packages/jest-mock-apollo) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo) |
-| jest-mock-router | [directory](packages/jest-mock-router) | [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-router.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-router) |
-| koa-liveness-ping | [directory](packages/koa-liveness-ping) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping) |
-| koa-metrics | [directory](packages/koa-metrics) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-metrics.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-metrics) |
-| koa-performance | [directory](packages/koa-performance) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-performance) |
-| koa-shopify-auth | [directory](packages/koa-shopify-auth) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth) |
-| koa-shopify-graphql-proxy | [directory](packages/koa-shopify-graphql-proxy) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy) |
-| koa-shopify-webhooks | [directory](packages/koa-shopify-webhooks) | [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks) |
-| logger | [directory](packages/logger) | [![npm version](https://badge.fury.io/js/%40shopify%2Flogger.svg)](https://badge.fury.io/js/%40shopify%2Flogger) |
-| magic-entries-webpack-plugin | [directory](packages/magic-entries-webpack-plugin) | [![npm version](https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin) |
-| mime-types | [directory](packages/mime-types) | [![npm version](https://badge.fury.io/js/%40shopify%2Fmime-types.svg)](https://badge.fury.io/js/%40shopify%2Fmime-types) |
-| network | [directory](packages/network) | [![npm version](https://badge.fury.io/js/%40shopify%2Fnetwork.svg)](https://badge.fury.io/js/%40shopify%2Fnetwork) |
-| performance | [directory](packages/performance) | [![npm version](https://badge.fury.io/js/%40shopify%2Fperformance.svg)](https://badge.fury.io/js/%40shopify%2Fperformance) |
-| polyfills | [directory](packages/polyfills) | [![npm version](https://badge.fury.io/js/%40shopify%2Fpolyfills.svg)](https://badge.fury.io/js/%40shopify%2Fpolyfills) |
-| predicates | [directory](packages/predicates) | [![npm version](https://badge.fury.io/js/%40shopify%2Fpredicates.svg)](https://badge.fury.io/js/%40shopify%2Fpredicates) |
-| react-app-bridge-universal-provider | [directory](packages/react-app-bridge-universal-provider) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider) |
-| react-async | [directory](packages/react-async) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-async.svg)](https://badge.fury.io/js/%40shopify%2Freact-async) |
-| react-compose | [directory](packages/react-compose) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-compose.svg)](https://badge.fury.io/js/%40shopify%2Freact-compose) |
-| react-cookie | [directory](packages/react-cookie) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-cookie.svg)](https://badge.fury.io/js/%40shopify%2Freact-cookie) |
-| react-csrf | [directory](packages/react-csrf) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-csrf.svg)](https://badge.fury.io/js/%40shopify%2Freact-csrf) |
-| react-csrf-universal-provider | [directory](packages/react-csrf-universal-provider) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider) |
-| react-effect | [directory](packages/react-effect) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect) |
-| react-form | [directory](packages/react-form) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form.svg)](https://badge.fury.io/js/%40shopify%2Freact-form) |
-| react-form-state | [directory](packages/react-form-state) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state) |
-| react-google-analytics | [directory](packages/react-google-analytics) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg)](https://badge.fury.io/js/%40shopify%2Freact-google-analytics) |
-| react-graphql | [directory](packages/react-graphql) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-graphql.svg)](https://badge.fury.io/js/%40shopify%2Freact-graphql) |
-| react-graphql-universal-provider | [directory](packages/react-graphql-universal-provider) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider) |
-| react-hooks | [directory](packages/react-hooks) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-hooks.svg)](https://badge.fury.io/js/%40shopify%2Freact-hooks) |
-| react-html | [directory](packages/react-html) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-html.svg)](https://badge.fury.io/js/%40shopify%2Freact-html) |
-| react-hydrate | [directory](packages/react-hydrate) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-hydrate.svg)](https://badge.fury.io/js/%40shopify%2Freact-hydrate) |
-| react-i18n | [directory](packages/react-i18n) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-i18n.svg)](https://badge.fury.io/js/%40shopify%2Freact-i18n) |
-| react-i18n-universal-provider | [directory](packages/react-i18n-universal-provider) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-i18n-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-i18n-universal-provider) |
-| react-idle | [directory](packages/react-idle) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-idle.svg)](https://badge.fury.io/js/%40shopify%2Freact-idle) |
-| react-import-remote | [directory](packages/react-import-remote) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-import-remote.svg)](https://badge.fury.io/js/%40shopify%2Freact-import-remote) |
-| react-intersection-observer | [directory](packages/react-intersection-observer) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg)](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer) |
-| react-network | [directory](packages/react-network) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-network.svg)](https://badge.fury.io/js/%40shopify%2Freact-network) |
-| react-performance | [directory](packages/react-performance) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-performance.svg)](https://badge.fury.io/js/%40shopify%2Freact-performance) |
-| react-router | [directory](packages/react-router) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-router.svg)](https://badge.fury.io/js/%40shopify%2Freact-router) |
-| react-server | [directory](packages/react-server) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-server.svg)](https://badge.fury.io/js/%40shopify%2Freact-server) |
-| react-shortcuts | [directory](packages/react-shortcuts) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-shortcuts.svg)](https://badge.fury.io/js/%40shopify%2Freact-shortcuts) |
-| react-testing | [directory](packages/react-testing) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-testing.svg)](https://badge.fury.io/js/%40shopify%2Freact-testing) |
-| react-tracking-pixel | [directory](packages/react-tracking-pixel) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel.svg)](https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel) |
-| react-universal-provider | [directory](packages/react-universal-provider) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-universal-provider) |
-| react-web-worker | [directory](packages/react-web-worker) | [![npm version](https://badge.fury.io/js/%40shopify%2Freact-web-worker.svg)](https://badge.fury.io/js/%40shopify%2Freact-web-worker) |
-| rpc | [directory](packages/rpc) | [![npm version](https://badge.fury.io/js/%40shopify%2Frpc.svg)](https://badge.fury.io/js/%40shopify%2Frpc) |
-| semaphore | [directory](packages/semaphore) | [![npm version](https://badge.fury.io/js/%40shopify%2Fsemaphore.svg)](https://badge.fury.io/js/%40shopify%2Fsemaphore) |
-| sewing-kit-koa | [directory](packages/sewing-kit-koa) | [![npm version](https://badge.fury.io/js/%40shopify%2Fsewing-kit-koa.svg)](https://badge.fury.io/js/%40shopify%2Fsewing-kit-koa) |
-| statsd | [directory](packages/statsd) | [![npm version](https://badge.fury.io/js/%40shopify%2Fstatsd.svg)](https://badge.fury.io/js/%40shopify%2Fstatsd) |
-| useful-types | [directory](packages/useful-types) | [![npm version](https://badge.fury.io/js/%40shopify%2Fuseful-types.svg)](https://badge.fury.io/js/%40shopify%2Fuseful-types) |
-| web-worker | [directory](packages/web-worker) | [![npm version](https://badge.fury.io/js/%40shopify%2Fweb-worker.svg)](https://badge.fury.io/js/%40shopify%2Fweb-worker) |
-| with-env | [directory](packages/with-env) | [![npm version](https://badge.fury.io/js/%40shopify%2Fwith-env.svg)](https://badge.fury.io/js/%40shopify%2Fwith-env) |
+| Package | Version | Description |
+| ------- | ------- | ----------- |
+| [address](packages/address) | <a href="https://badge.fury.io/js/%40shopify%2Faddress"><img src="https://badge.fury.io/js/%40shopify%2Faddress.svg" width="200px" /></a> | Address utilities for formatting addresses |
+| [address-consts](packages/address-consts) | <a href="https://badge.fury.io/js/%40shopify%2Faddress-consts"><img src="https://badge.fury.io/js/%40shopify%2Faddress-consts.svg" width="200px" /></a> | Constants and types relating to `@shopify/address` |
+| [address-mocks](packages/address-mocks) | <a href="https://badge.fury.io/js/%40shopify%2Faddress-mocks"><img src="https://badge.fury.io/js/%40shopify%2Faddress-mocks.svg" width="200px" /></a> | Address mocks for `@shopify/address` |
+| [admin-graphql-api-utilities](packages/admin-graphql-api-utilities) | <a href="https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities"><img src="https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg" width="200px" /></a> | A set of utilities to use when consuming Shopify’s admin GraphQL API |
+| [ast-utilities](packages/ast-utilities) | <a href="https://badge.fury.io/js/%40shopify%2Fast-utilities"><img src="https://badge.fury.io/js/%40shopify%2Fast-utilities.svg" width="200px" /></a> | Utilities for working with Abstract Syntax Trees (ASTs) |
+| [async](packages/async) | <a href="https://badge.fury.io/js/%40shopify%2Fasync"><img src="https://badge.fury.io/js/%40shopify%2Fasync.svg" width="200px" /></a> | Primitives for loading parts of an application asynchronously |
+| [browser](packages/browser) | <a href="https://badge.fury.io/js/%40shopify%2Fbrowser"><img src="https://badge.fury.io/js/%40shopify%2Fbrowser.svg" width="200px" /></a> | Utilities for extracting browser information from user-agents |
+| [csrf-token-fetcher](packages/csrf-token-fetcher) | <a href="https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher"><img src="https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg" width="200px" /></a> | JavaScript utility function to fetch the CSRF token required to make requests to a Rails server |
+| [css-utilities](packages/css-utilities) | <a href="https://badge.fury.io/js/%40shopify%2Fcss-utilities"><img src="https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg" width="200px" /></a> | A set of CSS styling-related utilities |
+| [dates](packages/dates) | <a href="https://badge.fury.io/js/%40shopify%2Fdates"><img src="https://badge.fury.io/js/%40shopify%2Fdates.svg" width="200px" /></a> | Lightweight date operations library |
+| [decorators](packages/decorators) | <a href="https://badge.fury.io/js/%40shopify%2Fdecorators"><img src="https://badge.fury.io/js/%40shopify%2Fdecorators.svg" width="200px" /></a> | A set of decorators to aid your JavaScript journey |
+| [enzyme-utilities](packages/enzyme-utilities) | <a href="https://badge.fury.io/js/%40shopify%2Fenzyme-utilities"><img src="https://badge.fury.io/js/%40shopify%2Fenzyme-utilities.svg" width="200px" /></a> | Enzyme utilities for testing React components |
+| [function-enhancers](packages/function-enhancers) | <a href="https://badge.fury.io/js/%40shopify%2Ffunction-enhancers"><img src="https://badge.fury.io/js/%40shopify%2Ffunction-enhancers.svg" width="200px" /></a> | A set of helpers to enhance functions |
+| [graphql-persisted](packages/graphql-persisted) | <a href="https://badge.fury.io/js/%40shopify%2Fgraphql-persisted"><img src="https://badge.fury.io/js/%40shopify%2Fgraphql-persisted.svg" width="200px" /></a> | Apollo and Koa integrations for persisted GraphQL queries. |
+| [graphql-testing](packages/graphql-testing) | <a href="https://badge.fury.io/js/%40shopify%2Fgraphql-testing"><img src="https://badge.fury.io/js/%40shopify%2Fgraphql-testing.svg" width="200px" /></a> | Utilities to create mock GraphQL factories |
+| [i18n](packages/i18n) | <a href="https://badge.fury.io/js/%40shopify%2Fi18n"><img src="https://badge.fury.io/js/%40shopify%2Fi18n.svg" width="200px" /></a> | Generic i18n-related utilities |
+| [jest-dom-mocks](packages/jest-dom-mocks) | <a href="https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks"><img src="https://badge.fury.io/js/%40shopify%2Fjest-dom-mocks.svg" width="200px" /></a> | Jest mocking utilities for working with the DOM |
+| [jest-koa-mocks](packages/jest-koa-mocks) | <a href="https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks"><img src="https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks.svg" width="200px" /></a> | Utilities to easily stub Koa context and cookies |
+| [jest-mock-apollo](packages/jest-mock-apollo) | <a href="https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo"><img src="https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg" width="200px" /></a> | Jest + Enzyme mocks for Apollo 2.x |
+| [jest-mock-router](packages/jest-mock-router) | <a href="https://badge.fury.io/js/%40shopify%2Fjest-mock-router"><img src="https://badge.fury.io/js/%40shopify%2Fjest-mock-router.svg" width="200px" /></a> | Jest + Enzyme mocks for React Router 3.x |
+| [koa-liveness-ping](packages/koa-liveness-ping) | <a href="https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping"><img src="https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping.svg" width="200px" /></a> | A package for creating liveness ping middleware for use with Koa |
+| [koa-metrics](packages/koa-metrics) | <a href="https://badge.fury.io/js/%40shopify%2Fkoa-metrics"><img src="https://badge.fury.io/js/%40shopify%2Fkoa-metrics.svg" width="200px" /></a> | Aims to provide standard middleware and instrumentation tooling for metrics in Koa |
+| [koa-performance](packages/koa-performance) | <a href="https://badge.fury.io/js/%40shopify%2Fkoa-performance"><img src="https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg" width="200px" /></a> | Creating middleware that sends performance-related data through StatsD |
+| [koa-shopify-auth](packages/koa-shopify-auth) | <a href="https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth"><img src="https://badge.fury.io/js/%40shopify%2Fkoa-shopify-auth.svg" width="200px" /></a> | Middleware to authenticate a Koa application with Shopify |
+| [koa-shopify-graphql-proxy](packages/koa-shopify-graphql-proxy) | <a href="https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy"><img src="https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg" width="200px" /></a> | A wrapper around `koa-better-http-proxy` which allows easy proxying of GraphQL requests from an embedded Shopify app |
+| [koa-shopify-webhooks](packages/koa-shopify-webhooks) | <a href="https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks"><img src="https://badge.fury.io/js/%40shopify%2Fkoa-shopify-webhooks.svg" width="200px" /></a> | Receive webhooks from Shopify with ease |
+| [logger](packages/logger) | <a href="https://badge.fury.io/js/%40shopify%2Flogger"><img src="https://badge.fury.io/js/%40shopify%2Flogger.svg" width="200px" /></a> | Opinionated logger for production-scale applications |
+| [magic-entries-webpack-plugin](packages/magic-entries-webpack-plugin) | <a href="https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin"><img src="https://badge.fury.io/js/%40shopify%2Fmagic-entries-webpack-plugin.svg" width="200px" /></a> | A webpack plugin that automatically sets up entrypoints from filename conventions |
+| [mime-types](packages/mime-types) | <a href="https://badge.fury.io/js/%40shopify%2Fmime-types"><img src="https://badge.fury.io/js/%40shopify%2Fmime-types.svg" width="200px" /></a> | MIME type consistency |
+| [network](packages/network) | <a href="https://badge.fury.io/js/%40shopify%2Fnetwork"><img src="https://badge.fury.io/js/%40shopify%2Fnetwork.svg" width="200px" /></a> | Common values related to dealing with the network |
+| [performance](packages/performance) | <a href="https://badge.fury.io/js/%40shopify%2Fperformance"><img src="https://badge.fury.io/js/%40shopify%2Fperformance.svg" width="200px" /></a> | Primitives for collecting browser performance metrics |
+| [polyfills](packages/polyfills) | <a href="https://badge.fury.io/js/%40shopify%2Fpolyfills"><img src="https://badge.fury.io/js/%40shopify%2Fpolyfills.svg" width="200px" /></a> | Blessed polyfills for web platform features |
+| [predicates](packages/predicates) | <a href="https://badge.fury.io/js/%40shopify%2Fpredicates"><img src="https://badge.fury.io/js/%40shopify%2Fpredicates.svg" width="200px" /></a> | A set of common JavaScript predicates |
+| [react-app-bridge-universal-provider](packages/react-app-bridge-universal-provider) | <a href="https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider"><img src="https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider.svg" width="200px" /></a> | A self-serializing/deserializing `app-bridge-react` provider that works for isomorphic applications |
+| [react-async](packages/react-async) | <a href="https://badge.fury.io/js/%40shopify%2Freact-async"><img src="https://badge.fury.io/js/%40shopify%2Freact-async.svg" width="200px" /></a> | Tools for creating powerful, asynchronously-loaded React components |
+| [react-bugsnag](packages/react-bugsnag) | <a href="https://badge.fury.io/js/%40shopify%2Freact-bugsnag"><img src="https://badge.fury.io/js/%40shopify%2Freact-bugsnag.svg" width="200px" /></a> | An opinionated wrapper for Bugsnag's React plugin |
+| [react-compose](packages/react-compose) | <a href="https://badge.fury.io/js/%40shopify%2Freact-compose"><img src="https://badge.fury.io/js/%40shopify%2Freact-compose.svg" width="200px" /></a> | Cleanly compose multiple component enhancers together with minimal fuss |
+| [react-cookie](packages/react-cookie) | <a href="https://badge.fury.io/js/%40shopify%2Freact-cookie"><img src="https://badge.fury.io/js/%40shopify%2Freact-cookie.svg" width="200px" /></a> | Cookies in React for the server and client |
+| [react-csrf](packages/react-csrf) | <a href="https://badge.fury.io/js/%40shopify%2Freact-csrf"><img src="https://badge.fury.io/js/%40shopify%2Freact-csrf.svg" width="200px" /></a> | Share CSRF tokens throughout a React application |
+| [react-csrf-universal-provider](packages/react-csrf-universal-provider) | <a href="https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider"><img src="https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider.svg" width="200px" /></a> | A self-serializing/deserializing CSRF token provider that works for isomorphic applications |
+| [react-effect](packages/react-effect) | <a href="https://badge.fury.io/js/%40shopify%2Freact-effect"><img src="https://badge.fury.io/js/%40shopify%2Freact-effect.svg" width="200px" /></a> | A component and set of utilities for performing effects within a universal React app |
+| [react-form](packages/react-form) | <a href="https://badge.fury.io/js/%40shopify%2Freact-form"><img src="https://badge.fury.io/js/%40shopify%2Freact-form.svg" width="200px" /></a> | Manage React forms tersely and safely-typed with no magic using React hooks |
+| [react-form-state](packages/react-form-state) | <a href="https://badge.fury.io/js/%40shopify%2Freact-form-state"><img src="https://badge.fury.io/js/%40shopify%2Freact-form-state.svg" width="200px" /></a> | Manage React forms tersely and type-safely with no magic |
+| [react-google-analytics](packages/react-google-analytics) | <a href="https://badge.fury.io/js/%40shopify%2Freact-google-analytics"><img src="https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg" width="200px" /></a> | Allows React apps to easily embed Google Analytics scripts |
+| [react-graphql](packages/react-graphql) | <a href="https://badge.fury.io/js/%40shopify%2Freact-graphql"><img src="https://badge.fury.io/js/%40shopify%2Freact-graphql.svg" width="200px" /></a> | Tools for creating type-safe and asynchronous GraphQL components for React |
+| [react-graphql-universal-provider](packages/react-graphql-universal-provider) | <a href="https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider"><img src="https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider.svg" width="200px" /></a> | A self-serializing/deserializing GraphQL provider that works for isomorphic applications |
+| [react-hooks](packages/react-hooks) | <a href="https://badge.fury.io/js/%40shopify%2Freact-hooks"><img src="https://badge.fury.io/js/%40shopify%2Freact-hooks.svg" width="200px" /></a> | A collection of primitive React hooks |
+| [react-html](packages/react-html) | <a href="https://badge.fury.io/js/%40shopify%2Freact-html"><img src="https://badge.fury.io/js/%40shopify%2Freact-html.svg" width="200px" /></a> | A component to render your React app with no static HTML |
+| [react-hydrate](packages/react-hydrate) | <a href="https://badge.fury.io/js/%40shopify%2Freact-hydrate"><img src="https://badge.fury.io/js/%40shopify%2Freact-hydrate.svg" width="200px" /></a> | Utilities for hydrating server-rendered React apps |
+| [react-i18n](packages/react-i18n) | <a href="https://badge.fury.io/js/%40shopify%2Freact-i18n"><img src="https://badge.fury.io/js/%40shopify%2Freact-i18n.svg" width="200px" /></a> | i18n utilities for React handling translations, formatting, and more |
+| [react-i18n-universal-provider](packages/react-i18n-universal-provider) | <a href="https://badge.fury.io/js/%40shopify%2Freact-i18n-universal-provider"><img src="https://badge.fury.io/js/%40shopify%2Freact-i18n-universal-provider.svg" width="200px" /></a> | A self-serializing/deserializing i18n provider that works for isomorphic applications |
+| [react-idle](packages/react-idle) | <a href="https://badge.fury.io/js/%40shopify%2Freact-idle"><img src="https://badge.fury.io/js/%40shopify%2Freact-idle.svg" width="200px" /></a> | Utilities for working with idle callbacks in React |
+| [react-import-remote](packages/react-import-remote) | <a href="https://badge.fury.io/js/%40shopify%2Freact-import-remote"><img src="https://badge.fury.io/js/%40shopify%2Freact-import-remote.svg" width="200px" /></a> | Asynchronous script loading for React |
+| [react-intersection-observer](packages/react-intersection-observer) | <a href="https://badge.fury.io/js/%40shopify%2Freact-intersection-observer"><img src="https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg" width="200px" /></a> | A React wrapper around the Intersection Observer API |
+| [react-network](packages/react-network) | <a href="https://badge.fury.io/js/%40shopify%2Freact-network"><img src="https://badge.fury.io/js/%40shopify%2Freact-network.svg" width="200px" /></a> | A collection of components that allow you to set common HTTP headers from within your React application |
+| [react-performance](packages/react-performance) | <a href="https://badge.fury.io/js/%40shopify%2Freact-performance"><img src="https://badge.fury.io/js/%40shopify%2Freact-performance.svg" width="200px" /></a> | Primitives to measure your React application's performance using `@shopify/performance` |
+| [react-router](packages/react-router) | <a href="https://badge.fury.io/js/%40shopify%2Freact-router"><img src="https://badge.fury.io/js/%40shopify%2Freact-router.svg" width="200px" /></a> | A universal router for React |
+| [react-server](packages/react-server) | <a href="https://badge.fury.io/js/%40shopify%2Freact-server"><img src="https://badge.fury.io/js/%40shopify%2Freact-server.svg" width="200px" /></a> | Utilities for React server-side rendering |
+| [react-shortcuts](packages/react-shortcuts) | <a href="https://badge.fury.io/js/%40shopify%2Freact-shortcuts"><img src="https://badge.fury.io/js/%40shopify%2Freact-shortcuts.svg" width="200px" /></a> | Declaratively and efficiently match shortcut combinations in your React application |
+| [react-testing](packages/react-testing) | <a href="https://badge.fury.io/js/%40shopify%2Freact-testing"><img src="https://badge.fury.io/js/%40shopify%2Freact-testing.svg" width="200px" /></a> | A library for testing React components according to our conventions |
+| [react-tracking-pixel](packages/react-tracking-pixel) | <a href="https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel"><img src="https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel.svg" width="200px" /></a> | Allows React apps to easily embed tracking pixel iframes |
+| [react-universal-provider](packages/react-universal-provider) | <a href="https://badge.fury.io/js/%40shopify%2Freact-universal-provider"><img src="https://badge.fury.io/js/%40shopify%2Freact-universal-provider.svg" width="200px" /></a> | Factory function and utilities to create self-serializing/deserializing providers that work for isomorphic applications |
+| [react-web-worker](packages/react-web-worker) | <a href="https://badge.fury.io/js/%40shopify%2Freact-web-worker"><img src="https://badge.fury.io/js/%40shopify%2Freact-web-worker.svg" width="200px" /></a> | A hook for using web workers in React applications |
+| [rpc](packages/rpc) | <a href="https://badge.fury.io/js/%40shopify%2Frpc"><img src="https://badge.fury.io/js/%40shopify%2Frpc.svg" width="200px" /></a> | Utilities for `postMessage`-based remote procedure calls |
+| [semaphore](packages/semaphore) | <a href="https://badge.fury.io/js/%40shopify%2Fsemaphore"><img src="https://badge.fury.io/js/%40shopify%2Fsemaphore.svg" width="200px" /></a> | Counting semaphore |
+| [sewing-kit-koa](packages/sewing-kit-koa) | <a href="https://badge.fury.io/js/%40shopify%2Fsewing-kit-koa"><img src="https://badge.fury.io/js/%40shopify%2Fsewing-kit-koa.svg" width="200px" /></a> | Easily access Sewing Kit assets from a Koa server |
+| [statsd](packages/statsd) | <a href="https://badge.fury.io/js/%40shopify%2Fstatsd"><img src="https://badge.fury.io/js/%40shopify%2Fstatsd.svg" width="200px" /></a> | An opinionated StatsD client for Shopify Node.js servers and other StatsD utilities |
+| [useful-types](packages/useful-types) | <a href="https://badge.fury.io/js/%40shopify%2Fuseful-types"><img src="https://badge.fury.io/js/%40shopify%2Fuseful-types.svg" width="200px" /></a> | A few handy TypeScript types |
+| [web-worker](packages/web-worker) | <a href="https://badge.fury.io/js/%40shopify%2Fweb-worker"><img src="https://badge.fury.io/js/%40shopify%2Fweb-worker.svg" width="200px" /></a> | Tools for making web workers fun to use |
+| [with-env](packages/with-env) | <a href="https://badge.fury.io/js/%40shopify%2Fwith-env"><img src="https://badge.fury.io/js/%40shopify%2Fwith-env.svg" width="200px" /></a> | A utility for executing code under a specific `NODE_ENV` |
 
 ### Gem Index
 
-| package |     |     |
-| ------- | --- | --- |
-| quilt_rails | [directory](gems/quilt_rails) | [![Gem Version](https://badge.fury.io/rb/quilt_rails.svg)](https://badge.fury.io/rb/quilt_rails) |
+| Gem | Version | Description |
+| --- | ------- | ----------- |
+| [quilt_rails](gems/quilt_rails) | <a href="https://badge.fury.io/rb/quilt_rails"><img src="https://badge.fury.io/rb/quilt_rails.svg" width="200px" /></a> | A turn-key solution for integrating server-rendered React into your Rails app using Quilt libraries |
 
 ## Want to contribute?
 
@@ -102,7 +102,7 @@ Check out our [Contributing Guide](./.github/CONTRIBUTING.md)
 
 ## Questions?
 
-For Shopifolk, you can reach out to us in Slack in the `#web-foundation-tech` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via Github issues.
+For Shopifolk, you can reach out to us in Slack in the `#web-foundation-tech` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via GitHub issues.
 
 ## License
 

--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -133,6 +133,8 @@ function App() {
 export default App;
 ```
 
+**Note:** This solution works out of the box for initial server-side renders. If you wish to have consistent access to request headers on subsequent client-side renders, take a look at [`NetworkUniversalProvider`](https://github.com/Shopify/quilt/tree/master/packages/react-network#networkuniversalprovider).
+
 ##### Example: sending custom headers from Rails controller
 
 In some cases you may want to send custom headers from Rails to your React server. Quilt facilitates this case by providing consumers with a `headers` argument on the `render_react` call.

--- a/gems/quilt_rails/package.json
+++ b/gems/quilt_rails/package.json
@@ -1,7 +1,8 @@
 {
   "name": "quilt_rails",
   "private": true,
-  "description": "A file that dev up insists on creating so don't delete this.",
+  "description": "A turn-key solution for integrating server-rendered React into your Rails app using Quilt libraries",
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {},
+  "comment": "A file that dev up insists on creating so don't delete this"
 }

--- a/gems/quilt_rails/quilt_rails.gemspec
+++ b/gems/quilt_rails/quilt_rails.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors     = ["Mathew Allen"]
   spec.email       = ["mathew.allen@shopify.com"]
   spec.homepage    = "https://github.com/Shopify/quilt/tree/master/gems/quilt_rails"
-  spec.summary     = "A turn-key solution for integrating server-rendered react into your Rails app using Quilt libraries."
-  spec.description = "A turn-key solution for integrating server-rendered react into your Rails app using Quilt libraries."
+  spec.summary     = "A turn-key solution for integrating server-rendered React into your Rails app using Quilt libraries."
+  spec.description = "A turn-key solution for integrating server-rendered React into your Rails app using Quilt libraries."
   spec.license     = "MIT"
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quilt",
   "version": "1.0.0",
-  "description": "Shopify's javascript application utilities",
+  "description": "A loosely related set of packages for JavaScript/TypeScript projects at Shopify",
   "scripts": {
     "publish": "lerna publish",
     "build": "yarn tsc --build packages",

--- a/packages/address-consts/package.json
+++ b/packages/address-consts/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/address-consts",
   "version": "2.0.0",
   "license": "MIT",
-  "description": "Constants and types relating to @shopify/address",
+  "description": "Constants and types relating to `@shopify/address`",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/address-mocks/README.md
+++ b/packages/address-mocks/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Faddress-mocks.svg)](https://badge.fury.io/js/%40shopify%2Faddress-mocks)
 ![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/%40shopify/shopify%2address-mocks.svg)
 
-Address mocks for @shopify/address library.
+Address mocks for `@shopify/address`.
 
 ## Installation
 

--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/address-mocks",
   "version": "1.3.4",
   "license": "MIT",
-  "description": "Address mocks for @shopify/address library.",
+  "description": "Address mocks for `@shopify/address`",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/address/README.md
+++ b/packages/address/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Faddress.svg)](https://badge.fury.io/js/%40shopify%2Faddress)
 ![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/%40shopify/shopify%2address.svg)
 
-Address utilities for loading and ordering addresses.
+Address utilities for formatting addresses.
 
 ## Installation
 

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/address",
   "version": "2.8.4",
   "license": "MIT",
-  "description": "Address utilities for formatting addresses.",
+  "description": "Address utilities for formatting addresses",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/admin-graphql-api-utilities/README.md
+++ b/packages/admin-graphql-api-utilities/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fadmin-graphql-api-utilities.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/admin-graphql-api-utilities.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/admin-graphql-api-utilities.svg)
 
-A set of utilities to use when consuming Shopify’s admin graphql api.
+A set of utilities to use when consuming Shopify’s admin GraphQL API.
 
 ## Installation
 

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/admin-graphql-api-utilities",
   "version": "0.0.12",
   "license": "MIT",
-  "description": "A set of utilities to use when consuming Shopify’s admin graphql api.",
+  "description": "A set of utilities to use when consuming Shopify’s admin GraphQL API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/ast-utilities/README.md
+++ b/packages/ast-utilities/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fast-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fast-utilities.svg)
 
-Utilities for working with Abstract Syntax Trees (ASTs)
+Utilities for working with Abstract Syntax Trees (ASTs).
 
 ## Installation
 

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/async",
   "version": "2.1.4",
   "license": "MIT",
-  "description": "Primitives for loading parts of an application asynchronously.",
+  "description": "Primitives for loading parts of an application asynchronously",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,5 +1,10 @@
 # `@shopify/browser`
 
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
+[![npm version](https://badge.fury.io/js/%40shopify%2Fbrowser.svg)](https://badge.fury.io/js/%40shopify%2Fbrowser.svg)
+[![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/browser.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/browser.svg)
+
 A package providing a simple wrapper around [`ua-parser-js`](https://www.npmjs.com/package/ua-parser-js) to make extracting browser information from user-agents less cumbersome.
 
 ## Installation

--- a/packages/csrf-token-fetcher/README.md
+++ b/packages/csrf-token-fetcher/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg)](https://badge.fury.io/js/%40shopify%2Fcsrf-token-fetcher.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/csrf-token-fetcher.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/csrf-token-fetcher.svg)
 
-JavaScript utility function to fetch the CSRF token required to make requests to a Rails server
+JavaScript utility function to fetch the CSRF token required to make requests to a Rails server.
 
 ## Installation
 

--- a/packages/css-utilities/README.md
+++ b/packages/css-utilities/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg)](https://badge.fury.io/js/%40shopify%2Fcss-utilities.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/css-utilities.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/css-utilities.svg)
 
-A set of css styling related utilities.
+A set of CSS styling-related utilities.
 
 ## Installation
 

--- a/packages/css-utilities/package.json
+++ b/packages/css-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/css-utilities",
   "version": "1.0.5",
   "license": "MIT",
-  "description": "A set of css styling related utilities.",
+  "description": "A set of CSS styling-related utilities",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/dates",
   "version": "0.4.0",
   "license": "MIT",
-  "description": "Lightweight date operations library.",
+  "description": "Lightweight date operations library",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/decorators/README.md
+++ b/packages/decorators/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fdecorators.svg)](https://badge.fury.io/js/%40shopify%2Fdecorators.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/decorators.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/decorators.svg)
 
-A set of decorators to aid your javascript journey.
+A set of decorators to aid your JavaScript journey.
 
 ## Installation
 

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/decorators",
   "version": "1.1.11",
   "license": "MIT",
-  "description": "A set of decorators to aid your JavaScript journey.",
+  "description": "A set of decorators to aid your JavaScript journey",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/enzyme-utilities/package.json
+++ b/packages/enzyme-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/enzyme-utilities",
   "version": "2.1.12",
   "license": "MIT",
-  "description": "Enzyme utilities for testing React components.",
+  "description": "Enzyme utilities for testing React components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/function-enhancers/package.json
+++ b/packages/function-enhancers/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/function-enhancers",
   "version": "1.0.9",
   "license": "MIT",
-  "description": "A set of helpers to enhance functions.",
+  "description": "A set of helpers to enhance functions",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/graphql-testing/README.md
+++ b/packages/graphql-testing/README.md
@@ -5,8 +5,8 @@
 
 This package provides utilities to help in the following testing scenarios:
 
-1. Testing a graphQL operation with mock data.
-2. Testing the state of your application before/after all the graphQL operations resolve.
+1. Testing a GraphQL operation with mock data
+2. Testing the state of your application before/after all the GraphQL operations resolve
 
 ## Installation
 

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/graphql-testing",
   "version": "4.1.1",
   "license": "MIT",
-  "description": "Utilities to create mock graphql factory.",
+  "description": "Utilities to create mock GraphQL factories",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/i18n",
   "version": "0.1.10",
   "license": "MIT",
-  "description": "Generic i18n-related utilities.",
+  "description": "Generic i18n-related utilities",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/jest-dom-mocks",
   "version": "2.9.0",
   "license": "MIT",
-  "description": "",
+  "description": "Jest mocking utilities for working with the DOM",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/jest-koa-mocks/README.md
+++ b/packages/jest-koa-mocks/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks.svg)](https://badge.fury.io/js/%40shopify%2Fjest-koa-mocks)
 
-Utilities to easily stub Koa context and cookies. The utilities are designed to help you write unit tests for your koa middleware without needing to set up any kind of actual server in your test environment. When test writing is easy and fun you'll want to write more tests. ✨😎
+Utilities to easily stub Koa context and cookies. The utilities are designed to help you write unit tests for your Koa middleware without needing to set up any kind of actual server in your test environment. When test writing is easy and fun you'll want to write more tests. ✨😎
 
 ## Installation
 

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/jest-koa-mocks",
   "version": "2.2.2",
   "license": "MIT",
-  "description": "",
+  "description": "Utilities to easily stub Koa context and cookies",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/jest-mock-apollo/README.md
+++ b/packages/jest-mock-apollo/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo.svg)](https://badge.fury.io/js/%40shopify%2Fjest-mock-apollo)
 
-:warning: This is being replace with [`@shopify/graphql-testing`](../../packages/graphql-testing)
+:warning: This is being replaced with [`@shopify/graphql-testing`](../../packages/graphql-testing)
 
 Jest + Enzyme mocks for Apollo 2.x.
 

--- a/packages/jest-mock-apollo/package.json
+++ b/packages/jest-mock-apollo/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/jest-mock-apollo",
   "version": "4.0.7",
   "license": "MIT",
-  "description": "Jest + Enzyme mocks for Apollo 2.x.",
+  "description": "Jest + Enzyme mocks for Apollo 2.x",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/jest-mock-router/package.json
+++ b/packages/jest-mock-router/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/jest-mock-router",
   "version": "1.0.24",
   "license": "MIT",
-  "description": "Jest + Enzyme mocks for React Router 3.x.",
+  "description": "Jest + Enzyme mocks for React Router 3.x",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/koa-liveness-ping/README.md
+++ b/packages/koa-liveness-ping/README.md
@@ -1,8 +1,12 @@
 # `@shopify/koa-liveness-ping`
 
-A package for creating a liveness ping middleware for use with koa
+[![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
+[![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-liveness-ping)
 
-A liveness ping is a URL at which your application will respond with a `200` whenever your server is running. It can be used, for example, for liveness checks in kubernetes deployments.
+A package for creating liveness ping middleware for use with Koa.
+
+A liveness ping is a URL at which your application will respond with a `200` whenever your server is running. It can be used, for example, for liveness checks in Kubernetes deployments.
 
 ## Installation
 

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/koa-liveness-ping",
   "version": "0.1.26",
   "license": "MIT",
-  "description": "A package for creating a liveness ping middleware for use with koa",
+  "description": "A package for creating liveness ping middleware for use with Koa",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/koa-metrics/README.md
+++ b/packages/koa-metrics/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-metrics.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-metrics.svg)
 
-Opinionated performance metric tracking for Koa, implemented with DogStatsD
+Opinionated performance metric tracking for Koa, implemented with DogStatsD.
 
 ## Installation
 

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/koa-metrics",
   "version": "0.4.1",
   "license": "MIT",
-  "description": "Aims to provide standard middlewares and instrumentation tooling for metrics in Koa.",
+  "description": "Aims to provide standard middleware and instrumentation tooling for metrics in Koa",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/koa-performance/README.md
+++ b/packages/koa-performance/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-performance.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/koa-performance.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/koa-performance.svg)
 
-A middleware which makes it easy to send metrics from your front end application and forward them to a StatsD server of your choice.
+Middleware which makes it easy to send metrics from your front-end application and forward them to a StatsD server of your choice.
 
 Best used with [`@shopify/performance`](https://www.npmjs.com/package/@shopify/performance) and/or [`@shopify/react-performance`](https://www.npmjs.com/package/@shopify/react-performance).
 

--- a/packages/koa-performance/package.json
+++ b/packages/koa-performance/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/koa-performance",
   "version": "1.2.4",
   "license": "MIT",
-  "description": "Creating a middleware that send performance related data through StatsD.",
+  "description": "Creating middleware that sends performance-related data through StatsD",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/koa-shopify-auth/package.json
+++ b/packages/koa-shopify-auth/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/koa-shopify-auth",
   "version": "3.1.63",
   "license": "MIT",
-  "description": "",
+  "description": "Middleware to authenticate a Koa application with Shopify",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/koa-shopify-graphql-proxy/README.md
+++ b/packages/koa-shopify-graphql-proxy/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy.svg)](https://badge.fury.io/js/%40shopify%2Fkoa-shopify-graphql-proxy)
 
-A wrapper around koa-better-http-proxy which allows easy proxying of graphql requests from an embedded shopify app.
+A wrapper around `koa-better-http-proxy` which allows easy proxying of GraphQL requests from an embedded Shopify app.
 
 ## Installation
 

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/koa-shopify-graphql-proxy",
   "version": "4.0.0",
   "license": "MIT",
-  "description": "A wrapper around koa-better-http-proxy which allows easy proxying of graphql requests from an embedded shopify app.",
+  "description": "A wrapper around `koa-better-http-proxy` which allows easy proxying of GraphQL requests from an embedded Shopify app",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/koa-shopify-webhooks/package.json
+++ b/packages/koa-shopify-webhooks/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/koa-shopify-webhooks",
   "version": "2.4.2",
   "license": "MIT",
-  "description": "Receive webhooks from Shopify with ease.",
+  "description": "Receive webhooks from Shopify with ease",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
 [![npm version](https://badge.fury.io/js/%40shopify%2Flogger.svg)](https://badge.fury.io/js/%40shopify%2Flogger.svg)
 
-Opinionated logger for production-scale applications
+Opinionated logger for production-scale applications.
 
 ## Installation
 

--- a/packages/mime-types/README.md
+++ b/packages/mime-types/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fmime-types.svg)](https://badge.fury.io/js/%40shopify%2Fmime-types.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/mime-types.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/mime-types.svg)
 
-Mime type consistency
+MIME type consistency.
 
 ## Installation
 

--- a/packages/mime-types/package.json
+++ b/packages/mime-types/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/mime-types",
   "version": "0.1.0",
   "license": "MIT",
-  "description": "Mime type consistency",
+  "description": "MIME type consistency",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/performance",
   "version": "1.2.8",
   "license": "MIT",
-  "description": "Primitives for collecting browser performance metrics.",
+  "description": "Primitives for collecting browser performance metrics",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/polyfills/README.md
+++ b/packages/polyfills/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fpolyfills.svg)](https://badge.fury.io/js/%40shopify%2Fpolyfills.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/polyfills.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/polyfills.svg)
 
-Blessed polyfills for web platform features. Exports browser, node, and Jest/ JSDom polyfills where appropriate.
+Blessed polyfills for web platform features. Exports browser, Node, and Jest/jsdom polyfills where appropriate.
 
 The following polyfills are currently provided:
 

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/polyfills",
   "version": "1.2.1",
   "license": "MIT",
-  "description": "Blessed polyfills for web platform features.",
+  "description": "Blessed polyfills for web platform features",
   "sideEffects": true,
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/predicates/README.md
+++ b/packages/predicates/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fpredicates.svg)](https://badge.fury.io/js/%40shopify%2Fpredicates.svg)
 
-A set of common Javascript predicates. The functions in this library either take one input and return `true` / `false`, or return a customized function that does so.
+A set of common JavaScript predicates. The functions in this library either take one input and return `true`/`false`, or return a customized function that does so.
 
 ## Installation
 

--- a/packages/predicates/package.json
+++ b/packages/predicates/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/predicates",
   "version": "1.2.5",
   "license": "MIT",
-  "description": "A set of common Javascript predicates",
+  "description": "A set of common JavaScript predicates",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-app-bridge-universal-provider/README.md
+++ b/packages/react-app-bridge-universal-provider/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-app-bridge-universal-provider.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-app-bridge-universal-provider.svg)
 
-A self-serializing/deserializing [app-bridge-react](https://github.com/Shopify/app-bridge/tree/master/packages/app-bridge-react) provider that works for isomorphic applications.
+A self-serializing/deserializing [`app-bridge-react`](https://github.com/Shopify/app-bridge/tree/master/packages/app-bridge-react) provider that works for isomorphic applications.
 
 ## Installation
 

--- a/packages/react-app-bridge-universal-provider/package.json
+++ b/packages/react-app-bridge-universal-provider/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-app-bridge-universal-provider",
   "version": "1.0.32",
   "license": "MIT",
-  "description": "A self-serializing/deserializing app-bridge-react provider that works for isomorphic applications.",
+  "description": "A self-serializing/deserializing `app-bridge-react` provider that works for isomorphic applications",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-async",
   "version": "3.1.18",
   "license": "MIT",
-  "description": "Tools for creating powerful, asynchronously-loaded React components.",
+  "description": "Tools for creating powerful, asynchronously-loaded React components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-bugsnag/README.md
+++ b/packages/react-bugsnag/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-bugsnag.svg)](https://badge.fury.io/js/%40shopify%2Freact-bugsnag.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-bugsnag.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-bugsnag.svg)
 
-A wrapper for bugsnag&#x27; and its React plugin with smart defaults and support for universal Server-Side-Rendered applications.
+An opinionated wrapper for Bugsnag's React plugin with smart defaults and support for universal server-side-rendered applications.
 
 ## Installation
 

--- a/packages/react-bugsnag/package.json
+++ b/packages/react-bugsnag/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-bugsnag",
   "version": "1.0.0",
   "license": "MIT",
-  "description": "An opinionated wrapper for bugsnag&#x27;s React plugin",
+  "description": "An opinionated wrapper for Bugsnag's React plugin",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-csrf-universal-provider/README.md
+++ b/packages/react-csrf-universal-provider/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-csrf-universal-provider.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-csrf-universal-provider.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-csrf-universal-provider.svg)
 
-A self-serializing/deserializing CSRF token provider that works for for isomorphic applications.
+A self-serializing/deserializing CSRF token provider that works for isomorphic applications.
 
 ## Installation
 

--- a/packages/react-csrf-universal-provider/package.json
+++ b/packages/react-csrf-universal-provider/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-csrf-universal-provider",
   "version": "1.1.17",
   "license": "MIT",
-  "description": "A self-serializing/deserializing CSRF token provider that works for for isomorphic applications.",
+  "description": "A self-serializing/deserializing CSRF token provider that works for isomorphic applications",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-csrf/README.md
+++ b/packages/react-csrf/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-csrf.svg)](https://badge.fury.io/js/%40shopify%2Freact-csrf.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-csrf.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-csrf.svg)
 
-Share csrf token throughout a react application.
+Share CSRF tokens throughout a React application.
 
 ## Installation
 

--- a/packages/react-csrf/package.json
+++ b/packages/react-csrf/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-csrf",
   "version": "1.0.11",
   "license": "MIT",
-  "description": "Share csrf token throughout a react application.",
+  "description": "Share CSRF tokens throughout a React application",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-effect.svg)](https://badge.fury.io/js/%40shopify%2Freact-effect.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-effect.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-effect.svg)
 
-This package contains a component and set of utilities for performing multiple effects during one single pass of server rendering in a universal React application.
+This package contains a component and set of utilities for performing multiple effects during a single pass of server-side rendering in a universal React application.
 
 ## Installation
 

--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg)](https://badge.fury.io/js/%40shopify%2Freact-form-state.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-form-state.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-form-state.svg)
 
-Manage react forms tersely and safely-typed with no magic.
+Manage React forms tersely and type-safely with no magic.
 
 This library is now superseded by [@shopify/react-form](https://github.com/Shopify/quilt/tree/master/packages/react-form) as it allows you to write the preferred, functional, and hooks-driven React components over class-based ones.
 

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-form-state",
   "version": "0.11.25",
   "license": "MIT",
-  "description": "Manage react forms tersely and type-safe with no magic.",
+  "description": "Manage React forms tersely and type-safely with no magic",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-form",
   "version": "0.7.0",
   "license": "MIT",
-  "description": "Manage react forms tersely and safely-typed with no magic using React hooks.",
+  "description": "Manage React forms tersely and safely-typed with no magic using React hooks",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-google-analytics/README.md
+++ b/packages/react-google-analytics/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg)](https://badge.fury.io/js/%40shopify%2Freact-google-analytics.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-google-analytics.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-google-analytics.svg)
 
-Allows React apps to easily embed tracking pixel iframes
+Allows React apps to easily embed Google Analytics scripts.
 
 ## Installation
 

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-google-analytics",
   "version": "3.1.15",
   "license": "MIT",
-  "description": "Google Analytics",
+  "description": "Allows React apps to easily embed Google Analytics scripts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-graphql-universal-provider/README.md
+++ b/packages/react-graphql-universal-provider/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-graphql-universal-provider.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-graphql-universal-provider.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-graphql-universal-provider.svg)
 
+A self-serializing/deserializing GraphQL provider that works for isomorphic applications.
+
 ## Installation
 
 ```bash

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-graphql-universal-provider",
   "version": "3.1.11",
   "license": "MIT",
-  "description": "A self-serializing/deserializing GraphQL provider that works for isomorphic applications.",
+  "description": "A self-serializing/deserializing GraphQL provider that works for isomorphic applications",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-graphql",
   "version": "6.1.11",
   "license": "MIT",
-  "description": "Tools for creating type-safe and asynchronous GraphQL components for React.",
+  "description": "Tools for creating type-safe and asynchronous GraphQL components for React",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-hooks",
   "version": "1.10.0",
   "license": "MIT",
-  "description": "A collection of primitive React hooks.",
+  "description": "A collection of primitive React hooks",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-html",
   "version": "9.3.12",
   "license": "MIT",
-  "description": "A component to render your react app with no static HTML.",
+  "description": "A component to render your React app with no static HTML",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-i18n-universal-provider",
   "version": "1.0.60",
   "license": "MIT",
-  "description": "A self-serializing/deserializing i18n provider that works for isomorphic applications.",
+  "description": "A self-serializing/deserializing i18n provider that works for isomorphic applications",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-i18n",
   "version": "5.0.1",
   "license": "MIT",
-  "description": "i18n utilities for React handling translations, formatting, and more.",
+  "description": "i18n utilities for React handling translations, formatting, and more",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-idle/README.md
+++ b/packages/react-idle/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-idle.svg)](https://badge.fury.io/js/%40shopify%2Freact-idle.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-idle.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-idle.svg)
 
-Utilities for working with [idle callbacks](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) in React
+Utilities for working with [idle callbacks](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) in React.
 
 ## Installation
 

--- a/packages/react-import-remote/README.md
+++ b/packages/react-import-remote/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-import-remote.svg)](https://badge.fury.io/js/%40shopify%2Freact-import-remote.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-import-remote.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-import-remote.svg)
 
-Asynchronous script loading for React
+Asynchronous script loading for React.
 
 ## Installation
 

--- a/packages/react-intersection-observer/README.md
+++ b/packages/react-intersection-observer/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg)](https://badge.fury.io/js/%40shopify%2Freact-intersection-observer.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-intersection-observer.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-intersection-observer.svg)
 
-A React wrapper around the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+A React wrapper around the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
 
 ## Installation
 

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-intersection-observer",
   "version": "2.0.14",
   "license": "MIT",
-  "description": "A React wrapper around the IntersectionObserver API",
+  "description": "A React wrapper around the Intersection Observer API",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-network",
   "version": "3.5.0",
   "license": "MIT",
-  "description": "A collection of components that allow you to set common HTTP headers from within your React application.",
+  "description": "A collection of components that allow you to set common HTTP headers from within your React application",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-performance.svg)](https://badge.fury.io/js/%40shopify%2Freact-performance.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-performance.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-performance.svg)
 
-Primitives to measure your React application's performance using `@shopify/performance`
+Primitives to measure your React application's performance using `@shopify/performance`.
 
 ## Table of Contents
 

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-performance",
   "version": "1.3.4",
   "license": "MIT",
-  "description": "Primitives to measure your React application&#x27;s performance using @shopify/performance",
+  "description": "Primitives to measure your React application's performance using `@shopify/performance`",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-router",
   "version": "0.0.28",
   "license": "MIT",
-  "description": "A universal router for React.",
+  "description": "A universal router for React",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-server",
   "version": "0.16.0",
   "license": "MIT",
-  "description": "Utilities for React server-side rendering.",
+  "description": "Utilities for React server-side rendering",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-shortcuts",
   "version": "3.0.13",
   "license": "MIT",
-  "description": "Declaratively and efficiently match shortcut combinations in your react application",
+  "description": "Declaratively and efficiently match shortcut combinations in your React application",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-testing",
   "version": "2.1.2",
   "license": "MIT",
-  "description": "A library for testing React components according to our conventions.",
+  "description": "A library for testing React components according to our conventions",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/react-tracking-pixel/README.md
+++ b/packages/react-tracking-pixel/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel.svg)](https://badge.fury.io/js/%40shopify%2Freact-tracking-pixel.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-tracking-pixel.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-tracking-pixel.svg)
 
-Allows React apps to easily embed tracking pixel iframes
+Allows React apps to easily embed tracking pixel iframes.
 
 ## Installation
 

--- a/packages/react-universal-provider/README.md
+++ b/packages/react-universal-provider/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-universal-provider.svg)](https://badge.fury.io/js/%40shopify%2Freact-universal-provider.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/react-universal-provider.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/react-universal-provider.svg)
 
-Factory function and utilities to create self-serializing/deserializing provider that works for isomorphic applications.
+Factory function and utilities to create self-serializing/deserializing providers that work for isomorphic applications.
 
 ## Table of contents
 

--- a/packages/react-universal-provider/package.json
+++ b/packages/react-universal-provider/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/react-universal-provider",
   "version": "1.1.17",
   "license": "MIT",
-  "description": "Factory function and utilities to create self-serializing/deserializing provider that works for isomorphic applications.",
+  "description": "Factory function and utilities to create self-serializing/deserializing providers that work for isomorphic applications",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/rpc",
   "version": "1.0.6",
   "license": "MIT",
-  "description": "Utilities for postmessage-based remote procedure calls.",
+  "description": "Utilities for `postMessage`-based remote procedure calls",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/semaphore/README.md
+++ b/packages/semaphore/README.md
@@ -1,9 +1,9 @@
 # `@shopify/semaphore`
 
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fsemaphore.svg)](https://badge.fury.io/js/%40shopify%2Fsemaphore.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/semaphore.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/semaphore.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fsemaphore.svg)](https://badge.fury.io/js/%40shopify%2Fsemaphore.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/semaphore.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/semaphore.svg)
 
-The Semaphore class implements a counting [semaphore](https://en.wikipedia.org/wiki/Semaphore_(programming)).
+The Semaphore class implements a counting [semaphore](<https://en.wikipedia.org/wiki/Semaphore_(programming)>).
 It can be useful to control concurrent access to a pool of resources such as:
 
 1. Maintaining a pool of web workers to run background scripts
@@ -29,7 +29,7 @@ Create a semaphore instance by calling the `Semaphore` constructor with a count 
 const semaphore = new Semaphore(3);
 ```
 
-If you need a [lock/mutex](https://en.wikipedia.org/wiki/Lock_(computer_science)), a semaphore with a count of 1 will effectively act as one:
+If you need a [lock/mutex](<https://en.wikipedia.org/wiki/Lock_(computer_science)>), a semaphore with a count of 1 will effectively act as one:
 
 ```typescript
 const mutex = new Semaphore(1);
@@ -57,7 +57,6 @@ The `.release)()` method returns a promise that gets resolved when the permit is
 await permit.release();
 ```
 
-
 ## Example
 
 ```typescript
@@ -68,8 +67,7 @@ const fetchSemaphore = new Semaphore(MAX_SIMULTANEOUS_FETCHES);
 async function callApi(path) {
   const permit = await fetchSemaphore.acquire();
 
-  return fetch(path)
-    .finally(() => permit.release());
+  return fetch(path).finally(() => permit.release());
 }
 
 callApi(apples).then(renderApples);

--- a/packages/sewing-kit-koa/README.md
+++ b/packages/sewing-kit-koa/README.md
@@ -67,13 +67,9 @@ import {getAssets} from '@shopify/sewing-kit-koa';
 
 app.use(async ctx => {
   const assets = getAssets(ctx);
-  
-  const styles = (await assets.styles({name: 'error'})).map(
-    ({path}) => path,
-  );
-  const scripts = (await assets.scripts({name: 'error'})).map(
-    ({path}) => path,
-  );
+
+  const styles = (await assets.styles({name: 'error'})).map(({path}) => path);
+  const scripts = (await assets.scripts({name: 'error'})).map(({path}) => path);
 
   ctx.body = `Error page needs the following assets: ${[
     ...styles,

--- a/packages/sewing-kit-koa/package.json
+++ b/packages/sewing-kit-koa/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/sewing-kit-koa",
   "version": "6.3.3",
   "license": "MIT",
-  "description": "Easily access Sewing Kit assets from a Koa server.",
+  "description": "Easily access Sewing Kit assets from a Koa server",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/statsd/README.md
+++ b/packages/statsd/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fstatsd.svg)](https://badge.fury.io/js/%40shopify%2Fstatsd.svg)
 
-An opinionated StatsD client for Shopify Node.js server and other StatsD utilities.
+An opinionated StatsD client for Shopify Node.js servers and other StatsD utilities.
 
 ## Installation
 

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/statsd",
   "version": "1.2.3",
   "license": "MIT",
-  "description": "An opinionated StatsD client for Shopify Node.js server and other StatsD utilities.",
+  "description": "An opinionated StatsD client for Shopify Node.js servers and other StatsD utilities",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/web-worker",
   "version": "1.4.0",
   "license": "MIT",
-  "description": "Tools for making web workers fun to use.",
+  "description": "Tools for making web workers fun to use",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/with-env/README.md
+++ b/packages/with-env/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator.svg)](https://badge.fury.io/js/%40shopify%2Freact-shopify-app-route-propagator)
 
-A utility for executing code under a specific NODE_ENV.
+A utility for executing code under a specific `NODE_ENV`.
 
 ## Installation
 

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/with-env",
   "version": "1.1.8",
   "license": "MIT",
-  "description": "A utility for executing code under a specific NODE_ENV.",
+  "description": "A utility for executing code under a specific `NODE_ENV`",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,22 +1,25 @@
 const {readdirSync, existsSync} = require('fs');
 const path = require('path');
 
-const jsPackageNames = getPackageNames('js');
-const gemNames = getPackageNames('ruby');
+const jsPackages = getPackages('js');
+const gems = getPackages('ruby');
 
 module.exports = function (plop) {
   plop.setGenerator('package', {
-    description: 'create a new package from scratch',
+    description: 'Create a new package from scratch',
     prompts: [
       {
         type: 'input',
         name: 'name',
         message: "What should this package's name be? Ex. react-utilities",
+        validate: validatePackageName,
+        filter: plop.getHelper('kebabCase'),
       },
       {
         type: 'input',
         name: 'description',
         message: "What should this package's description be?",
+        filter: stripDescription,
       },
       {
         type: 'confirm',
@@ -27,38 +30,37 @@ module.exports = function (plop) {
     actions: [
       {
         type: 'add',
-        path: 'packages/{{kebabCase name}}/package.json',
+        path: 'packages/{{name}}/package.json',
         templateFile: 'templates/package.hbs.json',
       },
       {
         type: 'add',
-        path: 'packages/{{kebabCase name}}/tsconfig.json',
+        path: 'packages/{{name}}/tsconfig.json',
         templateFile: 'templates/tsconfig.hbs.json',
       },
       {
         type: 'add',
-        path: 'packages/{{kebabCase name}}/README.md',
+        path: 'packages/{{name}}/README.md',
         templateFile: 'templates/README.hbs.md',
       },
       {
         type: 'add',
-        path: 'packages/{{kebabCase name}}/CHANGELOG.md',
+        path: 'packages/{{name}}/CHANGELOG.md',
         templateFile: 'templates/CHANGELOG.hbs.md',
       },
       {
         type: 'add',
-        path: 'packages/{{kebabCase name}}/src/index.ts',
+        path: 'packages/{{name}}/src/index.ts',
         templateFile: 'templates/index.hbs',
       },
       {
         type: 'add',
-        path: 'packages/{{kebabCase name}}/src/{{properCase name}}.ts',
+        path: 'packages/{{name}}/src/{{properCase name}}.ts',
         templateFile: 'templates/my-package.hbs.ts',
       },
       {
         type: 'add',
-        path:
-          'packages/{{kebabCase name}}/src/test/{{properCase name}}.test.ts',
+        path: 'packages/{{name}}/src/test/{{properCase name}}.test.ts',
         templateFile: 'templates/test.hbs.ts',
       },
       {
@@ -66,8 +68,7 @@ module.exports = function (plop) {
         path: 'packages/tsconfig.json',
         transform: (file, {name}) => {
           const tsConfig = JSON.parse(file);
-          const kebabCase = plop.getHelper('kebabCase');
-          tsConfig.references.push({path: `./${kebabCase(name)}`});
+          tsConfig.references.push({path: `./${name}`});
           tsConfig.references.sort(({path: firstPath}, {path: secondPath}) =>
             firstPath.localeCompare(secondPath),
           );
@@ -86,23 +87,43 @@ module.exports = function (plop) {
         path: 'README.md',
         templateFile: 'templates/ROOT_README.hbs.md',
         force: true,
-        data: {jsPackageNames, gemNames},
+        data: {jsPackages, gems},
       },
     ],
   });
 };
 
-function getPackageNames(type = 'js') {
+function getPackages(type = 'js') {
   const packagesPath = path.join(
     __dirname,
     type === 'js' ? 'packages' : 'gems',
   );
-  return readdirSync(packagesPath).filter(packageName => {
+
+  return readdirSync(packagesPath).reduce((acc, packageName) => {
     const packageJSONPath = path.join(
       packagesPath,
       packageName,
       'package.json',
     );
-    return existsSync(packageJSONPath);
-  });
+
+    if (existsSync(packageJSONPath)) {
+      const {name, description} = require(packageJSONPath);
+
+      acc.push({name: name.replace('@shopify/', ''), description});
+    }
+
+    return acc;
+  }, []);
+}
+
+function validatePackageName(name) {
+  return (
+    /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/g.test(
+      `@shopify/${name}`,
+    ) || `Your package name (@shopify/${name}) does not confirm to npm rules!`
+  );
+}
+
+function stripDescription(desc) {
+  return desc.replace(/[.\s]*$/g, '').replace(/^\s*/g, '');
 }

--- a/templates/README.hbs.md
+++ b/templates/README.hbs.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2F{{name}}.svg)](https://badge.fury.io/js/%40shopify%2F{{name}}.svg) {{#if usedInBrowser}} [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/{{name}}.svg) {{/if}}
 
-{{description}}
+{{{description}}}.
 
 ## Installation
 

--- a/templates/ROOT_README.hbs.md
+++ b/templates/ROOT_README.hbs.md
@@ -1,35 +1,34 @@
 [comment]: # (NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead)
-# quilt
+# Quilt
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
 [![Build Status](https://travis-ci.org/Shopify/quilt.svg?branch=master)](https://travis-ci.org/Shopify/quilt)
 [![codecov](https://codecov.io/gh/Shopify/quilt/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/quilt)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Shopify/quilt.svg)](https://greenkeeper.io/)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
-A loosely related set of packages for JavaScript / TypeScript projects at Shopify.
+A loosely related set of packages for JavaScript/TypeScript projects at Shopify.
 
 These libraries compose together to help you create performant modern JS apps that you love to develop and test. These packages are developed primarily to be used on top of the stack we like best for our JS apps; Typescript for the flavor, Koa for the server, React for UI, Apollo for data fetching, and Jest for tests. That said, you can mix and match as you like.
 
 ## Usage
 
-The Quilt repo is managed as a monorepo that is composed of many npm packages.
-Each package has its own `README` and documentation describing usage.
+The Quilt repo is managed as a monorepo that is composed of {{jsPackages.length}} npm packages and one Ruby gem.
+Each package/gem has its own `README.md` and documentation describing usage.
 
 ### Package Index
 
-| package |     |     |
-| ------- | --- | --- |
-{{#each jsPackageNames}}
-| {{this}} | [directory](packages/{{this}}) | [![npm version](https://badge.fury.io/js/%40shopify%2F{{this}}.svg)](https://badge.fury.io/js/%40shopify%2F{{this}}) |
+| Package | Version | Description |
+| ------- | ------- | ----------- |
+{{#each jsPackages}}
+| [{{name}}](packages/{{name}}) | <a href="https://badge.fury.io/js/%40shopify%2F{{name}}"><img src="https://badge.fury.io/js/%40shopify%2F{{name}}.svg" width="200px" /></a> | {{{description}}} |
 {{/each}}
 
 ### Gem Index
 
-| package |     |     |
-| ------- | --- | --- |
-{{#each gemNames}}
-| {{this}} | [directory](gems/{{this}}) | [![Gem Version](https://badge.fury.io/rb/{{this}}.svg)](https://badge.fury.io/rb/{{this}}) |
+| Gem | Version | Description |
+| --- | ------- | ----------- |
+{{#each gems}}
+| [{{name}}](gems/{{name}}) | <a href="https://badge.fury.io/rb/{{name}}"><img src="https://badge.fury.io/rb/{{name}}.svg" width="200px" /></a> | {{{description}}} |
 {{/each}}
 
 ## Want to contribute?
@@ -38,7 +37,7 @@ Check out our [Contributing Guide](./.github/CONTRIBUTING.md)
 
 ## Questions?
 
-For Shopifolk, you can reach out to us in Slack in the `#web-foundation-tech` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via Github issues.
+For Shopifolk, you can reach out to us in Slack in the `#web-foundation-tech` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via GitHub issues.
 
 ## License
 

--- a/templates/my-package.hbs.ts
+++ b/templates/my-package.hbs.ts
@@ -1,3 +1,3 @@
 export default function someFunction() {
-  return 'Hello {{kebabCase name}}!';
+  return 'Hello {{name}}!';
 }

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -2,7 +2,7 @@
   "name": "@shopify/{{name}}",
   "version": "0.0.0",
   "license": "MIT",
-  "description": "{{description}}",
+  "description": "{{{description}}}",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Description

Fixes #1500 

This PR does some minor polish on package descriptions and the repo-level [`README.md`](https://github.com/Shopify/quilt/blob/1500-readme/README.md).

- [x] Polish package descriptions (capitalization, getting rid of trailing periods, etc.)
- [x] Reformat/polish repo `README.md` (add descriptions, etc.)
- [x] Add validators/cleaners to plop package generator
- [x] Prevent characters in descriptions from getting escaped in templates (e.g. `'` vs. `&#x27;`)
- [x] Polish descriptions in package-level `README.md`s

---

- [x] Minor doc update to `quilt_rails` regarding new `NetworkUniversalProvider`

## Tophat

You can test the changes made to the plop template/generators using the following steps:
1. `dev cd quilt && git fetch --all && git checkout 1500-readme`
2. `yarn generate docs` to generate a new repo `README.md` with package names and descriptions pulled from individual `package.json`s
3. `yarn generate package` to create a test package
   - Package name and description should be checked and cleaned if necessary (i.e. npm rules, leading/trailing whitespace and periods removed)
   - Generated files and directories should be properly named
   - Package `README.md` should preserve description formatting