### PR TITLE
Accept query params in gid

### DIFF
--- a/packages/admin-graphql-api-utilities/CHANGELOG.md
+++ b/packages/admin-graphql-api-utilities/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased]
+
+- Let `parseGid` parse GIDs containing query parameters.
+
 ## [0.0.4] - 2019-01-09
 
 - Start of Changelog

--- a/packages/admin-graphql-api-utilities/src/index.ts
+++ b/packages/admin-graphql-api-utilities/src/index.ts
@@ -1,7 +1,7 @@
-const GID_REGEXP = /\/(\w+(-\w+)*)$/;
+const GID_REGEXP = /\/(\w+(-\w+)*)(?:\?(?:[\w-_]+=[\w-_]+&)*(?:[\w-_]+=[\w-_]+))?$/;
 
 export function parseGid(gid: string): string {
-  // appends forward slash to help identify invalid id
+  // prepends forward slash to help identify invalid id
   const id = `/${gid}`;
   const matches = GID_REGEXP.exec(id);
   if (matches && matches[1] !== undefined) {

--- a/packages/admin-graphql-api-utilities/src/test/index.test.ts
+++ b/packages/admin-graphql-api-utilities/src/test/index.test.ts
@@ -28,6 +28,24 @@ describe('admin-graphql-api-utilities', () => {
       const gid = `gid://shopify/Section/${id}`;
       expect(parseGid(gid)).toStrictEqual(id);
     });
+
+    it('returns the id portion of a gid with a query parameter', () => {
+      const id = v4();
+      const gid = `gid://shopify/Section/${id}?foo=bar`;
+      expect(parseGid(gid)).toStrictEqual(id);
+    });
+
+    it('returns the id portion of a gid with multiple query parameters', () => {
+      const id = v4();
+      const gid = `gid://shopify/Section/${id}?foo=bar&baz=0`;
+      expect(parseGid(gid)).toStrictEqual(id);
+    });
+
+    it('returns the id portion of a gid with a query parameter with extended character set', () => {
+      const id = v4();
+      const gid = `gid://shopify/Section/${id}?foo-a=bar_baz`;
+      expect(parseGid(gid)).toStrictEqual(id);
+    });
   });
 
   describe('composeGid()', () => {


### PR DESCRIPTION
## Description

[This PR in Core](https://github.com/Shopify/shopify/pull/244251) will be adding query params to some GIDs, `gid://shopify/OnlineStoreProductPage/1?sessionId=xyz`. We don't need to be able to extract those query params in the front-end, they are only there to distinguish objects with the same ID. This is required to make sure Apollo doesn't poison its cache with unrelated objects.

More context can be found on [this issue](https://github.com/Shopify/shopify/issues/236662).

Also related to https://github.com/Shopify/quilt/issues/1504

## Type of change

- [x] admin-graphql-api-utilities Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
