### PR TITLE
✨ Add useDelayedCallback hook

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Added
+
+- Added `useDelayedCallback` hook ([#1595](https://github.com/Shopify/quilt/pull/1595))
+
 ## [1.10.0] - 2020-05-14
 
 ### Added

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -14,6 +14,7 @@ $ yarn add @shopify/react-hooks
 ## List of hooks
 
 - [useDebouncedValue()](#usedebouncedvalue)
+- [useDelayedCallback()](#usedelayedcallback)
 - [useForceUpdate()](#useforceupdate)
 - [useInterval()](#useinterval)
 - [useLazyRef()](#uselazyref)
@@ -28,7 +29,7 @@ $ yarn add @shopify/react-hooks
 
 ### `useDebouncedValue()`
 
-This hook provide a debounced value.
+This hook provides a debounced value.
 
 ```tsx
 function MyComponent() {
@@ -48,9 +49,32 @@ function MyComponent() {
 }
 ```
 
+### `useDelayedCallback()`
+
+This hook provides a delayed callback function. It takes a callback and a delay in milliseconds. This might be useful when you want to invoke a callback after a certain delay.
+
+```tsx
+function MyComponent() {
+  const delay = 300;
+  const callback = () => {
+    console.log(
+      `Oh, you KNOW I'm calling that callback after ${delay} milliseconds!`,
+    );
+  };
+
+  const callbackWithDelay = useDelayedCallback(callback, delay);
+
+  const onClick = () => {
+    callbackWithDelay();
+  };
+
+  return <button onClick={onClick}>Click me!</button>;
+}
+```
+
 ### `useForceUpdate()`
 
-This hook provide a `forceUpdate` function which will force a component to re-render. This might be useful when you want to re-render after a mutable object gets updated.
+This hook provides a `forceUpdate` function which will force a component to re-render. This might be useful when you want to re-render after a mutable object gets updated.
 
 ```tsx
 const mutableObject = {foo: 'bar'};
@@ -67,7 +91,7 @@ export default function ResourceListFiltersExample() {
 
 ### `useOnValueChange()`
 
-This hook will track a given value and invoke a callback when it has changed.
+This hook tracks a given value and invokes a callback when it has changed.
 
 ```tsx
 function MyComponent({foo}: {foo: string}) {
@@ -147,7 +171,7 @@ function MyComponent() {
 
 ### `useMedia()` & `useMediaLayout()`
 
-This hook will listen to a [MediaQueryList](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList) created via [matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) and return true or false if it matches the media query string.
+This hook listens to a [MediaQueryList](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList) created via [matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) and returns true or false if it matches the media query string.
 
 `useMediaLayout` is similar to `useMedia` but it uses `useLayoutEffect` internally to re-render synchronously.
 
@@ -192,7 +216,7 @@ function MockComponent() {
 
 ### `usePrevious()`
 
-This hook will store the previous value of a given variable.
+This hook stores the previous value of a given variable.
 
 ```tsx
 function Score({value}) {
@@ -210,7 +234,7 @@ function Score({value}) {
 
 ### `useToggle()`
 
-This hook will provide an object that contains a boolean state value and a set of memoised callbacks to toggle it, force it to true and force it to false. It accepts one argument that is the initial value of the state. This is useful for toggling the active state of modals and popovers.
+This hook provides an object that contains a boolean state value and a set of memoised callbacks to toggle it, force it to true, and force it to false. It accepts one argument that is the initial value of the state. This is useful for toggling the active state of modals and popovers.
 
 ```tsx
 function MyComponent() {

--- a/packages/react-hooks/src/hooks/delayed-callback.ts
+++ b/packages/react-hooks/src/hooks/delayed-callback.ts
@@ -1,0 +1,25 @@
+import {useEffect, useState} from 'react';
+
+export function useDelayedCallback(callback: Function, delay: number) {
+  const [timeoutId, setTimeoutId] = useState<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (timeoutId != null) {
+        clearTimeout(timeoutId);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function callbackWithDelay() {
+    const callbackId = setTimeout(() => {
+      callback();
+      setTimeoutId(undefined);
+    }, delay);
+
+    setTimeoutId(callbackId);
+  }
+
+  return callbackWithDelay;
+}

--- a/packages/react-hooks/src/hooks/index.ts
+++ b/packages/react-hooks/src/hooks/index.ts
@@ -8,3 +8,4 @@ export {usePrevious} from './previous';
 export {useTimeout} from './timeout';
 export {useToggle} from './toggle';
 export {useForceUpdate} from './force-update';
+export {useDelayedCallback} from './delayed-callback';

--- a/packages/react-hooks/src/hooks/tests/delayed-callback.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/delayed-callback.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {clock} from '@shopify/jest-dom-mocks';
+
+import {useDelayedCallback} from '../delayed-callback';
+
+interface Props {
+  callback(): void;
+  delay: number;
+}
+
+function FakeComponent({callback, delay}: Props) {
+  const callbackWithDelay = useDelayedCallback(callback, delay);
+
+  return <button onClick={callbackWithDelay} type="button" />;
+}
+
+describe('useDelayedCallback', () => {
+  beforeEach(() => {
+    clock.mock();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("doesn't call the callback right away", async () => {
+    const callbackSpy = jest.fn();
+    const delay = 1000;
+
+    const fakeComponent = await mount(
+      <FakeComponent callback={callbackSpy} delay={delay} />,
+    );
+
+    fakeComponent.find('button').trigger('onClick');
+
+    expect(callbackSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls the callback after delay', async () => {
+    const callbackSpy = jest.fn();
+    const delay = 250;
+
+    const fakeComponent = await mount(
+      <FakeComponent callback={callbackSpy} delay={delay} />,
+    );
+
+    fakeComponent.find('button').trigger('onClick');
+
+    fakeComponent.act(() => {
+      clock.tick(delay);
+    });
+
+    expect(callbackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the callback multiple times after delay if invoked multiple times', async () => {
+    const callbackSpy = jest.fn();
+    const delay = 400;
+
+    const fakeComponent = await mount(
+      <FakeComponent callback={callbackSpy} delay={delay} />,
+    );
+
+    fakeComponent.find('button').trigger('onClick');
+
+    fakeComponent.act(() => {
+      clock.tick(delay);
+    });
+
+    fakeComponent.find('button').trigger('onClick');
+
+    fakeComponent.act(() => {
+      clock.tick(delay);
+    });
+
+    expect(callbackSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("doesn't call the callback if the component unmounts before the delay", async () => {
+    const callbackSpy = jest.fn();
+    const delay = 300;
+
+    const fakeComponent = await mount(
+      <FakeComponent callback={callbackSpy} delay={delay} />,
+    );
+
+    fakeComponent.find('button').trigger('onClick');
+
+    fakeComponent.unmount();
+
+    expect(callbackSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

- Adds a new `useDelayedCallback` hook to the `react-hooks` package. 

- It's useful for when you want to call a function after a given delay. For example, in `web`, we are currently looking to use it to call the `onClose()` of a `Modal` after a slight delay, in order to wait for the progress bar to become 100% filled visually. Without the delay, the `Modal` closes abruptly before the progress bar reaches 100% visually.

- This PR also introduces minor corrections in `README.md` to fix grammar errors/typos/inconsistent verb tenses. 

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
