### PR TITLE
Explicitly set status code on successful response to 200

### DIFF
--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -141,6 +141,8 @@ export function createRender(render: RenderFunction, options: Options = {}) {
 
       ctx.set(Header.ContentType, 'text/html');
       ctx.body = response;
+
+      ctx.status = StatusCode.Ok;
     } catch (error) {
       const errorMessage = `React server-side rendering error:\n${
         error.stack || error.message

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Effect} from '@shopify/react-effect/server';
+import {StatusCode} from '@shopify/react-network';
 import {middleware as sewingKitKoaMiddleware} from '@shopify/sewing-kit-koa';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import withEnv from '@shopify/with-env';
@@ -34,6 +35,7 @@ describe('createRender', () => {
     await renderFunction(ctx, noop);
 
     expect(await readStream(ctx.body)).toContain(myCoolApp);
+    expect(ctx.status).toEqual(Status.InternalServerError);
   });
 
   it('response contains x-quilt-data from headers', async () => {
@@ -114,6 +116,7 @@ describe('createRender', () => {
 
         expect(await readStream(ctx.body)).toContain(error.message);
         expect(await readStream(ctx.body)).toContain(error.stack);
+        expect(ctx.status).toEqual(Status.InternalServerError);
       });
     });
 


### PR DESCRIPTION
## Description

When using react-server via the `quilt_rails` gem, I'm noticing proxied requests are return `404 Not Found`. The response doesn't seem to be set anywhere in the successful render path of `react-server`, so I've set it explicitly to `200 Ok` which seems to fix the issue. However, I'm not quite sure yet if this is a problem within `react-server`, `react-network` (`usesStatus`), or in the rails proxy somewhere.

The default status code for koa contexts is `404` as mentioned by [koa's docs](https://github.com/koajs/koa/blob/master/docs/api/response.md#responsestatus).

## Type of change

- [x] `react-server` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
