### PR TITLE
[@shopify/jest-mock-apollo] Provide more useful errors

### DIFF
--- a/packages/jest-mock-apollo/CHANGELOG.md
+++ b/packages/jest-mock-apollo/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Mock client now throws useful errors and fails tests when required mocks are not provided
 
 ## [4.0.6] - 2020-03-13
 

--- a/packages/jest-mock-apollo/src/MockApolloLink.ts
+++ b/packages/jest-mock-apollo/src/MockApolloLink.ts
@@ -38,38 +38,41 @@ export default class MockApolloLink extends ApolloLink {
             : mockForOperation;
       }
 
-      let result: ExecutionResult | Error;
+      let result: ExecutionResult;
 
       if (response == null) {
         let message = `Can’t perform GraphQL operation '${operationName}' because no valid mocks were found`;
 
         if (typeof mock === 'object') {
           const operationNames = Object.keys(mock);
-          // We will provide a more helpful message when it looks like they just provided data,
-          // not an object mapping names to fixtures.
-          const looksLikeDataNotFixtures = operationNames.every(
-            name => name === name.toLowerCase(),
-          );
 
-          message += looksLikeDataNotFixtures
-            ? ` (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({${operationName}: yourFixture}).'`
-            : ` (you provided an object that had mocks only for the following operations: ${Object.keys(
-                mock,
-              ).join(', ')}).`;
+          if (operationNames.length === 0) {
+            message += ' (it looks like you provided an empty mock object)';
+          } else if (
+            operationNames.every(name => name === name.toLowerCase())
+          ) {
+            // We will provide a more helpful message when it looks like they just provided data
+            message += ` (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({${operationName}: yourFixture})'`;
+          } else {
+            message += ` (you provided an object that had mocks only for the following operations: ${operationNames.join(
+              ', ',
+            )})`;
+          }
         } else {
           message +=
             ' (you provided a function that did not return a valid mock result)';
         }
 
-        const error = new Error(message);
-        result = error;
+        // We want to throw this error and break the test since it's not coming from the user-defined mocks
+        obs.error(new Error(message));
+        obs.complete();
+        return;
       } else if (response instanceof GraphQLError) {
-        result = {
-          errors: [response],
-        };
+        result = {errors: [response]};
       } else if (response instanceof Error) {
         result = {errors: [new GraphQLError(response.message)]};
       } else {
+        // We want to throw any errors and break the test since it's not coming from the user-defined mocks
         try {
           result = {
             data: normalizeGraphQLResponseWithOperation(
@@ -79,7 +82,9 @@ export default class MockApolloLink extends ApolloLink {
             ),
           };
         } catch (error) {
-          result = error;
+          obs.error(error);
+          obs.complete();
+          return;
         }
       }
 

--- a/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
+++ b/packages/jest-mock-apollo/src/test/MockApolloLink.test.ts
@@ -6,7 +6,7 @@ import {buildSchema, GraphQLError} from 'graphql';
 import MockApolloLink from '../MockApolloLink';
 import {MockGraphQLResponse} from '../types';
 
-import petQuery from './fixtures/PetQuery.graphql';
+import {PetQuery as petQuery} from './fixtures/PetQuery.graphql';
 
 const schemaSrc = readFileSync(
   path.resolve(__dirname, './fixtures/schema.graphql'),
@@ -24,50 +24,58 @@ const mockRequest = {
   toKey: () => '',
 };
 
+function expectObservableError(obs, errorMessage) {
+  return new Promise(resolve => {
+    obs.subscribe(
+      () => {
+        throw new Error(`Expected error ("${errorMessage}") but none thrown`);
+      },
+      error => {
+        expect(error.message).toBe(errorMessage);
+        resolve(true);
+      },
+    );
+  });
+}
+
 describe('MockApolloLink', () => {
-  it('returns error message with empty mock object', async () => {
+  it('throws error when given empty mock object', async () => {
     const mockApolloLink = new MockApolloLink({}, schema);
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
-    });
-
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({Pets: yourFixture}).'",
-    });
+    expect(
+      await expectObservableError(
+        mockApolloLink.request(mockRequest),
+        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (it looks like you provided an empty mock object)",
+      ),
+    ).toBe(true);
   });
 
-  it('returns error message when there are no matching mocks', async () => {
+  it('throws error when there are no matching mocks', async () => {
     const mockApolloLink = new MockApolloLink(
       {LostPets: {}, PetsForSale: {}},
       schema,
     );
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
-    });
-
-    expect(result).toMatchObject({
-      message:
-        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
-    });
+    expect(
+      await expectObservableError(
+        mockApolloLink.request(mockRequest),
+        "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale)",
+      ),
+    ).toBe(true);
   });
 
-  it('returns error message with empty mock function', async () => {
+  it('throws error when given empty mock function', async () => {
     const mockApolloLink = new MockApolloLink(
       () => (null as unknown) as MockGraphQLResponse,
       schema,
     );
 
-    const result = await new Promise(resolve => {
-      mockApolloLink.request(mockRequest).subscribe(resolve);
-    });
-
-    expect(result).toMatchObject({
-      message:
+    expect(
+      await expectObservableError(
+        mockApolloLink.request(mockRequest),
         "Can’t perform GraphQL operation 'Pets' because no valid mocks were found (you provided a function that did not return a valid mock result)",
-    });
+      ),
+    ).toBe(true);
   });
 
   it('returns a GraphQLError when there is a GraphQLError matching an operation', async () => {

--- a/packages/jest-mock-apollo/src/test/fixtures/PetQuery.graphql
+++ b/packages/jest-mock-apollo/src/test/fixtures/PetQuery.graphql
@@ -1,4 +1,10 @@
-query Pet {
+query PetQuery {
+  pets {
+    ...CatInfo
+  }
+}
+
+mutation PetMutation($name: String!) {
   pets {
     ...CatInfo
   }

--- a/packages/jest-mock-apollo/src/test/fixtures/schema.graphql
+++ b/packages/jest-mock-apollo/src/test/fixtures/schema.graphql
@@ -1,5 +1,6 @@
 schema {
-  query: QueryRoot
+  query: Root
+  mutation: Root
 }
 
 type Dog {
@@ -12,6 +13,6 @@ type Cat {
 
 union Pet = Dog | Cat
 
-type QueryRoot {
+type Root {
   pets: [Pet!]!
 }

--- a/packages/jest-mock-apollo/src/test/index.test.tsx
+++ b/packages/jest-mock-apollo/src/test/index.test.tsx
@@ -3,17 +3,19 @@ import path from 'path';
 
 import React from 'react';
 import {ApolloClient} from 'apollo-client';
-import {graphql} from '@apollo/react-hoc';
+import {useQuery, useMutation} from '@apollo/react-hooks';
 import {ApolloProvider} from '@apollo/react-common';
 import {buildSchema} from 'graphql';
 import {createMount} from '@shopify/react-testing';
 
 import unionOrIntersectionTypes from './fixtures/schema-unions-and-interfaces.json';
-import petQuery from './fixtures/PetQuery.graphql';
+import {
+  PetQuery as petQuery,
+  PetMutation as petMutation,
+} from './fixtures/PetQuery.graphql';
 
 import configureClient from '..';
 
-// setup
 const schemaSrc = readFileSync(
   path.resolve(__dirname, './fixtures/schema.graphql'),
   'utf8',
@@ -30,45 +32,90 @@ const mount = createMount<{client: ApolloClient<any>}, {}>({
   },
 });
 
-interface Props {
-  data?: {
-    loading?: boolean;
-    pets?: any[];
-    error?: any;
-  };
-}
-
-// mock Component
-function SomePageBase(props: Props) {
-  if (!props.data) {
-    return null;
-  }
+function SomePage() {
   const {
-    data: {loading = true, pets, error},
-  } = props;
-  const errorMessage = error ? <p>{error.message}</p> : null;
+    data: {pets: queryData} = {pets: []},
+    error: queryError = {message: ''},
+    loading: queryLoading = true,
+  } = useQuery(petQuery);
+  const [
+    mutate,
+    {
+      data: {pets: mutationData} = {pets: []},
+      error: mutationError = {message: ''},
+      loading: mutationLoading = true,
+    },
+  ] = useMutation(petMutation);
 
-  const loadingMarkup = loading ? 'Loading' : 'Loaded!';
-  const petsMarkup = pets && pets.length ? pets[0].name : 'No pets';
+  const errorMarkup = `${queryError.message} ${mutationError.message}`;
+  const loadingMarkup = queryLoading || mutationLoading ? 'Loading' : 'Loaded!';
+  const pets = [...queryData, ...mutationData];
+  const petsMarkup =
+    pets && pets.length ? pets.map(pets => pets.name).join(', ') : 'No pets';
+
   return (
     <>
       <p>{loadingMarkup}</p>
       <p>{petsMarkup}</p>
-      {errorMessage}
+      <p>{errorMarkup}</p>
+      <button
+        type="submit"
+        onClick={async () => {
+          try {
+            await mutate({variables: {name: 'Sophie'}});
+          } catch (error) {
+            return undefined;
+          }
+        }}
+      >
+        Mutate
+      </button>
     </>
   );
 }
-const SomePage = graphql(petQuery)(SomePageBase);
 
+function clickButton(wrapper) {
+  wrapper.find('button', {type: 'submit'}).trigger('onClick');
+}
+
+async function waitToResolve(wrapper, graphQLClient = client) {
+  await wrapper.act(() => Promise.all(graphQLClient.graphQLResults));
+}
+
+async function expectQueryError(wrapper, graphQLClient, errorMessage) {
+  const errorSpy = jest.fn();
+
+  await wrapper.act(() =>
+    Promise.all(graphQLClient.graphQLResults).catch(error => {
+      errorSpy(error.message);
+      return null;
+    }),
+  );
+
+  expect(errorSpy).toHaveBeenCalledWith(errorMessage);
+
+  return true;
+}
+
+const PetQuery = {
+  pets: [
+    {
+      __typename: 'Cat',
+      name: 'Garfield',
+    },
+  ],
+};
+const PetMutation = ({variables: {name}}) => ({
+  pets: [
+    {
+      __typename: 'Cat',
+      name,
+    },
+  ],
+});
 const client = createGraphQLClient({
-  Pet: {
-    pets: [
-      {
-        __typename: 'Cat',
-        name: 'Garfield',
-      },
-    ],
-  },
+  PetQuery,
+  PetMutation,
 });
 
 describe('jest-mock-apollo', () => {
@@ -76,23 +123,81 @@ describe('jest-mock-apollo', () => {
     const client = createGraphQLClient();
     const somePage = mount(<SomePage />, {client});
 
-    await somePage.act(() => Promise.all(client.graphQLRequests));
-
-    expect(somePage).toContainReactText(
-      "GraphQL error: Can’t perform GraphQL operation 'Pet' because no mocks were set.",
-    );
+    expect(
+      await expectQueryError(
+        somePage,
+        client,
+        "Can’t perform GraphQL operation 'PetQuery' because no valid mocks were found (it looks like you provided an empty mock object)",
+      ),
+    ).toBe(true);
   });
 
-  it('resolves mock query and renders data', async () => {
-    const somePage = mount(<SomePage />, {
-      client,
+  describe('queries', () => {
+    it('resolves mock query and renders data', async () => {
+      const somePage = mount(<SomePage />, {
+        client,
+      });
+
+      await waitToResolve(somePage, client);
+
+      const query = client.graphQLRequests.lastOperation('PetQuery');
+
+      expect(query).toMatchObject({operationName: 'PetQuery'});
+      expect(somePage).toContainReactText('Garfield');
     });
 
-    await somePage.act(() => Promise.all(client.graphQLRequests));
+    it('throws useful error when query is not mocked', async () => {
+      const client = createGraphQLClient({
+        PetMutation,
+      });
+      const somePage = mount(<SomePage />, {
+        client,
+      });
 
-    const query = client.graphQLRequests.lastOperation('Pet');
-    expect(query).toMatchObject({operationName: 'Pet'});
+      expect(
+        await expectQueryError(
+          somePage,
+          client,
+          "Can’t perform GraphQL operation 'PetQuery' because no valid mocks were found (you provided an object that had mocks only for the following operations: PetMutation)",
+        ),
+      ).toBe(true);
+    });
+  });
 
-    expect(somePage).toContainReactText('Garfield');
+  describe('mutations', () => {
+    it('resolves mock mutation', async () => {
+      const somePage = mount(<SomePage />, {
+        client,
+      });
+
+      await waitToResolve(somePage, client);
+      clickButton(somePage);
+      await waitToResolve(somePage, client);
+
+      const query = client.graphQLRequests.lastOperation('PetMutation');
+
+      expect(query).toMatchObject({operationName: 'PetMutation'});
+      expect(somePage).toContainReactText('Garfield, Sophie');
+    });
+
+    it('throws useful error when mutation is not mocked', async () => {
+      const client = createGraphQLClient({
+        PetQuery,
+      });
+      const somePage = mount(<SomePage />, {
+        client,
+      });
+
+      await waitToResolve(somePage, client);
+      clickButton(somePage);
+
+      expect(
+        await expectQueryError(
+          somePage,
+          client,
+          "Can’t perform GraphQL operation 'PetMutation' because no valid mocks were found (you provided an object that had mocks only for the following operations: PetQuery)",
+        ),
+      ).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #617 

In our `@shopify/jest-mock-apollo` package, errors pertaining to missing mocks (queries, mutations) are not easily visible to the consumer and are obfuscated by more confusing messages (e.g. `Cannot read property 'data' of undefined`).  This PR fixes this by propagating errors using the intended error API instead of as query data.

Since this affects return behaviour it should probably require a major version bump.

## Screenshots

| Before (broken test for illustration) | After (broken test for illustration) |
| --- | --- | 
| <img width="1341" alt="Screen Shot 2020-06-22 at 6 28 10 PM" src="https://user-images.githubusercontent.com/46533681/85341463-3dacbe00-b4b6-11ea-8b0e-2dd2512b300e.png"> | <img width="1199" alt="Screen Shot 2020-06-22 at 4 28 14 PM" src="https://user-images.githubusercontent.com/46533681/85332610-41d0df80-b4a6-11ea-8393-74d58704fe7a.png"> |

## Tophat

I've added tests to cover the missing cases, but you can play around with the tests to see the different behaviours:

1. `dev cd quilt && git fetch --all && git checkout 617-test-error`
2. Navigate to `packages/jest-mock-apollo/src/test/index.test.tsx`
3. Break one of the non-error tests by mocking an empty/insufficient client
4. `dev test packages/jest-mock-apollo/src/test/index.test.tsx`
5. The test should fail, and you should get useful error messages in the console like in the screenshot above

## Type of change

- [x] `@shopify/jest-mock-apollo` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
