### PR TITLE
[Koa-shopify-auth] Add slash in redirect url

### DIFF
--- a/packages/koa-shopify-auth/src/auth/client/request-storage-access.ts
+++ b/packages/koa-shopify-auth/src/auth/client/request-storage-access.ts
@@ -4,10 +4,10 @@ const requestStorageAccess = (shop: string, prefix = '/') => {
       function redirect() {
         var targetInfo = {
           myshopifyUrl: "https://${encodeURIComponent(shop)}",
-          hasStorageAccessUrl: "${prefix}auth/inline?shop=${encodeURIComponent(
+          hasStorageAccessUrl: "${prefix}/auth/inline?shop=${encodeURIComponent(
     shop,
   )}",
-          doesNotHaveStorageAccessUrl: "${prefix}auth/enable_cookies?shop=${encodeURIComponent(
+          doesNotHaveStorageAccessUrl: "${prefix}/auth/enable_cookies?shop=${encodeURIComponent(
     shop,
   )}",
           appTargetUrl: "${prefix}?shop=${encodeURIComponent(shop)}"


### PR DESCRIPTION
## Description

Fixes (issue #1550 )
Fix missing `/` between `prefix` and `auth` in redirect URL when passing prefix

## Type of change

- [x] <@shoppify/koa-shopify-auth> Patch: Bug (non-breaking change which fixes an issue)expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
