### PR TITLE
✨ automatically pass request id header to graphql request

### DIFF
--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -27,6 +27,7 @@
     "@shopify/react-graphql": "^6.1.16",
     "@shopify/react-hooks": "^1.11.1",
     "@shopify/react-html": "^9.3.15",
+    "@shopify/react-network": "^3.5.4",
     "apollo-cache-inmemory": ">=1.0.0 <2.0.0",
     "apollo-client": ">=2.0.0 <3.0.0",
     "apollo-link": ">=1.0.0 <2.0.0",

--- a/packages/react-graphql-universal-provider/src/request-id-link.ts
+++ b/packages/react-graphql-universal-provider/src/request-id-link.ts
@@ -1,0 +1,10 @@
+import {setContext} from 'apollo-link-context';
+
+export function createRequestIdLink(requestId: string) {
+  return setContext((_, {headers}) => ({
+    headers: {
+      ...headers,
+      'X-Request-ID': requestId,
+    },
+  }));
+}

--- a/packages/react-graphql-universal-provider/src/test/request-id-link.test.ts
+++ b/packages/react-graphql-universal-provider/src/test/request-id-link.test.ts
@@ -1,0 +1,16 @@
+import {ApolloLink, Observable} from 'apollo-link';
+
+import {createRequestIdLink} from '../request-id-link';
+
+describe('createRequestIdLink()', () => {
+  it('create a link that add request id value to the header', () => {
+    const mockRequestId = '06a2f67e-b080-446f-bffa-7851ddad3a45';
+    const requestIdLink = createRequestIdLink(mockRequestId);
+
+    const mockLink = new ApolloLink(operation => {
+      expect(operation.getContext().header['X-Request-ID']).toBe(mockRequestId);
+
+      return Observable.of({data: {foo: {bar: true}}});
+    });
+  });
+});

--- a/packages/react-graphql-universal-provider/tsconfig.json
+++ b/packages/react-graphql-universal-provider/tsconfig.json
@@ -12,9 +12,10 @@
   ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "references": [
-    {"path": "../react-effect"},
     {"path": "../react-graphql"},
+    {"path": "../react-hooks"},
     {"path": "../react-html"},
-    {"path": "../react-hooks"}
+    {"path": "../react-network"},
+    {"path": "../react-effect"}
   ]
 }


### PR DESCRIPTION
## Description

Part of https://github.com/Shopify/shopify-rails/issues/282

This PR aim to pass request-id header to any graphql request (the way `useRequestHeader` works, this will usually only happen with server side graphql requests).

After which we can use the unique request-id value to trace a request from Rails => Node => Graphql request to Rails and back to see if what actually cause the error during a browser request.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

To 🎩 
You need this PR so request id will pass from Rails to Node https://github.com/Shopify/quilt/pull/1608
After I use `yarn tophat react-graphql-universal-provider ../consuming-repo` and log the request id in graphql controller to see the same value being pass.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
