### PR TITLE
Allow proxy option in react-server webpack plugin

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -17,6 +17,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Change createServer default ip from `localhost` to `0.0.0.0` and remove 3000 as a default port. ([#1585](https://github.com/Shopify/quilt/pull/1585))
 
+- Allow `proxy` option to be specified by webpack plugin config (and forwarded to `createServer`). ([#1598](https://github.com/Shopify/quilt/pull/1598))
+
 - Allow `proxy` and `app` options to be passed to `createServer`. ([#1591](https://github.com/Shopify/quilt/pull/1591))
 
 ## [0.16.0] - 2020-06-16

--- a/packages/react-server/src/webpack-plugin/shared.ts
+++ b/packages/react-server/src/webpack-plugin/shared.ts
@@ -8,6 +8,7 @@ export interface Options {
   assetPrefix?: string;
   host?: string;
   port?: number;
+  proxy?: boolean;
 }
 
 export enum Entrypoint {

--- a/packages/react-server/src/webpack-plugin/webpack-plugin.ts
+++ b/packages/react-server/src/webpack-plugin/webpack-plugin.ts
@@ -19,12 +19,14 @@ export class ReactServerPlugin {
     port,
     assetPrefix,
     basePath = '.',
+    proxy = false,
   }: Partial<Options> = {}) {
     this.options = {
       basePath,
       host,
       port,
       assetPrefix,
+      proxy,
     };
   }
 
@@ -58,7 +60,7 @@ export class ReactServerPlugin {
 }
 
 function serverSource(options: Options, compiler: Compiler) {
-  const {port, host, assetPrefix} = options;
+  const {port, host, assetPrefix, proxy} = options;
 
   return `
     ${HEADER}
@@ -92,6 +94,7 @@ function serverSource(options: Options, compiler: Compiler) {
       port: ${port},
       ip: ${JSON.stringify(host)},
       assetPrefix: ${JSON.stringify(assetPrefix)},
+      proxy: ${proxy},
       render,
       ${
         errorSSRComponentExists(options, compiler)


### PR DESCRIPTION
## Description

Expose proxy option from https://github.com/Shopify/quilt/pull/1591 in the webpack plugin for `react-server`.

## Type of change

- [x] `react-server` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
