### PR TITLE
Fix links in react-server README

### DIFF
--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -51,11 +51,11 @@ If you already have an existing node server, you can opt in to using only the re
 
 ## Webpack Plugin
 
-We also provide a [webpack plugin](./docs/webpack-plugin) to automatically generate the server and client entries for an application.
+We also provide a [webpack plugin](./docs/webpack-plugin.md) to automatically generate the server and client entries for an application.
 
 ### Deployment (Shopify specific)
 
-For Shopifolk, we have a [walkthrough](https://docs.shopifycloud.com/getting_started/rails-with-node-walkthrough) for getting an app ready to deploy.
+For Shopifolk, we have a [walkthrough](https://platform-docs.docs.shopify.io/getting_started/rails-with-a-private-node-server.html) for getting an app ready to deploy.
 
 ## API
 


### PR DESCRIPTION
## Description

Update some broken links on the `react-server` package README.

## Type of change

- [x] `react-server` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
