### PR TITLE
Add parseGidWithParams, composeGidFactory and update composeGid to support params

### DIFF
--- a/packages/admin-graphql-api-utilities/CHANGELOG.md
+++ b/packages/admin-graphql-api-utilities/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Add `parseGidWithParams` and `createComposeGidFunction`. Also add support for optional params in `composeGid` ([#1548](https://github.com/Shopify/quilt/pull/1548))
+- Add `parseGidWithParams` and `composeGidFactory`. Also add support for optional params in `composeGid` ([#1548](https://github.com/Shopify/quilt/pull/1548))
 
 ## [0.0.14] - 2020-06-30
 

--- a/packages/admin-graphql-api-utilities/CHANGELOG.md
+++ b/packages/admin-graphql-api-utilities/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Add `parseGidWithParams` and `createComposeGidFunction`. Also add support for optional params in `composeGid` ([#1548](https://github.com/Shopify/quilt/pull/1548))
 
 ## [0.0.14] - 2020-06-30
 

--- a/packages/admin-graphql-api-utilities/README.md
+++ b/packages/admin-graphql-api-utilities/README.md
@@ -13,6 +13,19 @@ $ yarn add @shopify/admin-graphql-api-utilities
 
 ## API Reference
 
+### `parseGidType(gid: string): string`
+
+Given a Gid string, parse out the type.
+
+#### Example Usage
+
+```typescript
+import {parseGidType} from '@shopify/admin-graphql-api-utilities';
+
+parseGidType('gid://shopify/Customer/12345');
+// → 'Customer'
+```
+
 ### `function parseGid(gid: string): string`
 
 Given a Gid string, parse out the id.
@@ -26,7 +39,38 @@ parseGid('gid://shopify/Customer/12345');
 // → '12345'
 ```
 
-### `function composeGid(key: string, id: number | string): string`
+### `function parseGidWithParams(gid: string): ParsedGid`
+
+Given a Gid string, parse out the id and its params.
+
+#### Example Usage
+
+```typescript
+import {parseGidWithParams} from '@shopify/admin-graphql-api-utilities';
+
+parseGidWithParams('gid://shopify/Customer/12345?sessionId=123&foo=bar');
+// → {
+//     id: '12345',
+//     params: {sessionId: '123', foo: 'bar'}
+//   }
+```
+
+### `function composeGidFactory(namespace: string): Function`
+
+Create a new `composeGid` with a given namespace instead of the default `shopify` namespace.
+
+#### Example Usage
+
+```typescript
+import {composeGidFactory} from '@shopify/admin-graphql-api-utilities';
+
+const composeGid = composeGidFactory('CustomApp');
+
+composeGid('Product', '123');
+// → 'gid://CustomApp/Product/123'
+```
+
+### `function composeGid(key: string, id: number | string, params: Record<string, string> = {}): string`
 
 Given a key and id, compose a Gid string.
 
@@ -38,8 +82,8 @@ import {composeGid} from '@shopify/admin-graphql-api-utilities';
 composeGid('Customer', 12345);
 // → 'gid://shopify/Customer/12345'
 
-composeGid('Customer', '67890');
-// → 'gid://shopify/Customer/67890'
+composeGid('Customer', '67890', {foo: 'bar'});
+// → 'gid://shopify/Customer/67890?foo=bar'
 ```
 
 ### `function nodesFromEdges(edges)`

--- a/packages/admin-graphql-api-utilities/src/index.ts
+++ b/packages/admin-graphql-api-utilities/src/index.ts
@@ -1,4 +1,19 @@
-const GID_REGEXP = /\/(\w+(-\w+)*)(?:\?(?:[\w-_]+=[\w-_]+&)*(?:[\w-_]+=[\w-_]+))?$/;
+const GID_TYPE_REGEXP = /^gid:\/\/[\w-]+\/([\w-]+)\//;
+const GID_REGEXP = /\/(\w[\w-]*)(?:\?([\w-]+=[\w-]+(&[\w-]+=[\w-]+)*))*$/;
+
+interface ParsedGID {
+  id: string;
+  params: Record<string, string>;
+}
+
+export function parseGidType(gid: string): string {
+  const matches = GID_TYPE_REGEXP.exec(gid);
+
+  if (matches && matches[1] !== undefined) {
+    return matches[1];
+  }
+  throw new Error(`Invalid gid: ${gid}`);
+}
 
 export function parseGid(gid: string): string {
   // prepends forward slash to help identify invalid id
@@ -10,9 +25,59 @@ export function parseGid(gid: string): string {
   throw new Error(`Invalid gid: ${gid}`);
 }
 
-export function composeGid(key: string, id: number | string): string {
-  return `gid://shopify/${key}/${id}`;
+export function parseGidWithParams(gid: string): ParsedGID {
+  // appends forward slash to help identify invalid id
+  const id = `/${gid}`;
+  const matches = GID_REGEXP.exec(id);
+  if (matches && matches[1] !== undefined) {
+    const params =
+      matches[2] === undefined
+        ? {}
+        : matches[2]
+            .split('&')
+            .reduce<Record<string, string>>((acc, keyVal) => {
+              const [key, value] = keyVal.split('=');
+              acc[key] = value;
+              return acc;
+            }, {});
+
+    return {
+      id: matches[1],
+      params,
+    };
+  }
+  throw new Error(`Invalid gid: ${gid}`);
 }
+
+export function createComposeGidFunction(namescape: string) {
+  return function composeGid(
+    key: string,
+    id: number | string,
+    params: Record<string, string> = {},
+  ): string {
+    const gid = `gid://${namescape}/${key}/${id}`;
+    const paramKeys = Object.keys(params);
+
+    if (paramKeys.length === 0) {
+      return gid;
+    }
+
+    const queryParams = paramKeys
+      .map(query => {
+        if (params[query] == null) {
+          return null;
+        }
+
+        return `${query}=${params[query]}`;
+      })
+      .filter(Boolean)
+      .join('&');
+
+    return `${gid}?${queryParams}`;
+  };
+}
+
+export const composeGid = createComposeGidFunction('shopify');
 
 interface Edge<T> {
   node: T;

--- a/packages/admin-graphql-api-utilities/src/index.ts
+++ b/packages/admin-graphql-api-utilities/src/index.ts
@@ -1,7 +1,7 @@
 const GID_TYPE_REGEXP = /^gid:\/\/[\w-]+\/([\w-]+)\//;
 const GID_REGEXP = /\/(\w[\w-]*)(?:\?(.*))*$/;
 
-interface ParsedGID {
+interface ParsedGid {
   id: string;
   params: Record<string, string>;
 }
@@ -25,7 +25,7 @@ export function parseGid(gid: string): string {
   throw new Error(`Invalid gid: ${gid}`);
 }
 
-export function parseGidWithParams(gid: string): ParsedGID {
+export function parseGidWithParams(gid: string): ParsedGid {
   // appends forward slash to help identify invalid id
   const id = `/${gid}`;
   const matches = GID_REGEXP.exec(id);

--- a/packages/admin-graphql-api-utilities/src/test/index.test.ts
+++ b/packages/admin-graphql-api-utilities/src/test/index.test.ts
@@ -4,7 +4,7 @@ import {
   parseGidType,
   parseGid,
   parseGidWithParams,
-  createComposeGidFunction,
+  composeGidFactory,
   composeGid,
   nodesFromEdges,
   keyFromEdges,
@@ -126,9 +126,9 @@ describe('admin-graphql-api-utilities', () => {
     });
   });
 
-  describe('createComposeGidFunction()', () => {
+  describe('composeGidFactory()', () => {
     it('returns a function to compose "shopify" gid', () => {
-      const customComposeGid = createComposeGidFunction('shopify');
+      const customComposeGid = composeGidFactory('shopify');
       const id = 123;
       const key = 'Section';
       expect(customComposeGid(key, id)).toStrictEqual(
@@ -137,7 +137,7 @@ describe('admin-graphql-api-utilities', () => {
     });
 
     it('returns a function to compose "custom" gid', () => {
-      const customComposeGid = createComposeGidFunction('custom-app');
+      const customComposeGid = composeGidFactory('custom-app');
       const id = 123;
       const key = 'Section';
       expect(customComposeGid(key, id)).toStrictEqual(
@@ -146,7 +146,7 @@ describe('admin-graphql-api-utilities', () => {
     });
 
     it('returns the composed Gid with params', () => {
-      const customComposeGid = createComposeGidFunction('custom-app');
+      const customComposeGid = composeGidFactory('custom-app');
       const id = 'button';
       const key = 'Section';
       const params = {foo: 'bar', hello: 'world'};

--- a/packages/admin-graphql-api-utilities/src/test/index.test.ts
+++ b/packages/admin-graphql-api-utilities/src/test/index.test.ts
@@ -1,8 +1,34 @@
 import {v4} from 'uuid';
 
-import {parseGid, composeGid, nodesFromEdges, keyFromEdges} from '..';
+import {
+  parseGidType,
+  parseGid,
+  parseGidWithParams,
+  createComposeGidFunction,
+  composeGid,
+  nodesFromEdges,
+  keyFromEdges,
+} from '..';
 
 describe('admin-graphql-api-utilities', () => {
+  describe('parseGidType()', () => {
+    it('returns the type from a GID without param', () => {
+      const parsedType = parseGidType(
+        'gid://shopify/my_custom_type/my--id__123',
+      );
+
+      expect(parsedType).toBe('my_custom_type');
+    });
+
+    it('returns the type from a GID with params', () => {
+      const parsedType = parseGidType(
+        'gid://shopify/my_type/my--id__123?query1=value1&query2=value2',
+      );
+
+      expect(parsedType).toBe('my_type');
+    });
+  });
+
   describe('parseGid()', () => {
     it('throw Error for an invalid id', () => {
       const key = 'gid://shopify/Section/';
@@ -48,6 +74,29 @@ describe('admin-graphql-api-utilities', () => {
     });
   });
 
+  describe('parseGidWithParams()', () => {
+    it('returns the ID and empty params from a GID without params', () => {
+      const parsedGid = parseGidWithParams(
+        'gid://shopify/my_type/my--id__123?query1=value1&query2=value2',
+      );
+
+      expect(parsedGid.id).toBe('my--id__123');
+      expect(parsedGid.params).toStrictEqual({
+        query1: 'value1',
+        query2: 'value2',
+      });
+    });
+
+    it('returns the ID and params from a GID with params', () => {
+      const parsedGid = parseGidWithParams(
+        'gid://custom-app/my_type/my--id__123',
+      );
+
+      expect(parsedGid.id).toBe('my--id__123');
+      expect(parsedGid.params).toStrictEqual({});
+    });
+  });
+
   describe('composeGid()', () => {
     it('returns the composed Gid using key and number id', () => {
       const id = 123;
@@ -65,6 +114,45 @@ describe('admin-graphql-api-utilities', () => {
       const id = v4();
       const key = 'Section';
       expect(composeGid(key, id)).toStrictEqual(`gid://shopify/${key}/${id}`);
+    });
+
+    it('returns the composed Gid with params', () => {
+      const id = 'button';
+      const key = 'Section';
+      const params = {foo: 'bar', hello: 'world'};
+      expect(composeGid(key, id, params)).toStrictEqual(
+        `gid://shopify/${key}/${id}?foo=bar&hello=world`,
+      );
+    });
+  });
+
+  describe('createComposeGidFunction()', () => {
+    it('returns a function to compose "shopify" gid', () => {
+      const customComposeGid = createComposeGidFunction('shopify');
+      const id = 123;
+      const key = 'Section';
+      expect(customComposeGid(key, id)).toStrictEqual(
+        `gid://shopify/${key}/${id}`,
+      );
+    });
+
+    it('returns a function to compose "custom" gid', () => {
+      const customComposeGid = createComposeGidFunction('custom-app');
+      const id = 123;
+      const key = 'Section';
+      expect(customComposeGid(key, id)).toStrictEqual(
+        `gid://custom-app/${key}/${id}`,
+      );
+    });
+
+    it('returns the composed Gid with params', () => {
+      const customComposeGid = createComposeGidFunction('custom-app');
+      const id = 'button';
+      const key = 'Section';
+      const params = {foo: 'bar', hello: 'world'};
+      expect(customComposeGid(key, id, params)).toStrictEqual(
+        `gid://custom-app/${key}/${id}?foo=bar&hello=world`,
+      );
     });
   });
 

--- a/packages/jest-mock-apollo/src/test/index.test.tsx
+++ b/packages/jest-mock-apollo/src/test/index.test.tsx
@@ -74,8 +74,8 @@ function SomePage() {
   );
 }
 
-function clickButton(wrapper) {
-  wrapper.find('button', {type: 'submit'}).trigger('onClick');
+async function clickButton(wrapper) {
+  await wrapper.find('button', {type: 'submit'}).trigger('onClick');
 }
 
 async function waitToResolve(wrapper, graphQLClient = client) {
@@ -171,7 +171,7 @@ describe('jest-mock-apollo', () => {
       });
 
       await waitToResolve(somePage, client);
-      clickButton(somePage);
+      await clickButton(somePage);
       await waitToResolve(somePage, client);
 
       const query = client.graphQLRequests.lastOperation('PetMutation');


### PR DESCRIPTION
## Description

Following what was done in https://github.com/Shopify/quilt/pull/1524, I'm making a PR to fully support params in `parseGidWithParams` and also `composeGid`. I also added a factory function to create a custom `composeGid` with a specific namespace.

- [x] admin-graphql-api-utilities: Minor