### PR TITLE
Remove dependency on javascript-utilities

### DIFF
--- a/packages/react-async/CHANGELOG.md
+++ b/packages/react-async/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- Removed dependency on deprecated `@shopify/javascript-utilities` package ([#1560](https://github.com/Shopify/quilt/pull/1560))
+
 ## [3.1.16] - 2020-05-01
 
 ### Fixed

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-async/README.md",
   "dependencies": {
     "@shopify/async": "^2.1.5",
-    "@shopify/javascript-utilities": "^2.4.0",
     "@shopify/react-effect": "^3.2.12",
     "@shopify/react-hooks": "^1.10.1",
     "@shopify/react-hydrate": "^1.1.24",

--- a/packages/react-async/src/EventListener.tsx
+++ b/packages/react-async/src/EventListener.tsx
@@ -1,8 +1,4 @@
 import React from 'react';
-import {
-  addEventListener,
-  removeEventListener,
-} from '@shopify/javascript-utilities/events';
 
 export interface BaseEventProps {
   event: string;
@@ -35,11 +31,11 @@ export class EventListener extends React.PureComponent<Props, never> {
 
   private attachListener() {
     const {event, handler, capture, passive} = this.props;
-    addEventListener(window, event, handler, {capture, passive});
+    window.addEventListener(event, handler, {capture, passive});
   }
 
   private detachListener(prevProps?: BaseEventProps) {
     const {event, handler, capture} = prevProps || this.props;
-    removeEventListener(window, event, handler, capture);
+    window.removeEventListener(event, handler, capture);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2463,16 +2463,6 @@
     pkg-dir "4.2.0"
     pluralize "^8.0.0"
 
-"@shopify/javascript-utilities@^2.4.0":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.4.1.tgz#99e1994381fc33a2609f7792b6812feee32362fa"
-  integrity sha512-CDp4nWHjVXTr+rYV5RMBs8aJ5PbXUdbz47jnKisBWa9GFwJktZFj2PxefXqfLd51KpIuQpFnA/NMvq4M5tdTlw==
-  dependencies:
-    "@types/lodash" "^4.14.65"
-    "@types/react" "^16.0.2"
-    lodash "^4.17.4"
-    lodash-decorators "^4.3.5"
-
 "@shopify/tophat@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@shopify/tophat/-/tophat-0.0.3.tgz#e23ecde28fc94315b489e03e6e9149d9c0680f8d"
@@ -2865,11 +2855,6 @@
     "@types/node" "*"
     "@types/webpack" "*"
 
-"@types/lodash@^4.14.65":
-  version "4.14.144"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.144.tgz#12e57fc99064bce45e5ab3c8bc4783feb75eab8e"
-  integrity sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==
-
 "@types/lolex@^2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@types/lolex/-/lolex-2.1.3.tgz#793557c9b8ad319b4c8e4c6548b90893f4aa5f69"
@@ -2983,7 +2968,7 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.9.19", "@types/react@^16.0.2":
+"@types/react@*", "@types/react@16.9.19":
   version "16.9.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
   integrity sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==
@@ -10066,13 +10051,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-decorators@^4.3.5:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash-decorators/-/lodash-decorators-4.5.0.tgz#a4bb63dfbb512f0dd9409f7af452e4e2edcb80f4"
-  integrity sha512-isfVBBSzzXu7Z6abY/Bit5hCbM+gPhQx/DluTPAmzUPF3KRtvLLRNBgVFUxw6B8vwTMGyQFRVqbvQBli9hsXZA==
-  dependencies:
-    tslib "^1.7.1"
-
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -14067,7 +14045,7 @@ ts-node@^8:
     source-map-support "^0.5.6"
     yn "3.1.1"
 
-tslib@^1, tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
## Description

Remove dependency on deprecated  javascript-utilities package

See https://github.com/Shopify/javascript-utilities/blob/master/src/events.ts to note that addEventListener / removeEventListener are effectively aliases of the built-in versions in the browsers that Shopify supports.

## Type of change

- [x] react-async Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
