### PR TITLE
Fixed error when using chrome autofill

### DIFF
--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -67,7 +67,10 @@ export default class ShortcutManager {
     }
 
     function keyGroupIsHeld(keyGroup: ModifierKey[]) {
-      return keyGroup.every((key: ModifierKey) => event.getModifierState(key));
+      return keyGroup.every(
+        (key: ModifierKey) =>
+          event.getModifierState && event.getModifierState(key),
+      );
     }
 
     return hasKeyGroups(heldKeys)


### PR DESCRIPTION
## Description

Fixed error when using chrome autofill

`Uncaught TypeError: event.getModifierState is not a function`

When using native autofill feature in Chrome, keydown event is raised but event object is missing getModifierState function and causes this error.

Added an additional check on getModifierState.
