### PR TITLE
Add error link

### DIFF
--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -31,13 +31,18 @@
     "apollo-cache-inmemory": ">=1.0.0 <2.0.0",
     "apollo-client": ">=2.0.0 <3.0.0",
     "apollo-link": ">=1.0.0 <2.0.0",
-    "apollo-link-context": ">=1.0.0 <2.0.0"
+    "apollo-link-context": ">=1.0.0 <2.0.0",
+    "apollo-link-error": ">=1.0.0 <2.0.0",
+    "graphql": ">=14.0.0 <15.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0"
   },
-  "devDependencies": {
-    "@shopify/react-effect": "^3.2.12"
+  "devDependencies":
+    "@shopify/react-effect": "^3.2.12",
+    "@shopify/with-env": "^1.1.9",
+    "apollo-link-http-common": "^0.2.16",
+    "graphql-tag": "^2.11.0"
   },
   "files": [
     "dist/*",

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -10,6 +10,8 @@ import {useRequestHeader} from '@shopify/react-network';
 import {isServer} from './utilities';
 import {csrfLink} from './csrf-link';
 import {createRequestIdLink} from './request-id-link';
+import {createErrorHandlerLink} from './error-link';
+import {createNetworkErrorLink} from './network-error-link';
 
 interface Props<TCacheShape extends NormalizedCacheObject> {
   children?: React.ReactNode;
@@ -39,6 +41,8 @@ export function GraphQLUniversalProvider<
 
     const clientOptions = createClientOptions();
     const ssrLink = createSsrExtractableLink();
+    const errorLink = createErrorHandlerLink();
+    const networkErrorLink = createNetworkErrorLink();
     const requestIdLink = requestID
       ? createRequestIdLink(requestID)
       : undefined;
@@ -47,6 +51,8 @@ export function GraphQLUniversalProvider<
     const link = ApolloLink.from([
       ssrLink,
       csrfLink,
+      errorLink,
+      networkErrorLink,
       ...(requestIdLink ? [requestIdLink] : []),
       ...(finalLink ? [finalLink] : []),
     ]);

--- a/packages/react-graphql-universal-provider/src/error-link.ts
+++ b/packages/react-graphql-universal-provider/src/error-link.ts
@@ -1,0 +1,54 @@
+import {ApolloLink, Observable} from 'apollo-link';
+import {GraphQLError} from 'graphql';
+
+function errorMessage(serverError: any): string {
+  const {response, result} = serverError;
+  const errorsFromResult = result && result.errors;
+
+  let message = `${response.url} responded with status ${response.status}`;
+
+  if (errorsFromResult) {
+    message = message.concat(` and error message "${errorsFromResult}"`);
+  }
+  return message;
+}
+
+function wrapServerError(serverError: any): GraphQLError {
+  return new GraphQLError(
+    errorMessage(serverError),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    serverError,
+  );
+}
+
+export function createErrorHandlerLink() {
+  return new ApolloLink((operation, nextLink) => {
+    if (nextLink == null) {
+      throw new Error('The error handler link must not be a terminating link.');
+    }
+
+    return new Observable(observer => {
+      const sub = nextLink(operation).subscribe({
+        next: observer.next.bind(observer),
+        complete: observer.complete.bind(observer),
+        error: serverError => {
+          if (serverError == null || serverError.response == null) {
+            observer.error(serverError);
+            return;
+          }
+          observer.next({
+            errors: [wrapServerError(serverError)],
+          });
+        },
+      });
+      return () => {
+        if (sub) {
+          sub.unsubscribe();
+        }
+      };
+    });
+  });
+}

--- a/packages/react-graphql-universal-provider/src/network-error-link.ts
+++ b/packages/react-graphql-universal-provider/src/network-error-link.ts
@@ -1,0 +1,21 @@
+import {ApolloLink} from 'apollo-link';
+import {ErrorLink} from 'apollo-link-error';
+import {ServerParseError} from 'apollo-link-http-common';
+
+export function createNetworkErrorLink() {
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV === 'development') {
+    return new ErrorLink(({networkError}) => {
+      if (networkError && networkError.name === 'ServerParseError') {
+        networkError.message = (networkError as ServerParseError).bodyText;
+      }
+    });
+  } else {
+    return new ApolloLink((operation, nextLink) => {
+      if (nextLink == null) {
+        throw new Error('The parse error link must not be a terminating link');
+      }
+      return nextLink(operation);
+    });
+  }
+}

--- a/packages/react-graphql-universal-provider/src/test/error-link.test.ts
+++ b/packages/react-graphql-universal-provider/src/test/error-link.test.ts
@@ -1,0 +1,35 @@
+import gql from 'graphql-tag';
+import {GraphQLError} from 'graphql';
+import {StatusCode} from '@shopify/network';
+
+import {createErrorHandlerLink} from '../error-link';
+
+import {executeOnce, NetworkErrorLink} from './utilities';
+
+const testQuery = gql`
+  query Test {
+    name
+  }
+`;
+
+describe('createErrorHandlerLink()', () => {
+  it('calls the next link with a formatted GraphQL error response when the response has an error status', async () => {
+    const link = createErrorHandlerLink();
+    const response = new Response('', {status: StatusCode.Forbidden});
+    const errorLink = new NetworkErrorLink(response);
+    const {result} = await executeOnce(link.concat(errorLink), testQuery);
+
+    expect(result).toHaveProperty('errors');
+    expect(result!.errors![0]).toBeInstanceOf(GraphQLError);
+  });
+
+  it('surfaces the response’s status code in the GraphQLError message', async () => {
+    const statusCode = StatusCode.InternalServerError;
+    const link = createErrorHandlerLink();
+    const response = new Response('', {status: statusCode});
+    const errorLink = new NetworkErrorLink(response);
+    const {result} = await executeOnce(link.concat(errorLink), testQuery);
+
+    expect(result!.errors![0].message).toContain(`${statusCode}`);
+  });
+});

--- a/packages/react-graphql-universal-provider/src/test/network-error-link.test.ts
+++ b/packages/react-graphql-universal-provider/src/test/network-error-link.test.ts
@@ -1,0 +1,83 @@
+import gql from 'graphql-tag';
+import withEnv from '@shopify/with-env';
+
+import {createNetworkErrorLink} from '../network-error-link';
+
+import {
+  wrapLinkWithContext,
+  executeOnce,
+  ServerParseErrorLink,
+} from './utilities';
+
+const testQuery = gql`
+  query Test {
+    name
+  }
+`;
+
+jest.mock('apollo-link-error', () => ({
+  ...require.requireActual('apollo-link-error'),
+  ErrorLink: jest.fn(),
+}));
+
+const createApolloErrorLink = require.requireMock('apollo-link-error')
+  .ErrorLink as jest.Mock;
+
+const host = 'something.com';
+const apiEndpointPath = '/something/graphql';
+
+describe('createParseErrorLink()', () => {
+  const unexpectedHTML =
+    "<html><h1>This is some HTML where you don't expect it!</h1><hmtl>";
+
+  beforeEach(() => {
+    createApolloErrorLink.mockReset();
+    createApolloErrorLink.mockImplementation(
+      cb => new ServerParseErrorLink(cb, unexpectedHTML),
+    );
+  });
+
+  it('creates an error link in development mode', () => {
+    withEnv('development', () => {
+      executeOnce(
+        wrapLinkWithContext(createNetworkErrorLink(), {
+          host,
+          apiEndpointPath,
+        }),
+        testQuery,
+      );
+
+      expect(createApolloErrorLink).toHaveBeenCalled();
+    });
+  });
+
+  it('creates a dummy link in production mode', () => {
+    withEnv('production', () => {
+      executeOnce(
+        wrapLinkWithContext(createNetworkErrorLink(), {
+          host,
+          apiEndpointPath,
+        }),
+        testQuery,
+      ).catch(() => {
+        // ignore error thrown by createParseErrorLink because it's a terminating link
+      });
+
+      expect(createApolloErrorLink).not.toHaveBeenCalled();
+    });
+  });
+
+  it('passes along the response body as the error message in development mode', async () => {
+    await withEnv('development', async () => {
+      const {error} = await executeOnce(
+        wrapLinkWithContext(createNetworkErrorLink(), {
+          host,
+          apiEndpointPath,
+        }),
+        testQuery,
+      );
+
+      expect(error!.message).toStrictEqual(unexpectedHTML);
+    });
+  });
+});

--- a/packages/react-graphql-universal-provider/src/test/utilities.ts
+++ b/packages/react-graphql-universal-provider/src/test/utilities.ts
@@ -1,0 +1,191 @@
+import {GraphQLError} from 'graphql';
+import {
+  ApolloLink,
+  execute,
+  Operation,
+  Observable,
+  FetchResult,
+  NextLink,
+} from 'apollo-link';
+import {ErrorHandler} from 'apollo-link-error';
+import {DocumentNode} from 'graphql-typed';
+import {StatusCode} from '@shopify/network';
+
+interface ExecuteOnceOutcome {
+  operation: Operation;
+  result?: FetchResult;
+  error?: Error;
+}
+
+export function executeOnce(link: ApolloLink, query: DocumentNode) {
+  let op: Operation;
+  const storeLink = new ApolloLink((operation, nextLink) => {
+    op = operation;
+
+    if (nextLink == null) {
+      return null;
+    }
+
+    return nextLink(operation);
+  });
+
+  return new Promise<ExecuteOnceOutcome>(resolve => {
+    execute(storeLink.concat(link), {query}).subscribe({
+      next(result) {
+        resolve({operation: op, result});
+      },
+      error(error) {
+        resolve({operation: op, error});
+      },
+    });
+  });
+}
+
+type BeforeResult = (operation: Operation) => void;
+type SimpleResult = object | Error | Promise<object | Error>;
+
+export class SimpleLink extends ApolloLink {
+  constructor(
+    private result: object | Error | Promise<object | Error> = {data: {}},
+    private beforeResult: BeforeResult = noop,
+  ) {
+    super();
+  }
+
+  request(operation: Operation, nextLink?: NextLink) {
+    this.beforeResult(operation);
+
+    if (nextLink != null) {
+      return nextLink(operation);
+    }
+
+    return new Observable<FetchResult>(obs => {
+      function handleResult(result: Record<string, any> | Error) {
+        if (result instanceof Error) {
+          obs.error(result);
+        } else {
+          obs.next(result);
+        }
+
+        obs.complete();
+      }
+
+      if (this.result instanceof Promise) {
+        this.result.then(handleResult).catch(handleResult);
+      } else {
+        handleResult(this.result);
+      }
+    });
+  }
+}
+
+export class SimpleHttpLink extends SimpleLink {
+  constructor(
+    response: Response,
+    result?: SimpleResult,
+    beforeResult: BeforeResult = noop,
+  ) {
+    super(result, operation => {
+      beforeResult(operation);
+      operation.setContext({response});
+    });
+  }
+}
+
+export default class SetContextLink extends SimpleLink {
+  constructor(context: {[key: string]: any}, result?: SimpleResult) {
+    super(result, operation => {
+      operation.setContext(context);
+    });
+  }
+}
+
+export function wrapLinkWithContext(
+  link: ApolloLink,
+  context: {[key: string]: any},
+) {
+  return ApolloLink.from([new SetContextLink(context), link]);
+}
+
+export class InitializationErrorLink extends SimpleLink {
+  constructor(private error: Error = new Error()) {
+    super();
+  }
+
+  request(operation: Operation, nextLink?: NextLink) {
+    if (this.error) {
+      throw this.error;
+    }
+
+    return super.request(operation, nextLink);
+  }
+}
+
+export class NetworkError extends Error {
+  constructor(
+    public response: Response = new Response('', {
+      status: StatusCode.InternalServerError,
+    }),
+    url?: string,
+  ) {
+    super('Network error');
+
+    if (url) {
+      // It is marked as readonly, this gets around the resulting type error
+      Reflect.defineProperty(response, 'url', {value: url});
+    }
+  }
+}
+
+export class NetworkErrorLink extends SimpleLink {
+  error: NetworkError;
+
+  constructor(response?: Response, {url}: {url?: string} = {}) {
+    const error = new NetworkError(response, url);
+    super(error);
+    this.error = error;
+  }
+}
+
+export class ServerParseError extends Error {
+  bodyText: string;
+  name = 'ServerParseError';
+  statusCode = StatusCode.InternalServerError;
+  response = new Response('', {
+    status: StatusCode.InternalServerError,
+  });
+
+  constructor(errorText: string) {
+    super('Unexpected token < in JSON at position 0');
+    this.bodyText = errorText;
+  }
+}
+
+export class ServerParseErrorLink extends ApolloLink {
+  private link: ApolloLink;
+  constructor(parseErrorHandler: ErrorHandler, badJSONText: string) {
+    super();
+    this.link = new ApolloLink((operation, forward) => {
+      return new Observable(observer => {
+        const err = new ServerParseError(badJSONText);
+        parseErrorHandler({networkError: err, operation, forward});
+        observer.error(err);
+      });
+    });
+  }
+
+  request(
+    operation: Operation,
+    nextLink: NextLink,
+  ): Observable<FetchResult> | null {
+    return this.link.request(operation, nextLink);
+  }
+}
+
+export class GraphQLErrorLink extends SimpleLink {
+  constructor(graphQLError: GraphQLError) {
+    super({errors: [graphQLError]});
+  }
+}
+
+function noop() {}

--- a/packages/react-graphql-universal-provider/tsconfig.json
+++ b/packages/react-graphql-universal-provider/tsconfig.json
@@ -16,6 +16,7 @@
     {"path": "../react-hooks"},
     {"path": "../react-html"},
     {"path": "../react-network"},
-    {"path": "../react-effect"}
+    {"path": "../react-effect"},
+    {"path": "../with-env"}
   ]
 }


### PR DESCRIPTION
## Description

Part of resolving https://github.com/Shopify/shopify-rails/issues/282

Add default graphql error links. Mostly from [1](https://github.com/Shopify/web/blob/master/app/sections/Apps/AppList/graphql/appStore/link/error-handler.ts) & [2](https://github.com/Shopify/web/blob/master/packages/@web-utilities/graphql-client/link/parse-error.ts)

Before the error link
<img width="748" alt="before error link" src="https://user-images.githubusercontent.com/1610169/89351468-1a158f80-d680-11ea-85e0-475f690fa7c1.png">

after error link
<img width="751" alt="after error link" src="https://user-images.githubusercontent.com/1610169/89351482-1eda4380-d680-11ea-850e-f129120975c4.png">


## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
