### PR TITLE
[React Testing] Update README from toContainHtml to toContainReactHtml

### DIFF
--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -644,13 +644,13 @@ const myComponent = mount(<MyComponent />);
 expect(myComponent).toContainReactText('Hello world!');
 ```
 
-#### <a name="toContainHtml"></a> `.toContainHtml(text: string)`
+#### <a name="toContainReactHtml"></a> `.toContainReactHtml(text: string)`
 
 Asserts that the rendered output of the component contains the passed string as HTML (that is, the text is included in what you would get by calling `outerHTML` on all root DOM nodes rendered by the component).
 
 ```tsx
 const myComponent = mount(<MyComponent />);
-expect(myComponent).toContainHtml('<span>Hello world!</span>');
+expect(myComponent).toContainReactHtml('<span>Hello world!</span>');
 ```
 
 ## FAQ


### PR DESCRIPTION

## Description

It doesn't seem like there is a matcher called `toContainHtml`, it seems like this doc is referring to `toContainReactHtml`

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
