### PR TITLE
Add proxy and app configuration to createServer

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <-- ## [Unreleased] -->
 
+- Allow `proxy` and `app` options to be passed to `createServer`. ([#1591](https://github.com/Shopify/quilt/pull/1591))
+
 ## [0.16.0] - 2020-06-16
 
 ### Changed

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -17,10 +17,12 @@ interface Options {
   ip?: string;
   port?: number;
   assetPrefix?: string;
+  proxy?: boolean;
   assetName?: string | ValueFromContext<string>;
   serverMiddleware?: compose.Middleware<Context>[];
   render: RenderFunction;
   renderError?: RenderFunction;
+  app?: Koa;
 }
 
 /**
@@ -39,11 +41,14 @@ export function createServer(options: Options): Server {
     assetPrefix = process.env.CDN_URL,
     /* eslint-enable no-process-env */
     render,
+    renderError,
     serverMiddleware,
     assetName,
-    renderError,
+    proxy = false,
+    app = new Koa(),
   } = options;
-  const app = new Koa();
+
+  app.proxy = proxy;
 
   app.use(mount('/services/ping', ping));
 

--- a/packages/react-server/src/server/test/floopydoop.test.tsx
+++ b/packages/react-server/src/server/test/floopydoop.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Koa from 'koa';
 import {useTitle} from '@shopify/react-html';
 import {useCookie, CookieUniversalProvider} from '@shopify/react-cookie';
 import {saddle, unsaddle} from 'saddle-up';
@@ -18,6 +19,17 @@ jest.mock('@shopify/sewing-kit-koa', () => ({
 
 describe('createServer()', () => {
   afterAll(unsaddle);
+
+  it('configurable as koa proxy', async () => {
+    function MockApp() {}
+    const app = new Koa();
+
+    const wrapper = await saddle((port, host) =>
+      createServer({app, proxy: true, render: () => <MockApp />}),
+    );
+
+    expect(app.proxy).toBe(true);
+  });
 
   it('starts a server that responds with markup', async () => {
     function MockApp() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,7 +2929,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@16.9.5", "@types/react-dom@^16.0.11", "@types/react-dom@^16.9.5":
+"@types/react-dom@^16.0.11", "@types/react-dom@^16.9.5":
   version "16.9.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.5.tgz#5de610b04a35d07ffd8f44edad93a71032d9aaa7"
   integrity sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==
@@ -6019,12 +6019,12 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
-dot-prop@5.1.1, dot-prop@^3.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.1.1.tgz#85783b39f2a54e04ae1981489a0ef2b9719bbd7d"
-  integrity sha512-QCHI6Lkf+9fJMpwfAFsTvbiSh6ujoPmhCLiDvD/n4dGtLvHfhuBwPdN6z2x4YSOwwtTcLoO/LP70xELWGF/JVA==
+dot-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
+  integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
   dependencies:
-    is-obj "^2.0.0"
+    is-obj "^1.0.0"
 
 dotenv@^8.0.0:
   version "8.2.0"
@@ -8421,10 +8421,10 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
-  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-path-cwd@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description

Part 1 of https://github.com/Shopify/quilt/issues/1586

Adds `proxy` option to `createServer`. I also added `app` to inject an already instantiated koa application (we might want to make this interface more generic) because I don't think its possible to mock a constructor in JS to return 1 object. The `new` keyword breaks inject possibilities AFAICS, but I'd be happy to be proven wrong here.

## Type of change

- [x] `@shopify/react-server` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
