### PR TITLE
Fix bug because of precendence:

### DIFF
--- a/gems/quilt_rails/lib/quilt_rails/logger.rb
+++ b/gems/quilt_rails/lib/quilt_rails/logger.rb
@@ -3,7 +3,7 @@
 module Quilt
   module Logger
     def self.log(string)
-      if defined? Rails && Rails.logger.nil?
+      if Rails.logger.nil?
         puts string
       else
         Rails.logger.info(string)


### PR DESCRIPTION
Fix bug because of precendence:

- Calling `defined? Rails && Rails.logger.nil?` will always return
  true even if `Rails.logger` isn't nil.

  This is because `defined?` has a lower precedence that `&&`.
  List of precedence in ruby https://ruby-doc.org/core-2.6.2/doc/syntax/precedence_rdoc.html

  I have also modified the condition because it doesn't make sense.
  This gem is a Rails engine, `Rails` should always be defined.

