### PR TITLE
Add a `--skip-yarn` option on the `ReactSetupGenerator`:

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## [Unreleased] -->
 
+### Added
+
+- Added a `--skip-yarn` option when running the `bin/rails generate sewing_kit:install` generator. This option is mostly
+  using for tools to control when yarn dependencies get installed in the case where you implemented a caching mechanism.
+  ([#1552](https://github.com/Shopify/quilt/pull/1552))
+
 ## [3.1.1] - 2020-06-24
 
 ### Fixed

--- a/gems/quilt_rails/lib/generators/quilt/react_setup/react_setup_generator.rb
+++ b/gems/quilt_rails/lib/generators/quilt/react_setup/react_setup_generator.rb
@@ -3,17 +3,20 @@
 module Quilt
   class ReactSetupGenerator < Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
+    class_option :skip_yarn, type: :boolean, default: false
 
     desc "This generator adds a React app."
 
     def install_js_dependencies
+      return if options.skip_yarn?
+
       say "Installing react and types dependencies"
       system("yarn add "\
         "typescript@~3.8.0 "\
         "react@~16.11.0 "\
         "react-dom@~16.11.0 "\
         "@types/react@~16.9.0 "\
-        "@types/react-dom@~16.9.0 ") unless Rails.env.test?
+        "@types/react-dom@~16.9.0 ")
     end
 
     def create_tsconfig

--- a/gems/quilt_rails/test/generators/quilt/react_setup/react_setup_generator_test.rb
+++ b/gems/quilt_rails/test/generators/quilt/react_setup/react_setup_generator_test.rb
@@ -7,6 +7,7 @@ require 'generators/quilt/react_setup/react_setup_generator'
 class QuiltReactSetupGeneratorTest < Rails::Generators::TestCase
   tests Quilt::ReactSetupGenerator
   destination File.expand_path("./tmp", File.dirname(__FILE__))
+  self.default_arguments = %w(--skip-yarn)
 
   setup do
     prepare_destination


### PR DESCRIPTION
- ### Context

  For the Gestalt project, each Rails application will be boostraped
  using a tool to generate Shopify's flavoured app. The application
  will be provisioned in the cloud, in this context installing JS
  dependencies of the app is useless. What we really need is to add
  the JS dependencies as part of the yarn package.json and lock
  the version in the yarn lockfile.

  ### Problem

  Yarn doesn't have a way to add new dependencies to a project
  without downloading them (i.e modify only the package.json/yarn.lock)
  files. Downloading those dependencies takes a realllly long time,
  basically 50% of the time to boostrap an app is dedicated to
  downloading JS dependencies.

  ### Solution

  Introduce a flag on this generator to not add/install JS
  dependencies.
  Having that flag will allow us to control programatically
  when JS dependencies get installed.

