### PR TITLE
✨ add request id to logging

### DIFF
--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -5,11 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
-
 ## [Unreleased]
 
-Added `ResponseType` function
+Added `ResponseType` function ([#1579](https://github.com/Shopify/quilt/pull/1573))
 
 ## [1.4.0] - 2019-06-27
 

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add request_id, hostname, and ips as part of the log. ([#1579](https://github.com/Shopify/quilt/pull/1579)).
+
 ### Changed
 
 - Change createServer default ip from `localhost` to `0.0.0.0` and remove 3000 as a default port. ([#1585](https://github.com/Shopify/quilt/pull/1585))

--- a/packages/react-server/src/logger/logger.ts
+++ b/packages/react-server/src/logger/logger.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-process-env */
 import {Context, Request} from 'koa';
 import chalk from 'chalk';
+import {Header} from '@shopify/react-network';
 
 import {KoaNextFunction} from '../types';
 
@@ -50,13 +51,16 @@ function endRequest(ctx: Context, requestDuration: number) {
   }
 
   /* eslint-disable @typescript-eslint/camelcase */
-  const logObject: any = {
+  const logObject = {
     datetime: new Date().toISOString(),
     http_method: ctx.method.toUpperCase(),
     http_response: ctx.message || '',
     http_status: ctx.status,
+    hostname: ctx.request.hostname,
+    ips: ctx.request.ips,
+    request_id: ctx.header['X-Request-ID'],
     uri: ctx.originalUrl,
-    user_agent: ctx.header['User-Agent'],
+    user_agent: ctx.header[Header.UserAgent],
     payload: logger.buffer,
   };
   /* eslint-enable @typescript-eslint/camelcase */


### PR DESCRIPTION
## Description

`request_id` is missing in the logging which is essential during debugging in Splunk to be able to trace the chain of requests from Rails request to Node request to GraphQL request.

### @shopify/react-server
- Add request_id, hostname, ip to logging from header for debugging

## Type of change

- @shopify/react-server: minor

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
