### PR TITLE
Fix an issue with bundle size increased

### DIFF
--- a/packages/polyfills/CHANGELOG.md
+++ b/packages/polyfills/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Fix an issue with bundle size increased by ~20kb [#1518](https://github.com/Shopify/quilt/pull/1518)
 
 ## [1.2.0] - 2020-05-27
 

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -24,16 +24,15 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/polyfills/README.md",
   "dependencies": {
+    "@babel/polyfill": "^7.10.1",
     "@shopify/useful-types": "^2.2.0",
     "browser-unhandled-rejection": "^1.0.2",
     "caniuse-api": "^3.0.0",
-    "core-js": "^2.6.5",
     "formdata-polyfill": "^3.0.18",
     "intersection-observer": "^0.5.1",
     "intl-pluralrules": "^0.2.1",
     "mutationobserver-shim": "^0.3.3",
     "node-fetch": "^2.3.0",
-    "regenerator-runtime": "^0.13.4",
     "tslib": "^1.9.3",
     "url-polyfill": "^1.1.7",
     "whatwg-fetch": "^3.0.0"

--- a/packages/polyfills/src/base.ts
+++ b/packages/polyfills/src/base.ts
@@ -1,14 +1,1 @@
-// Cover all standardized ES6 APIs.
-require('core-js/es6');
-// Standard now
-require('core-js/fn/array/includes');
-require('core-js/fn/string/pad-start');
-require('core-js/fn/string/pad-end');
-require('core-js/fn/symbol/async-iterator');
-require('core-js/fn/object/get-own-property-descriptors');
-require('core-js/fn/object/values');
-require('core-js/fn/object/entries');
-require('core-js/fn/promise/finally');
-// Ensure that we polyfill ES6 compat for anything web-related, if it exists.
-require('core-js/web');
-require('regenerator-runtime/runtime');
+require('@babel/polyfill');

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,6 +808,14 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.6.0"
 
+"@babel/polyfill@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.10.1.tgz#d56d4c8be8dd6ec4dce2649474e9b707089f739f"
+  integrity sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.4"
+
 "@babel/preset-env@^7.4.3":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.6.3.tgz#9e1bf05a2e2d687036d24c40e4639dc46cef2271"


### PR DESCRIPTION
## Description

We had reports that the new version of `@shopify/polyfills` [increase the bundle size by about 20kb](https://shrink-ray.shopifycloud.com/repos/brochure2/commits/b6a838e9800d1f32c9ff71c7cd19b43e96d319a6/entrypoints). After some investigation, using directly the `core-js` import was the cause of the issue.

Instead of only include the polyfills needed, the new version includes every polyfill.

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/4728325/84897132-23687f80-b073-11ea-9ab2-4f1ca56de263.png) | ![image](https://user-images.githubusercontent.com/4728325/84897075-0e8bec00-b073-11ea-972d-9a9728607d97.png) |


## Type of change
Reverting to the original strategy until we move to `core-js@3`

- [x] `@shopify/polyfills Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
