### PR TITLE
Append engine mount

### DIFF
--- a/gems/quilt_rails/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/gems/quilt_rails/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -20,7 +20,7 @@ Style/Alias:
   - prefer_alias
   - prefer_alias_method
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: ignore_implicit
@@ -30,7 +30,7 @@ Layout/AlignHash:
   - ignore_implicit
   - ignore_explicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
   SupportedStyles:
   - with_first_parameter
@@ -75,13 +75,6 @@ Style/BlockDelimiters:
   - lambda
   - proc
   - it
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-  SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
 
 Layout/CaseIndentation:
   EnforcedStyle: end
@@ -172,7 +165,7 @@ Naming/FileName:
   Regex:
   IgnoreExecutableScripts: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - consistent
@@ -225,7 +218,7 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   Width: 2
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses
@@ -233,10 +226,10 @@ Layout/IndentFirstArrayElement:
   - align_brackets
   IndentationWidth:
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   IndentationWidth:
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses
@@ -340,9 +333,9 @@ Style/PercentQLiterals:
 Naming/PredicateName:
   NamePrefix:
   - is_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
   - is_
-  NameWhitelist:
+  AllowedMethods:
   - is_a?
   Exclude:
   - 'spec/**/*'
@@ -467,7 +460,7 @@ Style/TernaryParentheses:
   - require_no_parentheses
   AllowSafeAssignment: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
   - final_newline
@@ -478,7 +471,7 @@ Style/TrivialAccessors:
   AllowPredicates: true
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
   - to_ary
   - to_a
   - to_c
@@ -509,7 +502,7 @@ Style/WhileUntilModifier:
 Metrics/BlockNesting:
   Max: 3
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   AllowHeredoc: true
   AllowURI: true
@@ -561,7 +554,7 @@ Lint/UnusedMethodArgument:
 Naming/AccessorMethodName:
   Enabled: true
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
 Style/ArrayJoin:
@@ -584,6 +577,7 @@ Layout/BlockEndNewline:
 
 Style/CaseEquality:
   Enabled: true
+  AllowOnConstant: true
 
 Style/CharacterLiteral:
   Enabled: true
@@ -664,6 +658,9 @@ Style/IfWithSemicolon:
   Enabled: true
 
 Style/IdenticalConditionalBranches:
+  Enabled: true
+
+Layout/IndentationStyle:
   Enabled: true
 
 Style/InfiniteLoop:
@@ -810,22 +807,19 @@ Layout/SpaceInsideRangeLiteral:
 Style/SymbolLiteral:
   Enabled: true
 
-Layout/Tab:
-  Enabled: true
-
 Layout/TrailingWhitespace:
   Enabled: true
 
 Style/UnlessElse:
   Enabled: true
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Style/VariableInterpolation:
@@ -840,8 +834,8 @@ Style/WhileUntilDo:
 Style/ZeroLengthPredicate:
   Enabled: true
 
-Layout/IndentHeredoc:
-  EnforcedStyle: squiggly
+Layout/HeredocIndentation:
+  Enabled: true
 
 Lint/AmbiguousOperator:
   Enabled: true
@@ -864,7 +858,7 @@ Lint/DeprecatedClassMethods:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -879,9 +873,6 @@ Lint/EmptyEnsure:
 Lint/EmptyInterpolation:
   Enabled: true
 
-Lint/EndInMethod:
-  Enabled: true
-
 Lint/EnsureReturn:
   Enabled: true
 
@@ -891,8 +882,8 @@ Lint/FloatOutOfRange:
 Lint/FormatParameterMismatch:
   Enabled: true
 
-Lint/HandleExceptions:
-  Enabled: true
+Lint/SuppressedException:
+  AllowComments: true
 
 Lint/ImplicitStringConcatenation:
   Description: Checks for adjacent string literals on the same line, which could
@@ -947,7 +938,7 @@ Lint/ShadowedException:
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
@@ -956,13 +947,13 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: true
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: true
 
-Lint/UnneededCopEnableDirective:
+Lint/RedundantCopEnableDirective:
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/UnreachableCode:
@@ -1024,4 +1015,7 @@ Style/ModuleFunction:
   EnforcedStyle: extend_self
 
 Lint/OrderedMagicComments:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
   Enabled: true

--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## [Unreleased] -->
 
+- Added automatic route mounting for `Quilt::Engine` that is easily overridable within the main application.
+  ([#1576](https://github.com/Shopify/quilt/pull/1576))
+
 - Added a custom error page for `Quilt::ReactRenderable::ReactServerNoResponseError` that automatically refreshes until the react server has started.
   ([#1566](https://github.com/Shopify/quilt/pull/1566))
 

--- a/gems/quilt_rails/lib/quilt_rails/engine.rb
+++ b/gems/quilt_rails/lib/quilt_rails/engine.rb
@@ -3,5 +3,11 @@
 module Quilt
   class Engine < ::Rails::Engine
     isolate_namespace Quilt
+
+    initializer(:mount_quilt, before: :add_builtin_route) do |app|
+      app.routes.append do
+        mount(Quilt::Engine, at: '/') unless has_named_route?(:quilt)
+      end
+    end
   end
 end

--- a/gems/quilt_rails/test/controllers/routing_test.rb
+++ b/gems/quilt_rails/test/controllers/routing_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "action_controller"
+
+module Quilt
+  class RoutingTest < ActionDispatch::IntegrationTest
+    include ActiveSupport::Testing::Isolation
+
+    class PerformanceReportController < ActionController::Base; end
+    class UiController < ActionController::Base; end
+
+    setup { boot_dummy }
+
+    test "routes on app without routes" do
+      assert_recognizes(
+        { controller: "quilt/performance_report", action: "create" },
+        { path: "/performance_report", method: "post" }
+      )
+      assert_recognizes(
+        { controller: "quilt/ui", action: "index", path: "anything" },
+        { path: "/anything" }
+      )
+      # Use after https://github.com/rails/rails/pull/39981 is released.
+      # assert_recognizes(
+      #   { controller: "quilt/ui", action: "index" },
+      #   { path: "/" }
+      # )
+    end
+
+    test "routes on app with engine mount" do
+      Rails.application.routes.draw do
+        mount(Quilt::Engine, at: '/quilt')
+      end
+
+      assert_recognizes(
+        { controller: "quilt/performance_report", action: "create" },
+        { path: "/quilt/performance_report", method: "post" }
+      )
+      assert_recognizes(
+        { controller: "quilt/ui", action: "index", path: "anything" },
+        { path: "/quilt/anything" }
+      )
+      # Use after https://github.com/rails/rails/pull/39981 is released.
+      # assert_recognizes(
+      #   { controller: "quilt/ui", action: "index" },
+      #   { path: "/path" }
+      # )
+    end
+
+    test "routes on app with custom controllers" do
+      Rails.application.routes.draw do
+        post '/performance_report', to: 'quilt/routing_test/performance_report#create'
+        get '/*path', to: 'quilt/routing_test/ui#index'
+        root 'quilt/routing_test/ui#index'
+      end
+
+      assert_recognizes(
+        { controller: "quilt/routing_test/performance_report", action: "create" },
+        { path: "/performance_report", method: "post" }
+      )
+      assert_recognizes(
+        { controller: "quilt/routing_test/ui", action: "index", path: "anything" },
+        { path: "/anything" }
+      )
+      assert_recognizes(
+        { controller: "quilt/routing_test/ui", action: "index" },
+        { path: "/" }
+      )
+    end
+
+    private
+
+    def boot_dummy
+      Rails.env = "development"
+      require_relative "../dummy/config/environment"
+      @routes = Rails.application.routes
+      @controller = nil
+    end
+  end
+end

--- a/gems/quilt_rails/test/dummy/config/routes.rb
+++ b/gems/quilt_rails/test/dummy/config/routes.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount Quilt::Engine => "/"
 end


### PR DESCRIPTION
## Description

Adds automatic engine mounting via a prepend hook. This is to prevent other engine routes being overridden by the main engine mount. If the gem automatically prepends the quilt engine, then other engines can draw on the application routes without worrying about precedence.

## Type of change

- [x] quilt_rails Patch: Bug (non-breaking change)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
