### PR TITLE
🐛 Update Router to 1. always take in location, 2. use location.href i…

### DIFF
--- a/packages/react-router/src/components/Router/Router.tsx
+++ b/packages/react-router/src/components/Router/Router.tsx
@@ -20,8 +20,11 @@ export default function Router({location, children}: Props) {
     throw new Error(NO_LOCATION_ERROR);
   }
 
+  const locationString =
+    typeof location === 'object' ? location.href : location;
+
   return (
-    <StaticRouter location={location} context={{}}>
+    <StaticRouter location={locationString} context={{}}>
       {children}
     </StaticRouter>
   );

--- a/packages/react-router/src/components/Router/test/Router.test.tsx
+++ b/packages/react-router/src/components/Router/test/Router.test.tsx
@@ -47,4 +47,14 @@ describe('Router', () => {
       mount(<Router />);
     }).toThrow(NO_LOCATION_ERROR);
   });
+
+  it('mounts a StaticRouter on the server with location string when location passed in is an object', () => {
+    isClient.mockReturnValue(false);
+
+    const href = 'http://www.shopify.com/';
+    const location = new URL(href);
+    const wrapper = mount(<Router location={location} />);
+
+    expect(wrapper).toContainReactComponent(StaticRouter, {location: href});
+  });
 });


### PR DESCRIPTION
…f location is an object

## Description

To reproduce the error
1. load up https://github.com/Shopify/gestalt-web-application-example
2. Goto `/` url to see
<img width="1024" alt="Screen Shot 2020-07-28 at 1 46 59 PM" src="https://user-images.githubusercontent.com/1610169/88702080-de575480-d0d8-11ea-9720-194b0a0af009.png">
3. Goto `/test123` to see
<img width="606" alt="Screen Shot 2020-07-28 at 1 47 07 PM" src="https://user-images.githubusercontent.com/1610169/88702109-ec0cda00-d0d8-11ea-9e99-91b70b287d25.png">
4. Remove wrapping <Page/> from `NotFound.tsx` and reload `/test123`
5. See the following page with the incorrect image 
<img width="962" alt="Screen Shot 2020-07-28 at 1 49 16 PM" src="https://user-images.githubusercontent.com/1610169/88702352-34c49300-d0d9-11ea-8753-f9035aec9eb5.png">
and see browser error
<img width="625" alt="Screen Shot 2020-07-28 at 1 49 22 PM" src="https://user-images.githubusercontent.com/1610169/88702410-44dc7280-d0d9-11ea-967a-18b853229498.png">

To check the error is fix
6. quit gestalt-web-application-example server
6. in quilt folder , run command `yarn build && yarn tophat react-router ../gestalt-web-application-example`
7. `dev s` in gestalt-web-application-example server folder
8. reload `/test123`
9. See the expected image below and no react miss-match error in browser 
<img width="955" alt="Screen Shot 2020-07-28 at 1 52 33 PM" src="https://user-images.githubusercontent.com/1610169/88702686-a866a000-d0d9-11ea-9e72-6263ddeac7e4.png">





## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
