### PR TITLE
Query component uses hook

### DIFF
--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Replace Apollo declarative Query component with `useQuery` hook ([#1519](https://github.com/Shopify/quilt/pull/1519))
 
 ## [6.1.9] - 2020-05-14
 

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-graphql/README.md",
   "dependencies": {
     "@apollo/react-common": ">=3.0.0 <4.0.0",
-    "@apollo/react-components": ">=3.0.0 <4.0.0",
     "@apollo/react-hooks": ">=3.0.0 <4.0.0",
     "@shopify/async": "^2.1.5",
     "@shopify/react-async": "^3.1.19",

--- a/packages/react-graphql/src/Query.tsx
+++ b/packages/react-graphql/src/Query.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
-import {Query as ApolloQuery} from '@apollo/react-components';
 import {OperationVariables} from 'apollo-client';
+import {DocumentNode} from 'graphql-typed';
 
-import {QueryProps} from './types';
+import {useQuery, QueryHookResult, QueryHookOptions} from './hooks';
 
-// eslint-disable-next-line react/prefer-stateless-function
-class QueryTypeClass<
-  Data = any,
-  Variables = OperationVariables
-> extends React.Component<QueryProps<Data, Variables>> {}
+interface QueryComponentOptions<Data, Variables> extends QueryHookOptions {
+  children: (result: QueryHookResult<Data, Variables>) => JSX.Element | null;
+  query: DocumentNode<Data, Variables>;
+}
 
-export const Query: typeof QueryTypeClass = ApolloQuery as any;
+export function Query<Data = any, Variables = OperationVariables>({
+  children,
+  query,
+  ...options
+}: QueryComponentOptions<Data, Variables>) {
+  const result = useQuery<Data, Variables>(query, options);
+
+  return children(result);
+}

--- a/packages/react-graphql/src/Query.tsx
+++ b/packages/react-graphql/src/Query.tsx
@@ -1,3 +1,4 @@
+import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
 import {OperationVariables} from 'apollo-client';
 import {DocumentNode} from 'graphql-typed';
 
@@ -13,7 +14,13 @@ export function Query<Data = any, Variables = OperationVariables>({
   query,
   ...options
 }: QueryComponentOptions<Data, Variables>) {
-  const result = useQuery<Data, Variables>(query, options);
+  const opts = [options] as IfAllNullableKeys<
+    Variables,
+    [QueryHookOptions<Data, NoInfer<Variables>>?],
+    [QueryHookOptions<Data, NoInfer<Variables>>]
+  >;
+
+  const result = useQuery(query, ...opts);
 
   return children(result);
 }

--- a/packages/react-graphql/src/tests/Query.test.tsx
+++ b/packages/react-graphql/src/tests/Query.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import {createGraphQLFactory} from '@shopify/graphql-testing';
+
+import {Query} from '../Query';
+import {mountWithGraphQL} from '../hooks/tests/utilities';
+
+const petQuery = gql`
+  query PetQuery {
+    pets {
+      name
+    }
+  }
+`;
+
+const createGraphQL = createGraphQLFactory();
+const mockData = {
+  pets: [
+    {
+      __typename: 'Cat',
+      name: 'Garfield',
+    },
+  ],
+};
+
+describe('<Query />', () => {
+  it('returns the data', async () => {
+    const graphQL = createGraphQL({PetQuery: mockData});
+    const renderPropSpy = jest.fn(() => null);
+
+    await mountWithGraphQL(<Query query={petQuery}>{renderPropSpy}</Query>, {
+      graphQL,
+    });
+
+    expect(renderPropSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: mockData,
+      }),
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-components@>=3.0.0 <4.0.0", "@apollo/react-components@^3.1.5":
+"@apollo/react-components@^3.1.5":
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-3.1.5.tgz#040d2f35ce4947747efe16f76d59dcbd797ffdaf"
   integrity sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==


### PR DESCRIPTION
## Description

Fixes Shopify/quilt#1475

Client-side queries are being executed on the server when using the Apollo Query component re-exported from `react-graphql`. This PR replaces the declarative  component with our own implementation which uses the custom useQuery hook and handles client-only queries correctly.

## Type of change

- [x] `react-graphql` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
