### PR TITLE
@shopify/network: add getResponseType

### DIFF
--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased]
+Added `getResponseType` function
+
 ## [1.4.0] - 2019-06-27
 
 - Added the following headers: 'X-XSS-Protection', 'X-Frame-Options', 'X-Download-Options', 'X-Content-Type-Options', 'Strict-Transport-Security', 'Referrer-Policy' ([#752](https://github.com/Shopify/quilt/pull/752))

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -17,10 +17,12 @@ Import any of the enums or functions in this package to get a friendly API to co
 
 - `Method`: enum for HTTP methods
 - `StatusCode`: enum for HTTP status codes (mapping from name to number)
+- `ResponseType`: response type enum (2xx, 3xx, etc)
 - `Header`: enum for common header names
 - `CspDirective`: enum for names of [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) directives
 - `CspSandboxAllow`: enum for values allowed in the [CSP `sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox) directive
 - `SpecialSource`: enum for "special" (non-URI) sources usable in many CSP directives
 - `nonceSource()`: function for generating nonce sources in CSP directives
+- `getResponseType`: returns the `ResponseType` for an HTTP status code
 - `HashAlgorithm`: enum for hash algorithms usable in several CSP directives
 - `hashSource()`: function for generating hash sources in CSP directives

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -158,8 +158,33 @@ export enum HashAlgorithm {
   Sha512 = 'sha512',
 }
 
+export enum ResponseType {
+  Informational = '1xx',
+  Success = '2xx',
+  Redirection = '3xx',
+  ClientError = '4xx',
+  ServerError = '5xx',
+  Unknown = 'Unknown',
+}
+
 export function nonceSource(nonce: string) {
   return `'nonce-${nonce}'`;
+}
+
+export function getResponseType(status: number | StatusCode) {
+  if (status >= 100 && status < 200) {
+    return ResponseType.Informational;
+  } else if (status >= 200 && status < 300) {
+    return ResponseType.Success;
+  } else if (status >= 300 && status < 400) {
+    return ResponseType.Redirection;
+  } else if (status >= 400 && status < 500) {
+    return ResponseType.ClientError;
+  } else if (status >= 500 && status < 600) {
+    return ResponseType.ServerError;
+  } else {
+    return ResponseType.Unknown;
+  }
 }
 
 export function hashSource(hashAlgorithm: HashAlgorithm, value: string) {


### PR DESCRIPTION
## Description
Adds `getResponseType` function to @shopify/network package. Copied from https://github.com/Shopify/web/blob/master/packages/@shopify/network-next/index.ts.

Needed for https://github.com/Shopify/arrive-website/pull/1002.

## Type of change
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
