### PR TITLE
Fix typo in ReactServerNoResponseError message

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## [Unreleased] -->
 
+### Fixed
+- Fix typo in [error message](https://github.com/Shopify/quilt/blob/fefe904fe6e59f11c59092e523f6ee63ba1fd09d/gems/quilt_rails/lib/quilt_rails/react_renderable.rb#L56). ([#1528](https://github.com/Shopify/quilt/pull/1528))
+
 ### Remove
 
 - Remove demo app from quilt_rails.

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -53,7 +53,7 @@ module Quilt
     class ReactServerNoResponseError < StandardError
       def initialize(url)
         # rubocop:disable LineLength
-        super "Errno::ECONNREFUSED: Waiting for React server to boot up. If this error presists verify that @shopify/react-server is configured on #{url}"
+        super "Errno::ECONNREFUSED: Waiting for React server to boot up. If this error persists verify that @shopify/react-server is configured on #{url}"
         # rubocop:enable LineLength
       end
     end


### PR DESCRIPTION
## Description
Fixed a typo in one of the error messages present in the `quilt_rails` package. The error is raised in the `react_renderable` file under the name of `ReactServerNoResponseError`. The initial message had a typo for "presists" which I would imagine is supposed to be "persists" (though it may be a term I'm not aware of :) )

## Type of change
Spelling fix in `quilt_rails`

- [x] `quilt_rails` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
