### PR TITLE
Modified Address package to also query for Optional Labels.

### DIFF
--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Add `optionalLabels` to `Country` interface. [#1610](https://github.com/Shopify/quilt/pull/1610)
 
 ## [2.0.0] - 2020-03-10
 

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -69,6 +69,9 @@ export interface Country {
     postalCode: string;
     zone: string;
   };
+  optionalLabels: {
+    address2: string;
+  };
   formatting: {
     edit: string;
     show: string;

--- a/packages/address-mocks/CHANGELOG.md
+++ b/packages/address-mocks/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Updated mocks for countries and country calls to include `optionalLabels`. [#1610](https://github.com/Shopify/quilt/pull/1610)
 
 ## [1.3.0] - 2020-03-10
 

--- a/packages/address-mocks/src/fixtures/countries_af.ts
+++ b/packages/address-mocks/src/fixtures/countries_af.ts
@@ -20,6 +20,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -47,9 +50,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -73,6 +79,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -101,9 +110,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -128,9 +140,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -154,6 +169,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -182,6 +200,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -208,6 +229,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -236,37 +260,112 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Buenos Aires Province', code: 'B'},
-          {name: 'Catamarca', code: 'K'},
-          {name: 'Chaco', code: 'H'},
-          {name: 'Chubut', code: 'U'},
-          {name: 'Buenos Aires', code: 'C'},
-          {name: 'Córdoba', code: 'X'},
-          {name: 'Corrientes', code: 'W'},
-          {name: 'Entre Ríos', code: 'E'},
-          {name: 'Formosa', code: 'P'},
-          {name: 'Jujuy', code: 'Y'},
-          {name: 'La Pampa', code: 'L'},
-          {name: 'La Rioja', code: 'F'},
-          {name: 'Mendoza', code: 'M'},
-          {name: 'Misiones', code: 'N'},
-          {name: 'Neuquén', code: 'Q'},
-          {name: 'Río Negro', code: 'R'},
-          {name: 'Salta', code: 'A'},
-          {name: 'San Juan', code: 'J'},
-          {name: 'San Luis', code: 'D'},
-          {name: 'Santa Cruz', code: 'Z'},
-          {name: 'Santa Fe', code: 'S'},
-          {name: 'Santiago del Estero', code: 'G'},
-          {name: 'Tierra del Fuego', code: 'V'},
-          {name: 'Tucumán', code: 'T'},
+          {
+            name: 'Buenos Aires Province',
+            code: 'B',
+          },
+          {
+            name: 'Catamarca',
+            code: 'K',
+          },
+          {
+            name: 'Chaco',
+            code: 'H',
+          },
+          {
+            name: 'Chubut',
+            code: 'U',
+          },
+          {
+            name: 'Buenos Aires (Autonomous City)',
+            code: 'C',
+          },
+          {
+            name: 'Córdoba',
+            code: 'X',
+          },
+          {
+            name: 'Corrientes',
+            code: 'W',
+          },
+          {
+            name: 'Entre Ríos',
+            code: 'E',
+          },
+          {
+            name: 'Formosa',
+            code: 'P',
+          },
+          {
+            name: 'Jujuy',
+            code: 'Y',
+          },
+          {
+            name: 'La Pampa',
+            code: 'L',
+          },
+          {
+            name: 'La Rioja',
+            code: 'F',
+          },
+          {
+            name: 'Mendoza',
+            code: 'M',
+          },
+          {
+            name: 'Misiones',
+            code: 'N',
+          },
+          {
+            name: 'Neuquén',
+            code: 'Q',
+          },
+          {
+            name: 'Río Negro',
+            code: 'R',
+          },
+          {
+            name: 'Salta',
+            code: 'A',
+          },
+          {
+            name: 'San Juan',
+            code: 'J',
+          },
+          {
+            name: 'San Luis',
+            code: 'D',
+          },
+          {
+            name: 'Santa Cruz',
+            code: 'Z',
+          },
+          {
+            name: 'Santa Fe',
+            code: 'S',
+          },
+          {
+            name: 'Santiago del Estero',
+            code: 'G',
+          },
+          {
+            name: 'Tierra del Fuego',
+            code: 'V',
+          },
+          {
+            name: 'Tucumán',
+            code: 'T',
+          },
         ],
       },
       {
@@ -288,9 +387,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -315,6 +417,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -333,7 +438,7 @@ const data = {
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'Suburb',
           company: 'Company',
           country: 'Country/Region',
           firstName: 'First name',
@@ -342,6 +447,9 @@ const data = {
           postalCode: 'Postcode',
           zone: 'State/territory',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -349,14 +457,38 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province} {zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Australian Capital Territory', code: 'ACT'},
-          {name: 'New South Wales', code: 'NSW'},
-          {name: 'Northern Territory', code: 'NT'},
-          {name: 'Queensland', code: 'QLD'},
-          {name: 'South Australia', code: 'SA'},
-          {name: 'Tasmania', code: 'TAS'},
-          {name: 'Victoria', code: 'VIC'},
-          {name: 'Western Australia', code: 'WA'},
+          {
+            name: 'Australian Capital Territory',
+            code: 'ACT',
+          },
+          {
+            name: 'New South Wales',
+            code: 'NSW',
+          },
+          {
+            name: 'Northern Territory',
+            code: 'NT',
+          },
+          {
+            name: 'Queensland',
+            code: 'QLD',
+          },
+          {
+            name: 'South Australia',
+            code: 'SA',
+          },
+          {
+            name: 'Tasmania',
+            code: 'TAS',
+          },
+          {
+            name: 'Victoria',
+            code: 'VIC',
+          },
+          {
+            name: 'Western Australia',
+            code: 'WA',
+          },
         ],
       },
       {
@@ -367,8 +499,8 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'REGION',
         labels: {
-          address1: 'Address',
-          address2: 'Apartment, suite, etc.',
+          address1: 'Street and house number',
+          address2: 'Additional address',
           city: 'City',
           company: 'Company',
           country: 'Country/Region',
@@ -378,9 +510,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Additional address (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -405,9 +540,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -431,6 +569,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -459,6 +600,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -485,6 +629,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -513,6 +660,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -527,7 +677,7 @@ const data = {
         continent: 'Europe',
         phoneNumberPrefix: 375,
         autocompletionField: 'address1',
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
@@ -538,11 +688,14 @@ const data = {
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -567,9 +720,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -593,6 +749,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -621,6 +780,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -647,6 +809,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -675,6 +840,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -701,6 +869,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -729,9 +900,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -755,6 +929,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -783,6 +960,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -799,7 +979,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'STATE',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -810,6 +990,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'State',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -817,33 +1000,114 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province}_{zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Acre', code: 'AC'},
-          {name: 'Alagoas', code: 'AL'},
-          {name: 'Amapá', code: 'AP'},
-          {name: 'Amazonas', code: 'AM'},
-          {name: 'Bahia', code: 'BA'},
-          {name: 'Ceará', code: 'CE'},
-          {name: 'Federal District', code: 'DF'},
-          {name: 'Espírito Santo', code: 'ES'},
-          {name: 'Goiás', code: 'GO'},
-          {name: 'Maranhão', code: 'MA'},
-          {name: 'Mato Grosso', code: 'MT'},
-          {name: 'Mato Grosso do Sul', code: 'MS'},
-          {name: 'Minas Gerais', code: 'MG'},
-          {name: 'Pará', code: 'PA'},
-          {name: 'Paraíba', code: 'PB'},
-          {name: 'Paraná', code: 'PR'},
-          {name: 'Pernambuco', code: 'PE'},
-          {name: 'Piauí', code: 'PI'},
-          {name: 'Rio Grande do Norte', code: 'RN'},
-          {name: 'Rio Grande do Sul', code: 'RS'},
-          {name: 'Rio de Janeiro', code: 'RJ'},
-          {name: 'Rondônia', code: 'RO'},
-          {name: 'Roraima', code: 'RR'},
-          {name: 'Santa Catarina', code: 'SC'},
-          {name: 'São Paulo', code: 'SP'},
-          {name: 'Sergipe', code: 'SE'},
-          {name: 'Tocantins', code: 'TO'},
+          {
+            name: 'Acre',
+            code: 'AC',
+          },
+          {
+            name: 'Alagoas',
+            code: 'AL',
+          },
+          {
+            name: 'Amapá',
+            code: 'AP',
+          },
+          {
+            name: 'Amazonas',
+            code: 'AM',
+          },
+          {
+            name: 'Bahia',
+            code: 'BA',
+          },
+          {
+            name: 'Ceará',
+            code: 'CE',
+          },
+          {
+            name: 'Federal District',
+            code: 'DF',
+          },
+          {
+            name: 'Espírito Santo',
+            code: 'ES',
+          },
+          {
+            name: 'Goiás',
+            code: 'GO',
+          },
+          {
+            name: 'Maranhão',
+            code: 'MA',
+          },
+          {
+            name: 'Mato Grosso',
+            code: 'MT',
+          },
+          {
+            name: 'Mato Grosso do Sul',
+            code: 'MS',
+          },
+          {
+            name: 'Minas Gerais',
+            code: 'MG',
+          },
+          {
+            name: 'Pará',
+            code: 'PA',
+          },
+          {
+            name: 'Paraíba',
+            code: 'PB',
+          },
+          {
+            name: 'Paraná',
+            code: 'PR',
+          },
+          {
+            name: 'Pernambuco',
+            code: 'PE',
+          },
+          {
+            name: 'Piauí',
+            code: 'PI',
+          },
+          {
+            name: 'Rio Grande do Norte',
+            code: 'RN',
+          },
+          {
+            name: 'Rio Grande do Sul',
+            code: 'RS',
+          },
+          {
+            name: 'Rio de Janeiro',
+            code: 'RJ',
+          },
+          {
+            name: 'Rondônia',
+            code: 'RO',
+          },
+          {
+            name: 'Roraima',
+            code: 'RR',
+          },
+          {
+            name: 'Santa Catarina',
+            code: 'SC',
+          },
+          {
+            name: 'São Paulo',
+            code: 'SP',
+          },
+          {
+            name: 'Sergipe',
+            code: 'SE',
+          },
+          {
+            name: 'Tocantins',
+            code: 'TO',
+          },
         ],
       },
       {
@@ -864,6 +1128,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -892,6 +1159,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -918,6 +1188,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -946,9 +1219,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -972,6 +1248,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1000,6 +1279,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1026,6 +1308,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1054,6 +1339,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1071,7 +1359,7 @@ const data = {
         provinceKey: 'PROVINCE',
         labels: {
           address1: 'Address',
-          address2: 'Apt./Unit No.',
+          address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
           country: 'Country/Region',
@@ -1081,6 +1369,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -1088,19 +1379,58 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province} {zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Alberta', code: 'AB'},
-          {name: 'British Columbia', code: 'BC'},
-          {name: 'Manitoba', code: 'MB'},
-          {name: 'New Brunswick', code: 'NB'},
-          {name: 'Newfoundland and Labrador', code: 'NL'},
-          {name: 'Northwest Territories', code: 'NT'},
-          {name: 'Nova Scotia', code: 'NS'},
-          {name: 'Nunavut', code: 'NU'},
-          {name: 'Ontario', code: 'ON'},
-          {name: 'Prince Edward Island', code: 'PE'},
-          {name: 'Quebec', code: 'QC'},
-          {name: 'Saskatchewan', code: 'SK'},
-          {name: 'Yukon', code: 'YT'},
+          {
+            name: 'Alberta',
+            code: 'AB',
+          },
+          {
+            name: 'British Columbia',
+            code: 'BC',
+          },
+          {
+            name: 'Manitoba',
+            code: 'MB',
+          },
+          {
+            name: 'New Brunswick',
+            code: 'NB',
+          },
+          {
+            name: 'Newfoundland and Labrador',
+            code: 'NL',
+          },
+          {
+            name: 'Northwest Territories',
+            code: 'NT',
+          },
+          {
+            name: 'Nova Scotia',
+            code: 'NS',
+          },
+          {
+            name: 'Nunavut',
+            code: 'NU',
+          },
+          {
+            name: 'Ontario',
+            code: 'ON',
+          },
+          {
+            name: 'Prince Edward Island',
+            code: 'PE',
+          },
+          {
+            name: 'Quebec',
+            code: 'QC',
+          },
+          {
+            name: 'Saskatchewan',
+            code: 'SK',
+          },
+          {
+            name: 'Yukon',
+            code: 'YT',
+          },
         ],
       },
       {
@@ -1122,9 +1452,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1148,6 +1481,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1176,6 +1512,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1202,6 +1541,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1230,6 +1572,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -1257,29 +1602,80 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{province}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Antofagasta', code: 'AN'},
-          {name: 'Araucanía', code: 'AR'},
-          {name: 'Arica y Parinacota', code: 'AP'},
-          {name: 'Atacama', code: 'AT'},
-          {name: 'Aysén', code: 'AI'},
-          {name: 'Bío Bío', code: 'BI'},
-          {name: 'Coquimbo', code: 'CO'},
-          {name: 'Los Lagos', code: 'LL'},
-          {name: 'Los Ríos', code: 'LR'},
-          {name: 'Magallanes Region', code: 'MA'},
-          {name: 'Maule', code: 'ML'},
-          {name: 'Ñuble', code: 'NB'},
-          {name: 'Libertador General Bernardo O’Higgins', code: 'LI'},
-          {name: 'Santiago Metropolitan', code: 'RM'},
-          {name: 'Tarapacá', code: 'TA'},
-          {name: 'Valparaíso', code: 'VS'},
+          {
+            name: 'Arica y Parinacota',
+            code: 'AP',
+          },
+          {
+            name: 'Tarapacá',
+            code: 'TA',
+          },
+          {
+            name: 'Antofagasta',
+            code: 'AN',
+          },
+          {
+            name: 'Atacama',
+            code: 'AT',
+          },
+          {
+            name: 'Coquimbo',
+            code: 'CO',
+          },
+          {
+            name: 'Valparaíso',
+            code: 'VS',
+          },
+          {
+            name: 'Santiago Metropolitan',
+            code: 'RM',
+          },
+          {
+            name: 'Libertador General Bernardo O’Higgins',
+            code: 'LI',
+          },
+          {
+            name: 'Maule',
+            code: 'ML',
+          },
+          {
+            name: 'Ñuble',
+            code: 'NB',
+          },
+          {
+            name: 'Bío Bío',
+            code: 'BI',
+          },
+          {
+            name: 'Araucanía',
+            code: 'AR',
+          },
+          {
+            name: 'Los Ríos',
+            code: 'LR',
+          },
+          {
+            name: 'Los Lagos',
+            code: 'LL',
+          },
+          {
+            name: 'Aysén',
+            code: 'AI',
+          },
+          {
+            name: 'Magallanes Region',
+            code: 'MA',
+          },
         ],
       },
       {
@@ -1290,7 +1686,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'PROVINCE',
         labels: {
-          address1: 'Address',
+          address1: 'Full address',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -1301,6 +1697,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -1308,37 +1707,130 @@ const data = {
             '{firstName} {lastName}_{company}_{address1} {address2} {city}_{zip} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Anhui', code: 'AH'},
-          {name: 'Beijing', code: 'BJ'},
-          {name: 'Chongqing', code: 'CQ'},
-          {name: 'Fujian', code: 'FJ'},
-          {name: 'Gansu', code: 'GS'},
-          {name: 'Guangdong', code: 'GD'},
-          {name: 'Guangxi', code: 'GX'},
-          {name: 'Guizhou', code: 'GZ'},
-          {name: 'Hainan', code: 'HI'},
-          {name: 'Hebei', code: 'HE'},
-          {name: 'Heilongjiang', code: 'HL'},
-          {name: 'Henan', code: 'HA'},
-          {name: 'Hubei', code: 'HB'},
-          {name: 'Hunan', code: 'HN'},
-          {name: 'Inner Mongolia', code: 'NM'},
-          {name: 'Jiangsu', code: 'JS'},
-          {name: 'Jiangxi', code: 'JX'},
-          {name: 'Jilin', code: 'JL'},
-          {name: 'Liaoning', code: 'LN'},
-          {name: 'Ningxia', code: 'NX'},
-          {name: 'Qinghai', code: 'QH'},
-          {name: 'Shaanxi', code: 'SN'},
-          {name: 'Shandong', code: 'SD'},
-          {name: 'Shanghai', code: 'SH'},
-          {name: 'Shanxi', code: 'SX'},
-          {name: 'Sichuan', code: 'SC'},
-          {name: 'Tianjin', code: 'TJ'},
-          {name: 'Xinjiang', code: 'XJ'},
-          {name: 'Tibet', code: 'YZ'},
-          {name: 'Yunnan', code: 'YN'},
-          {name: 'Zhejiang', code: 'ZJ'},
+          {
+            name: 'Anhui',
+            code: 'AH',
+          },
+          {
+            name: 'Beijing',
+            code: 'BJ',
+          },
+          {
+            name: 'Chongqing',
+            code: 'CQ',
+          },
+          {
+            name: 'Fujian',
+            code: 'FJ',
+          },
+          {
+            name: 'Gansu',
+            code: 'GS',
+          },
+          {
+            name: 'Guangdong',
+            code: 'GD',
+          },
+          {
+            name: 'Guangxi',
+            code: 'GX',
+          },
+          {
+            name: 'Guizhou',
+            code: 'GZ',
+          },
+          {
+            name: 'Hainan',
+            code: 'HI',
+          },
+          {
+            name: 'Hebei',
+            code: 'HE',
+          },
+          {
+            name: 'Heilongjiang',
+            code: 'HL',
+          },
+          {
+            name: 'Henan',
+            code: 'HA',
+          },
+          {
+            name: 'Hubei',
+            code: 'HB',
+          },
+          {
+            name: 'Hunan',
+            code: 'HN',
+          },
+          {
+            name: 'Inner Mongolia',
+            code: 'NM',
+          },
+          {
+            name: 'Jiangsu',
+            code: 'JS',
+          },
+          {
+            name: 'Jiangxi',
+            code: 'JX',
+          },
+          {
+            name: 'Jilin',
+            code: 'JL',
+          },
+          {
+            name: 'Liaoning',
+            code: 'LN',
+          },
+          {
+            name: 'Ningxia',
+            code: 'NX',
+          },
+          {
+            name: 'Qinghai',
+            code: 'QH',
+          },
+          {
+            name: 'Shaanxi',
+            code: 'SN',
+          },
+          {
+            name: 'Shandong',
+            code: 'SD',
+          },
+          {
+            name: 'Shanghai',
+            code: 'SH',
+          },
+          {
+            name: 'Shanxi',
+            code: 'SX',
+          },
+          {
+            name: 'Sichuan',
+            code: 'SC',
+          },
+          {
+            name: 'Tianjin',
+            code: 'TJ',
+          },
+          {
+            name: 'Xinjiang',
+            code: 'XJ',
+          },
+          {
+            name: 'Tibet',
+            code: 'YZ',
+          },
+          {
+            name: 'Yunnan',
+            code: 'YN',
+          },
+          {
+            name: 'Zhejiang',
+            code: 'ZJ',
+          },
         ],
       },
       {
@@ -1359,6 +1851,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1387,6 +1882,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1414,6 +1912,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -1421,39 +1922,138 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Capital District', code: 'DC'},
-          {name: 'Amazonas', code: 'AMA'},
-          {name: 'Antioquia', code: 'ANT'},
-          {name: 'Arauca', code: 'ARA'},
-          {name: 'Atlántico', code: 'ATL'},
-          {name: 'Bolívar', code: 'BOL'},
-          {name: 'Boyacá', code: 'BOY'},
-          {name: 'Caldas', code: 'CAL'},
-          {name: 'Caquetá', code: 'CAQ'},
-          {name: 'Casanare', code: 'CAS'},
-          {name: 'Cauca', code: 'CAU'},
-          {name: 'Cesar', code: 'CES'},
-          {name: 'Chocó', code: 'CHO'},
-          {name: 'Córdoba', code: 'COR'},
-          {name: 'Cundinamarca', code: 'CUN'},
-          {name: 'Guainía', code: 'GUA'},
-          {name: 'Guaviare', code: 'GUV'},
-          {name: 'Huila', code: 'HUI'},
-          {name: 'La Guajira', code: 'LAG'},
-          {name: 'Magdalena', code: 'MAG'},
-          {name: 'Meta', code: 'MET'},
-          {name: 'Nariño', code: 'NAR'},
-          {name: 'Norte de Santander', code: 'NSA'},
-          {name: 'Putumayo', code: 'PUT'},
-          {name: 'Quindío', code: 'QUI'},
-          {name: 'Risaralda', code: 'RIS'},
-          {name: 'San Andrés & Providencia', code: 'SAP'},
-          {name: 'Santander', code: 'SAN'},
-          {name: 'Sucre', code: 'SUC'},
-          {name: 'Tolima', code: 'TOL'},
-          {name: 'Valle del Cauca', code: 'VAC'},
-          {name: 'Vaupés', code: 'VAU'},
-          {name: 'Vichada', code: 'VID'},
+          {
+            name: 'Capital District',
+            code: 'DC',
+          },
+          {
+            name: 'Amazonas',
+            code: 'AMA',
+          },
+          {
+            name: 'Antioquia',
+            code: 'ANT',
+          },
+          {
+            name: 'Arauca',
+            code: 'ARA',
+          },
+          {
+            name: 'Atlántico',
+            code: 'ATL',
+          },
+          {
+            name: 'Bolívar',
+            code: 'BOL',
+          },
+          {
+            name: 'Boyacá',
+            code: 'BOY',
+          },
+          {
+            name: 'Caldas',
+            code: 'CAL',
+          },
+          {
+            name: 'Caquetá',
+            code: 'CAQ',
+          },
+          {
+            name: 'Casanare',
+            code: 'CAS',
+          },
+          {
+            name: 'Cauca',
+            code: 'CAU',
+          },
+          {
+            name: 'Cesar',
+            code: 'CES',
+          },
+          {
+            name: 'Chocó',
+            code: 'CHO',
+          },
+          {
+            name: 'Córdoba',
+            code: 'COR',
+          },
+          {
+            name: 'Cundinamarca',
+            code: 'CUN',
+          },
+          {
+            name: 'Guainía',
+            code: 'GUA',
+          },
+          {
+            name: 'Guaviare',
+            code: 'GUV',
+          },
+          {
+            name: 'Huila',
+            code: 'HUI',
+          },
+          {
+            name: 'La Guajira',
+            code: 'LAG',
+          },
+          {
+            name: 'Magdalena',
+            code: 'MAG',
+          },
+          {
+            name: 'Meta',
+            code: 'MET',
+          },
+          {
+            name: 'Nariño',
+            code: 'NAR',
+          },
+          {
+            name: 'Norte de Santander',
+            code: 'NSA',
+          },
+          {
+            name: 'Putumayo',
+            code: 'PUT',
+          },
+          {
+            name: 'Quindío',
+            code: 'QUI',
+          },
+          {
+            name: 'Risaralda',
+            code: 'RIS',
+          },
+          {
+            name: 'San Andrés & Providencia',
+            code: 'SAP',
+          },
+          {
+            name: 'Santander',
+            code: 'SAN',
+          },
+          {
+            name: 'Sucre',
+            code: 'SUC',
+          },
+          {
+            name: 'Tolima',
+            code: 'TOL',
+          },
+          {
+            name: 'Valle del Cauca',
+            code: 'VAC',
+          },
+          {
+            name: 'Vaupés',
+            code: 'VAU',
+          },
+          {
+            name: 'Vichada',
+            code: 'VID',
+          },
         ],
       },
       {
@@ -1474,6 +2074,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1502,6 +2105,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1528,6 +2134,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1556,6 +2165,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1582,6 +2194,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1610,9 +2225,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1637,9 +2255,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1663,6 +2284,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1691,9 +2315,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1718,9 +2345,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1745,6 +2375,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1761,7 +2394,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'REGION',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -1772,9 +2405,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1798,6 +2434,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1826,6 +2465,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -1853,9 +2495,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1880,9 +2525,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -1907,6 +2555,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Governorate',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -1914,35 +2565,122 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}',
         },
         zones: [
-          {name: '6th of October', code: 'SU'},
-          {name: 'Al Sharqia', code: 'SHR'},
-          {name: 'Alexandria', code: 'ALX'},
-          {name: 'Aswan', code: 'ASN'},
-          {name: 'Asyut', code: 'AST'},
-          {name: 'Beheira', code: 'BH'},
-          {name: 'Beni Suef', code: 'BNS'},
-          {name: 'Cairo', code: 'C'},
-          {name: 'Dakahlia', code: 'DK'},
-          {name: 'Damietta', code: 'DT'},
-          {name: 'Faiyum', code: 'FYM'},
-          {name: 'Gharbia', code: 'GH'},
-          {name: 'Giza', code: 'GZ'},
-          {name: 'Helwan', code: 'HU'},
-          {name: 'Ismailia', code: 'IS'},
-          {name: 'Kafr el-Sheikh', code: 'KFS'},
-          {name: 'Luxor', code: 'LX'},
-          {name: 'Matrouh', code: 'MT'},
-          {name: 'Minya', code: 'MN'},
-          {name: 'Monufia', code: 'MNF'},
-          {name: 'New Valley', code: 'WAD'},
-          {name: 'North Sinai', code: 'SIN'},
-          {name: 'Port Said', code: 'PTS'},
-          {name: 'Qalyubia', code: 'KB'},
-          {name: 'Qena', code: 'KN'},
-          {name: 'Red Sea', code: 'BA'},
-          {name: 'Sohag', code: 'SHG'},
-          {name: 'South Sinai', code: 'JS'},
-          {name: 'Suez', code: 'SUZ'},
+          {
+            name: '6th of October',
+            code: 'SU',
+          },
+          {
+            name: 'Al Sharqia',
+            code: 'SHR',
+          },
+          {
+            name: 'Alexandria',
+            code: 'ALX',
+          },
+          {
+            name: 'Aswan',
+            code: 'ASN',
+          },
+          {
+            name: 'Asyut',
+            code: 'AST',
+          },
+          {
+            name: 'Beheira',
+            code: 'BH',
+          },
+          {
+            name: 'Beni Suef',
+            code: 'BNS',
+          },
+          {
+            name: 'Cairo',
+            code: 'C',
+          },
+          {
+            name: 'Dakahlia',
+            code: 'DK',
+          },
+          {
+            name: 'Damietta',
+            code: 'DT',
+          },
+          {
+            name: 'Faiyum',
+            code: 'FYM',
+          },
+          {
+            name: 'Gharbia',
+            code: 'GH',
+          },
+          {
+            name: 'Giza',
+            code: 'GZ',
+          },
+          {
+            name: 'Helwan',
+            code: 'HU',
+          },
+          {
+            name: 'Ismailia',
+            code: 'IS',
+          },
+          {
+            name: 'Kafr el-Sheikh',
+            code: 'KFS',
+          },
+          {
+            name: 'Luxor',
+            code: 'LX',
+          },
+          {
+            name: 'Matrouh',
+            code: 'MT',
+          },
+          {
+            name: 'Minya',
+            code: 'MN',
+          },
+          {
+            name: 'Monufia',
+            code: 'MNF',
+          },
+          {
+            name: 'New Valley',
+            code: 'WAD',
+          },
+          {
+            name: 'North Sinai',
+            code: 'SIN',
+          },
+          {
+            name: 'Port Said',
+            code: 'PTS',
+          },
+          {
+            name: 'Qalyubia',
+            code: 'KB',
+          },
+          {
+            name: 'Qena',
+            code: 'KN',
+          },
+          {
+            name: 'Red Sea',
+            code: 'BA',
+          },
+          {
+            name: 'Sohag',
+            code: 'SHG',
+          },
+          {
+            name: 'South Sinai',
+            code: 'JS',
+          },
+          {
+            name: 'Suez',
+            code: 'SUZ',
+          },
         ],
       },
       {
@@ -1963,6 +2701,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1991,6 +2732,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -2017,6 +2761,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2045,9 +2792,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2071,6 +2821,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2099,6 +2852,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -2125,6 +2881,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2153,9 +2912,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2179,6 +2941,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2207,9 +2972,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2233,6 +3001,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2261,9 +3032,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2288,9 +3062,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2314,6 +3091,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2342,6 +3122,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -2368,6 +3151,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2396,9 +3182,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2422,6 +3211,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2450,6 +3242,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -2476,6 +3271,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2504,9 +3302,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2531,9 +3332,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2557,6 +3361,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2585,9 +3392,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2612,6 +3422,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -2619,28 +3432,94 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province}_{zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Alta Verapaz', code: 'AVE'},
-          {name: 'Baja Verapaz', code: 'BVE'},
-          {name: 'Chimaltenango', code: 'CMT'},
-          {name: 'Chiquimula', code: 'CQM'},
-          {name: 'El Progreso', code: 'EPR'},
-          {name: 'Escuintla', code: 'ESC'},
-          {name: 'Guatemala', code: 'GUA'},
-          {name: 'Huehuetenango', code: 'HUE'},
-          {name: 'Izabal', code: 'IZA'},
-          {name: 'Jalapa', code: 'JAL'},
-          {name: 'Jutiapa', code: 'JUT'},
-          {name: 'Petén', code: 'PET'},
-          {name: 'Quetzaltenango', code: 'QUE'},
-          {name: 'Quiché', code: 'QUI'},
-          {name: 'Retalhuleu', code: 'RET'},
-          {name: 'Sacatepéquez', code: 'SAC'},
-          {name: 'San Marcos', code: 'SMA'},
-          {name: 'Santa Rosa', code: 'SRO'},
-          {name: 'Sololá', code: 'SOL'},
-          {name: 'Suchitepéquez', code: 'SUC'},
-          {name: 'Totonicapán', code: 'TOT'},
-          {name: 'Zacapa', code: 'ZAC'},
+          {
+            name: 'Alta Verapaz',
+            code: 'AVE',
+          },
+          {
+            name: 'Baja Verapaz',
+            code: 'BVE',
+          },
+          {
+            name: 'Chimaltenango',
+            code: 'CMT',
+          },
+          {
+            name: 'Chiquimula',
+            code: 'CQM',
+          },
+          {
+            name: 'El Progreso',
+            code: 'EPR',
+          },
+          {
+            name: 'Escuintla',
+            code: 'ESC',
+          },
+          {
+            name: 'Guatemala',
+            code: 'GUA',
+          },
+          {
+            name: 'Huehuetenango',
+            code: 'HUE',
+          },
+          {
+            name: 'Izabal',
+            code: 'IZA',
+          },
+          {
+            name: 'Jalapa',
+            code: 'JAL',
+          },
+          {
+            name: 'Jutiapa',
+            code: 'JUT',
+          },
+          {
+            name: 'Petén',
+            code: 'PET',
+          },
+          {
+            name: 'Quetzaltenango',
+            code: 'QUE',
+          },
+          {
+            name: 'Quiché',
+            code: 'QUI',
+          },
+          {
+            name: 'Retalhuleu',
+            code: 'RET',
+          },
+          {
+            name: 'Sacatepéquez',
+            code: 'SAC',
+          },
+          {
+            name: 'San Marcos',
+            code: 'SMA',
+          },
+          {
+            name: 'Santa Rosa',
+            code: 'SRO',
+          },
+          {
+            name: 'Sololá',
+            code: 'SOL',
+          },
+          {
+            name: 'Suchitepéquez',
+            code: 'SUC',
+          },
+          {
+            name: 'Totonicapán',
+            code: 'TOT',
+          },
+          {
+            name: 'Zacapa',
+            code: 'ZAC',
+          },
         ],
       },
       {
@@ -2661,6 +3540,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2689,6 +3571,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -2716,9 +3601,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2742,6 +3630,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2770,9 +3661,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2796,6 +3690,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2824,9 +3721,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2842,7 +3742,7 @@ const data = {
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'District',
           company: 'Company',
           country: 'Country/Region',
           firstName: 'First name',
@@ -2851,6 +3751,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}_{phone}',
@@ -2858,9 +3761,18 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {country}_{phone}',
         },
         zones: [
-          {name: 'Hong Kong Island', code: 'HK'},
-          {name: 'Kowloon', code: 'KL'},
-          {name: 'New Territories', code: 'NT'},
+          {
+            name: 'Hong Kong Island',
+            code: 'HK',
+          },
+          {
+            name: 'Kowloon',
+            code: 'KL',
+          },
+          {
+            name: 'New Territories',
+            code: 'NT',
+          },
         ],
       },
       {
@@ -2881,6 +3793,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2909,9 +3824,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2936,6 +3854,9 @@ const data = {
           postalCode: 'PIN code',
           zone: 'State',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -2943,42 +3864,154 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Andaman and Nicobar Islands', code: 'AN'},
-          {name: 'Andhra Pradesh', code: 'AP'},
-          {name: 'Arunachal Pradesh', code: 'AR'},
-          {name: 'Assam', code: 'AS'},
-          {name: 'Bihar', code: 'BR'},
-          {name: 'Chandigarh', code: 'CH'},
-          {name: 'Chhattisgarh', code: 'CG'},
-          {name: 'Dadra and Nagar Haveli', code: 'DN'},
-          {name: 'Daman and Diu', code: 'DD'},
-          {name: 'Delhi', code: 'DL'},
-          {name: 'Goa', code: 'GA'},
-          {name: 'Gujarat', code: 'GJ'},
-          {name: 'Haryana', code: 'HR'},
-          {name: 'Himachal Pradesh', code: 'HP'},
-          {name: 'Jammu and Kashmir', code: 'JK'},
-          {name: 'Jharkhand', code: 'JH'},
-          {name: 'Karnataka', code: 'KA'},
-          {name: 'Kerala', code: 'KL'},
-          {name: 'Lakshadweep', code: 'LD'},
-          {name: 'Madhya Pradesh', code: 'MP'},
-          {name: 'Maharashtra', code: 'MH'},
-          {name: 'Manipur', code: 'MN'},
-          {name: 'Meghalaya', code: 'ML'},
-          {name: 'Mizoram', code: 'MZ'},
-          {name: 'Nagaland', code: 'NL'},
-          {name: 'Odisha', code: 'OR'},
-          {name: 'Puducherry', code: 'PY'},
-          {name: 'Punjab', code: 'PB'},
-          {name: 'Rajasthan', code: 'RJ'},
-          {name: 'Sikkim', code: 'SK'},
-          {name: 'Tamil Nadu', code: 'TN'},
-          {name: 'Telangana', code: 'TS'},
-          {name: 'Tripura', code: 'TR'},
-          {name: 'Uttar Pradesh', code: 'UP'},
-          {name: 'Uttarakhand', code: 'UK'},
-          {name: 'West Bengal', code: 'WB'},
+          {
+            name: 'Andaman and Nicobar Islands',
+            code: 'AN',
+          },
+          {
+            name: 'Andhra Pradesh',
+            code: 'AP',
+          },
+          {
+            name: 'Arunachal Pradesh',
+            code: 'AR',
+          },
+          {
+            name: 'Assam',
+            code: 'AS',
+          },
+          {
+            name: 'Bihar',
+            code: 'BR',
+          },
+          {
+            name: 'Chandigarh',
+            code: 'CH',
+          },
+          {
+            name: 'Chhattisgarh',
+            code: 'CG',
+          },
+          {
+            name: 'Dadra and Nagar Haveli',
+            code: 'DN',
+          },
+          {
+            name: 'Daman and Diu',
+            code: 'DD',
+          },
+          {
+            name: 'Delhi',
+            code: 'DL',
+          },
+          {
+            name: 'Goa',
+            code: 'GA',
+          },
+          {
+            name: 'Gujarat',
+            code: 'GJ',
+          },
+          {
+            name: 'Haryana',
+            code: 'HR',
+          },
+          {
+            name: 'Himachal Pradesh',
+            code: 'HP',
+          },
+          {
+            name: 'Jammu and Kashmir',
+            code: 'JK',
+          },
+          {
+            name: 'Jharkhand',
+            code: 'JH',
+          },
+          {
+            name: 'Karnataka',
+            code: 'KA',
+          },
+          {
+            name: 'Kerala',
+            code: 'KL',
+          },
+          {
+            name: 'Ladakh',
+            code: 'LA',
+          },
+          {
+            name: 'Lakshadweep',
+            code: 'LD',
+          },
+          {
+            name: 'Madhya Pradesh',
+            code: 'MP',
+          },
+          {
+            name: 'Maharashtra',
+            code: 'MH',
+          },
+          {
+            name: 'Manipur',
+            code: 'MN',
+          },
+          {
+            name: 'Meghalaya',
+            code: 'ML',
+          },
+          {
+            name: 'Mizoram',
+            code: 'MZ',
+          },
+          {
+            name: 'Nagaland',
+            code: 'NL',
+          },
+          {
+            name: 'Odisha',
+            code: 'OR',
+          },
+          {
+            name: 'Puducherry',
+            code: 'PY',
+          },
+          {
+            name: 'Punjab',
+            code: 'PB',
+          },
+          {
+            name: 'Rajasthan',
+            code: 'RJ',
+          },
+          {
+            name: 'Sikkim',
+            code: 'SK',
+          },
+          {
+            name: 'Tamil Nadu',
+            code: 'TN',
+          },
+          {
+            name: 'Telangana',
+            code: 'TS',
+          },
+          {
+            name: 'Tripura',
+            code: 'TR',
+          },
+          {
+            name: 'Uttar Pradesh',
+            code: 'UP',
+          },
+          {
+            name: 'Uttarakhand',
+            code: 'UK',
+          },
+          {
+            name: 'West Bengal',
+            code: 'WB',
+          },
         ],
       },
       {
@@ -3000,6 +4033,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{country}_{phone}',
@@ -3007,40 +4043,142 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Aceh', code: 'AC'},
-          {name: 'Bali', code: 'BA'},
-          {name: 'Bangka–Belitung Islands', code: 'BB'},
-          {name: 'Banten', code: 'BT'},
-          {name: 'Bengkulu', code: 'BE'},
-          {name: 'Gorontalo', code: 'GO'},
-          {name: 'Jakarta', code: 'JK'},
-          {name: 'Jambi', code: 'JA'},
-          {name: 'West Java', code: 'JB'},
-          {name: 'Central Java', code: 'JT'},
-          {name: 'East Java', code: 'JI'},
-          {name: 'West Kalimantan', code: 'KB'},
-          {name: 'South Kalimantan', code: 'KS'},
-          {name: 'Central Kalimantan', code: 'KT'},
-          {name: 'East Kalimantan', code: 'KI'},
-          {name: 'North Kalimantan', code: 'KU'},
-          {name: 'Riau Islands', code: 'KR'},
-          {name: 'Lampung', code: 'LA'},
-          {name: 'Maluku', code: 'MA'},
-          {name: 'North Maluku', code: 'MU'},
-          {name: 'West Nusa Tenggara', code: 'NB'},
-          {name: 'East Nusa Tenggara', code: 'NT'},
-          {name: 'Papua', code: 'PA'},
-          {name: 'West Papua', code: 'PB'},
-          {name: 'Riau', code: 'RI'},
-          {name: 'West Sulawesi', code: 'SR'},
-          {name: 'South Sulawesi', code: 'SN'},
-          {name: 'Central Sulawesi', code: 'ST'},
-          {name: 'Southeast Sulawesi', code: 'SG'},
-          {name: 'North Sulawesi', code: 'SA'},
-          {name: 'West Sumatra', code: 'SB'},
-          {name: 'South Sumatra', code: 'SS'},
-          {name: 'North Sumatra', code: 'SU'},
-          {name: 'Yogyakarta', code: 'YO'},
+          {
+            name: 'Aceh',
+            code: 'AC',
+          },
+          {
+            name: 'Bali',
+            code: 'BA',
+          },
+          {
+            name: 'Bangka–Belitung Islands',
+            code: 'BB',
+          },
+          {
+            name: 'Banten',
+            code: 'BT',
+          },
+          {
+            name: 'Bengkulu',
+            code: 'BE',
+          },
+          {
+            name: 'Gorontalo',
+            code: 'GO',
+          },
+          {
+            name: 'Jakarta',
+            code: 'JK',
+          },
+          {
+            name: 'Jambi',
+            code: 'JA',
+          },
+          {
+            name: 'West Java',
+            code: 'JB',
+          },
+          {
+            name: 'Central Java',
+            code: 'JT',
+          },
+          {
+            name: 'East Java',
+            code: 'JI',
+          },
+          {
+            name: 'West Kalimantan',
+            code: 'KB',
+          },
+          {
+            name: 'South Kalimantan',
+            code: 'KS',
+          },
+          {
+            name: 'Central Kalimantan',
+            code: 'KT',
+          },
+          {
+            name: 'East Kalimantan',
+            code: 'KI',
+          },
+          {
+            name: 'North Kalimantan',
+            code: 'KU',
+          },
+          {
+            name: 'Riau Islands',
+            code: 'KR',
+          },
+          {
+            name: 'Lampung',
+            code: 'LA',
+          },
+          {
+            name: 'Maluku',
+            code: 'MA',
+          },
+          {
+            name: 'North Maluku',
+            code: 'MU',
+          },
+          {
+            name: 'North Sumatra',
+            code: 'SU',
+          },
+          {
+            name: 'West Nusa Tenggara',
+            code: 'NB',
+          },
+          {
+            name: 'East Nusa Tenggara',
+            code: 'NT',
+          },
+          {
+            name: 'Papua',
+            code: 'PA',
+          },
+          {
+            name: 'West Papua',
+            code: 'PB',
+          },
+          {
+            name: 'Riau',
+            code: 'RI',
+          },
+          {
+            name: 'South Sumatra',
+            code: 'SS',
+          },
+          {
+            name: 'West Sulawesi',
+            code: 'SR',
+          },
+          {
+            name: 'South Sulawesi',
+            code: 'SN',
+          },
+          {
+            name: 'Central Sulawesi',
+            code: 'ST',
+          },
+          {
+            name: 'Southeast Sulawesi',
+            code: 'SG',
+          },
+          {
+            name: 'North Sulawesi',
+            code: 'SA',
+          },
+          {
+            name: 'West Sumatra',
+            code: 'SB',
+          },
+          {
+            name: 'Yogyakarta',
+            code: 'YO',
+          },
         ],
       },
       {
@@ -3062,9 +4200,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3088,6 +4229,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3116,6 +4260,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'County',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -3123,32 +4270,110 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Carlow', code: 'CW'},
-          {name: 'Cavan', code: 'CN'},
-          {name: 'Clare', code: 'CE'},
-          {name: 'Cork', code: 'CO'},
-          {name: 'Donegal', code: 'DL'},
-          {name: 'Dublin', code: 'D'},
-          {name: 'Galway', code: 'G'},
-          {name: 'Kerry', code: 'KY'},
-          {name: 'Kildare', code: 'KE'},
-          {name: 'Kilkenny', code: 'KK'},
-          {name: 'Laois', code: 'LS'},
-          {name: 'Leitrim', code: 'LM'},
-          {name: 'Limerick', code: 'LK'},
-          {name: 'Longford', code: 'LD'},
-          {name: 'Louth', code: 'LH'},
-          {name: 'Mayo', code: 'MO'},
-          {name: 'Meath', code: 'MH'},
-          {name: 'Monaghan', code: 'MN'},
-          {name: 'Offaly', code: 'OY'},
-          {name: 'Roscommon', code: 'RN'},
-          {name: 'Sligo', code: 'SO'},
-          {name: 'Tipperary', code: 'TA'},
-          {name: 'Waterford', code: 'WD'},
-          {name: 'Westmeath', code: 'WH'},
-          {name: 'Wexford', code: 'WX'},
-          {name: 'Wicklow', code: 'WW'},
+          {
+            name: 'Carlow',
+            code: 'CW',
+          },
+          {
+            name: 'Cavan',
+            code: 'CN',
+          },
+          {
+            name: 'Clare',
+            code: 'CE',
+          },
+          {
+            name: 'Cork',
+            code: 'CO',
+          },
+          {
+            name: 'Donegal',
+            code: 'DL',
+          },
+          {
+            name: 'Dublin',
+            code: 'D',
+          },
+          {
+            name: 'Galway',
+            code: 'G',
+          },
+          {
+            name: 'Kerry',
+            code: 'KY',
+          },
+          {
+            name: 'Kildare',
+            code: 'KE',
+          },
+          {
+            name: 'Kilkenny',
+            code: 'KK',
+          },
+          {
+            name: 'Laois',
+            code: 'LS',
+          },
+          {
+            name: 'Leitrim',
+            code: 'LM',
+          },
+          {
+            name: 'Limerick',
+            code: 'LK',
+          },
+          {
+            name: 'Longford',
+            code: 'LD',
+          },
+          {
+            name: 'Louth',
+            code: 'LH',
+          },
+          {
+            name: 'Mayo',
+            code: 'MO',
+          },
+          {
+            name: 'Meath',
+            code: 'MH',
+          },
+          {
+            name: 'Monaghan',
+            code: 'MN',
+          },
+          {
+            name: 'Offaly',
+            code: 'OY',
+          },
+          {
+            name: 'Roscommon',
+            code: 'RN',
+          },
+          {
+            name: 'Sligo',
+            code: 'SO',
+          },
+          {
+            name: 'Tipperary',
+            code: 'TA',
+          },
+          {
+            name: 'Waterford',
+            code: 'WD',
+          },
+          {
+            name: 'Westmeath',
+            code: 'WH',
+          },
+          {
+            name: 'Wexford',
+            code: 'WX',
+          },
+          {
+            name: 'Wicklow',
+            code: 'WW',
+          },
         ],
       },
       {
@@ -3169,6 +4394,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3197,9 +4425,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3213,7 +4444,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'PROVINCE',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -3224,123 +4455,456 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Agrigento', code: 'AG'},
-          {name: 'Alessandria', code: 'AL'},
-          {name: 'Ancona', code: 'AN'},
-          {name: 'Aosta', code: 'AO'},
-          {name: 'Arezzo', code: 'AR'},
-          {name: 'Ascoli Piceno', code: 'AP'},
-          {name: 'Asti', code: 'AT'},
-          {name: 'Avellino', code: 'AV'},
-          {name: 'Bari', code: 'BA'},
-          {name: 'Barletta-Andria-Trani', code: 'BT'},
-          {name: 'Belluno', code: 'BL'},
-          {name: 'Benevento', code: 'BN'},
-          {name: 'Bergamo', code: 'BG'},
-          {name: 'Biella', code: 'BI'},
-          {name: 'Bologna', code: 'BO'},
-          {name: 'South Tyrol', code: 'BZ'},
-          {name: 'Brescia', code: 'BS'},
-          {name: 'Brindisi', code: 'BR'},
-          {name: 'Cagliari', code: 'CA'},
-          {name: 'Caltanissetta', code: 'CL'},
-          {name: 'Campobasso', code: 'CB'},
-          {name: 'Carbonia-Iglesias', code: 'CI'},
-          {name: 'Caserta', code: 'CE'},
-          {name: 'Catania', code: 'CT'},
-          {name: 'Catanzaro', code: 'CZ'},
-          {name: 'Chieti', code: 'CH'},
-          {name: 'Como', code: 'CO'},
-          {name: 'Cosenza', code: 'CS'},
-          {name: 'Cremona', code: 'CR'},
-          {name: 'Crotone', code: 'KR'},
-          {name: 'Cuneo', code: 'CN'},
-          {name: 'Enna', code: 'EN'},
-          {name: 'Fermo', code: 'FM'},
-          {name: 'Ferrara', code: 'FE'},
-          {name: 'Florence', code: 'FI'},
-          {name: 'Foggia', code: 'FG'},
-          {name: 'Forlì-Cesena', code: 'FC'},
-          {name: 'Frosinone', code: 'FR'},
-          {name: 'Genoa', code: 'GE'},
-          {name: 'Gorizia', code: 'GO'},
-          {name: 'Grosseto', code: 'GR'},
-          {name: 'Imperia', code: 'IM'},
-          {name: 'Isernia', code: 'IS'},
-          {name: 'L’Aquila', code: 'AQ'},
-          {name: 'La Spezia', code: 'SP'},
-          {name: 'Latina', code: 'LT'},
-          {name: 'Lecce', code: 'LE'},
-          {name: 'Lecco', code: 'LC'},
-          {name: 'Livorno', code: 'LI'},
-          {name: 'Lodi', code: 'LO'},
-          {name: 'Lucca', code: 'LU'},
-          {name: 'Macerata', code: 'MC'},
-          {name: 'Mantua', code: 'MN'},
-          {name: 'Massa and Carrara', code: 'MS'},
-          {name: 'Matera', code: 'MT'},
-          {name: 'Medio Campidano', code: 'VS'},
-          {name: 'Messina', code: 'ME'},
-          {name: 'Milan', code: 'MI'},
-          {name: 'Modena', code: 'MO'},
-          {name: 'Monza and Brianza', code: 'MB'},
-          {name: 'Naples', code: 'NA'},
-          {name: 'Novara', code: 'NO'},
-          {name: 'Nuoro', code: 'NU'},
-          {name: 'Ogliastra', code: 'OG'},
-          {name: 'Olbia-Tempio', code: 'OT'},
-          {name: 'Oristano', code: 'OR'},
-          {name: 'Padua', code: 'PD'},
-          {name: 'Palermo', code: 'PA'},
-          {name: 'Parma', code: 'PR'},
-          {name: 'Pavia', code: 'PV'},
-          {name: 'Perugia', code: 'PG'},
-          {name: 'Pesaro and Urbino', code: 'PU'},
-          {name: 'Pescara', code: 'PE'},
-          {name: 'Piacenza', code: 'PC'},
-          {name: 'Pisa', code: 'PI'},
-          {name: 'Pistoia', code: 'PT'},
-          {name: 'Pordenone', code: 'PN'},
-          {name: 'Potenza', code: 'PZ'},
-          {name: 'Prato', code: 'PO'},
-          {name: 'Ragusa', code: 'RG'},
-          {name: 'Ravenna', code: 'RA'},
-          {name: 'Reggio Calabria', code: 'RC'},
-          {name: 'Reggio Emilia', code: 'RE'},
-          {name: 'Rieti', code: 'RI'},
-          {name: 'Rimini', code: 'RN'},
-          {name: 'Rome', code: 'RM'},
-          {name: 'Rovigo', code: 'RO'},
-          {name: 'Salerno', code: 'SA'},
-          {name: 'Sassari', code: 'SS'},
-          {name: 'Savona', code: 'SV'},
-          {name: 'Siena', code: 'SI'},
-          {name: 'Syracuse', code: 'SR'},
-          {name: 'Sondrio', code: 'SO'},
-          {name: 'Taranto', code: 'TA'},
-          {name: 'Teramo', code: 'TE'},
-          {name: 'Terni', code: 'TR'},
-          {name: 'Turin', code: 'TO'},
-          {name: 'Trapani', code: 'TP'},
-          {name: 'Trentino', code: 'TN'},
-          {name: 'Treviso', code: 'TV'},
-          {name: 'Trieste', code: 'TS'},
-          {name: 'Udine', code: 'UD'},
-          {name: 'Varese', code: 'VA'},
-          {name: 'Venice', code: 'VE'},
-          {name: 'Verbano-Cusio-Ossola', code: 'VB'},
-          {name: 'Vercelli', code: 'VC'},
-          {name: 'Verona', code: 'VR'},
-          {name: 'Vibo Valentia', code: 'VV'},
-          {name: 'Vicenza', code: 'VI'},
-          {name: 'Viterbo', code: 'VT'},
+          {
+            name: 'Agrigento',
+            code: 'AG',
+          },
+          {
+            name: 'Alessandria',
+            code: 'AL',
+          },
+          {
+            name: 'Ancona',
+            code: 'AN',
+          },
+          {
+            name: 'Aosta',
+            code: 'AO',
+          },
+          {
+            name: 'Arezzo',
+            code: 'AR',
+          },
+          {
+            name: 'Ascoli Piceno',
+            code: 'AP',
+          },
+          {
+            name: 'Asti',
+            code: 'AT',
+          },
+          {
+            name: 'Avellino',
+            code: 'AV',
+          },
+          {
+            name: 'Bari',
+            code: 'BA',
+          },
+          {
+            name: 'Barletta-Andria-Trani',
+            code: 'BT',
+          },
+          {
+            name: 'Belluno',
+            code: 'BL',
+          },
+          {
+            name: 'Benevento',
+            code: 'BN',
+          },
+          {
+            name: 'Bergamo',
+            code: 'BG',
+          },
+          {
+            name: 'Biella',
+            code: 'BI',
+          },
+          {
+            name: 'Bologna',
+            code: 'BO',
+          },
+          {
+            name: 'South Tyrol',
+            code: 'BZ',
+          },
+          {
+            name: 'Brescia',
+            code: 'BS',
+          },
+          {
+            name: 'Brindisi',
+            code: 'BR',
+          },
+          {
+            name: 'Cagliari',
+            code: 'CA',
+          },
+          {
+            name: 'Caltanissetta',
+            code: 'CL',
+          },
+          {
+            name: 'Campobasso',
+            code: 'CB',
+          },
+          {
+            name: 'Carbonia-Iglesias',
+            code: 'CI',
+          },
+          {
+            name: 'Caserta',
+            code: 'CE',
+          },
+          {
+            name: 'Catania',
+            code: 'CT',
+          },
+          {
+            name: 'Catanzaro',
+            code: 'CZ',
+          },
+          {
+            name: 'Chieti',
+            code: 'CH',
+          },
+          {
+            name: 'Como',
+            code: 'CO',
+          },
+          {
+            name: 'Cosenza',
+            code: 'CS',
+          },
+          {
+            name: 'Cremona',
+            code: 'CR',
+          },
+          {
+            name: 'Crotone',
+            code: 'KR',
+          },
+          {
+            name: 'Cuneo',
+            code: 'CN',
+          },
+          {
+            name: 'Enna',
+            code: 'EN',
+          },
+          {
+            name: 'Fermo',
+            code: 'FM',
+          },
+          {
+            name: 'Ferrara',
+            code: 'FE',
+          },
+          {
+            name: 'Florence',
+            code: 'FI',
+          },
+          {
+            name: 'Foggia',
+            code: 'FG',
+          },
+          {
+            name: 'Forlì-Cesena',
+            code: 'FC',
+          },
+          {
+            name: 'Frosinone',
+            code: 'FR',
+          },
+          {
+            name: 'Genoa',
+            code: 'GE',
+          },
+          {
+            name: 'Gorizia',
+            code: 'GO',
+          },
+          {
+            name: 'Grosseto',
+            code: 'GR',
+          },
+          {
+            name: 'Imperia',
+            code: 'IM',
+          },
+          {
+            name: 'Isernia',
+            code: 'IS',
+          },
+          {
+            name: 'L’Aquila',
+            code: 'AQ',
+          },
+          {
+            name: 'La Spezia',
+            code: 'SP',
+          },
+          {
+            name: 'Latina',
+            code: 'LT',
+          },
+          {
+            name: 'Lecce',
+            code: 'LE',
+          },
+          {
+            name: 'Lecco',
+            code: 'LC',
+          },
+          {
+            name: 'Livorno',
+            code: 'LI',
+          },
+          {
+            name: 'Lodi',
+            code: 'LO',
+          },
+          {
+            name: 'Lucca',
+            code: 'LU',
+          },
+          {
+            name: 'Macerata',
+            code: 'MC',
+          },
+          {
+            name: 'Mantua',
+            code: 'MN',
+          },
+          {
+            name: 'Massa and Carrara',
+            code: 'MS',
+          },
+          {
+            name: 'Matera',
+            code: 'MT',
+          },
+          {
+            name: 'Medio Campidano',
+            code: 'VS',
+          },
+          {
+            name: 'Messina',
+            code: 'ME',
+          },
+          {
+            name: 'Milan',
+            code: 'MI',
+          },
+          {
+            name: 'Modena',
+            code: 'MO',
+          },
+          {
+            name: 'Monza and Brianza',
+            code: 'MB',
+          },
+          {
+            name: 'Naples',
+            code: 'NA',
+          },
+          {
+            name: 'Novara',
+            code: 'NO',
+          },
+          {
+            name: 'Nuoro',
+            code: 'NU',
+          },
+          {
+            name: 'Ogliastra',
+            code: 'OG',
+          },
+          {
+            name: 'Olbia-Tempio',
+            code: 'OT',
+          },
+          {
+            name: 'Oristano',
+            code: 'OR',
+          },
+          {
+            name: 'Padua',
+            code: 'PD',
+          },
+          {
+            name: 'Palermo',
+            code: 'PA',
+          },
+          {
+            name: 'Parma',
+            code: 'PR',
+          },
+          {
+            name: 'Pavia',
+            code: 'PV',
+          },
+          {
+            name: 'Perugia',
+            code: 'PG',
+          },
+          {
+            name: 'Pesaro and Urbino',
+            code: 'PU',
+          },
+          {
+            name: 'Pescara',
+            code: 'PE',
+          },
+          {
+            name: 'Piacenza',
+            code: 'PC',
+          },
+          {
+            name: 'Pisa',
+            code: 'PI',
+          },
+          {
+            name: 'Pistoia',
+            code: 'PT',
+          },
+          {
+            name: 'Pordenone',
+            code: 'PN',
+          },
+          {
+            name: 'Potenza',
+            code: 'PZ',
+          },
+          {
+            name: 'Prato',
+            code: 'PO',
+          },
+          {
+            name: 'Ragusa',
+            code: 'RG',
+          },
+          {
+            name: 'Ravenna',
+            code: 'RA',
+          },
+          {
+            name: 'Reggio Calabria',
+            code: 'RC',
+          },
+          {
+            name: 'Reggio Emilia',
+            code: 'RE',
+          },
+          {
+            name: 'Rieti',
+            code: 'RI',
+          },
+          {
+            name: 'Rimini',
+            code: 'RN',
+          },
+          {
+            name: 'Rome',
+            code: 'RM',
+          },
+          {
+            name: 'Rovigo',
+            code: 'RO',
+          },
+          {
+            name: 'Salerno',
+            code: 'SA',
+          },
+          {
+            name: 'Sassari',
+            code: 'SS',
+          },
+          {
+            name: 'Savona',
+            code: 'SV',
+          },
+          {
+            name: 'Siena',
+            code: 'SI',
+          },
+          {
+            name: 'Syracuse',
+            code: 'SR',
+          },
+          {
+            name: 'Sondrio',
+            code: 'SO',
+          },
+          {
+            name: 'Taranto',
+            code: 'TA',
+          },
+          {
+            name: 'Teramo',
+            code: 'TE',
+          },
+          {
+            name: 'Terni',
+            code: 'TR',
+          },
+          {
+            name: 'Turin',
+            code: 'TO',
+          },
+          {
+            name: 'Trapani',
+            code: 'TP',
+          },
+          {
+            name: 'Trentino',
+            code: 'TN',
+          },
+          {
+            name: 'Treviso',
+            code: 'TV',
+          },
+          {
+            name: 'Trieste',
+            code: 'TS',
+          },
+          {
+            name: 'Udine',
+            code: 'UD',
+          },
+          {
+            name: 'Varese',
+            code: 'VA',
+          },
+          {
+            name: 'Venice',
+            code: 'VE',
+          },
+          {
+            name: 'Verbano-Cusio-Ossola',
+            code: 'VB',
+          },
+          {
+            name: 'Vercelli',
+            code: 'VC',
+          },
+          {
+            name: 'Verona',
+            code: 'VR',
+          },
+          {
+            name: 'Vibo Valentia',
+            code: 'VV',
+          },
+          {
+            name: 'Vicenza',
+            code: 'VI',
+          },
+          {
+            name: 'Viterbo',
+            code: 'VT',
+          },
         ],
       },
       {
@@ -3362,6 +4926,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -3380,7 +4947,7 @@ const data = {
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'City/ward/town/village',
           company: 'Company',
           country: 'Country/Region',
           firstName: 'First name',
@@ -3389,6 +4956,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Prefecture',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{lastName}{firstName}_{company}_{country}{zip}_{province}_{city}_{address1}_{address2}_{phone}',
@@ -3396,53 +4966,194 @@ const data = {
             '{country} 〒{zip}_{province} {city}_{address1}_{address2}_{company}_{lastName} {firstName}様_{phone}',
         },
         zones: [
-          {name: 'Hokkaidō', code: 'JP-01'},
-          {name: 'Aomori', code: 'JP-02'},
-          {name: 'Iwate', code: 'JP-03'},
-          {name: 'Miyagi', code: 'JP-04'},
-          {name: 'Akita', code: 'JP-05'},
-          {name: 'Yamagata', code: 'JP-06'},
-          {name: 'Fukushima', code: 'JP-07'},
-          {name: 'Ibaraki', code: 'JP-08'},
-          {name: 'Tochigi', code: 'JP-09'},
-          {name: 'Gunma', code: 'JP-10'},
-          {name: 'Saitama', code: 'JP-11'},
-          {name: 'Chiba', code: 'JP-12'},
-          {name: 'Tokyo', code: 'JP-13'},
-          {name: 'Kanagawa', code: 'JP-14'},
-          {name: 'Niigata', code: 'JP-15'},
-          {name: 'Toyama', code: 'JP-16'},
-          {name: 'Ishikawa', code: 'JP-17'},
-          {name: 'Fukui', code: 'JP-18'},
-          {name: 'Yamanashi', code: 'JP-19'},
-          {name: 'Nagano', code: 'JP-20'},
-          {name: 'Gifu', code: 'JP-21'},
-          {name: 'Shizuoka', code: 'JP-22'},
-          {name: 'Aichi', code: 'JP-23'},
-          {name: 'Mie', code: 'JP-24'},
-          {name: 'Shiga', code: 'JP-25'},
-          {name: 'Kyōto', code: 'JP-26'},
-          {name: 'Ōsaka', code: 'JP-27'},
-          {name: 'Hyōgo', code: 'JP-28'},
-          {name: 'Nara', code: 'JP-29'},
-          {name: 'Wakayama', code: 'JP-30'},
-          {name: 'Tottori', code: 'JP-31'},
-          {name: 'Shimane', code: 'JP-32'},
-          {name: 'Okayama', code: 'JP-33'},
-          {name: 'Hiroshima', code: 'JP-34'},
-          {name: 'Yamaguchi', code: 'JP-35'},
-          {name: 'Tokushima', code: 'JP-36'},
-          {name: 'Kagawa', code: 'JP-37'},
-          {name: 'Ehime', code: 'JP-38'},
-          {name: 'Kōchi', code: 'JP-39'},
-          {name: 'Fukuoka', code: 'JP-40'},
-          {name: 'Saga', code: 'JP-41'},
-          {name: 'Nagasaki', code: 'JP-42'},
-          {name: 'Kumamoto', code: 'JP-43'},
-          {name: 'Ōita', code: 'JP-44'},
-          {name: 'Miyazaki', code: 'JP-45'},
-          {name: 'Kagoshima', code: 'JP-46'},
-          {name: 'Okinawa', code: 'JP-47'},
+          {
+            name: 'Hokkaidō',
+            code: 'JP-01',
+          },
+          {
+            name: 'Aomori',
+            code: 'JP-02',
+          },
+          {
+            name: 'Iwate',
+            code: 'JP-03',
+          },
+          {
+            name: 'Miyagi',
+            code: 'JP-04',
+          },
+          {
+            name: 'Akita',
+            code: 'JP-05',
+          },
+          {
+            name: 'Yamagata',
+            code: 'JP-06',
+          },
+          {
+            name: 'Fukushima',
+            code: 'JP-07',
+          },
+          {
+            name: 'Ibaraki',
+            code: 'JP-08',
+          },
+          {
+            name: 'Tochigi',
+            code: 'JP-09',
+          },
+          {
+            name: 'Gunma',
+            code: 'JP-10',
+          },
+          {
+            name: 'Saitama',
+            code: 'JP-11',
+          },
+          {
+            name: 'Chiba',
+            code: 'JP-12',
+          },
+          {
+            name: 'Tokyo',
+            code: 'JP-13',
+          },
+          {
+            name: 'Kanagawa',
+            code: 'JP-14',
+          },
+          {
+            name: 'Niigata',
+            code: 'JP-15',
+          },
+          {
+            name: 'Toyama',
+            code: 'JP-16',
+          },
+          {
+            name: 'Ishikawa',
+            code: 'JP-17',
+          },
+          {
+            name: 'Fukui',
+            code: 'JP-18',
+          },
+          {
+            name: 'Yamanashi',
+            code: 'JP-19',
+          },
+          {
+            name: 'Nagano',
+            code: 'JP-20',
+          },
+          {
+            name: 'Gifu',
+            code: 'JP-21',
+          },
+          {
+            name: 'Shizuoka',
+            code: 'JP-22',
+          },
+          {
+            name: 'Aichi',
+            code: 'JP-23',
+          },
+          {
+            name: 'Mie',
+            code: 'JP-24',
+          },
+          {
+            name: 'Shiga',
+            code: 'JP-25',
+          },
+          {
+            name: 'Kyōto',
+            code: 'JP-26',
+          },
+          {
+            name: 'Ōsaka',
+            code: 'JP-27',
+          },
+          {
+            name: 'Hyōgo',
+            code: 'JP-28',
+          },
+          {
+            name: 'Nara',
+            code: 'JP-29',
+          },
+          {
+            name: 'Wakayama',
+            code: 'JP-30',
+          },
+          {
+            name: 'Tottori',
+            code: 'JP-31',
+          },
+          {
+            name: 'Shimane',
+            code: 'JP-32',
+          },
+          {
+            name: 'Okayama',
+            code: 'JP-33',
+          },
+          {
+            name: 'Hiroshima',
+            code: 'JP-34',
+          },
+          {
+            name: 'Yamaguchi',
+            code: 'JP-35',
+          },
+          {
+            name: 'Tokushima',
+            code: 'JP-36',
+          },
+          {
+            name: 'Kagawa',
+            code: 'JP-37',
+          },
+          {
+            name: 'Ehime',
+            code: 'JP-38',
+          },
+          {
+            name: 'Kōchi',
+            code: 'JP-39',
+          },
+          {
+            name: 'Fukuoka',
+            code: 'JP-40',
+          },
+          {
+            name: 'Saga',
+            code: 'JP-41',
+          },
+          {
+            name: 'Nagasaki',
+            code: 'JP-42',
+          },
+          {
+            name: 'Kumamoto',
+            code: 'JP-43',
+          },
+          {
+            name: 'Ōita',
+            code: 'JP-44',
+          },
+          {
+            name: 'Miyazaki',
+            code: 'JP-45',
+          },
+          {
+            name: 'Kagoshima',
+            code: 'JP-46',
+          },
+          {
+            name: 'Okinawa',
+            code: 'JP-47',
+          },
         ],
       },
       {
@@ -3463,6 +5174,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3491,6 +5205,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -3517,6 +5234,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3545,6 +5265,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -3571,6 +5294,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3599,9 +5325,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3625,6 +5354,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3653,9 +5385,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{zip}{city}_{address2}_{address1}_{company}_{firstName}{lastName}_{country}_{phone}',
           show:
             '{zip} {city}_{address2}_{address1}_{company}_{firstName} {lastName}_{country}_{phone}',
         },
@@ -3679,6 +5414,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3707,6 +5445,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -3733,6 +5474,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3761,6 +5505,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -3788,9 +5535,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3814,6 +5564,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3842,9 +5595,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3868,6 +5624,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3896,9 +5655,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3922,6 +5684,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3950,9 +5715,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3976,6 +5744,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4004,29 +5775,80 @@ const data = {
           postalCode: 'Postcode',
           zone: 'State/territory',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Johor', code: 'JHR'},
-          {name: 'Kedah', code: 'KDH'},
-          {name: 'Kelantan', code: 'KTN'},
-          {name: 'Kuala Lumpur', code: 'KUL'},
-          {name: 'Labuan', code: 'LBN'},
-          {name: 'Malacca', code: 'MLK'},
-          {name: 'Negeri Sembilan', code: 'NSN'},
-          {name: 'Pahang', code: 'PHG'},
-          {name: 'Perak', code: 'PRK'},
-          {name: 'Perlis', code: 'PLS'},
-          {name: 'Penang', code: 'PNG'},
-          {name: 'Putrajaya', code: 'PJY'},
-          {name: 'Sabah', code: 'SBH'},
-          {name: 'Sarawak', code: 'SWK'},
-          {name: 'Selangor', code: 'SGR'},
-          {name: 'Terengganu', code: 'TRG'},
+          {
+            name: 'Johor',
+            code: 'JHR',
+          },
+          {
+            name: 'Kedah',
+            code: 'KDH',
+          },
+          {
+            name: 'Kelantan',
+            code: 'KTN',
+          },
+          {
+            name: 'Kuala Lumpur',
+            code: 'KUL',
+          },
+          {
+            name: 'Labuan',
+            code: 'LBN',
+          },
+          {
+            name: 'Malacca',
+            code: 'MLK',
+          },
+          {
+            name: 'Negeri Sembilan',
+            code: 'NSN',
+          },
+          {
+            name: 'Pahang',
+            code: 'PHG',
+          },
+          {
+            name: 'Penang',
+            code: 'PNG',
+          },
+          {
+            name: 'Perak',
+            code: 'PRK',
+          },
+          {
+            name: 'Perlis',
+            code: 'PLS',
+          },
+          {
+            name: 'Putrajaya',
+            code: 'PJY',
+          },
+          {
+            name: 'Sabah',
+            code: 'SBH',
+          },
+          {
+            name: 'Sarawak',
+            code: 'SWK',
+          },
+          {
+            name: 'Selangor',
+            code: 'SGR',
+          },
+          {
+            name: 'Terengganu',
+            code: 'TRG',
+          },
         ],
       },
       {
@@ -4047,6 +5869,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4075,6 +5900,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -4101,6 +5929,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4129,9 +5960,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4155,6 +5989,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4183,6 +6020,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -4210,9 +6050,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4226,7 +6069,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'STATE',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -4237,45 +6080,144 @@ const data = {
           postalCode: 'Postal code',
           zone: 'State',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Aguascalientes', code: 'AGS'},
-          {name: 'Baja California', code: 'BC'},
-          {name: 'Baja California Sur', code: 'BCS'},
-          {name: 'Campeche', code: 'CAMP'},
-          {name: 'Chiapas', code: 'CHIS'},
-          {name: 'Chihuahua', code: 'CHIH'},
-          {name: 'Ciudad de Mexico', code: 'DF'},
-          {name: 'Coahuila', code: 'COAH'},
-          {name: 'Colima', code: 'COL'},
-          {name: 'Durango', code: 'DGO'},
-          {name: 'Guanajuato', code: 'GTO'},
-          {name: 'Guerrero', code: 'GRO'},
-          {name: 'Hidalgo', code: 'HGO'},
-          {name: 'Jalisco', code: 'JAL'},
-          {name: 'Mexico State', code: 'MEX'},
-          {name: 'Michoacán', code: 'MICH'},
-          {name: 'Morelos', code: 'MOR'},
-          {name: 'Nayarit', code: 'NAY'},
-          {name: 'Nuevo León', code: 'NL'},
-          {name: 'Oaxaca', code: 'OAX'},
-          {name: 'Puebla', code: 'PUE'},
-          {name: 'Querétaro', code: 'QRO'},
-          {name: 'Quintana Roo', code: 'Q ROO'},
-          {name: 'San Luis Potosí', code: 'SLP'},
-          {name: 'Sinaloa', code: 'SIN'},
-          {name: 'Sonora', code: 'SON'},
-          {name: 'Tabasco', code: 'TAB'},
-          {name: 'Tamaulipas', code: 'TAMPS'},
-          {name: 'Tlaxcala', code: 'TLAX'},
-          {name: 'Veracruz', code: 'VER'},
-          {name: 'Yucatán', code: 'YUC'},
-          {name: 'Zacatecas', code: 'ZAC'},
+          {
+            name: 'Aguascalientes',
+            code: 'AGS',
+          },
+          {
+            name: 'Baja California',
+            code: 'BC',
+          },
+          {
+            name: 'Baja California Sur',
+            code: 'BCS',
+          },
+          {
+            name: 'Campeche',
+            code: 'CAMP',
+          },
+          {
+            name: 'Chiapas',
+            code: 'CHIS',
+          },
+          {
+            name: 'Chihuahua',
+            code: 'CHIH',
+          },
+          {
+            name: 'Ciudad de Mexico',
+            code: 'DF',
+          },
+          {
+            name: 'Coahuila',
+            code: 'COAH',
+          },
+          {
+            name: 'Colima',
+            code: 'COL',
+          },
+          {
+            name: 'Durango',
+            code: 'DGO',
+          },
+          {
+            name: 'Guanajuato',
+            code: 'GTO',
+          },
+          {
+            name: 'Guerrero',
+            code: 'GRO',
+          },
+          {
+            name: 'Hidalgo',
+            code: 'HGO',
+          },
+          {
+            name: 'Jalisco',
+            code: 'JAL',
+          },
+          {
+            name: 'Mexico State',
+            code: 'MEX',
+          },
+          {
+            name: 'Michoacán',
+            code: 'MICH',
+          },
+          {
+            name: 'Morelos',
+            code: 'MOR',
+          },
+          {
+            name: 'Nayarit',
+            code: 'NAY',
+          },
+          {
+            name: 'Nuevo León',
+            code: 'NL',
+          },
+          {
+            name: 'Oaxaca',
+            code: 'OAX',
+          },
+          {
+            name: 'Puebla',
+            code: 'PUE',
+          },
+          {
+            name: 'Querétaro',
+            code: 'QRO',
+          },
+          {
+            name: 'Quintana Roo',
+            code: 'Q ROO',
+          },
+          {
+            name: 'San Luis Potosí',
+            code: 'SLP',
+          },
+          {
+            name: 'Sinaloa',
+            code: 'SIN',
+          },
+          {
+            name: 'Sonora',
+            code: 'SON',
+          },
+          {
+            name: 'Tabasco',
+            code: 'TAB',
+          },
+          {
+            name: 'Tamaulipas',
+            code: 'TAMPS',
+          },
+          {
+            name: 'Tlaxcala',
+            code: 'TLAX',
+          },
+          {
+            name: 'Veracruz',
+            code: 'VER',
+          },
+          {
+            name: 'Yucatán',
+            code: 'YUC',
+          },
+          {
+            name: 'Zacatecas',
+            code: 'ZAC',
+          },
         ],
       },
       {
@@ -4295,11 +6237,14 @@ const data = {
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4324,9 +6269,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4349,7 +6297,10 @@ const data = {
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4378,9 +6329,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4404,6 +6358,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4432,9 +6389,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4459,9 +6419,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4485,6 +6448,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4513,6 +6479,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -4539,6 +6508,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4567,6 +6539,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -4583,7 +6558,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'REGION',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -4594,9 +6569,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4620,6 +6598,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4648,9 +6629,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4675,6 +6659,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -4682,22 +6669,70 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Auckland', code: 'AUK'},
-          {name: 'Bay of Plenty', code: 'BOP'},
-          {name: 'Canterbury', code: 'CAN'},
-          {name: 'Gisborne', code: 'GIS'},
-          {name: 'Hawke’s Bay', code: 'HKB'},
-          {name: 'Manawatu-Wanganui', code: 'MWT'},
-          {name: 'Marlborough', code: 'MBH'},
-          {name: 'Nelson', code: 'NSN'},
-          {name: 'Northland', code: 'NTL'},
-          {name: 'Otago', code: 'OTA'},
-          {name: 'Southland', code: 'STL'},
-          {name: 'Taranaki', code: 'TKI'},
-          {name: 'Tasman', code: 'TAS'},
-          {name: 'Waikato', code: 'WKO'},
-          {name: 'Wellington', code: 'WGN'},
-          {name: 'West Coast', code: 'WTC'},
+          {
+            name: 'Auckland',
+            code: 'AUK',
+          },
+          {
+            name: 'Bay of Plenty',
+            code: 'BOP',
+          },
+          {
+            name: 'Canterbury',
+            code: 'CAN',
+          },
+          {
+            name: 'Gisborne',
+            code: 'GIS',
+          },
+          {
+            name: 'Hawke’s Bay',
+            code: 'HKB',
+          },
+          {
+            name: 'Manawatu-Wanganui',
+            code: 'MWT',
+          },
+          {
+            name: 'Marlborough',
+            code: 'MBH',
+          },
+          {
+            name: 'Nelson',
+            code: 'NSN',
+          },
+          {
+            name: 'Northland',
+            code: 'NTL',
+          },
+          {
+            name: 'Otago',
+            code: 'OTA',
+          },
+          {
+            name: 'Southland',
+            code: 'STL',
+          },
+          {
+            name: 'Taranaki',
+            code: 'TKI',
+          },
+          {
+            name: 'Tasman',
+            code: 'TAS',
+          },
+          {
+            name: 'Waikato',
+            code: 'WKO',
+          },
+          {
+            name: 'Wellington',
+            code: 'WGN',
+          },
+          {
+            name: 'West Coast',
+            code: 'WTC',
+          },
         ],
       },
       {
@@ -4719,9 +6754,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -4746,9 +6784,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4773,6 +6814,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'State',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -4780,43 +6824,154 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Abia', code: 'AB'},
-          {name: 'Federal Capital Territory', code: 'FC'},
-          {name: 'Adamawa', code: 'AD'},
-          {name: 'Akwa Ibom', code: 'AK'},
-          {name: 'Anambra', code: 'AN'},
-          {name: 'Bauchi', code: 'BA'},
-          {name: 'Bayelsa', code: 'BY'},
-          {name: 'Benue', code: 'BE'},
-          {name: 'Borno', code: 'BO'},
-          {name: 'Cross River', code: 'CR'},
-          {name: 'Delta', code: 'DE'},
-          {name: 'Ebonyi', code: 'EB'},
-          {name: 'Edo', code: 'ED'},
-          {name: 'Ekiti', code: 'EK'},
-          {name: 'Enugu', code: 'EN'},
-          {name: 'Gombe', code: 'GO'},
-          {name: 'Imo', code: 'IM'},
-          {name: 'Jigawa', code: 'JI'},
-          {name: 'Kaduna', code: 'KD'},
-          {name: 'Kano', code: 'KN'},
-          {name: 'Katsina', code: 'KT'},
-          {name: 'Kebbi', code: 'KE'},
-          {name: 'Kogi', code: 'KO'},
-          {name: 'Kwara', code: 'KW'},
-          {name: 'Lagos', code: 'LA'},
-          {name: 'Nasarawa', code: 'NA'},
-          {name: 'Niger', code: 'NI'},
-          {name: 'Ogun', code: 'OG'},
-          {name: 'Ondo', code: 'ON'},
-          {name: 'Osun', code: 'OS'},
-          {name: 'Oyo', code: 'OY'},
-          {name: 'Plateau', code: 'PL'},
-          {name: 'Rivers', code: 'RI'},
-          {name: 'Sokoto', code: 'SO'},
-          {name: 'Taraba', code: 'TA'},
-          {name: 'Yobe', code: 'YO'},
-          {name: 'Zamfara', code: 'ZA'},
+          {
+            name: 'Abia',
+            code: 'AB',
+          },
+          {
+            name: 'Federal Capital Territory',
+            code: 'FC',
+          },
+          {
+            name: 'Adamawa',
+            code: 'AD',
+          },
+          {
+            name: 'Akwa Ibom',
+            code: 'AK',
+          },
+          {
+            name: 'Anambra',
+            code: 'AN',
+          },
+          {
+            name: 'Bauchi',
+            code: 'BA',
+          },
+          {
+            name: 'Bayelsa',
+            code: 'BY',
+          },
+          {
+            name: 'Benue',
+            code: 'BE',
+          },
+          {
+            name: 'Borno',
+            code: 'BO',
+          },
+          {
+            name: 'Cross River',
+            code: 'CR',
+          },
+          {
+            name: 'Delta',
+            code: 'DE',
+          },
+          {
+            name: 'Ebonyi',
+            code: 'EB',
+          },
+          {
+            name: 'Edo',
+            code: 'ED',
+          },
+          {
+            name: 'Ekiti',
+            code: 'EK',
+          },
+          {
+            name: 'Enugu',
+            code: 'EN',
+          },
+          {
+            name: 'Gombe',
+            code: 'GO',
+          },
+          {
+            name: 'Imo',
+            code: 'IM',
+          },
+          {
+            name: 'Jigawa',
+            code: 'JI',
+          },
+          {
+            name: 'Kaduna',
+            code: 'KD',
+          },
+          {
+            name: 'Kano',
+            code: 'KN',
+          },
+          {
+            name: 'Katsina',
+            code: 'KT',
+          },
+          {
+            name: 'Kebbi',
+            code: 'KE',
+          },
+          {
+            name: 'Kogi',
+            code: 'KO',
+          },
+          {
+            name: 'Kwara',
+            code: 'KW',
+          },
+          {
+            name: 'Lagos',
+            code: 'LA',
+          },
+          {
+            name: 'Nasarawa',
+            code: 'NA',
+          },
+          {
+            name: 'Niger',
+            code: 'NI',
+          },
+          {
+            name: 'Ogun',
+            code: 'OG',
+          },
+          {
+            name: 'Ondo',
+            code: 'ON',
+          },
+          {
+            name: 'Osun',
+            code: 'OS',
+          },
+          {
+            name: 'Oyo',
+            code: 'OY',
+          },
+          {
+            name: 'Plateau',
+            code: 'PL',
+          },
+          {
+            name: 'Rivers',
+            code: 'RI',
+          },
+          {
+            name: 'Sokoto',
+            code: 'SO',
+          },
+          {
+            name: 'Taraba',
+            code: 'TA',
+          },
+          {
+            name: 'Yobe',
+            code: 'YO',
+          },
+          {
+            name: 'Zamfara',
+            code: 'ZA',
+          },
         ],
       },
       {
@@ -4837,6 +6992,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4865,6 +7023,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -4891,6 +7052,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4919,9 +7083,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4935,7 +7102,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'REGION',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -4946,9 +7113,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4973,9 +7143,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -4999,6 +7172,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5027,6 +7203,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -5054,6 +7233,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}_{phone}',
@@ -5061,19 +7243,58 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Bocas del Toro', code: 'PA-1'},
-          {name: 'Chiriquí', code: 'PA-4'},
-          {name: 'Coclé', code: 'PA-2'},
-          {name: 'Colón', code: 'PA-3'},
-          {name: 'Darién', code: 'PA-5'},
-          {name: 'Emberá', code: 'PA-EM'},
-          {name: 'Herrera', code: 'PA-6'},
-          {name: 'Guna Yala', code: 'PA-KY'},
-          {name: 'Los Santos', code: 'PA-7'},
-          {name: 'Ngöbe-Buglé', code: 'PA-NB'},
-          {name: 'Panamá', code: 'PA-8'},
-          {name: 'West Panamá', code: 'PA-10'},
-          {name: 'Veraguas', code: 'PA-9'},
+          {
+            name: 'Bocas del Toro',
+            code: 'PA-1',
+          },
+          {
+            name: 'Chiriquí',
+            code: 'PA-4',
+          },
+          {
+            name: 'Coclé',
+            code: 'PA-2',
+          },
+          {
+            name: 'Colón',
+            code: 'PA-3',
+          },
+          {
+            name: 'Darién',
+            code: 'PA-5',
+          },
+          {
+            name: 'Emberá',
+            code: 'PA-EM',
+          },
+          {
+            name: 'Herrera',
+            code: 'PA-6',
+          },
+          {
+            name: 'Guna Yala',
+            code: 'PA-KY',
+          },
+          {
+            name: 'Los Santos',
+            code: 'PA-7',
+          },
+          {
+            name: 'Ngöbe-Buglé',
+            code: 'PA-NB',
+          },
+          {
+            name: 'Panamá',
+            code: 'PA-8',
+          },
+          {
+            name: 'West Panamá',
+            code: 'PA-10',
+          },
+          {
+            name: 'Veraguas',
+            code: 'PA-9',
+          },
         ],
       },
       {
@@ -5094,6 +7315,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5120,11 +7344,14 @@ const data = {
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5149,6 +7376,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -5156,32 +7386,110 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Amazonas', code: 'PE-AMA'},
-          {name: 'Ancash', code: 'PE-ANC'},
-          {name: 'Apurímac', code: 'PE-APU'},
-          {name: 'Arequipa', code: 'PE-ARE'},
-          {name: 'Ayacucho', code: 'PE-AYA'},
-          {name: 'Cajamarca', code: 'PE-CAJ'},
-          {name: 'El Callao', code: 'PE-CAL'},
-          {name: 'Cusco', code: 'PE-CUS'},
-          {name: 'Huancavelica', code: 'PE-HUV'},
-          {name: 'Huánuco', code: 'PE-HUC'},
-          {name: 'Ica', code: 'PE-ICA'},
-          {name: 'Junín', code: 'PE-JUN'},
-          {name: 'La Libertad', code: 'PE-LAL'},
-          {name: 'Lambayeque', code: 'PE-LAM'},
-          {name: 'Lima Region', code: 'PE-LIM'},
-          {name: 'Lima', code: 'PE-LMA'},
-          {name: 'Loreto', code: 'PE-LOR'},
-          {name: 'Madre de Dios', code: 'PE-MDD'},
-          {name: 'Moquegua', code: 'PE-MOQ'},
-          {name: 'Pasco', code: 'PE-PAS'},
-          {name: 'Piura', code: 'PE-PIU'},
-          {name: 'Puno', code: 'PE-PUN'},
-          {name: 'San Martín', code: 'PE-SAM'},
-          {name: 'Tacna', code: 'PE-TAC'},
-          {name: 'Tumbes', code: 'PE-TUM'},
-          {name: 'Ucayali', code: 'PE-UCA'},
+          {
+            name: 'Amazonas',
+            code: 'PE-AMA',
+          },
+          {
+            name: 'Ancash',
+            code: 'PE-ANC',
+          },
+          {
+            name: 'Apurímac',
+            code: 'PE-APU',
+          },
+          {
+            name: 'Arequipa',
+            code: 'PE-ARE',
+          },
+          {
+            name: 'Ayacucho',
+            code: 'PE-AYA',
+          },
+          {
+            name: 'Cajamarca',
+            code: 'PE-CAJ',
+          },
+          {
+            name: 'El Callao',
+            code: 'PE-CAL',
+          },
+          {
+            name: 'Cusco',
+            code: 'PE-CUS',
+          },
+          {
+            name: 'Huancavelica',
+            code: 'PE-HUV',
+          },
+          {
+            name: 'Huánuco',
+            code: 'PE-HUC',
+          },
+          {
+            name: 'Ica',
+            code: 'PE-ICA',
+          },
+          {
+            name: 'Junín',
+            code: 'PE-JUN',
+          },
+          {
+            name: 'La Libertad',
+            code: 'PE-LAL',
+          },
+          {
+            name: 'Lambayeque',
+            code: 'PE-LAM',
+          },
+          {
+            name: 'Lima Region',
+            code: 'PE-LIM',
+          },
+          {
+            name: 'Lima',
+            code: 'PE-LMA',
+          },
+          {
+            name: 'Loreto',
+            code: 'PE-LOR',
+          },
+          {
+            name: 'Madre de Dios',
+            code: 'PE-MDD',
+          },
+          {
+            name: 'Moquegua',
+            code: 'PE-MOQ',
+          },
+          {
+            name: 'Pasco',
+            code: 'PE-PAS',
+          },
+          {
+            name: 'Piura',
+            code: 'PE-PIU',
+          },
+          {
+            name: 'Puno',
+            code: 'PE-PUN',
+          },
+          {
+            name: 'San Martín',
+            code: 'PE-SAM',
+          },
+          {
+            name: 'Tacna',
+            code: 'PE-TAC',
+          },
+          {
+            name: 'Tumbes',
+            code: 'PE-TUM',
+          },
+          {
+            name: 'Ucayali',
+            code: 'PE-UCA',
+          },
         ],
       },
       {
@@ -5203,9 +7511,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5230,9 +7541,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5257,9 +7571,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5284,6 +7601,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -5291,26 +7611,86 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Azores', code: 'PT-20'},
-          {name: 'Aveiro', code: 'PT-01'},
-          {name: 'Beja', code: 'PT-02'},
-          {name: 'Braga', code: 'PT-03'},
-          {name: 'Bragança', code: 'PT-04'},
-          {name: 'Castelo Branco', code: 'PT-05'},
-          {name: 'Coimbra', code: 'PT-06'},
-          {name: 'Évora', code: 'PT-07'},
-          {name: 'Faro', code: 'PT-08'},
-          {name: 'Guarda', code: 'PT-09'},
-          {name: 'Leiria', code: 'PT-10'},
-          {name: 'Lisbon', code: 'PT-11'},
-          {name: 'Madeira', code: 'PT-30'},
-          {name: 'Portalegre', code: 'PT-12'},
-          {name: 'Porto', code: 'PT-13'},
-          {name: 'Santarém', code: 'PT-14'},
-          {name: 'Setúbal', code: 'PT-15'},
-          {name: 'Viana do Castelo', code: 'PT-16'},
-          {name: 'Vila Real', code: 'PT-17'},
-          {name: 'Viseu', code: 'PT-18'},
+          {
+            name: 'Azores',
+            code: 'PT-20',
+          },
+          {
+            name: 'Aveiro',
+            code: 'PT-01',
+          },
+          {
+            name: 'Beja',
+            code: 'PT-02',
+          },
+          {
+            name: 'Braga',
+            code: 'PT-03',
+          },
+          {
+            name: 'Bragança',
+            code: 'PT-04',
+          },
+          {
+            name: 'Castelo Branco',
+            code: 'PT-05',
+          },
+          {
+            name: 'Coimbra',
+            code: 'PT-06',
+          },
+          {
+            name: 'Évora',
+            code: 'PT-07',
+          },
+          {
+            name: 'Faro',
+            code: 'PT-08',
+          },
+          {
+            name: 'Guarda',
+            code: 'PT-09',
+          },
+          {
+            name: 'Leiria',
+            code: 'PT-10',
+          },
+          {
+            name: 'Lisbon',
+            code: 'PT-11',
+          },
+          {
+            name: 'Madeira',
+            code: 'PT-30',
+          },
+          {
+            name: 'Portalegre',
+            code: 'PT-12',
+          },
+          {
+            name: 'Porto',
+            code: 'PT-13',
+          },
+          {
+            name: 'Santarém',
+            code: 'PT-14',
+          },
+          {
+            name: 'Setúbal',
+            code: 'PT-15',
+          },
+          {
+            name: 'Viana do Castelo',
+            code: 'PT-16',
+          },
+          {
+            name: 'Vila Real',
+            code: 'PT-17',
+          },
+          {
+            name: 'Viseu',
+            code: 'PT-18',
+          },
         ],
       },
       {
@@ -5331,6 +7711,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5359,9 +7742,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5386,55 +7772,184 @@ const data = {
           postalCode: 'Postal code',
           zone: 'County',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Alba', code: 'AB'},
-          {name: 'Arad', code: 'AR'},
-          {name: 'Argeș', code: 'AG'},
-          {name: 'Bacău', code: 'BC'},
-          {name: 'Bihor', code: 'BH'},
-          {name: 'Bistriţa-Năsăud', code: 'BN'},
-          {name: 'Botoşani', code: 'BT'},
-          {name: 'Brăila', code: 'BR'},
-          {name: 'Braşov', code: 'BV'},
-          {name: 'Bucharest', code: 'B'},
-          {name: 'Buzău', code: 'BZ'},
-          {name: 'Caraș-Severin', code: 'CS'},
-          {name: 'Cluj', code: 'CJ'},
-          {name: 'Constanța', code: 'CT'},
-          {name: 'Covasna', code: 'CV'},
-          {name: 'Călărași', code: 'CL'},
-          {name: 'Dolj', code: 'DJ'},
-          {name: 'Dâmbovița', code: 'DB'},
-          {name: 'Galați', code: 'GL'},
-          {name: 'Giurgiu', code: 'GR'},
-          {name: 'Gorj', code: 'GJ'},
-          {name: 'Harghita', code: 'HR'},
-          {name: 'Hunedoara', code: 'HD'},
-          {name: 'Ialomița', code: 'IL'},
-          {name: 'Iași', code: 'IS'},
-          {name: 'Ilfov', code: 'IF'},
-          {name: 'Maramureş', code: 'MM'},
-          {name: 'Mehedinți', code: 'MH'},
-          {name: 'Mureş', code: 'MS'},
-          {name: 'Neamţ', code: 'NT'},
-          {name: 'Olt', code: 'OT'},
-          {name: 'Prahova', code: 'PH'},
-          {name: 'Sălaj', code: 'SJ'},
-          {name: 'Satu Mare', code: 'SM'},
-          {name: 'Sibiu', code: 'SB'},
-          {name: 'Suceava', code: 'SV'},
-          {name: 'Teleorman', code: 'TR'},
-          {name: 'Timiș', code: 'TM'},
-          {name: 'Tulcea', code: 'TL'},
-          {name: 'Vâlcea', code: 'VL'},
-          {name: 'Vaslui', code: 'VS'},
-          {name: 'Vrancea', code: 'VN'},
+          {
+            name: 'Alba',
+            code: 'AB',
+          },
+          {
+            name: 'Arad',
+            code: 'AR',
+          },
+          {
+            name: 'Argeș',
+            code: 'AG',
+          },
+          {
+            name: 'Bacău',
+            code: 'BC',
+          },
+          {
+            name: 'Bihor',
+            code: 'BH',
+          },
+          {
+            name: 'Bistriţa-Năsăud',
+            code: 'BN',
+          },
+          {
+            name: 'Botoşani',
+            code: 'BT',
+          },
+          {
+            name: 'Brăila',
+            code: 'BR',
+          },
+          {
+            name: 'Braşov',
+            code: 'BV',
+          },
+          {
+            name: 'Bucharest',
+            code: 'B',
+          },
+          {
+            name: 'Buzău',
+            code: 'BZ',
+          },
+          {
+            name: 'Caraș-Severin',
+            code: 'CS',
+          },
+          {
+            name: 'Cluj',
+            code: 'CJ',
+          },
+          {
+            name: 'Constanța',
+            code: 'CT',
+          },
+          {
+            name: 'Covasna',
+            code: 'CV',
+          },
+          {
+            name: 'Călărași',
+            code: 'CL',
+          },
+          {
+            name: 'Dolj',
+            code: 'DJ',
+          },
+          {
+            name: 'Dâmbovița',
+            code: 'DB',
+          },
+          {
+            name: 'Galați',
+            code: 'GL',
+          },
+          {
+            name: 'Giurgiu',
+            code: 'GR',
+          },
+          {
+            name: 'Gorj',
+            code: 'GJ',
+          },
+          {
+            name: 'Harghita',
+            code: 'HR',
+          },
+          {
+            name: 'Hunedoara',
+            code: 'HD',
+          },
+          {
+            name: 'Ialomița',
+            code: 'IL',
+          },
+          {
+            name: 'Iași',
+            code: 'IS',
+          },
+          {
+            name: 'Ilfov',
+            code: 'IF',
+          },
+          {
+            name: 'Maramureş',
+            code: 'MM',
+          },
+          {
+            name: 'Mehedinți',
+            code: 'MH',
+          },
+          {
+            name: 'Mureş',
+            code: 'MS',
+          },
+          {
+            name: 'Neamţ',
+            code: 'NT',
+          },
+          {
+            name: 'Olt',
+            code: 'OT',
+          },
+          {
+            name: 'Prahova',
+            code: 'PH',
+          },
+          {
+            name: 'Sălaj',
+            code: 'SJ',
+          },
+          {
+            name: 'Satu Mare',
+            code: 'SM',
+          },
+          {
+            name: 'Sibiu',
+            code: 'SB',
+          },
+          {
+            name: 'Suceava',
+            code: 'SV',
+          },
+          {
+            name: 'Teleorman',
+            code: 'TR',
+          },
+          {
+            name: 'Timiș',
+            code: 'TM',
+          },
+          {
+            name: 'Tulcea',
+            code: 'TL',
+          },
+          {
+            name: 'Vâlcea',
+            code: 'VL',
+          },
+          {
+            name: 'Vaslui',
+            code: 'VS',
+          },
+          {
+            name: 'Vrancea',
+            code: 'VN',
+          },
         ],
       },
       {
@@ -5456,6 +7971,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -5463,88 +7981,334 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Altai Krai', code: 'ALT'},
-          {name: 'Altai', code: 'AL'},
-          {name: 'Amur', code: 'AMU'},
-          {name: 'Arkhangelsk', code: 'ARK'},
-          {name: 'Astrakhan', code: 'AST'},
-          {name: 'Belgorod', code: 'BEL'},
-          {name: 'Bryansk', code: 'BRY'},
-          {name: 'Chechen', code: 'CE'},
-          {name: 'Chelyabinsk', code: 'CHE'},
-          {name: 'Chukotka Okrug', code: 'CHU'},
-          {name: 'Chuvash', code: 'CU'},
-          {name: 'Irkutsk', code: 'IRK'},
-          {name: 'Ivanovo', code: 'IVA'},
-          {name: 'Jewish', code: 'YEV'},
-          {name: 'Kabardino-Balkar', code: 'KB'},
-          {name: 'Kaliningrad', code: 'KGD'},
-          {name: 'Kaluga', code: 'KLU'},
-          {name: 'Kamchatka Krai', code: 'KAM'},
-          {name: 'Karachay-Cherkess', code: 'KC'},
-          {name: 'Kemerovo', code: 'KEM'},
-          {name: 'Khabarovsk Krai', code: 'KHA'},
-          {name: 'Khanty-Mansi', code: 'KHM'},
-          {name: 'Kirov', code: 'KIR'},
-          {name: 'Komi', code: 'KO'},
-          {name: 'Kostroma', code: 'KOS'},
-          {name: 'Krasnodar Krai', code: 'KDA'},
-          {name: 'Krasnoyarsk Krai', code: 'KYA'},
-          {name: 'Kurgan', code: 'KGN'},
-          {name: 'Kursk', code: 'KRS'},
-          {name: 'Leningrad', code: 'LEN'},
-          {name: 'Lipetsk', code: 'LIP'},
-          {name: 'Magadan', code: 'MAG'},
-          {name: 'Mari El', code: 'ME'},
-          {name: 'Moscow', code: 'MOW'},
-          {name: 'Moscow Province', code: 'MOS'},
-          {name: 'Murmansk', code: 'MUR'},
-          {name: 'Nizhny Novgorod', code: 'NIZ'},
-          {name: 'Novgorod', code: 'NGR'},
-          {name: 'Novosibirsk', code: 'NVS'},
-          {name: 'Omsk', code: 'OMS'},
-          {name: 'Orenburg', code: 'ORE'},
-          {name: 'Oryol', code: 'ORL'},
-          {name: 'Penza', code: 'PNZ'},
-          {name: 'Perm Krai', code: 'PER'},
-          {name: 'Primorsky Krai', code: 'PRI'},
-          {name: 'Pskov', code: 'PSK'},
-          {name: 'Adygea', code: 'AD'},
-          {name: 'Bashkortostan', code: 'BA'},
-          {name: 'Buryat', code: 'BU'},
-          {name: 'Dagestan', code: 'DA'},
-          {name: 'Ingushetia', code: 'IN'},
-          {name: 'Kalmykia', code: 'KL'},
-          {name: 'Karelia', code: 'KR'},
-          {name: 'Khakassia', code: 'KK'},
-          {name: 'Mordovia', code: 'MO'},
-          {name: 'North Ossetia-Alania', code: 'SE'},
-          {name: 'Tatarstan', code: 'TA'},
-          {name: 'Rostov', code: 'ROS'},
-          {name: 'Ryazan', code: 'RYA'},
-          {name: 'Saint Petersburg', code: 'SPE'},
-          {name: 'Sakha', code: 'SA'},
-          {name: 'Sakhalin', code: 'SAK'},
-          {name: 'Samara', code: 'SAM'},
-          {name: 'Saratov', code: 'SAR'},
-          {name: 'Smolensk', code: 'SMO'},
-          {name: 'Stavropol Krai', code: 'STA'},
-          {name: 'Sverdlovsk', code: 'SVE'},
-          {name: 'Tambov', code: 'TAM'},
-          {name: 'Tomsk', code: 'TOM'},
-          {name: 'Tula', code: 'TUL'},
-          {name: 'Tver', code: 'TVE'},
-          {name: 'Tyumen', code: 'TYU'},
-          {name: 'Tuva', code: 'TY'},
-          {name: 'Udmurt', code: 'UD'},
-          {name: 'Ulyanovsk', code: 'ULY'},
-          {name: 'Vladimir', code: 'VLA'},
-          {name: 'Volgograd', code: 'VGG'},
-          {name: 'Vologda', code: 'VLG'},
-          {name: 'Voronezh', code: 'VOR'},
-          {name: 'Yamalo-Nenets Okrug', code: 'YAN'},
-          {name: 'Yaroslavl', code: 'YAR'},
-          {name: 'Zabaykalsky Krai', code: 'ZAB'},
+          {
+            name: 'Altai Krai',
+            code: 'ALT',
+          },
+          {
+            name: 'Altai',
+            code: 'AL',
+          },
+          {
+            name: 'Amur',
+            code: 'AMU',
+          },
+          {
+            name: 'Arkhangelsk',
+            code: 'ARK',
+          },
+          {
+            name: 'Astrakhan',
+            code: 'AST',
+          },
+          {
+            name: 'Belgorod',
+            code: 'BEL',
+          },
+          {
+            name: 'Bryansk',
+            code: 'BRY',
+          },
+          {
+            name: 'Chechen',
+            code: 'CE',
+          },
+          {
+            name: 'Chelyabinsk',
+            code: 'CHE',
+          },
+          {
+            name: 'Chukotka Okrug',
+            code: 'CHU',
+          },
+          {
+            name: 'Chuvash',
+            code: 'CU',
+          },
+          {
+            name: 'Irkutsk',
+            code: 'IRK',
+          },
+          {
+            name: 'Ivanovo',
+            code: 'IVA',
+          },
+          {
+            name: 'Jewish',
+            code: 'YEV',
+          },
+          {
+            name: 'Kabardino-Balkar',
+            code: 'KB',
+          },
+          {
+            name: 'Kaliningrad',
+            code: 'KGD',
+          },
+          {
+            name: 'Kaluga',
+            code: 'KLU',
+          },
+          {
+            name: 'Kamchatka Krai',
+            code: 'KAM',
+          },
+          {
+            name: 'Karachay-Cherkess',
+            code: 'KC',
+          },
+          {
+            name: 'Kemerovo',
+            code: 'KEM',
+          },
+          {
+            name: 'Khabarovsk Krai',
+            code: 'KHA',
+          },
+          {
+            name: 'Khanty-Mansi',
+            code: 'KHM',
+          },
+          {
+            name: 'Kirov',
+            code: 'KIR',
+          },
+          {
+            name: 'Komi',
+            code: 'KO',
+          },
+          {
+            name: 'Kostroma',
+            code: 'KOS',
+          },
+          {
+            name: 'Krasnodar Krai',
+            code: 'KDA',
+          },
+          {
+            name: 'Krasnoyarsk Krai',
+            code: 'KYA',
+          },
+          {
+            name: 'Kurgan',
+            code: 'KGN',
+          },
+          {
+            name: 'Kursk',
+            code: 'KRS',
+          },
+          {
+            name: 'Leningrad',
+            code: 'LEN',
+          },
+          {
+            name: 'Lipetsk',
+            code: 'LIP',
+          },
+          {
+            name: 'Magadan',
+            code: 'MAG',
+          },
+          {
+            name: 'Mari El',
+            code: 'ME',
+          },
+          {
+            name: 'Moscow',
+            code: 'MOW',
+          },
+          {
+            name: 'Moscow Province',
+            code: 'MOS',
+          },
+          {
+            name: 'Murmansk',
+            code: 'MUR',
+          },
+          {
+            name: 'Nizhny Novgorod',
+            code: 'NIZ',
+          },
+          {
+            name: 'Novgorod',
+            code: 'NGR',
+          },
+          {
+            name: 'Novosibirsk',
+            code: 'NVS',
+          },
+          {
+            name: 'Omsk',
+            code: 'OMS',
+          },
+          {
+            name: 'Orenburg',
+            code: 'ORE',
+          },
+          {
+            name: 'Oryol',
+            code: 'ORL',
+          },
+          {
+            name: 'Penza',
+            code: 'PNZ',
+          },
+          {
+            name: 'Perm Krai',
+            code: 'PER',
+          },
+          {
+            name: 'Primorsky Krai',
+            code: 'PRI',
+          },
+          {
+            name: 'Pskov',
+            code: 'PSK',
+          },
+          {
+            name: 'Adygea',
+            code: 'AD',
+          },
+          {
+            name: 'Bashkortostan',
+            code: 'BA',
+          },
+          {
+            name: 'Buryat',
+            code: 'BU',
+          },
+          {
+            name: 'Dagestan',
+            code: 'DA',
+          },
+          {
+            name: 'Ingushetia',
+            code: 'IN',
+          },
+          {
+            name: 'Kalmykia',
+            code: 'KL',
+          },
+          {
+            name: 'Karelia',
+            code: 'KR',
+          },
+          {
+            name: 'Khakassia',
+            code: 'KK',
+          },
+          {
+            name: 'Mordovia',
+            code: 'MO',
+          },
+          {
+            name: 'North Ossetia-Alania',
+            code: 'SE',
+          },
+          {
+            name: 'Tatarstan',
+            code: 'TA',
+          },
+          {
+            name: 'Rostov',
+            code: 'ROS',
+          },
+          {
+            name: 'Ryazan',
+            code: 'RYA',
+          },
+          {
+            name: 'Saint Petersburg',
+            code: 'SPE',
+          },
+          {
+            name: 'Sakha',
+            code: 'SA',
+          },
+          {
+            name: 'Sakhalin',
+            code: 'SAK',
+          },
+          {
+            name: 'Samara',
+            code: 'SAM',
+          },
+          {
+            name: 'Saratov',
+            code: 'SAR',
+          },
+          {
+            name: 'Smolensk',
+            code: 'SMO',
+          },
+          {
+            name: 'Stavropol Krai',
+            code: 'STA',
+          },
+          {
+            name: 'Sverdlovsk',
+            code: 'SVE',
+          },
+          {
+            name: 'Tambov',
+            code: 'TAM',
+          },
+          {
+            name: 'Tomsk',
+            code: 'TOM',
+          },
+          {
+            name: 'Tula',
+            code: 'TUL',
+          },
+          {
+            name: 'Tver',
+            code: 'TVE',
+          },
+          {
+            name: 'Tyumen',
+            code: 'TYU',
+          },
+          {
+            name: 'Tuva',
+            code: 'TY',
+          },
+          {
+            name: 'Udmurt',
+            code: 'UD',
+          },
+          {
+            name: 'Ulyanovsk',
+            code: 'ULY',
+          },
+          {
+            name: 'Vladimir',
+            code: 'VLA',
+          },
+          {
+            name: 'Volgograd',
+            code: 'VGG',
+          },
+          {
+            name: 'Vologda',
+            code: 'VLG',
+          },
+          {
+            name: 'Voronezh',
+            code: 'VOR',
+          },
+          {
+            name: 'Yamalo-Nenets Okrug',
+            code: 'YAN',
+          },
+          {
+            name: 'Yaroslavl',
+            code: 'YAR',
+          },
+          {
+            name: 'Zabaykalsky Krai',
+            code: 'ZAB',
+          },
         ],
       },
       {
@@ -5565,6 +8329,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5593,6 +8360,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -5620,9 +8390,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5646,6 +8419,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5674,6 +8450,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -5701,9 +8480,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5728,9 +8510,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5754,6 +8539,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5782,6 +8570,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -5808,6 +8599,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5836,6 +8630,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -5863,9 +8660,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5890,9 +8690,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5916,6 +8719,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5944,6 +8750,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -5971,6 +8780,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -5978,15 +8790,42 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}_{zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Eastern Cape', code: 'EC'},
-          {name: 'Free State', code: 'FS'},
-          {name: 'Gauteng', code: 'GT'},
-          {name: 'KwaZulu-Natal', code: 'NL'},
-          {name: 'Limpopo', code: 'LP'},
-          {name: 'Mpumalanga', code: 'MP'},
-          {name: 'North West', code: 'NW'},
-          {name: 'Northern Cape', code: 'NC'},
-          {name: 'Western Cape', code: 'WC'},
+          {
+            name: 'Eastern Cape',
+            code: 'EC',
+          },
+          {
+            name: 'Free State',
+            code: 'FS',
+          },
+          {
+            name: 'Gauteng',
+            code: 'GT',
+          },
+          {
+            name: 'KwaZulu-Natal',
+            code: 'NL',
+          },
+          {
+            name: 'Limpopo',
+            code: 'LP',
+          },
+          {
+            name: 'Mpumalanga',
+            code: 'MP',
+          },
+          {
+            name: 'North West',
+            code: 'NW',
+          },
+          {
+            name: 'Northern Cape',
+            code: 'NC',
+          },
+          {
+            name: 'Western Cape',
+            code: 'WC',
+          },
         ],
       },
       {
@@ -6007,6 +8846,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6035,6 +8877,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{company}_{lastName}{firstName}_{zip}_{country}_{province}{city}_{address1}_{address2}_{phone}',
@@ -6042,23 +8887,74 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Busan', code: 'KR-26'},
-          {name: 'North Chungcheong', code: 'KR-43'},
-          {name: 'South Chungcheong', code: 'KR-44'},
-          {name: 'Daegu', code: 'KR-27'},
-          {name: 'Daejeon', code: 'KR-30'},
-          {name: 'Gangwon', code: 'KR-42'},
-          {name: 'Gwangju City', code: 'KR-29'},
-          {name: 'North Gyeongsang', code: 'KR-47'},
-          {name: 'Gyeonggi', code: 'KR-41'},
-          {name: 'South Gyeongsang', code: 'KR-48'},
-          {name: 'Incheon', code: 'KR-28'},
-          {name: 'Jeju', code: 'KR-49'},
-          {name: 'North Jeolla', code: 'KR-45'},
-          {name: 'South Jeolla', code: 'KR-46'},
-          {name: 'Sejong', code: 'KR-50'},
-          {name: 'Seoul', code: 'KR-11'},
-          {name: 'Ulsan', code: 'KR-31'},
+          {
+            name: 'Busan',
+            code: 'KR-26',
+          },
+          {
+            name: 'North Chungcheong',
+            code: 'KR-43',
+          },
+          {
+            name: 'South Chungcheong',
+            code: 'KR-44',
+          },
+          {
+            name: 'Daegu',
+            code: 'KR-27',
+          },
+          {
+            name: 'Daejeon',
+            code: 'KR-30',
+          },
+          {
+            name: 'Gangwon',
+            code: 'KR-42',
+          },
+          {
+            name: 'Gwangju City',
+            code: 'KR-29',
+          },
+          {
+            name: 'North Gyeongsang',
+            code: 'KR-47',
+          },
+          {
+            name: 'Gyeonggi',
+            code: 'KR-41',
+          },
+          {
+            name: 'South Gyeongsang',
+            code: 'KR-48',
+          },
+          {
+            name: 'Incheon',
+            code: 'KR-28',
+          },
+          {
+            name: 'Jeju',
+            code: 'KR-49',
+          },
+          {
+            name: 'North Jeolla',
+            code: 'KR-45',
+          },
+          {
+            name: 'South Jeolla',
+            code: 'KR-46',
+          },
+          {
+            name: 'Sejong',
+            code: 'KR-50',
+          },
+          {
+            name: 'Seoul',
+            code: 'KR-11',
+          },
+          {
+            name: 'Ulsan',
+            code: 'KR-31',
+          },
         ],
       },
       {
@@ -6078,7 +8974,10 @@ const data = {
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6096,7 +8995,7 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'PROVINCE',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
@@ -6107,65 +9006,224 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
         zones: [
-          {name: 'A Coruña', code: 'C'},
-          {name: 'Álava', code: 'VI'},
-          {name: 'Albacete', code: 'AB'},
-          {name: 'Alicante', code: 'A'},
-          {name: 'Almería', code: 'AL'},
-          {name: 'Asturias Province', code: 'O'},
-          {name: 'Ávila', code: 'AV'},
-          {name: 'Badajoz', code: 'BA'},
-          {name: 'Balears Province', code: 'PM'},
-          {name: 'Barcelona', code: 'B'},
-          {name: 'Burgos', code: 'BU'},
-          {name: 'Cáceres', code: 'CC'},
-          {name: 'Cádiz', code: 'CA'},
-          {name: 'Cantabria Province', code: 'S'},
-          {name: 'Castellón', code: 'CS'},
-          {name: 'Ceuta', code: 'CE'},
-          {name: 'Ciudad Real', code: 'CR'},
-          {name: 'Córdoba', code: 'CO'},
-          {name: 'Cuenca', code: 'CU'},
-          {name: 'Girona', code: 'GI'},
-          {name: 'Granada', code: 'GR'},
-          {name: 'Guadalajara', code: 'GU'},
-          {name: 'Gipuzkoa', code: 'SS'},
-          {name: 'Huelva', code: 'H'},
-          {name: 'Huesca', code: 'HU'},
-          {name: 'Jaén', code: 'J'},
-          {name: 'La Rioja Province', code: 'LO'},
-          {name: 'Las Palmas', code: 'GC'},
-          {name: 'León', code: 'LE'},
-          {name: 'Lleida', code: 'L'},
-          {name: 'Lugo', code: 'LU'},
-          {name: 'Madrid Province', code: 'M'},
-          {name: 'Málaga', code: 'MA'},
-          {name: 'Melilla', code: 'ML'},
-          {name: 'Murcia', code: 'MU'},
-          {name: 'Navarra', code: 'NA'},
-          {name: 'Ourense', code: 'OR'},
-          {name: 'Palencia', code: 'P'},
-          {name: 'Pontevedra', code: 'PO'},
-          {name: 'Salamanca', code: 'SA'},
-          {name: 'Santa Cruz de Tenerife', code: 'TF'},
-          {name: 'Segovia', code: 'SG'},
-          {name: 'Seville', code: 'SE'},
-          {name: 'Soria', code: 'SO'},
-          {name: 'Tarragona', code: 'T'},
-          {name: 'Teruel', code: 'TE'},
-          {name: 'Toledo', code: 'TO'},
-          {name: 'Valencia', code: 'V'},
-          {name: 'Valladolid', code: 'VA'},
-          {name: 'Biscay', code: 'BI'},
-          {name: 'Zamora', code: 'ZA'},
-          {name: 'Zaragoza', code: 'Z'},
+          {
+            name: 'A Coruña',
+            code: 'C',
+          },
+          {
+            name: 'Álava',
+            code: 'VI',
+          },
+          {
+            name: 'Albacete',
+            code: 'AB',
+          },
+          {
+            name: 'Alicante',
+            code: 'A',
+          },
+          {
+            name: 'Almería',
+            code: 'AL',
+          },
+          {
+            name: 'Asturias Province',
+            code: 'O',
+          },
+          {
+            name: 'Ávila',
+            code: 'AV',
+          },
+          {
+            name: 'Badajoz',
+            code: 'BA',
+          },
+          {
+            name: 'Balears Province',
+            code: 'PM',
+          },
+          {
+            name: 'Barcelona',
+            code: 'B',
+          },
+          {
+            name: 'Burgos',
+            code: 'BU',
+          },
+          {
+            name: 'Cáceres',
+            code: 'CC',
+          },
+          {
+            name: 'Cádiz',
+            code: 'CA',
+          },
+          {
+            name: 'Cantabria Province',
+            code: 'S',
+          },
+          {
+            name: 'Castellón',
+            code: 'CS',
+          },
+          {
+            name: 'Ceuta',
+            code: 'CE',
+          },
+          {
+            name: 'Ciudad Real',
+            code: 'CR',
+          },
+          {
+            name: 'Córdoba',
+            code: 'CO',
+          },
+          {
+            name: 'Cuenca',
+            code: 'CU',
+          },
+          {
+            name: 'Girona',
+            code: 'GI',
+          },
+          {
+            name: 'Granada',
+            code: 'GR',
+          },
+          {
+            name: 'Guadalajara',
+            code: 'GU',
+          },
+          {
+            name: 'Gipuzkoa',
+            code: 'SS',
+          },
+          {
+            name: 'Huelva',
+            code: 'H',
+          },
+          {
+            name: 'Huesca',
+            code: 'HU',
+          },
+          {
+            name: 'Jaén',
+            code: 'J',
+          },
+          {
+            name: 'La Rioja Province',
+            code: 'LO',
+          },
+          {
+            name: 'Las Palmas',
+            code: 'GC',
+          },
+          {
+            name: 'León',
+            code: 'LE',
+          },
+          {
+            name: 'Lleida',
+            code: 'L',
+          },
+          {
+            name: 'Lugo',
+            code: 'LU',
+          },
+          {
+            name: 'Madrid Province',
+            code: 'M',
+          },
+          {
+            name: 'Málaga',
+            code: 'MA',
+          },
+          {
+            name: 'Melilla',
+            code: 'ML',
+          },
+          {
+            name: 'Murcia',
+            code: 'MU',
+          },
+          {
+            name: 'Navarra',
+            code: 'NA',
+          },
+          {
+            name: 'Ourense',
+            code: 'OR',
+          },
+          {
+            name: 'Palencia',
+            code: 'P',
+          },
+          {
+            name: 'Pontevedra',
+            code: 'PO',
+          },
+          {
+            name: 'Salamanca',
+            code: 'SA',
+          },
+          {
+            name: 'Santa Cruz de Tenerife',
+            code: 'TF',
+          },
+          {
+            name: 'Segovia',
+            code: 'SG',
+          },
+          {
+            name: 'Seville',
+            code: 'SE',
+          },
+          {
+            name: 'Soria',
+            code: 'SO',
+          },
+          {
+            name: 'Tarragona',
+            code: 'T',
+          },
+          {
+            name: 'Teruel',
+            code: 'TE',
+          },
+          {
+            name: 'Toledo',
+            code: 'TO',
+          },
+          {
+            name: 'Valencia',
+            code: 'V',
+          },
+          {
+            name: 'Valladolid',
+            code: 'VA',
+          },
+          {
+            name: 'Biscay',
+            code: 'BI',
+          },
+          {
+            name: 'Zamora',
+            code: 'ZA',
+          },
+          {
+            name: 'Zaragoza',
+            code: 'Z',
+          },
         ],
       },
       {
@@ -6186,6 +9244,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6214,9 +9275,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6240,6 +9304,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6268,6 +9335,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -6294,6 +9364,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6322,9 +9395,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6349,9 +9425,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6375,6 +9454,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6403,9 +9485,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -6429,6 +9514,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6457,9 +9545,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6473,9 +9564,9 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'REGION',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'City/town',
           company: 'Company',
           country: 'Country/Region',
           firstName: 'First name',
@@ -6484,9 +9575,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6500,8 +9594,8 @@ const data = {
         autocompletionField: 'address1',
         provinceKey: 'REGION',
         labels: {
-          address1: 'Address',
-          address2: 'Apartment, suite, etc.',
+          address1: 'Street and house number',
+          address2: 'Additional address',
           city: 'City',
           company: 'Company',
           country: 'Country/Region',
@@ -6511,9 +9605,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Additional address (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6537,6 +9634,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6565,6 +9665,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -6592,9 +9695,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6619,9 +9725,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6646,6 +9755,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -6653,84 +9765,318 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Amnat Charoen', code: 'TH-37'},
-          {name: 'Ang Thong', code: 'TH-15'},
-          {name: 'Bangkok', code: 'TH-10'},
-          {name: 'Bueng Kan', code: 'TH-38'},
-          {name: 'Buri Ram', code: 'TH-31'},
-          {name: 'Chachoengsao', code: 'TH-24'},
-          {name: 'Chai Nat', code: 'TH-18'},
-          {name: 'Chaiyaphum', code: 'TH-36'},
-          {name: 'Chanthaburi', code: 'TH-22'},
-          {name: 'Chiang Mai', code: 'TH-50'},
-          {name: 'Chiang Rai', code: 'TH-57'},
-          {name: 'Chon Buri', code: 'TH-20'},
-          {name: 'Chumphon', code: 'TH-86'},
-          {name: 'Kalasin', code: 'TH-46'},
-          {name: 'Kamphaeng Phet', code: 'TH-62'},
-          {name: 'Kanchanaburi', code: 'TH-71'},
-          {name: 'Khon Kaen', code: 'TH-40'},
-          {name: 'Krabi', code: 'TH-81'},
-          {name: 'Lampang', code: 'TH-52'},
-          {name: 'Lamphun', code: 'TH-51'},
-          {name: 'Loei', code: 'TH-42'},
-          {name: 'Lopburi', code: 'TH-16'},
-          {name: 'Mae Hong Son', code: 'TH-58'},
-          {name: 'Maha Sarakham', code: 'TH-44'},
-          {name: 'Mukdahan', code: 'TH-49'},
-          {name: 'Nakhon Nayok', code: 'TH-26'},
-          {name: 'Nakhon Pathom', code: 'TH-73'},
-          {name: 'Nakhon Phanom', code: 'TH-48'},
-          {name: 'Nakhon Ratchasima', code: 'TH-30'},
-          {name: 'Nakhon Sawan', code: 'TH-60'},
-          {name: 'Nakhon Si Thammarat', code: 'TH-80'},
-          {name: 'Nan', code: 'TH-55'},
-          {name: 'Narathiwat', code: 'TH-96'},
-          {name: 'Nong Bua Lam Phu', code: 'TH-39'},
-          {name: 'Nong Khai', code: 'TH-43'},
-          {name: 'Nonthaburi', code: 'TH-12'},
-          {name: 'Pathum Thani', code: 'TH-13'},
-          {name: 'Pattani', code: 'TH-94'},
-          {name: 'Pattaya', code: 'TH-S'},
-          {name: 'Phang Nga', code: 'TH-82'},
-          {name: 'Phatthalung', code: 'TH-93'},
-          {name: 'Phayao', code: 'TH-56'},
-          {name: 'Phetchabun', code: 'TH-67'},
-          {name: 'Phetchaburi', code: 'TH-76'},
-          {name: 'Phichit', code: 'TH-66'},
-          {name: 'Phitsanulok', code: 'TH-65'},
-          {name: 'Phra Nakhon Si Ayutthaya', code: 'TH-14'},
-          {name: 'Phrae', code: 'TH-54'},
-          {name: 'Phuket', code: 'TH-83'},
-          {name: 'Prachin Buri', code: 'TH-25'},
-          {name: 'Prachuap Khiri Khan', code: 'TH-77'},
-          {name: 'Ranong', code: 'TH-85'},
-          {name: 'Ratchaburi', code: 'TH-70'},
-          {name: 'Rayong', code: 'TH-21'},
-          {name: 'Roi Et', code: 'TH-45'},
-          {name: 'Sa Kaeo', code: 'TH-27'},
-          {name: 'Sakon Nakhon', code: 'TH-47'},
-          {name: 'Samut Prakan', code: 'TH-11'},
-          {name: 'Samut Sakhon', code: 'TH-74'},
-          {name: 'Samut Songkhram', code: 'TH-75'},
-          {name: 'Saraburi', code: 'TH-19'},
-          {name: 'Satun', code: 'TH-91'},
-          {name: 'Sing Buri', code: 'TH-17'},
-          {name: 'Si Sa Ket', code: 'TH-33'},
-          {name: 'Songkhla', code: 'TH-90'},
-          {name: 'Sukhothai', code: 'TH-64'},
-          {name: 'Suphanburi', code: 'TH-72'},
-          {name: 'Surat Thani', code: 'TH-84'},
-          {name: 'Surin', code: 'TH-32'},
-          {name: 'Tak', code: 'TH-63'},
-          {name: 'Trang', code: 'TH-92'},
-          {name: 'Trat', code: 'TH-23'},
-          {name: 'Ubon Ratchathani', code: 'TH-34'},
-          {name: 'Udon Thani', code: 'TH-41'},
-          {name: 'Uthai Thani', code: 'TH-61'},
-          {name: 'Uttaradit', code: 'TH-53'},
-          {name: 'Yala', code: 'TH-95'},
-          {name: 'Yasothon', code: 'TH-35'},
+          {
+            name: 'Amnat Charoen',
+            code: 'TH-37',
+          },
+          {
+            name: 'Ang Thong',
+            code: 'TH-15',
+          },
+          {
+            name: 'Bangkok',
+            code: 'TH-10',
+          },
+          {
+            name: 'Bueng Kan',
+            code: 'TH-38',
+          },
+          {
+            name: 'Buri Ram',
+            code: 'TH-31',
+          },
+          {
+            name: 'Chachoengsao',
+            code: 'TH-24',
+          },
+          {
+            name: 'Chai Nat',
+            code: 'TH-18',
+          },
+          {
+            name: 'Chaiyaphum',
+            code: 'TH-36',
+          },
+          {
+            name: 'Chanthaburi',
+            code: 'TH-22',
+          },
+          {
+            name: 'Chiang Mai',
+            code: 'TH-50',
+          },
+          {
+            name: 'Chiang Rai',
+            code: 'TH-57',
+          },
+          {
+            name: 'Chon Buri',
+            code: 'TH-20',
+          },
+          {
+            name: 'Chumphon',
+            code: 'TH-86',
+          },
+          {
+            name: 'Kalasin',
+            code: 'TH-46',
+          },
+          {
+            name: 'Kamphaeng Phet',
+            code: 'TH-62',
+          },
+          {
+            name: 'Kanchanaburi',
+            code: 'TH-71',
+          },
+          {
+            name: 'Khon Kaen',
+            code: 'TH-40',
+          },
+          {
+            name: 'Krabi',
+            code: 'TH-81',
+          },
+          {
+            name: 'Lampang',
+            code: 'TH-52',
+          },
+          {
+            name: 'Lamphun',
+            code: 'TH-51',
+          },
+          {
+            name: 'Loei',
+            code: 'TH-42',
+          },
+          {
+            name: 'Lopburi',
+            code: 'TH-16',
+          },
+          {
+            name: 'Mae Hong Son',
+            code: 'TH-58',
+          },
+          {
+            name: 'Maha Sarakham',
+            code: 'TH-44',
+          },
+          {
+            name: 'Mukdahan',
+            code: 'TH-49',
+          },
+          {
+            name: 'Nakhon Nayok',
+            code: 'TH-26',
+          },
+          {
+            name: 'Nakhon Pathom',
+            code: 'TH-73',
+          },
+          {
+            name: 'Nakhon Phanom',
+            code: 'TH-48',
+          },
+          {
+            name: 'Nakhon Ratchasima',
+            code: 'TH-30',
+          },
+          {
+            name: 'Nakhon Sawan',
+            code: 'TH-60',
+          },
+          {
+            name: 'Nakhon Si Thammarat',
+            code: 'TH-80',
+          },
+          {
+            name: 'Nan',
+            code: 'TH-55',
+          },
+          {
+            name: 'Narathiwat',
+            code: 'TH-96',
+          },
+          {
+            name: 'Nong Bua Lam Phu',
+            code: 'TH-39',
+          },
+          {
+            name: 'Nong Khai',
+            code: 'TH-43',
+          },
+          {
+            name: 'Nonthaburi',
+            code: 'TH-12',
+          },
+          {
+            name: 'Pathum Thani',
+            code: 'TH-13',
+          },
+          {
+            name: 'Pattani',
+            code: 'TH-94',
+          },
+          {
+            name: 'Pattaya',
+            code: 'TH-S',
+          },
+          {
+            name: 'Phang Nga',
+            code: 'TH-82',
+          },
+          {
+            name: 'Phatthalung',
+            code: 'TH-93',
+          },
+          {
+            name: 'Phayao',
+            code: 'TH-56',
+          },
+          {
+            name: 'Phetchabun',
+            code: 'TH-67',
+          },
+          {
+            name: 'Phetchaburi',
+            code: 'TH-76',
+          },
+          {
+            name: 'Phichit',
+            code: 'TH-66',
+          },
+          {
+            name: 'Phitsanulok',
+            code: 'TH-65',
+          },
+          {
+            name: 'Phra Nakhon Si Ayutthaya',
+            code: 'TH-14',
+          },
+          {
+            name: 'Phrae',
+            code: 'TH-54',
+          },
+          {
+            name: 'Phuket',
+            code: 'TH-83',
+          },
+          {
+            name: 'Prachin Buri',
+            code: 'TH-25',
+          },
+          {
+            name: 'Prachuap Khiri Khan',
+            code: 'TH-77',
+          },
+          {
+            name: 'Ranong',
+            code: 'TH-85',
+          },
+          {
+            name: 'Ratchaburi',
+            code: 'TH-70',
+          },
+          {
+            name: 'Rayong',
+            code: 'TH-21',
+          },
+          {
+            name: 'Roi Et',
+            code: 'TH-45',
+          },
+          {
+            name: 'Sa Kaeo',
+            code: 'TH-27',
+          },
+          {
+            name: 'Sakon Nakhon',
+            code: 'TH-47',
+          },
+          {
+            name: 'Samut Prakan',
+            code: 'TH-11',
+          },
+          {
+            name: 'Samut Sakhon',
+            code: 'TH-74',
+          },
+          {
+            name: 'Samut Songkhram',
+            code: 'TH-75',
+          },
+          {
+            name: 'Saraburi',
+            code: 'TH-19',
+          },
+          {
+            name: 'Satun',
+            code: 'TH-91',
+          },
+          {
+            name: 'Sing Buri',
+            code: 'TH-17',
+          },
+          {
+            name: 'Si Sa Ket',
+            code: 'TH-33',
+          },
+          {
+            name: 'Songkhla',
+            code: 'TH-90',
+          },
+          {
+            name: 'Sukhothai',
+            code: 'TH-64',
+          },
+          {
+            name: 'Suphanburi',
+            code: 'TH-72',
+          },
+          {
+            name: 'Surat Thani',
+            code: 'TH-84',
+          },
+          {
+            name: 'Surin',
+            code: 'TH-32',
+          },
+          {
+            name: 'Tak',
+            code: 'TH-63',
+          },
+          {
+            name: 'Trang',
+            code: 'TH-92',
+          },
+          {
+            name: 'Trat',
+            code: 'TH-23',
+          },
+          {
+            name: 'Ubon Ratchathani',
+            code: 'TH-34',
+          },
+          {
+            name: 'Udon Thani',
+            code: 'TH-41',
+          },
+          {
+            name: 'Uthai Thani',
+            code: 'TH-61',
+          },
+          {
+            name: 'Uttaradit',
+            code: 'TH-53',
+          },
+          {
+            name: 'Yala',
+            code: 'TH-95',
+          },
+          {
+            name: 'Yasothon',
+            code: 'TH-35',
+          },
         ],
       },
       {
@@ -6751,6 +10097,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6779,6 +10128,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -6805,6 +10157,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6833,6 +10188,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -6859,6 +10217,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6887,9 +10248,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6914,9 +10278,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6941,11 +10308,14 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{zip}{city}_{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+            '{zip}{city}_{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{phone}',
         },
         zones: [],
       },
@@ -6967,6 +10337,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6995,6 +10368,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -7021,6 +10397,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'State',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7049,6 +10428,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -7075,6 +10457,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7103,6 +10488,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Emirate',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}_{phone}',
@@ -7110,13 +10498,34 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province}_{country}_{phone}',
         },
         zones: [
-          {name: 'Abu Dhabi', code: 'AZ'},
-          {name: 'Ajman', code: 'AJ'},
-          {name: 'Dubai', code: 'DU'},
-          {name: 'Fujairah', code: 'FU'},
-          {name: 'Ras al-Khaimah', code: 'RK'},
-          {name: 'Sharjah', code: 'SH'},
-          {name: 'Umm al-Quwain', code: 'UQ'},
+          {
+            name: 'Abu Dhabi',
+            code: 'AZ',
+          },
+          {
+            name: 'Ajman',
+            code: 'AJ',
+          },
+          {
+            name: 'Dubai',
+            code: 'DU',
+          },
+          {
+            name: 'Fujairah',
+            code: 'FU',
+          },
+          {
+            name: 'Ras al-Khaimah',
+            code: 'RK',
+          },
+          {
+            name: 'Sharjah',
+            code: 'SH',
+          },
+          {
+            name: 'Umm al-Quwain',
+            code: 'UQ',
+          },
         ],
       },
       {
@@ -7137,6 +10546,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postcode',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7165,6 +10577,9 @@ const data = {
           postalCode: 'ZIP code',
           zone: 'State',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
@@ -7172,68 +10587,254 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province} {zip}_{country}_{phone}',
         },
         zones: [
-          {name: 'Alabama', code: 'AL'},
-          {name: 'Alaska', code: 'AK'},
-          {name: 'American Samoa', code: 'AS'},
-          {name: 'Arizona', code: 'AZ'},
-          {name: 'Arkansas', code: 'AR'},
-          {name: 'California', code: 'CA'},
-          {name: 'Colorado', code: 'CO'},
-          {name: 'Connecticut', code: 'CT'},
-          {name: 'Delaware', code: 'DE'},
-          {name: 'Washington DC', code: 'DC'},
-          {name: 'Micronesia', code: 'FM'},
-          {name: 'Florida', code: 'FL'},
-          {name: 'Georgia', code: 'GA'},
-          {name: 'Guam', code: 'GU'},
-          {name: 'Hawaii', code: 'HI'},
-          {name: 'Idaho', code: 'ID'},
-          {name: 'Illinois', code: 'IL'},
-          {name: 'Indiana', code: 'IN'},
-          {name: 'Iowa', code: 'IA'},
-          {name: 'Kansas', code: 'KS'},
-          {name: 'Kentucky', code: 'KY'},
-          {name: 'Louisiana', code: 'LA'},
-          {name: 'Maine', code: 'ME'},
-          {name: 'Marshall Islands', code: 'MH'},
-          {name: 'Maryland', code: 'MD'},
-          {name: 'Massachusetts', code: 'MA'},
-          {name: 'Michigan', code: 'MI'},
-          {name: 'Minnesota', code: 'MN'},
-          {name: 'Mississippi', code: 'MS'},
-          {name: 'Missouri', code: 'MO'},
-          {name: 'Montana', code: 'MT'},
-          {name: 'Nebraska', code: 'NE'},
-          {name: 'Nevada', code: 'NV'},
-          {name: 'New Hampshire', code: 'NH'},
-          {name: 'New Jersey', code: 'NJ'},
-          {name: 'New Mexico', code: 'NM'},
-          {name: 'New York', code: 'NY'},
-          {name: 'North Carolina', code: 'NC'},
-          {name: 'North Dakota', code: 'ND'},
-          {name: 'Northern Mariana Islands', code: 'MP'},
-          {name: 'Ohio', code: 'OH'},
-          {name: 'Oklahoma', code: 'OK'},
-          {name: 'Oregon', code: 'OR'},
-          {name: 'Palau', code: 'PW'},
-          {name: 'Pennsylvania', code: 'PA'},
-          {name: 'Puerto Rico', code: 'PR'},
-          {name: 'Rhode Island', code: 'RI'},
-          {name: 'South Carolina', code: 'SC'},
-          {name: 'South Dakota', code: 'SD'},
-          {name: 'Tennessee', code: 'TN'},
-          {name: 'Texas', code: 'TX'},
-          {name: 'Utah', code: 'UT'},
-          {name: 'Vermont', code: 'VT'},
-          {name: 'U.S. Virgin Islands', code: 'VI'},
-          {name: 'Virginia', code: 'VA'},
-          {name: 'Washington', code: 'WA'},
-          {name: 'West Virginia', code: 'WV'},
-          {name: 'Wisconsin', code: 'WI'},
-          {name: 'Wyoming', code: 'WY'},
-          {name: 'Armed Forces Americas', code: 'AA'},
-          {name: 'Armed Forces Europe', code: 'AE'},
-          {name: 'Armed Forces Pacific', code: 'AP'},
+          {
+            name: 'Alabama',
+            code: 'AL',
+          },
+          {
+            name: 'Alaska',
+            code: 'AK',
+          },
+          {
+            name: 'American Samoa',
+            code: 'AS',
+          },
+          {
+            name: 'Arizona',
+            code: 'AZ',
+          },
+          {
+            name: 'Arkansas',
+            code: 'AR',
+          },
+          {
+            name: 'California',
+            code: 'CA',
+          },
+          {
+            name: 'Colorado',
+            code: 'CO',
+          },
+          {
+            name: 'Connecticut',
+            code: 'CT',
+          },
+          {
+            name: 'Delaware',
+            code: 'DE',
+          },
+          {
+            name: 'Washington DC',
+            code: 'DC',
+          },
+          {
+            name: 'Micronesia',
+            code: 'FM',
+          },
+          {
+            name: 'Florida',
+            code: 'FL',
+          },
+          {
+            name: 'Georgia',
+            code: 'GA',
+          },
+          {
+            name: 'Guam',
+            code: 'GU',
+          },
+          {
+            name: 'Hawaii',
+            code: 'HI',
+          },
+          {
+            name: 'Idaho',
+            code: 'ID',
+          },
+          {
+            name: 'Illinois',
+            code: 'IL',
+          },
+          {
+            name: 'Indiana',
+            code: 'IN',
+          },
+          {
+            name: 'Iowa',
+            code: 'IA',
+          },
+          {
+            name: 'Kansas',
+            code: 'KS',
+          },
+          {
+            name: 'Kentucky',
+            code: 'KY',
+          },
+          {
+            name: 'Louisiana',
+            code: 'LA',
+          },
+          {
+            name: 'Maine',
+            code: 'ME',
+          },
+          {
+            name: 'Marshall Islands',
+            code: 'MH',
+          },
+          {
+            name: 'Maryland',
+            code: 'MD',
+          },
+          {
+            name: 'Massachusetts',
+            code: 'MA',
+          },
+          {
+            name: 'Michigan',
+            code: 'MI',
+          },
+          {
+            name: 'Minnesota',
+            code: 'MN',
+          },
+          {
+            name: 'Mississippi',
+            code: 'MS',
+          },
+          {
+            name: 'Missouri',
+            code: 'MO',
+          },
+          {
+            name: 'Montana',
+            code: 'MT',
+          },
+          {
+            name: 'Nebraska',
+            code: 'NE',
+          },
+          {
+            name: 'Nevada',
+            code: 'NV',
+          },
+          {
+            name: 'New Hampshire',
+            code: 'NH',
+          },
+          {
+            name: 'New Jersey',
+            code: 'NJ',
+          },
+          {
+            name: 'New Mexico',
+            code: 'NM',
+          },
+          {
+            name: 'New York',
+            code: 'NY',
+          },
+          {
+            name: 'North Carolina',
+            code: 'NC',
+          },
+          {
+            name: 'North Dakota',
+            code: 'ND',
+          },
+          {
+            name: 'Northern Mariana Islands',
+            code: 'MP',
+          },
+          {
+            name: 'Ohio',
+            code: 'OH',
+          },
+          {
+            name: 'Oklahoma',
+            code: 'OK',
+          },
+          {
+            name: 'Oregon',
+            code: 'OR',
+          },
+          {
+            name: 'Palau',
+            code: 'PW',
+          },
+          {
+            name: 'Pennsylvania',
+            code: 'PA',
+          },
+          {
+            name: 'Puerto Rico',
+            code: 'PR',
+          },
+          {
+            name: 'Rhode Island',
+            code: 'RI',
+          },
+          {
+            name: 'South Carolina',
+            code: 'SC',
+          },
+          {
+            name: 'South Dakota',
+            code: 'SD',
+          },
+          {
+            name: 'Tennessee',
+            code: 'TN',
+          },
+          {
+            name: 'Texas',
+            code: 'TX',
+          },
+          {
+            name: 'Utah',
+            code: 'UT',
+          },
+          {
+            name: 'Vermont',
+            code: 'VT',
+          },
+          {
+            name: 'U.S. Virgin Islands',
+            code: 'VI',
+          },
+          {
+            name: 'Virginia',
+            code: 'VA',
+          },
+          {
+            name: 'Washington',
+            code: 'WA',
+          },
+          {
+            name: 'West Virginia',
+            code: 'WV',
+          },
+          {
+            name: 'Wisconsin',
+            code: 'WI',
+          },
+          {
+            name: 'Wyoming',
+            code: 'WY',
+          },
+          {
+            name: 'Armed Forces Americas',
+            code: 'AA',
+          },
+          {
+            name: 'Armed Forces Europe',
+            code: 'AE',
+          },
+          {
+            name: 'Armed Forces Pacific',
+            code: 'AP',
+          },
         ],
       },
       {
@@ -7255,9 +10856,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7269,7 +10873,7 @@ const data = {
         continent: 'Asia',
         phoneNumberPrefix: 998,
         autocompletionField: 'address1',
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
@@ -7280,7 +10884,10 @@ const data = {
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7309,6 +10916,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -7336,9 +10946,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7362,6 +10975,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7390,6 +11006,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
@@ -7417,9 +11036,12 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7443,6 +11065,9 @@ const data = {
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7471,6 +11096,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -7496,11 +11124,14 @@ const data = {
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7525,6 +11156,9 @@ const data = {
           postalCode: 'Postal code',
           zone: 'Region',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
@@ -7538,7 +11172,10 @@ const data = {
   errors: [
     {
       message: 'Translations for `af` is currently not supported.',
-      extensions: {code: 'LOCALE_UNSUPPORTED', attribute: 'locale'},
+      extensions: {
+        code: 'LOCALE_UNSUPPORTED',
+        attribute: 'locale',
+      },
     },
   ],
 };

--- a/packages/address-mocks/src/fixtures/countries_en.ts
+++ b/packages/address-mocks/src/fixtures/countries_en.ts
@@ -12,12 +12,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -26,7 +29,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Åland Islands',
@@ -39,21 +41,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Albania',
@@ -66,12 +70,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -80,7 +87,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Algeria',
@@ -93,21 +99,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Andorra',
@@ -120,21 +128,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Angola',
@@ -147,12 +157,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -161,7 +174,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Anguilla',
@@ -174,12 +186,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -188,7 +203,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Antigua & Barbuda',
@@ -201,12 +215,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -215,7 +232,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Argentina',
@@ -228,22 +244,25 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'Buenos Aires',
+            name: 'Buenos Aires Province',
             code: 'B',
           },
           {
@@ -259,7 +278,7 @@ const data = {
             code: 'U',
           },
           {
-            name: 'Ciudad Autónoma de Buenos Aires',
+            name: 'Buenos Aires (Autonomous City)',
             code: 'C',
           },
           {
@@ -327,11 +346,11 @@ const data = {
             code: 'S',
           },
           {
-            name: 'Santiago Del Estero',
+            name: 'Santiago del Estero',
             code: 'G',
           },
           {
-            name: 'Tierra Del Fuego',
+            name: 'Tierra del Fuego',
             code: 'V',
           },
           {
@@ -339,7 +358,6 @@ const data = {
             code: 'T',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Armenia',
@@ -352,21 +370,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Aruba',
@@ -379,12 +399,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -393,7 +416,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Australia',
@@ -404,14 +426,17 @@ const data = {
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'Suburb',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postcode',
           zone: 'State/territory',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -453,7 +478,6 @@ const data = {
             code: 'WA',
           },
         ],
-        provinceKey: 'STATE_AND_TERRITORY',
       },
       {
         name: 'Austria',
@@ -462,25 +486,27 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
-          address2: 'Apartment, suite, etc.',
+          address1: 'Street and house number',
+          address2: 'Additional address',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Additional address (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Azerbaijan',
@@ -493,21 +519,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bahamas',
@@ -520,12 +548,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -534,7 +565,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bahrain',
@@ -547,12 +577,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -561,7 +594,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bangladesh',
@@ -574,12 +606,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -588,7 +623,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Barbados',
@@ -601,12 +635,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -615,7 +652,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Belarus',
@@ -628,21 +664,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Belgium',
@@ -655,21 +693,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Belize',
@@ -682,12 +722,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -696,7 +739,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Benin',
@@ -709,12 +751,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -723,7 +768,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bermuda',
@@ -736,12 +780,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -750,7 +797,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bhutan',
@@ -763,12 +809,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -777,7 +826,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bolivia',
@@ -790,12 +838,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -804,7 +855,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bosnia & Herzegovina',
@@ -817,21 +867,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Botswana',
@@ -844,12 +896,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -858,7 +913,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bouvet Island',
@@ -871,12 +925,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -885,7 +942,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Brazil',
@@ -894,16 +950,19 @@ const data = {
         autocompletionField: 'address1',
         continent: 'South America',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'State',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -937,7 +996,7 @@ const data = {
             code: 'CE',
           },
           {
-            name: 'Distrito Federal',
+            name: 'Federal District',
             code: 'DF',
           },
           {
@@ -1021,7 +1080,6 @@ const data = {
             code: 'TO',
           },
         ],
-        provinceKey: 'STATE',
       },
       {
         name: 'British Indian Ocean Territory',
@@ -1034,12 +1092,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1048,7 +1109,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'British Virgin Islands',
@@ -1061,12 +1121,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1075,7 +1138,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Brunei',
@@ -1088,12 +1150,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1102,7 +1167,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Bulgaria',
@@ -1115,21 +1179,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Burkina Faso',
@@ -1142,12 +1208,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1156,7 +1225,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Burundi',
@@ -1169,12 +1237,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1183,7 +1254,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Cambodia',
@@ -1196,12 +1266,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1210,7 +1283,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Cameroon',
@@ -1223,12 +1295,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1237,7 +1312,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Canada',
@@ -1247,15 +1321,18 @@ const data = {
         continent: 'North America',
         labels: {
           address1: 'Address',
-          address2: 'Apt./Unit No.',
+          address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1317,7 +1394,6 @@ const data = {
             code: 'YT',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Cape Verde',
@@ -1330,21 +1406,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Caribbean Netherlands',
@@ -1357,12 +1435,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1371,7 +1452,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Cayman Islands',
@@ -1384,12 +1464,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1398,7 +1481,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Central African Republic',
@@ -1411,12 +1493,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1425,7 +1510,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Chad',
@@ -1438,12 +1522,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1452,7 +1539,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Chile',
@@ -1465,21 +1551,88 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'State',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{country}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        zones: [],
-        provinceKey: 'STATE',
+        zones: [
+          {
+            name: 'Arica y Parinacota',
+            code: 'AP',
+          },
+          {
+            name: 'Tarapacá',
+            code: 'TA',
+          },
+          {
+            name: 'Antofagasta',
+            code: 'AN',
+          },
+          {
+            name: 'Atacama',
+            code: 'AT',
+          },
+          {
+            name: 'Coquimbo',
+            code: 'CO',
+          },
+          {
+            name: 'Valparaíso',
+            code: 'VS',
+          },
+          {
+            name: 'Santiago Metropolitan',
+            code: 'RM',
+          },
+          {
+            name: 'Libertador General Bernardo O’Higgins',
+            code: 'LI',
+          },
+          {
+            name: 'Maule',
+            code: 'ML',
+          },
+          {
+            name: 'Ñuble',
+            code: 'NB',
+          },
+          {
+            name: 'Bío Bío',
+            code: 'BI',
+          },
+          {
+            name: 'Araucanía',
+            code: 'AR',
+          },
+          {
+            name: 'Los Ríos',
+            code: 'LR',
+          },
+          {
+            name: 'Los Lagos',
+            code: 'LL',
+          },
+          {
+            name: 'Aysén',
+            code: 'AI',
+          },
+          {
+            name: 'Magallanes Region',
+            code: 'MA',
+          },
+        ],
       },
       {
         name: 'China',
@@ -1488,16 +1641,19 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Asia',
         labels: {
-          address1: 'Address',
+          address1: 'Full address',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1619,7 +1775,7 @@ const data = {
             code: 'XJ',
           },
           {
-            name: 'Xizang',
+            name: 'Tibet',
             code: 'YZ',
           },
           {
@@ -1631,7 +1787,6 @@ const data = {
             code: 'ZJ',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Christmas Island',
@@ -1644,12 +1799,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1658,7 +1816,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Cocos (Keeling) Islands',
@@ -1671,12 +1828,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1685,7 +1845,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Colombia',
@@ -1698,12 +1857,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1713,7 +1875,7 @@ const data = {
         },
         zones: [
           {
-            name: 'Bogotá, D.C.',
+            name: 'Capital District',
             code: 'DC',
           },
           {
@@ -1817,7 +1979,7 @@ const data = {
             code: 'RIS',
           },
           {
-            name: 'San Andrés, Providencia y Santa Catalina',
+            name: 'San Andrés & Providencia',
             code: 'SAP',
           },
           {
@@ -1845,7 +2007,6 @@ const data = {
             code: 'VID',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Comoros',
@@ -1858,12 +2019,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1872,7 +2036,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Congo - Brazzaville',
@@ -1885,12 +2048,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1899,7 +2065,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Congo - Kinshasa',
@@ -1912,12 +2077,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1926,7 +2094,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Cook Islands',
@@ -1939,12 +2106,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1953,7 +2123,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Costa Rica',
@@ -1966,12 +2135,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -1980,7 +2152,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Croatia',
@@ -1993,21 +2164,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Cuba',
@@ -2020,21 +2193,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Curaçao',
@@ -2047,12 +2222,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2061,7 +2239,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Cyprus',
@@ -2074,24 +2251,26 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
-        name: 'Czech Republic',
+        name: 'Czechia',
         code: 'CZ',
         phoneNumberPrefix: 420,
         autocompletionField: 'address1',
@@ -2101,21 +2280,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Côte d’Ivoire',
@@ -2128,12 +2309,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2142,7 +2326,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Denmark',
@@ -2151,25 +2334,27 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Djibouti',
@@ -2182,12 +2367,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2196,7 +2384,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Dominica',
@@ -2209,12 +2396,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2223,7 +2413,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Dominican Republic',
@@ -2236,21 +2425,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Ecuador',
@@ -2263,21 +2454,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Egypt',
@@ -2290,12 +2483,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Governorate',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2421,7 +2617,6 @@ const data = {
             code: 'SUZ',
           },
         ],
-        provinceKey: 'GOVERNORATE',
       },
       {
         name: 'El Salvador',
@@ -2434,12 +2629,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2448,7 +2646,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Equatorial Guinea',
@@ -2461,12 +2658,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2475,7 +2675,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Eritrea',
@@ -2488,12 +2687,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2502,7 +2704,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Estonia',
@@ -2515,21 +2716,52 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
+      },
+      {
+        name: 'Eswatini',
+        code: 'SZ',
+        phoneNumberPrefix: 268,
+        autocompletionField: 'address1',
+        continent: 'Africa',
+        labels: {
+          address1: 'Address',
+          address2: 'Apartment, suite, etc.',
+          city: 'City',
+          company: 'Company',
+          country: 'Country/Region',
+          firstName: 'First name',
+          lastName: 'Last name',
+          phone: 'Phone',
+          postalCode: 'Postal code',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Ethiopia',
@@ -2542,12 +2774,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2556,7 +2791,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Falkland Islands',
@@ -2569,12 +2803,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2583,7 +2820,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Faroe Islands',
@@ -2596,21 +2832,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Fiji',
@@ -2623,12 +2861,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2637,7 +2878,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Finland',
@@ -2650,21 +2890,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'France',
@@ -2677,12 +2919,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2691,7 +2936,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'French Guiana',
@@ -2704,21 +2948,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'French Polynesia',
@@ -2731,21 +2977,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'French Southern Territories',
@@ -2758,12 +3006,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2772,7 +3023,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Gabon',
@@ -2785,12 +3035,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2799,7 +3052,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Gambia',
@@ -2812,12 +3064,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2826,7 +3081,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Georgia',
@@ -2839,21 +3093,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Germany',
@@ -2866,21 +3122,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{country}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Ghana',
@@ -2893,12 +3151,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2907,7 +3168,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Gibraltar',
@@ -2920,12 +3180,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -2934,7 +3197,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Greece',
@@ -2947,21 +3209,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Greenland',
@@ -2974,21 +3238,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Grenada',
@@ -3001,12 +3267,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3015,7 +3284,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Guadeloupe',
@@ -3028,21 +3296,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Guatemala',
@@ -3055,12 +3325,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3158,7 +3431,6 @@ const data = {
             code: 'ZAC',
           },
         ],
-        provinceKey: 'REGION',
       },
       {
         name: 'Guernsey',
@@ -3171,12 +3443,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3185,7 +3460,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Guinea',
@@ -3198,12 +3472,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3212,7 +3489,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Guinea-Bissau',
@@ -3225,21 +3501,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Guyana',
@@ -3252,12 +3530,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3266,7 +3547,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Haiti',
@@ -3279,21 +3559,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Heard & McDonald Islands',
@@ -3306,12 +3588,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3320,7 +3605,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Honduras',
@@ -3333,21 +3617,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Hong Kong SAR China',
@@ -3358,14 +3644,17 @@ const data = {
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'District',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3387,7 +3676,6 @@ const data = {
             code: 'NT',
           },
         ],
-        provinceKey: 'REGION',
       },
       {
         name: 'Hungary',
@@ -3400,12 +3688,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3414,7 +3705,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Iceland',
@@ -3427,21 +3717,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'India',
@@ -3454,12 +3746,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'PIN code',
           zone: 'State',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3469,7 +3764,7 @@ const data = {
         },
         zones: [
           {
-            name: 'Andaman and Nicobar',
+            name: 'Andaman and Nicobar Islands',
             code: 'AN',
           },
           {
@@ -3493,7 +3788,7 @@ const data = {
             code: 'CH',
           },
           {
-            name: 'Chattisgarh',
+            name: 'Chhattisgarh',
             code: 'CG',
           },
           {
@@ -3541,6 +3836,10 @@ const data = {
             code: 'KL',
           },
           {
+            name: 'Ladakh',
+            code: 'LA',
+          },
+          {
             name: 'Lakshadweep',
             code: 'LD',
           },
@@ -3569,7 +3868,7 @@ const data = {
             code: 'NL',
           },
           {
-            name: 'Orissa',
+            name: 'Odisha',
             code: 'OR',
           },
           {
@@ -3613,7 +3912,6 @@ const data = {
             code: 'WB',
           },
         ],
-        provinceKey: 'STATE',
       },
       {
         name: 'Indonesia',
@@ -3626,18 +3924,21 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{country}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}',
         },
         zones: [
           {
@@ -3649,7 +3950,7 @@ const data = {
             code: 'BA',
           },
           {
-            name: 'Bangka Belitung',
+            name: 'Bangka–Belitung Islands',
             code: 'BB',
           },
           {
@@ -3673,39 +3974,39 @@ const data = {
             code: 'JA',
           },
           {
-            name: 'Jawa Barat',
+            name: 'West Java',
             code: 'JB',
           },
           {
-            name: 'Jawa Tengah',
+            name: 'Central Java',
             code: 'JT',
           },
           {
-            name: 'Jawa Timur',
+            name: 'East Java',
             code: 'JI',
           },
           {
-            name: 'Kalimantan Barat',
+            name: 'West Kalimantan',
             code: 'KB',
           },
           {
-            name: 'Kalimantan Selatan',
+            name: 'South Kalimantan',
             code: 'KS',
           },
           {
-            name: 'Kalimantan Tengah',
+            name: 'Central Kalimantan',
             code: 'KT',
           },
           {
-            name: 'Kalimantan Timur',
+            name: 'East Kalimantan',
             code: 'KI',
           },
           {
-            name: 'Kalimantan Utara',
+            name: 'North Kalimantan',
             code: 'KU',
           },
           {
-            name: 'Kepulauan Riau',
+            name: 'Riau Islands',
             code: 'KR',
           },
           {
@@ -3717,15 +4018,19 @@ const data = {
             code: 'MA',
           },
           {
-            name: 'Maluku Utara',
+            name: 'North Maluku',
             code: 'MU',
           },
           {
-            name: 'Nusa Tenggara Barat',
+            name: 'North Sumatra',
+            code: 'SU',
+          },
+          {
+            name: 'West Nusa Tenggara',
             code: 'NB',
           },
           {
-            name: 'Nusa Tenggara Timur',
+            name: 'East Nusa Tenggara',
             code: 'NT',
           },
           {
@@ -3733,7 +4038,7 @@ const data = {
             code: 'PA',
           },
           {
-            name: 'Papua Barat',
+            name: 'West Papua',
             code: 'PB',
           },
           {
@@ -3741,43 +4046,38 @@ const data = {
             code: 'RI',
           },
           {
-            name: 'Sulawesi Barat',
-            code: 'SR',
-          },
-          {
-            name: 'Sulawesi Selatan',
-            code: 'SN',
-          },
-          {
-            name: 'Sulawesi Tengah',
-            code: 'ST',
-          },
-          {
-            name: 'Sulawesi Tenggara',
-            code: 'SG',
-          },
-          {
-            name: 'Sulawesi Utara',
-            code: 'SA',
-          },
-          {
-            name: 'Sumatra Barat',
-            code: 'SB',
-          },
-          {
-            name: 'Sumatra Selatan',
+            name: 'South Sumatra',
             code: 'SS',
           },
           {
-            name: 'Sumatra Utara',
-            code: 'SU',
+            name: 'West Sulawesi',
+            code: 'SR',
+          },
+          {
+            name: 'South Sulawesi',
+            code: 'SN',
+          },
+          {
+            name: 'Central Sulawesi',
+            code: 'ST',
+          },
+          {
+            name: 'Southeast Sulawesi',
+            code: 'SG',
+          },
+          {
+            name: 'North Sulawesi',
+            code: 'SA',
+          },
+          {
+            name: 'West Sumatra',
+            code: 'SB',
           },
           {
             name: 'Yogyakarta',
             code: 'YO',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Iran',
@@ -3790,21 +4090,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Iraq',
@@ -3817,12 +4119,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3831,7 +4136,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Ireland',
@@ -3844,12 +4148,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'County',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3963,7 +4270,6 @@ const data = {
             code: 'WW',
           },
         ],
-        provinceKey: 'COUNTY',
       },
       {
         name: 'Isle of Man',
@@ -3976,12 +4282,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -3990,7 +4299,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Israel',
@@ -4003,21 +4311,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Italy',
@@ -4026,20 +4336,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
@@ -4105,7 +4418,7 @@ const data = {
             code: 'BO',
           },
           {
-            name: 'Bolzano',
+            name: 'South Tyrol',
             code: 'BZ',
           },
           {
@@ -4181,7 +4494,7 @@ const data = {
             code: 'FE',
           },
           {
-            name: 'Firenze',
+            name: 'Florence',
             code: 'FI',
           },
           {
@@ -4197,7 +4510,7 @@ const data = {
             code: 'FR',
           },
           {
-            name: 'Genova',
+            name: 'Genoa',
             code: 'GE',
           },
           {
@@ -4217,7 +4530,7 @@ const data = {
             code: 'IS',
           },
           {
-            name: "L'Aquila",
+            name: 'L’Aquila',
             code: 'AQ',
           },
           {
@@ -4253,11 +4566,11 @@ const data = {
             code: 'MC',
           },
           {
-            name: 'Mantova',
+            name: 'Mantua',
             code: 'MN',
           },
           {
-            name: 'Massa-Carrara',
+            name: 'Massa and Carrara',
             code: 'MS',
           },
           {
@@ -4273,7 +4586,7 @@ const data = {
             code: 'ME',
           },
           {
-            name: 'Milano',
+            name: 'Milan',
             code: 'MI',
           },
           {
@@ -4281,11 +4594,11 @@ const data = {
             code: 'MO',
           },
           {
-            name: 'Monza e Brianza',
+            name: 'Monza and Brianza',
             code: 'MB',
           },
           {
-            name: 'Napoli',
+            name: 'Naples',
             code: 'NA',
           },
           {
@@ -4309,7 +4622,7 @@ const data = {
             code: 'OR',
           },
           {
-            name: 'Padova',
+            name: 'Padua',
             code: 'PD',
           },
           {
@@ -4329,7 +4642,7 @@ const data = {
             code: 'PG',
           },
           {
-            name: 'Pesaro e Urbino',
+            name: 'Pesaro and Urbino',
             code: 'PU',
           },
           {
@@ -4385,7 +4698,7 @@ const data = {
             code: 'RN',
           },
           {
-            name: 'Roma',
+            name: 'Rome',
             code: 'RM',
           },
           {
@@ -4409,7 +4722,7 @@ const data = {
             code: 'SI',
           },
           {
-            name: 'Siracusa',
+            name: 'Syracuse',
             code: 'SR',
           },
           {
@@ -4429,7 +4742,7 @@ const data = {
             code: 'TR',
           },
           {
-            name: 'Torino',
+            name: 'Turin',
             code: 'TO',
           },
           {
@@ -4437,7 +4750,7 @@ const data = {
             code: 'TP',
           },
           {
-            name: 'Trento',
+            name: 'Trentino',
             code: 'TN',
           },
           {
@@ -4457,7 +4770,7 @@ const data = {
             code: 'VA',
           },
           {
-            name: 'Venezia',
+            name: 'Venice',
             code: 'VE',
           },
           {
@@ -4485,7 +4798,6 @@ const data = {
             code: 'VT',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Jamaica',
@@ -4498,12 +4810,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4512,7 +4827,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Japan',
@@ -4523,20 +4837,23 @@ const data = {
         labels: {
           address1: 'Address',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'City/ward/town/village',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Prefecture',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{company}_{lastName}{firstName}_{zip}_{country}_{province}{city}_{address1}_{address2}_{phone}',
+            '{lastName}{firstName}_{company}_{country}{zip}_{province}_{city}_{address1}_{address2}_{phone}',
           show:
-            '{country}_〒{zip} {province} {city} {address1} {address2}_{company}_{lastName} {firstName}様_{phone}',
+            '{country} 〒{zip}_{province} {city}_{address1}_{address2}_{company}_{lastName} {firstName}様_{phone}',
         },
         zones: [
           {
@@ -4588,7 +4905,7 @@ const data = {
             code: 'JP-12',
           },
           {
-            name: 'Tōkyō',
+            name: 'Tokyo',
             code: 'JP-13',
           },
           {
@@ -4728,7 +5045,6 @@ const data = {
             code: 'JP-47',
           },
         ],
-        provinceKey: 'PREFECTURE',
       },
       {
         name: 'Jersey',
@@ -4741,12 +5057,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4755,7 +5074,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Jordan',
@@ -4768,12 +5086,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4782,7 +5103,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Kazakhstan',
@@ -4795,12 +5115,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4809,7 +5132,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Kenya',
@@ -4822,12 +5144,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4836,7 +5161,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Kiribati',
@@ -4849,12 +5173,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4863,7 +5190,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Kosovo',
@@ -4876,21 +5202,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Kuwait',
@@ -4903,12 +5231,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4917,7 +5248,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Kyrgyzstan',
@@ -4930,21 +5260,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{zip}{city}_{address2}_{address1}_{company}_{firstName}{lastName}_{country}_{phone}',
           show:
             '{zip} {city}_{address2}_{address1}_{company}_{firstName} {lastName}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Laos',
@@ -4957,12 +5289,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4971,7 +5306,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Latvia',
@@ -4984,12 +5318,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -4998,7 +5335,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Lebanon',
@@ -5011,12 +5347,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5025,7 +5364,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Lesotho',
@@ -5038,12 +5376,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5052,7 +5393,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Liberia',
@@ -5065,21 +5405,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Libya',
@@ -5092,12 +5434,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5106,7 +5451,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Liechtenstein',
@@ -5119,21 +5463,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Lithuania',
@@ -5146,12 +5492,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5160,7 +5509,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Luxembourg',
@@ -5173,24 +5521,26 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
-        name: 'Macau SAR China',
+        name: 'Macao SAR China',
         code: 'MO',
         phoneNumberPrefix: 853,
         autocompletionField: 'address1',
@@ -5200,12 +5550,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5214,34 +5567,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
-      },
-      {
-        name: 'Macedonia',
-        code: 'MK',
-        phoneNumberPrefix: 389,
-        autocompletionField: 'address1',
-        continent: 'Europe',
-        labels: {
-          address1: 'Address',
-          address2: 'Apartment, suite, etc.',
-          city: 'City',
-          company: 'Company',
-          country: 'Country',
-          firstName: 'First name',
-          lastName: 'Last name',
-          phone: 'Phone',
-          postalCode: 'Postal code',
-          zone: 'Province',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Madagascar',
@@ -5254,21 +5579,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Malawi',
@@ -5281,12 +5608,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5295,7 +5625,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Malaysia',
@@ -5308,16 +5637,19 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postcode',
           zone: 'State/territory',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
@@ -5343,7 +5675,7 @@ const data = {
             code: 'LBN',
           },
           {
-            name: 'Melaka',
+            name: 'Malacca',
             code: 'MLK',
           },
           {
@@ -5355,16 +5687,16 @@ const data = {
             code: 'PHG',
           },
           {
+            name: 'Penang',
+            code: 'PNG',
+          },
+          {
             name: 'Perak',
             code: 'PRK',
           },
           {
             name: 'Perlis',
             code: 'PLS',
-          },
-          {
-            name: 'Pulau Pinang',
-            code: 'PNG',
           },
           {
             name: 'Putrajaya',
@@ -5387,7 +5719,6 @@ const data = {
             code: 'TRG',
           },
         ],
-        provinceKey: 'STATE_AND_TERRITORY',
       },
       {
         name: 'Maldives',
@@ -5400,12 +5731,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5414,7 +5748,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Mali',
@@ -5427,12 +5760,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5441,7 +5777,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Malta',
@@ -5454,12 +5789,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5468,7 +5806,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Martinique',
@@ -5481,21 +5818,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Mauritania',
@@ -5508,12 +5847,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5522,7 +5864,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Mauritius',
@@ -5535,12 +5876,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5549,7 +5893,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Mayotte',
@@ -5562,21 +5905,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Mexico',
@@ -5585,20 +5930,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'North America',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'State',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
@@ -5628,7 +5976,7 @@ const data = {
             code: 'CHIH',
           },
           {
-            name: 'Ciudad de México',
+            name: 'Ciudad de Mexico',
             code: 'DF',
           },
           {
@@ -5660,7 +6008,7 @@ const data = {
             code: 'JAL',
           },
           {
-            name: 'México',
+            name: 'Mexico State',
             code: 'MEX',
           },
           {
@@ -5732,7 +6080,6 @@ const data = {
             code: 'ZAC',
           },
         ],
-        provinceKey: 'STATE',
       },
       {
         name: 'Moldova',
@@ -5745,21 +6092,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Monaco',
@@ -5772,21 +6121,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Mongolia',
@@ -5799,12 +6150,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5813,7 +6167,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Montenegro',
@@ -5826,21 +6179,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Montserrat',
@@ -5853,12 +6208,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5867,7 +6225,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Morocco',
@@ -5880,21 +6237,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Mozambique',
@@ -5907,21 +6266,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Myanmar (Burma)',
@@ -5934,12 +6295,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5948,7 +6312,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Namibia',
@@ -5961,12 +6324,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -5975,7 +6341,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Nauru',
@@ -5988,12 +6353,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6002,7 +6370,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Nepal',
@@ -6015,12 +6382,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6029,7 +6399,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Netherlands',
@@ -6038,25 +6407,27 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Netherlands Antilles',
@@ -6069,12 +6440,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6083,7 +6457,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'New Caledonia',
@@ -6096,21 +6469,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'New Zealand',
@@ -6123,12 +6498,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6154,7 +6532,7 @@ const data = {
             code: 'GIS',
           },
           {
-            name: "Hawke's Bay",
+            name: 'Hawke’s Bay',
             code: 'HKB',
           },
           {
@@ -6202,7 +6580,6 @@ const data = {
             code: 'WTC',
           },
         ],
-        provinceKey: 'REGION',
       },
       {
         name: 'Nicaragua',
@@ -6215,21 +6592,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Niger',
@@ -6242,21 +6621,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Nigeria',
@@ -6269,12 +6650,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'State',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6288,7 +6672,7 @@ const data = {
             code: 'AB',
           },
           {
-            name: 'Abuja Federal Capital Territory',
+            name: 'Federal Capital Territory',
             code: 'FC',
           },
           {
@@ -6432,7 +6816,6 @@ const data = {
             code: 'ZA',
           },
         ],
-        provinceKey: 'STATE',
       },
       {
         name: 'Niue',
@@ -6445,12 +6828,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6459,7 +6845,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Norfolk Island',
@@ -6472,12 +6857,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6486,7 +6874,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'North Korea',
@@ -6499,12 +6886,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6513,7 +6903,35 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
+      },
+      {
+        name: 'North Macedonia',
+        code: 'MK',
+        phoneNumberPrefix: 389,
+        autocompletionField: 'address1',
+        continent: 'Europe',
+        labels: {
+          address1: 'Address',
+          address2: 'Apartment, suite, etc.',
+          city: 'City',
+          company: 'Company',
+          country: 'Country/Region',
+          firstName: 'First name',
+          lastName: 'Last name',
+          phone: 'Phone',
+          postalCode: 'Postal code',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
       },
       {
         name: 'Norway',
@@ -6522,25 +6940,27 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Oman',
@@ -6553,21 +6973,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Pakistan',
@@ -6580,12 +7002,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6594,7 +7019,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Palestinian Territories',
@@ -6607,12 +7031,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6621,7 +7048,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Panama',
@@ -6634,12 +7060,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6677,7 +7106,7 @@ const data = {
             code: 'PA-6',
           },
           {
-            name: 'Kuna Yala',
+            name: 'Guna Yala',
             code: 'PA-KY',
           },
           {
@@ -6693,7 +7122,7 @@ const data = {
             code: 'PA-8',
           },
           {
-            name: 'Panamá Oeste',
+            name: 'West Panamá',
             code: 'PA-10',
           },
           {
@@ -6701,7 +7130,6 @@ const data = {
             code: 'PA-9',
           },
         ],
-        provinceKey: 'REGION',
       },
       {
         name: 'Papua New Guinea',
@@ -6714,12 +7142,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6728,7 +7159,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Paraguay',
@@ -6741,21 +7171,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Peru',
@@ -6768,12 +7200,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6787,7 +7222,7 @@ const data = {
             code: 'PE-AMA',
           },
           {
-            name: 'Áncash',
+            name: 'Ancash',
             code: 'PE-ANC',
           },
           {
@@ -6807,11 +7242,11 @@ const data = {
             code: 'PE-CAJ',
           },
           {
-            name: 'Callao',
+            name: 'El Callao',
             code: 'PE-CAL',
           },
           {
-            name: 'Cuzco',
+            name: 'Cusco',
             code: 'PE-CUS',
           },
           {
@@ -6839,11 +7274,11 @@ const data = {
             code: 'PE-LAM',
           },
           {
-            name: 'Lima (departamento)',
+            name: 'Lima Region',
             code: 'PE-LIM',
           },
           {
-            name: 'Lima (provincia)',
+            name: 'Lima',
             code: 'PE-LMA',
           },
           {
@@ -6887,7 +7322,6 @@ const data = {
             code: 'PE-UCA',
           },
         ],
-        provinceKey: 'REGION',
       },
       {
         name: 'Philippines',
@@ -6900,21 +7334,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Pitcairn Islands',
@@ -6927,21 +7363,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Poland',
@@ -6954,21 +7392,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Portugal',
@@ -6981,12 +7421,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -6996,7 +7439,7 @@ const data = {
         },
         zones: [
           {
-            name: 'Açores',
+            name: 'Azores',
             code: 'PT-20',
           },
           {
@@ -7040,7 +7483,7 @@ const data = {
             code: 'PT-10',
           },
           {
-            name: 'Lisboa',
+            name: 'Lisbon',
             code: 'PT-11',
           },
           {
@@ -7076,7 +7519,6 @@ const data = {
             code: 'PT-18',
           },
         ],
-        provinceKey: 'REGION',
       },
       {
         name: 'Qatar',
@@ -7089,12 +7531,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7103,7 +7548,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Réunion',
@@ -7116,21 +7560,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Romania',
@@ -7143,16 +7589,19 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'County',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
@@ -7178,11 +7627,11 @@ const data = {
             code: 'BH',
           },
           {
-            name: 'Bistrița-Năsăud',
+            name: 'Bistriţa-Năsăud',
             code: 'BN',
           },
           {
-            name: 'Botoșani',
+            name: 'Botoşani',
             code: 'BT',
           },
           {
@@ -7190,11 +7639,11 @@ const data = {
             code: 'BR',
           },
           {
-            name: 'Brașov',
+            name: 'Braşov',
             code: 'BV',
           },
           {
-            name: 'București',
+            name: 'Bucharest',
             code: 'B',
           },
           {
@@ -7262,7 +7711,7 @@ const data = {
             code: 'IF',
           },
           {
-            name: 'Maramureș',
+            name: 'Maramureş',
             code: 'MM',
           },
           {
@@ -7270,11 +7719,11 @@ const data = {
             code: 'MH',
           },
           {
-            name: 'Mureș',
+            name: 'Mureş',
             code: 'MS',
           },
           {
-            name: 'Neamț',
+            name: 'Neamţ',
             code: 'NT',
           },
           {
@@ -7326,7 +7775,6 @@ const data = {
             code: 'VN',
           },
         ],
-        provinceKey: 'COUNTY',
       },
       {
         name: 'Russia',
@@ -7339,12 +7787,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7358,67 +7809,67 @@ const data = {
             code: 'ALT',
           },
           {
-            name: 'Altai Republic',
+            name: 'Altai',
             code: 'AL',
           },
           {
-            name: 'Amur Oblast',
+            name: 'Amur',
             code: 'AMU',
           },
           {
-            name: 'Arkhangelsk Oblast',
+            name: 'Arkhangelsk',
             code: 'ARK',
           },
           {
-            name: 'Astrakhan Oblast',
+            name: 'Astrakhan',
             code: 'AST',
           },
           {
-            name: 'Belgorod Oblast',
+            name: 'Belgorod',
             code: 'BEL',
           },
           {
-            name: 'Bryansk Oblast',
+            name: 'Bryansk',
             code: 'BRY',
           },
           {
-            name: 'Chechen Republic',
+            name: 'Chechen',
             code: 'CE',
           },
           {
-            name: 'Chelyabinsk Oblast',
+            name: 'Chelyabinsk',
             code: 'CHE',
           },
           {
-            name: 'Chukotka Autonomous Okrug',
+            name: 'Chukotka Okrug',
             code: 'CHU',
           },
           {
-            name: 'Chuvash Republic',
+            name: 'Chuvash',
             code: 'CU',
           },
           {
-            name: 'Irkutsk Oblast',
+            name: 'Irkutsk',
             code: 'IRK',
           },
           {
-            name: 'Ivanovo Oblast',
+            name: 'Ivanovo',
             code: 'IVA',
           },
           {
-            name: 'Jewish Autonomous Oblast',
+            name: 'Jewish',
             code: 'YEV',
           },
           {
-            name: 'Kabardino-Balkarian Republic',
+            name: 'Kabardino-Balkar',
             code: 'KB',
           },
           {
-            name: 'Kaliningrad Oblast',
+            name: 'Kaliningrad',
             code: 'KGD',
           },
           {
-            name: 'Kaluga Oblast',
+            name: 'Kaluga',
             code: 'KLU',
           },
           {
@@ -7426,11 +7877,11 @@ const data = {
             code: 'KAM',
           },
           {
-            name: 'Karachay–Cherkess Republic',
+            name: 'Karachay-Cherkess',
             code: 'KC',
           },
           {
-            name: 'Kemerovo Oblast',
+            name: 'Kemerovo',
             code: 'KEM',
           },
           {
@@ -7438,19 +7889,19 @@ const data = {
             code: 'KHA',
           },
           {
-            name: 'Khanty-Mansi Autonomous Okrug',
+            name: 'Khanty-Mansi',
             code: 'KHM',
           },
           {
-            name: 'Kirov Oblast',
+            name: 'Kirov',
             code: 'KIR',
           },
           {
-            name: 'Komi Republic',
+            name: 'Komi',
             code: 'KO',
           },
           {
-            name: 'Kostroma Oblast',
+            name: 'Kostroma',
             code: 'KOS',
           },
           {
@@ -7462,27 +7913,27 @@ const data = {
             code: 'KYA',
           },
           {
-            name: 'Kurgan Oblast',
+            name: 'Kurgan',
             code: 'KGN',
           },
           {
-            name: 'Kursk Oblast',
+            name: 'Kursk',
             code: 'KRS',
           },
           {
-            name: 'Leningrad Oblast',
+            name: 'Leningrad',
             code: 'LEN',
           },
           {
-            name: 'Lipetsk Oblast',
+            name: 'Lipetsk',
             code: 'LIP',
           },
           {
-            name: 'Magadan Oblast',
+            name: 'Magadan',
             code: 'MAG',
           },
           {
-            name: 'Mari El Republic',
+            name: 'Mari El',
             code: 'ME',
           },
           {
@@ -7490,39 +7941,39 @@ const data = {
             code: 'MOW',
           },
           {
-            name: 'Moscow Oblast',
+            name: 'Moscow Province',
             code: 'MOS',
           },
           {
-            name: 'Murmansk Oblast',
+            name: 'Murmansk',
             code: 'MUR',
           },
           {
-            name: 'Nizhny Novgorod Oblast',
+            name: 'Nizhny Novgorod',
             code: 'NIZ',
           },
           {
-            name: 'Novgorod Oblast',
+            name: 'Novgorod',
             code: 'NGR',
           },
           {
-            name: 'Novosibirsk Oblast',
+            name: 'Novosibirsk',
             code: 'NVS',
           },
           {
-            name: 'Omsk Oblast',
+            name: 'Omsk',
             code: 'OMS',
           },
           {
-            name: 'Orenburg Oblast',
+            name: 'Orenburg',
             code: 'ORE',
           },
           {
-            name: 'Oryol Oblast',
+            name: 'Oryol',
             code: 'ORL',
           },
           {
-            name: 'Penza Oblast',
+            name: 'Penza',
             code: 'PNZ',
           },
           {
@@ -7534,59 +7985,59 @@ const data = {
             code: 'PRI',
           },
           {
-            name: 'Pskov Oblast',
+            name: 'Pskov',
             code: 'PSK',
           },
           {
-            name: 'Republic of Adygeya',
+            name: 'Adygea',
             code: 'AD',
           },
           {
-            name: 'Republic of Bashkortostan',
+            name: 'Bashkortostan',
             code: 'BA',
           },
           {
-            name: 'Republic of Buryatia',
+            name: 'Buryat',
             code: 'BU',
           },
           {
-            name: 'Republic of Dagestan',
+            name: 'Dagestan',
             code: 'DA',
           },
           {
-            name: 'Republic of Ingushetia',
+            name: 'Ingushetia',
             code: 'IN',
           },
           {
-            name: 'Republic of Kalmykia',
+            name: 'Kalmykia',
             code: 'KL',
           },
           {
-            name: 'Republic of Karelia',
+            name: 'Karelia',
             code: 'KR',
           },
           {
-            name: 'Republic of Khakassia',
+            name: 'Khakassia',
             code: 'KK',
           },
           {
-            name: 'Republic of Mordovia',
+            name: 'Mordovia',
             code: 'MO',
           },
           {
-            name: 'Republic of North Ossetia–Alania',
+            name: 'North Ossetia-Alania',
             code: 'SE',
           },
           {
-            name: 'Republic of Tatarstan',
+            name: 'Tatarstan',
             code: 'TA',
           },
           {
-            name: 'Rostov Oblast',
+            name: 'Rostov',
             code: 'ROS',
           },
           {
-            name: 'Ryazan Oblast',
+            name: 'Ryazan',
             code: 'RYA',
           },
           {
@@ -7594,23 +8045,23 @@ const data = {
             code: 'SPE',
           },
           {
-            name: 'Sakha Republic (Yakutia)',
+            name: 'Sakha',
             code: 'SA',
           },
           {
-            name: 'Sakhalin Oblast',
+            name: 'Sakhalin',
             code: 'SAK',
           },
           {
-            name: 'Samara Oblast',
+            name: 'Samara',
             code: 'SAM',
           },
           {
-            name: 'Saratov Oblast',
+            name: 'Saratov',
             code: 'SAR',
           },
           {
-            name: 'Smolensk Oblast',
+            name: 'Smolensk',
             code: 'SMO',
           },
           {
@@ -7618,63 +8069,63 @@ const data = {
             code: 'STA',
           },
           {
-            name: 'Sverdlovsk Oblast',
+            name: 'Sverdlovsk',
             code: 'SVE',
           },
           {
-            name: 'Tambov Oblast',
+            name: 'Tambov',
             code: 'TAM',
           },
           {
-            name: 'Tomsk Oblast',
+            name: 'Tomsk',
             code: 'TOM',
           },
           {
-            name: 'Tula Oblast',
+            name: 'Tula',
             code: 'TUL',
           },
           {
-            name: 'Tver Oblast',
+            name: 'Tver',
             code: 'TVE',
           },
           {
-            name: 'Tyumen Oblast',
+            name: 'Tyumen',
             code: 'TYU',
           },
           {
-            name: 'Tyva Republic',
+            name: 'Tuva',
             code: 'TY',
           },
           {
-            name: 'Udmurtia',
+            name: 'Udmurt',
             code: 'UD',
           },
           {
-            name: 'Ulyanovsk Oblast',
+            name: 'Ulyanovsk',
             code: 'ULY',
           },
           {
-            name: 'Vladimir Oblast',
+            name: 'Vladimir',
             code: 'VLA',
           },
           {
-            name: 'Volgograd Oblast',
+            name: 'Volgograd',
             code: 'VGG',
           },
           {
-            name: 'Vologda Oblast',
+            name: 'Vologda',
             code: 'VLG',
           },
           {
-            name: 'Voronezh Oblast',
+            name: 'Voronezh',
             code: 'VOR',
           },
           {
-            name: 'Yamalo-Nenets Autonomous Okrug',
+            name: 'Yamalo-Nenets Okrug',
             code: 'YAN',
           },
           {
-            name: 'Yaroslavl Oblast',
+            name: 'Yaroslavl',
             code: 'YAR',
           },
           {
@@ -7682,7 +8133,6 @@ const data = {
             code: 'ZAB',
           },
         ],
-        provinceKey: 'REGION',
       },
       {
         name: 'Rwanda',
@@ -7695,12 +8145,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7709,34 +8162,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
-      },
-      {
-        name: 'Saint Martin',
-        code: 'SX',
-        phoneNumberPrefix: 1,
-        autocompletionField: 'address1',
-        continent: 'Central America',
-        labels: {
-          address1: 'Address',
-          address2: 'Apartment, suite, etc.',
-          city: 'City',
-          company: 'Company',
-          country: 'Country',
-          firstName: 'First name',
-          lastName: 'Last name',
-          phone: 'Phone',
-          postalCode: 'Postal code',
-          zone: 'Province',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Samoa',
@@ -7749,12 +8174,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7763,7 +8191,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'San Marino',
@@ -7776,21 +8203,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'São Tomé & Príncipe',
@@ -7803,12 +8232,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7817,7 +8249,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Saudi Arabia',
@@ -7830,12 +8261,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7844,7 +8278,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Senegal',
@@ -7857,21 +8290,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Serbia',
@@ -7884,21 +8319,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Seychelles',
@@ -7911,12 +8348,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7925,7 +8365,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Sierra Leone',
@@ -7938,12 +8377,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7952,7 +8394,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Singapore',
@@ -7965,12 +8406,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -7979,7 +8423,35 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
+      },
+      {
+        name: 'Sint Maarten',
+        code: 'SX',
+        phoneNumberPrefix: 1,
+        autocompletionField: 'address1',
+        continent: 'Central America',
+        labels: {
+          address1: 'Address',
+          address2: 'Apartment, suite, etc.',
+          city: 'City',
+          company: 'Company',
+          country: 'Country/Region',
+          firstName: 'First name',
+          lastName: 'Last name',
+          phone: 'Phone',
+          postalCode: 'Postal code',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
       },
       {
         name: 'Slovakia',
@@ -7992,21 +8464,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Slovenia',
@@ -8019,21 +8493,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Solomon Islands',
@@ -8046,12 +8522,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8060,7 +8539,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Somalia',
@@ -8073,12 +8551,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8087,7 +8568,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'South Africa',
@@ -8100,12 +8580,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8151,7 +8634,6 @@ const data = {
             code: 'WC',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'South Georgia & South Sandwich Islands',
@@ -8164,12 +8646,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8178,7 +8663,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'South Korea',
@@ -8191,12 +8675,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8210,11 +8697,11 @@ const data = {
             code: 'KR-26',
           },
           {
-            name: 'Chungbuk',
+            name: 'North Chungcheong',
             code: 'KR-43',
           },
           {
-            name: 'Chungnam',
+            name: 'South Chungcheong',
             code: 'KR-44',
           },
           {
@@ -8230,11 +8717,11 @@ const data = {
             code: 'KR-42',
           },
           {
-            name: 'Gwangju',
+            name: 'Gwangju City',
             code: 'KR-29',
           },
           {
-            name: 'Gyeongbuk',
+            name: 'North Gyeongsang',
             code: 'KR-47',
           },
           {
@@ -8242,7 +8729,7 @@ const data = {
             code: 'KR-41',
           },
           {
-            name: 'Gyeongnam',
+            name: 'South Gyeongsang',
             code: 'KR-48',
           },
           {
@@ -8254,11 +8741,11 @@ const data = {
             code: 'KR-49',
           },
           {
-            name: 'Jeonbuk',
+            name: 'North Jeolla',
             code: 'KR-45',
           },
           {
-            name: 'Jeonnam',
+            name: 'South Jeolla',
             code: 'KR-46',
           },
           {
@@ -8274,7 +8761,6 @@ const data = {
             code: 'KR-31',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'South Sudan',
@@ -8287,12 +8773,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8301,7 +8790,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Spain',
@@ -8310,20 +8798,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
         },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
@@ -8349,7 +8840,7 @@ const data = {
             code: 'AL',
           },
           {
-            name: 'Asturias',
+            name: 'Asturias Province',
             code: 'O',
           },
           {
@@ -8361,7 +8852,7 @@ const data = {
             code: 'BA',
           },
           {
-            name: 'Balears',
+            name: 'Balears Province',
             code: 'PM',
           },
           {
@@ -8381,7 +8872,7 @@ const data = {
             code: 'CA',
           },
           {
-            name: 'Cantabria',
+            name: 'Cantabria Province',
             code: 'S',
           },
           {
@@ -8417,7 +8908,7 @@ const data = {
             code: 'GU',
           },
           {
-            name: 'Guipúzcoa',
+            name: 'Gipuzkoa',
             code: 'SS',
           },
           {
@@ -8433,7 +8924,7 @@ const data = {
             code: 'J',
           },
           {
-            name: 'La Rioja',
+            name: 'La Rioja Province',
             code: 'LO',
           },
           {
@@ -8453,7 +8944,7 @@ const data = {
             code: 'LU',
           },
           {
-            name: 'Madrid',
+            name: 'Madrid Province',
             code: 'M',
           },
           {
@@ -8497,7 +8988,7 @@ const data = {
             code: 'SG',
           },
           {
-            name: 'Sevilla',
+            name: 'Seville',
             code: 'SE',
           },
           {
@@ -8525,7 +9016,7 @@ const data = {
             code: 'VA',
           },
           {
-            name: 'Vizcaya',
+            name: 'Biscay',
             code: 'BI',
           },
           {
@@ -8537,7 +9028,6 @@ const data = {
             code: 'Z',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Sri Lanka',
@@ -8550,12 +9040,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8564,7 +9057,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'St. Barthélemy',
@@ -8577,21 +9069,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'St. Helena',
@@ -8604,12 +9098,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8618,7 +9115,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'St. Kitts & Nevis',
@@ -8631,12 +9127,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8645,7 +9144,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'St. Lucia',
@@ -8658,12 +9156,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8672,7 +9173,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'St. Martin',
@@ -8685,21 +9185,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'St. Pierre & Miquelon',
@@ -8712,21 +9214,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'St. Vincent & Grenadines',
@@ -8739,12 +9243,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8753,7 +9260,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Sudan',
@@ -8766,21 +9272,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Suriname',
@@ -8793,12 +9301,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8807,7 +9318,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Svalbard & Jan Mayen',
@@ -8820,48 +9330,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
-      },
-      {
-        name: 'Swaziland',
-        code: 'SZ',
-        phoneNumberPrefix: 268,
-        autocompletionField: 'address1',
-        continent: 'Africa',
-        labels: {
-          address1: 'Address',
-          address2: 'Apartment, suite, etc.',
-          city: 'City',
-          company: 'Company',
-          country: 'Country',
-          firstName: 'First name',
-          lastName: 'Last name',
-          phone: 'Phone',
-          postalCode: 'Postal code',
-          zone: 'Province',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Sweden',
@@ -8870,25 +9355,27 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
+          address1: 'Street and house number',
           address2: 'Apartment, suite, etc.',
-          city: 'City',
+          city: 'City/town',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Switzerland',
@@ -8897,25 +9384,27 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: 'Address',
-          address2: 'Apartment, suite, etc.',
+          address1: 'Street and house number',
+          address2: 'Additional address',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Additional address (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Syria',
@@ -8928,12 +9417,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8942,7 +9434,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Taiwan',
@@ -8955,12 +9446,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -8969,7 +9463,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Tajikistan',
@@ -8982,21 +9475,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Tanzania',
@@ -9009,21 +9504,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Thailand',
@@ -9036,12 +9533,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Province',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9067,7 +9567,7 @@ const data = {
             code: 'TH-38',
           },
           {
-            name: 'Buriram',
+            name: 'Buri Ram',
             code: 'TH-31',
           },
           {
@@ -9207,7 +9707,7 @@ const data = {
             code: 'TH-S',
           },
           {
-            name: 'Phangnga',
+            name: 'Phang Nga',
             code: 'TH-82',
           },
           {
@@ -9303,7 +9803,7 @@ const data = {
             code: 'TH-17',
           },
           {
-            name: 'Sisaket',
+            name: 'Si Sa Ket',
             code: 'TH-33',
           },
           {
@@ -9315,7 +9815,7 @@ const data = {
             code: 'TH-64',
           },
           {
-            name: 'Suphan Buri',
+            name: 'Suphanburi',
             code: 'TH-72',
           },
           {
@@ -9363,7 +9863,6 @@ const data = {
             code: 'TH-35',
           },
         ],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Timor-Leste',
@@ -9376,12 +9875,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9390,7 +9892,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Togo',
@@ -9403,12 +9904,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9417,7 +9921,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Tokelau',
@@ -9430,12 +9933,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9444,7 +9950,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Tonga',
@@ -9457,12 +9962,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9471,7 +9979,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Trinidad & Tobago',
@@ -9484,12 +9991,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9498,7 +10008,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Tunisia',
@@ -9511,21 +10020,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Turkey',
@@ -9538,21 +10049,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Turkmenistan',
@@ -9565,21 +10078,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{zip}{city}_{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+            '{zip}{city}_{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Turks & Caicos Islands',
@@ -9592,12 +10107,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9606,7 +10124,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Tuvalu',
@@ -9619,12 +10136,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9633,7 +10153,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'U.S. Outlying Islands',
@@ -9646,12 +10165,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'State',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9660,7 +10182,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'STATE',
       },
       {
         name: 'Uganda',
@@ -9673,12 +10194,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9687,7 +10211,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Ukraine',
@@ -9700,12 +10223,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9714,7 +10240,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'United Arab Emirates',
@@ -9727,12 +10252,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
           zone: 'Emirate',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9770,7 +10298,6 @@ const data = {
             code: 'UQ',
           },
         ],
-        provinceKey: 'EMIRATE',
       },
       {
         name: 'United Kingdom',
@@ -9783,12 +10310,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postcode',
           zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9797,7 +10327,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'United States',
@@ -9810,12 +10339,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'ZIP code',
           zone: 'State',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -9861,11 +10393,11 @@ const data = {
             code: 'DE',
           },
           {
-            name: 'District of Columbia',
+            name: 'Washington DC',
             code: 'DC',
           },
           {
-            name: 'Federated States of Micronesia',
+            name: 'Micronesia',
             code: 'FM',
           },
           {
@@ -10037,7 +10569,7 @@ const data = {
             code: 'VT',
           },
           {
-            name: 'Virgin Islands',
+            name: 'U.S. Virgin Islands',
             code: 'VI',
           },
           {
@@ -10073,7 +10605,6 @@ const data = {
             code: 'AP',
           },
         ],
-        provinceKey: 'STATE',
       },
       {
         name: 'Uruguay',
@@ -10086,21 +10617,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Uzbekistan',
@@ -10113,12 +10646,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -10127,7 +10663,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
       },
       {
         name: 'Vanuatu',
@@ -10140,12 +10675,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -10154,7 +10692,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Vatican City',
@@ -10167,21 +10704,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Venezuela',
@@ -10194,12 +10733,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -10208,7 +10750,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Vietnam',
@@ -10221,12 +10762,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -10235,7 +10779,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Wallis & Futuna',
@@ -10248,21 +10791,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Western Sahara',
@@ -10275,12 +10820,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -10289,7 +10837,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Yemen',
@@ -10302,12 +10849,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -10316,7 +10866,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Zambia',
@@ -10329,21 +10878,23 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
       {
         name: 'Zimbabwe',
@@ -10356,12 +10907,15 @@ const data = {
           address2: 'Apartment, suite, etc.',
           city: 'City',
           company: 'Company',
-          country: 'Country',
+          country: 'Country/Region',
           firstName: 'First name',
           lastName: 'Last name',
           phone: 'Phone',
           postalCode: 'Postal code',
-          zone: 'Province',
+          zone: 'Region',
+        },
+        optionalLabels: {
+          address2: 'Apartment, suite, etc. (optional)',
         },
         formatting: {
           edit:
@@ -10370,7 +10924,6 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
       },
     ],
   },

--- a/packages/address-mocks/src/fixtures/countries_ja.ts
+++ b/packages/address-mocks/src/fixtures/countries_ja.ts
@@ -9,19 +9,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -36,15 +39,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '郡',
+          zone: '州',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -54,111 +60,111 @@ const data = {
         },
         zones: [
           {
-            name: 'Carlow',
+            name: 'カーロウ州',
             code: 'CW',
           },
           {
-            name: 'Cavan',
+            name: 'キャバン州',
             code: 'CN',
           },
           {
-            name: 'Clare',
+            name: 'クレア州',
             code: 'CE',
           },
           {
-            name: 'Cork',
+            name: 'コーク州',
             code: 'CO',
           },
           {
-            name: 'Donegal',
+            name: 'ドニゴール州',
             code: 'DL',
           },
           {
-            name: 'Dublin',
+            name: 'ダブリン州',
             code: 'D',
           },
           {
-            name: 'Galway',
+            name: 'ゴールウェイ州',
             code: 'G',
           },
           {
-            name: 'Kerry',
+            name: 'ケリー州',
             code: 'KY',
           },
           {
-            name: 'Kildare',
+            name: 'キルデア州',
             code: 'KE',
           },
           {
-            name: 'Kilkenny',
+            name: 'キルケニー州',
             code: 'KK',
           },
           {
-            name: 'Laois',
+            name: 'ラオース州',
             code: 'LS',
           },
           {
-            name: 'Leitrim',
+            name: 'リートリム州',
             code: 'LM',
           },
           {
-            name: 'Limerick',
+            name: 'リムリック州',
             code: 'LK',
           },
           {
-            name: 'Longford',
+            name: 'ロングフォード州',
             code: 'LD',
           },
           {
-            name: 'Louth',
+            name: 'ラウス州',
             code: 'LH',
           },
           {
-            name: 'Mayo',
+            name: 'メイヨー州',
             code: 'MO',
           },
           {
-            name: 'Meath',
+            name: 'ミース州',
             code: 'MH',
           },
           {
-            name: 'Monaghan',
+            name: 'モナハン州',
             code: 'MN',
           },
           {
-            name: 'Offaly',
+            name: 'オファリー州',
             code: 'OY',
           },
           {
-            name: 'Roscommon',
+            name: 'ロスコモン州',
             code: 'RN',
           },
           {
-            name: 'Sligo',
+            name: 'スライゴ州',
             code: 'SO',
           },
           {
-            name: 'Tipperary',
+            name: 'ティペラリー州',
             code: 'TA',
           },
           {
-            name: 'Waterford',
+            name: 'ウォーターフォード州',
             code: 'WD',
           },
           {
-            name: 'Westmeath',
+            name: 'ウェストミース州',
             code: 'WH',
           },
           {
-            name: 'Wexford',
+            name: 'ウェックスフォード州',
             code: 'WX',
           },
           {
-            name: 'Wicklow',
+            name: 'ウィックロー州',
             code: 'WW',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'COUNTY',
       },
       {
         name: 'アゼルバイジャン',
@@ -168,24 +174,27 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'COUNTY',
+        provinceKey: 'REGION',
       },
       {
         name: 'アフガニスタン',
@@ -195,15 +204,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -222,15 +234,18 @@ const data = {
         continent: 'North America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -240,11 +255,11 @@ const data = {
         },
         zones: [
           {
-            name: 'Alabama',
+            name: 'アラバマ州',
             code: 'AL',
           },
           {
-            name: 'Alaska',
+            name: 'アラスカ州',
             code: 'AK',
           },
           {
@@ -252,43 +267,43 @@ const data = {
             code: 'AS',
           },
           {
-            name: 'Arizona',
+            name: 'アリゾナ州',
             code: 'AZ',
           },
           {
-            name: 'Arkansas',
+            name: 'アーカンソー州',
             code: 'AR',
           },
           {
-            name: 'California',
+            name: 'カリフォルニア州',
             code: 'CA',
           },
           {
-            name: 'Colorado',
+            name: 'コロラド州',
             code: 'CO',
           },
           {
-            name: 'Connecticut',
+            name: 'コネチカット州',
             code: 'CT',
           },
           {
-            name: 'Delaware',
+            name: 'デラウェア州',
             code: 'DE',
           },
           {
-            name: 'District of Columbia',
+            name: 'Washington DC',
             code: 'DC',
           },
           {
-            name: 'Federated States of Micronesia',
+            name: 'ミクロネシア連邦',
             code: 'FM',
           },
           {
-            name: 'Florida',
+            name: 'フロリダ州',
             code: 'FL',
           },
           {
-            name: 'Georgia',
+            name: 'ジョージア州',
             code: 'GA',
           },
           {
@@ -296,103 +311,103 @@ const data = {
             code: 'GU',
           },
           {
-            name: 'Hawaii',
+            name: 'ハワイ州',
             code: 'HI',
           },
           {
-            name: 'Idaho',
+            name: 'アイダホ州',
             code: 'ID',
           },
           {
-            name: 'Illinois',
+            name: 'イリノイ州',
             code: 'IL',
           },
           {
-            name: 'Indiana',
+            name: 'インディアナ州',
             code: 'IN',
           },
           {
-            name: 'Iowa',
+            name: 'アイオワ州',
             code: 'IA',
           },
           {
-            name: 'Kansas',
+            name: 'カンザス州',
             code: 'KS',
           },
           {
-            name: 'Kentucky',
+            name: 'ケンタッキー州',
             code: 'KY',
           },
           {
-            name: 'Louisiana',
+            name: 'ルイジアナ州',
             code: 'LA',
           },
           {
-            name: 'Maine',
+            name: 'メイン州',
             code: 'ME',
           },
           {
-            name: 'Marshall Islands',
+            name: 'マーシャル諸島',
             code: 'MH',
           },
           {
-            name: 'Maryland',
+            name: 'メリーランド州',
             code: 'MD',
           },
           {
-            name: 'Massachusetts',
+            name: 'マサチューセッツ州',
             code: 'MA',
           },
           {
-            name: 'Michigan',
+            name: 'ミシガン州',
             code: 'MI',
           },
           {
-            name: 'Minnesota',
+            name: 'ミネソタ州',
             code: 'MN',
           },
           {
-            name: 'Mississippi',
+            name: 'ミシシッピ州',
             code: 'MS',
           },
           {
-            name: 'Missouri',
+            name: 'ミズーリ州',
             code: 'MO',
           },
           {
-            name: 'Montana',
+            name: 'モンタナ州',
             code: 'MT',
           },
           {
-            name: 'Nebraska',
+            name: 'ネブラスカ州',
             code: 'NE',
           },
           {
-            name: 'Nevada',
+            name: 'ネバダ州',
             code: 'NV',
           },
           {
-            name: 'New Hampshire',
+            name: 'ニューハンプシャー州',
             code: 'NH',
           },
           {
-            name: 'New Jersey',
+            name: 'ニュージャージー州',
             code: 'NJ',
           },
           {
-            name: 'New Mexico',
+            name: 'ニューメキシコ州',
             code: 'NM',
           },
           {
-            name: 'New York',
+            name: 'ニューヨーク州',
             code: 'NY',
           },
           {
-            name: 'North Carolina',
+            name: 'ノースカロライナ州',
             code: 'NC',
           },
           {
-            name: 'North Dakota',
+            name: 'ノースダコタ州',
             code: 'ND',
           },
           {
@@ -400,23 +415,23 @@ const data = {
             code: 'MP',
           },
           {
-            name: 'Ohio',
+            name: 'オハイオ州',
             code: 'OH',
           },
           {
-            name: 'Oklahoma',
+            name: 'オクラホマ州',
             code: 'OK',
           },
           {
-            name: 'Oregon',
+            name: 'オレゴン州',
             code: 'OR',
           },
           {
-            name: 'Palau',
+            name: 'パラオ',
             code: 'PW',
           },
           {
-            name: 'Pennsylvania',
+            name: 'ペンシルベニア州',
             code: 'PA',
           },
           {
@@ -424,71 +439,71 @@ const data = {
             code: 'PR',
           },
           {
-            name: 'Rhode Island',
+            name: 'ロードアイランド州',
             code: 'RI',
           },
           {
-            name: 'South Carolina',
+            name: 'サウスカロライナ州',
             code: 'SC',
           },
           {
-            name: 'South Dakota',
+            name: 'サウスダコタ州',
             code: 'SD',
           },
           {
-            name: 'Tennessee',
+            name: 'テネシー州',
             code: 'TN',
           },
           {
-            name: 'Texas',
+            name: 'テキサス州',
             code: 'TX',
           },
           {
-            name: 'Utah',
+            name: 'ユタ州',
             code: 'UT',
           },
           {
-            name: 'Vermont',
+            name: 'バーモント州',
             code: 'VT',
           },
           {
-            name: 'Virgin Islands',
+            name: 'U.S. Virgin Islands',
             code: 'VI',
           },
           {
-            name: 'Virginia',
+            name: 'バージニア州',
             code: 'VA',
           },
           {
-            name: 'Washington',
+            name: 'ワシントン州',
             code: 'WA',
           },
           {
-            name: 'West Virginia',
+            name: 'ウェストバージニア州',
             code: 'WV',
           },
           {
-            name: 'Wisconsin',
+            name: 'ウィスコンシン州',
             code: 'WI',
           },
           {
-            name: 'Wyoming',
+            name: 'ワイオミング州',
             code: 'WY',
           },
           {
-            name: 'Armed Forces Americas',
+            name: 'アメリカ軍',
             code: 'AA',
           },
           {
-            name: 'Armed Forces Europe',
+            name: '欧州戦力',
             code: 'AE',
           },
           {
-            name: 'Armed Forces Pacific',
+            name: '太平洋方面駐在軍',
             code: 'AP',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'STATE',
       },
       {
         name: 'アラブ首長国連邦',
@@ -498,15 +513,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: 'エミレーツ',
+          zone: '首長国',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -516,19 +534,19 @@ const data = {
         },
         zones: [
           {
-            name: 'Abu Dhabi',
+            name: 'アブダビ',
             code: 'AZ',
           },
           {
-            name: 'Ajman',
+            name: 'アジュマーン',
             code: 'AJ',
           },
           {
-            name: 'Dubai',
+            name: 'ドバイ首長国',
             code: 'DU',
           },
           {
-            name: 'Fujairah',
+            name: 'フジャイラ',
             code: 'FU',
           },
           {
@@ -536,7 +554,7 @@ const data = {
             code: 'RK',
           },
           {
-            name: 'Sharjah',
+            name: 'シャールジャ',
             code: 'SH',
           },
           {
@@ -544,7 +562,7 @@ const data = {
             code: 'UQ',
           },
         ],
-        provinceKey: 'STATE',
+        provinceKey: 'EMIRATE',
       },
       {
         name: 'アルジェリア',
@@ -554,24 +572,27 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '県',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'EMIRATE',
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'アルゼンチン',
@@ -581,117 +602,120 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
         },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'Buenos Aires',
+            name: 'ブエノスアイレス州',
             code: 'B',
           },
           {
-            name: 'Catamarca',
+            name: 'カタマルカ州',
             code: 'K',
           },
           {
-            name: 'Chaco',
+            name: 'チャコ州',
             code: 'H',
           },
           {
-            name: 'Chubut',
+            name: 'チュブ州',
             code: 'U',
           },
           {
-            name: 'Ciudad Autónoma de Buenos Aires',
+            name: 'ブエノスアイレス自治都市',
             code: 'C',
           },
           {
-            name: 'Córdoba',
+            name: 'コルドバ州',
             code: 'X',
           },
           {
-            name: 'Corrientes',
+            name: 'コリエンテス州',
             code: 'W',
           },
           {
-            name: 'Entre Ríos',
+            name: 'エントレ・リオス州',
             code: 'E',
           },
           {
-            name: 'Formosa',
+            name: 'フォルモサ州',
             code: 'P',
           },
           {
-            name: 'Jujuy',
+            name: 'フフイ州',
             code: 'Y',
           },
           {
-            name: 'La Pampa',
+            name: 'ラ・パンパ州',
             code: 'L',
           },
           {
-            name: 'La Rioja',
+            name: 'ラ・リオハ州',
             code: 'F',
           },
           {
-            name: 'Mendoza',
+            name: 'メンドーサ州',
             code: 'M',
           },
           {
-            name: 'Misiones',
+            name: 'ミシオネス州',
             code: 'N',
           },
           {
-            name: 'Neuquén',
+            name: 'ネウケン州',
             code: 'Q',
           },
           {
-            name: 'Río Negro',
+            name: 'リオネグロ州',
             code: 'R',
           },
           {
-            name: 'Salta',
+            name: 'サルタ州',
             code: 'A',
           },
           {
-            name: 'San Juan',
+            name: 'サンフアン州',
             code: 'J',
           },
           {
-            name: 'San Luis',
+            name: 'サンルイス州',
             code: 'D',
           },
           {
-            name: 'Santa Cruz',
+            name: 'サンタクルス州',
             code: 'Z',
           },
           {
-            name: 'Santa Fe',
+            name: 'サンタフェ州',
             code: 'S',
           },
           {
-            name: 'Santiago Del Estero',
+            name: 'サンティアゴ・デル・エステロ州',
             code: 'G',
           },
           {
-            name: 'Tierra Del Fuego',
+            name: 'ティエラ・デル・フエゴ州',
             code: 'V',
           },
           {
-            name: 'Tucumán',
+            name: 'トゥクマン州',
             code: 'T',
           },
         ],
@@ -705,15 +729,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -722,7 +749,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'アルバニア',
@@ -732,15 +759,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -759,19 +789,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -786,15 +819,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -813,15 +849,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -840,15 +879,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -867,19 +909,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -894,15 +939,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -921,15 +969,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -948,19 +999,22 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -974,58 +1028,61 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '県',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'Agrigento',
+            name: 'アグリジェント県',
             code: 'AG',
           },
           {
-            name: 'Alessandria',
+            name: 'アレッサンドリア県',
             code: 'AL',
           },
           {
-            name: 'Ancona',
+            name: 'アンコーナ県',
             code: 'AN',
           },
           {
-            name: 'Aosta',
+            name: 'アオスタ',
             code: 'AO',
           },
           {
-            name: 'Arezzo',
+            name: 'アレッツォ県',
             code: 'AR',
           },
           {
-            name: 'Ascoli Piceno',
+            name: 'アスコリ・ピチェーノ県',
             code: 'AP',
           },
           {
-            name: 'Asti',
+            name: 'アスティ県',
             code: 'AT',
           },
           {
-            name: 'Avellino',
+            name: 'アヴェッリーノ県',
             code: 'AV',
           },
           {
-            name: 'Bari',
+            name: 'バーリ県',
             code: 'BA',
           },
           {
@@ -1033,47 +1090,47 @@ const data = {
             code: 'BT',
           },
           {
-            name: 'Belluno',
+            name: 'ベッルーノ県',
             code: 'BL',
           },
           {
-            name: 'Benevento',
+            name: 'ベネヴェント県',
             code: 'BN',
           },
           {
-            name: 'Bergamo',
+            name: 'ベルガモ県',
             code: 'BG',
           },
           {
-            name: 'Biella',
+            name: 'ビエッラ県',
             code: 'BI',
           },
           {
-            name: 'Bologna',
+            name: 'ボローニャ県',
             code: 'BO',
           },
           {
-            name: 'Bolzano',
+            name: 'ボルツァーノ自治県',
             code: 'BZ',
           },
           {
-            name: 'Brescia',
+            name: 'ブレシア県',
             code: 'BS',
           },
           {
-            name: 'Brindisi',
+            name: 'ブリンディジ県',
             code: 'BR',
           },
           {
-            name: 'Cagliari',
+            name: 'カリャリ県',
             code: 'CA',
           },
           {
-            name: 'Caltanissetta',
+            name: 'カルタニッセッタ県',
             code: 'CL',
           },
           {
-            name: 'Campobasso',
+            name: 'カンポバッソ県',
             code: 'CB',
           },
           {
@@ -1081,59 +1138,59 @@ const data = {
             code: 'CI',
           },
           {
-            name: 'Caserta',
+            name: 'カゼルタ県',
             code: 'CE',
           },
           {
-            name: 'Catania',
+            name: 'カターニア県',
             code: 'CT',
           },
           {
-            name: 'Catanzaro',
+            name: 'カタンザーロ県',
             code: 'CZ',
           },
           {
-            name: 'Chieti',
+            name: 'キエーティ県',
             code: 'CH',
           },
           {
-            name: 'Como',
+            name: 'コモ県',
             code: 'CO',
           },
           {
-            name: 'Cosenza',
+            name: 'コゼンツァ県',
             code: 'CS',
           },
           {
-            name: 'Cremona',
+            name: 'クレモナ県',
             code: 'CR',
           },
           {
-            name: 'Crotone',
+            name: 'クロトーネ県',
             code: 'KR',
           },
           {
-            name: 'Cuneo',
+            name: 'クーネオ県',
             code: 'CN',
           },
           {
-            name: 'Enna',
+            name: 'エンナ県',
             code: 'EN',
           },
           {
-            name: 'Fermo',
+            name: 'フェルモ県',
             code: 'FM',
           },
           {
-            name: 'Ferrara',
+            name: 'フェラーラ県',
             code: 'FE',
           },
           {
-            name: 'Firenze',
+            name: 'フィレンツェ県',
             code: 'FI',
           },
           {
-            name: 'Foggia',
+            name: 'フォッジャ県',
             code: 'FG',
           },
           {
@@ -1141,111 +1198,111 @@ const data = {
             code: 'FC',
           },
           {
-            name: 'Frosinone',
+            name: 'フロジノーネ県',
             code: 'FR',
           },
           {
-            name: 'Genova',
+            name: 'ジェノヴァ',
             code: 'GE',
           },
           {
-            name: 'Gorizia',
+            name: 'ゴリツィア県',
             code: 'GO',
           },
           {
-            name: 'Grosseto',
+            name: 'グロッセート県',
             code: 'GR',
           },
           {
-            name: 'Imperia',
+            name: 'インペリア県',
             code: 'IM',
           },
           {
-            name: 'Isernia',
+            name: 'イゼルニア県',
             code: 'IS',
           },
           {
-            name: "L'Aquila",
+            name: 'ラクイラ県',
             code: 'AQ',
           },
           {
-            name: 'La Spezia',
+            name: 'ラ・スペツィア県',
             code: 'SP',
           },
           {
-            name: 'Latina',
+            name: 'ラティーナ県',
             code: 'LT',
           },
           {
-            name: 'Lecce',
+            name: 'レッチェ県',
             code: 'LE',
           },
           {
-            name: 'Lecco',
+            name: 'レッコ県',
             code: 'LC',
           },
           {
-            name: 'Livorno',
+            name: 'リヴォルノ県',
             code: 'LI',
           },
           {
-            name: 'Lodi',
+            name: 'ローディ県',
             code: 'LO',
           },
           {
-            name: 'Lucca',
+            name: 'ルッカ県',
             code: 'LU',
           },
           {
-            name: 'Macerata',
+            name: 'マチェラータ県',
             code: 'MC',
           },
           {
-            name: 'Mantova',
+            name: 'マントヴァ県',
             code: 'MN',
           },
           {
-            name: 'Massa-Carrara',
+            name: 'Massa and Carrara',
             code: 'MS',
           },
           {
-            name: 'Matera',
+            name: 'マテーラ県',
             code: 'MT',
           },
           {
-            name: 'Medio Campidano',
+            name: 'メディオ・カンピダーノ県',
             code: 'VS',
           },
           {
-            name: 'Messina',
+            name: 'メッシーナ県',
             code: 'ME',
           },
           {
-            name: 'Milano',
+            name: 'ミラノ県',
             code: 'MI',
           },
           {
-            name: 'Modena',
+            name: 'モデナ県',
             code: 'MO',
           },
           {
-            name: 'Monza e Brianza',
+            name: 'モンツァ・エ・ブリアンツァ県',
             code: 'MB',
           },
           {
-            name: 'Napoli',
+            name: 'ナポリ県',
             code: 'NA',
           },
           {
-            name: 'Novara',
+            name: 'ノヴァーラ県',
             code: 'NO',
           },
           {
-            name: 'Nuoro',
+            name: 'ヌーオロ県',
             code: 'NU',
           },
           {
-            name: 'Ogliastra',
+            name: 'オリアストラ県',
             code: 'OG',
           },
           {
@@ -1253,187 +1310,187 @@ const data = {
             code: 'OT',
           },
           {
-            name: 'Oristano',
+            name: 'オリスターノ県',
             code: 'OR',
           },
           {
-            name: 'Padova',
+            name: 'パドヴァ県',
             code: 'PD',
           },
           {
-            name: 'Palermo',
+            name: 'パレルモ県',
             code: 'PA',
           },
           {
-            name: 'Parma',
+            name: 'パルマ県',
             code: 'PR',
           },
           {
-            name: 'Pavia',
+            name: 'パヴィーア県',
             code: 'PV',
           },
           {
-            name: 'Perugia',
+            name: 'ペルージャ県',
             code: 'PG',
           },
           {
-            name: 'Pesaro e Urbino',
+            name: 'ペーザロ・エ・ウルビーノ県',
             code: 'PU',
           },
           {
-            name: 'Pescara',
+            name: 'ペスカーラ県',
             code: 'PE',
           },
           {
-            name: 'Piacenza',
+            name: 'ピアチェンツァ県',
             code: 'PC',
           },
           {
-            name: 'Pisa',
+            name: 'ピサ県',
             code: 'PI',
           },
           {
-            name: 'Pistoia',
+            name: 'ピストイア県',
             code: 'PT',
           },
           {
-            name: 'Pordenone',
+            name: 'ポルデノーネ県',
             code: 'PN',
           },
           {
-            name: 'Potenza',
+            name: 'ポテンツァ県',
             code: 'PZ',
           },
           {
-            name: 'Prato',
+            name: 'プラート県',
             code: 'PO',
           },
           {
-            name: 'Ragusa',
+            name: 'ラグーザ県',
             code: 'RG',
           },
           {
-            name: 'Ravenna',
+            name: 'ラヴェンナ県',
             code: 'RA',
           },
           {
-            name: 'Reggio Calabria',
+            name: 'レッジョ・カラブリア県',
             code: 'RC',
           },
           {
-            name: 'Reggio Emilia',
+            name: 'レッジョ・エミリア県',
             code: 'RE',
           },
           {
-            name: 'Rieti',
+            name: 'リエーティ県',
             code: 'RI',
           },
           {
-            name: 'Rimini',
+            name: 'リミニ県',
             code: 'RN',
           },
           {
-            name: 'Roma',
+            name: 'ローマ県',
             code: 'RM',
           },
           {
-            name: 'Rovigo',
+            name: 'ロヴィーゴ県',
             code: 'RO',
           },
           {
-            name: 'Salerno',
+            name: 'サレルノ県',
             code: 'SA',
           },
           {
-            name: 'Sassari',
+            name: 'サッサリ県',
             code: 'SS',
           },
           {
-            name: 'Savona',
+            name: 'サヴォーナ県',
             code: 'SV',
           },
           {
-            name: 'Siena',
+            name: 'シエーナ県',
             code: 'SI',
           },
           {
-            name: 'Siracusa',
+            name: 'シラクーザ県',
             code: 'SR',
           },
           {
-            name: 'Sondrio',
+            name: 'ソンドリオ県',
             code: 'SO',
           },
           {
-            name: 'Taranto',
+            name: 'ターラント県',
             code: 'TA',
           },
           {
-            name: 'Teramo',
+            name: 'テーラモ県',
             code: 'TE',
           },
           {
-            name: 'Terni',
+            name: 'テルニ県',
             code: 'TR',
           },
           {
-            name: 'Torino',
+            name: 'トリノ県',
             code: 'TO',
           },
           {
-            name: 'Trapani',
+            name: 'トラーパニ県',
             code: 'TP',
           },
           {
-            name: 'Trento',
+            name: 'トレント自治県',
             code: 'TN',
           },
           {
-            name: 'Treviso',
+            name: 'トレヴィーゾ県',
             code: 'TV',
           },
           {
-            name: 'Trieste',
+            name: 'トリエステ県',
             code: 'TS',
           },
           {
-            name: 'Udine',
+            name: 'ウーディネ県',
             code: 'UD',
           },
           {
-            name: 'Varese',
+            name: 'ヴァレーゼ県',
             code: 'VA',
           },
           {
-            name: 'Venezia',
+            name: 'ヴェネツィア県',
             code: 'VE',
           },
           {
-            name: 'Verbano-Cusio-Ossola',
+            name: 'ヴェルバーノ・クジオ・オッソラ県',
             code: 'VB',
           },
           {
-            name: 'Vercelli',
+            name: 'ヴェルチェッリ県',
             code: 'VC',
           },
           {
-            name: 'Verona',
+            name: 'ヴェローナ県',
             code: 'VR',
           },
           {
-            name: 'Vibo Valentia',
+            name: 'ヴィボ・ヴァレンツィア県',
             code: 'VV',
           },
           {
-            name: 'Vicenza',
+            name: 'ヴィチェンツァ県',
             code: 'VI',
           },
           {
-            name: 'Viterbo',
+            name: 'ヴィテルボ県',
             code: 'VT',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'イラク',
@@ -1443,15 +1500,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -1460,7 +1520,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'イラン',
@@ -1470,19 +1530,22 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -1497,15 +1560,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
-          postalCode: '郵便番号',
+          postalCode: 'PINコード',
           zone: '州',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -1515,151 +1581,155 @@ const data = {
         },
         zones: [
           {
-            name: 'Andaman and Nicobar',
+            name: 'アンダマン・ニコバル諸島',
             code: 'AN',
           },
           {
-            name: 'Andhra Pradesh',
+            name: 'アーンドラ・プラデーシュ州',
             code: 'AP',
           },
           {
-            name: 'Arunachal Pradesh',
+            name: 'アルナーチャル・プラデーシュ州',
             code: 'AR',
           },
           {
-            name: 'Assam',
+            name: 'アッサム州',
             code: 'AS',
           },
           {
-            name: 'Bihar',
+            name: 'ビハール州',
             code: 'BR',
           },
           {
-            name: 'Chandigarh',
+            name: 'チャンディーガル',
             code: 'CH',
           },
           {
-            name: 'Chattisgarh',
+            name: 'チャッティースガル州',
             code: 'CG',
           },
           {
-            name: 'Dadra and Nagar Haveli',
+            name: 'ダードラー及びナガル・ハヴェーリー連邦直轄領',
             code: 'DN',
           },
           {
-            name: 'Daman and Diu',
+            name: 'ダマン・ディーウ連邦直轄領',
             code: 'DD',
           },
           {
-            name: 'Delhi',
+            name: 'デリー',
             code: 'DL',
           },
           {
-            name: 'Goa',
+            name: 'ゴア州',
             code: 'GA',
           },
           {
-            name: 'Gujarat',
+            name: 'グジャラート州',
             code: 'GJ',
           },
           {
-            name: 'Haryana',
+            name: 'ハリヤーナー州',
             code: 'HR',
           },
           {
-            name: 'Himachal Pradesh',
+            name: 'ヒマーチャル・プラデーシュ州',
             code: 'HP',
           },
           {
-            name: 'Jammu and Kashmir',
+            name: 'ジャンムー・カシミール州',
             code: 'JK',
           },
           {
-            name: 'Jharkhand',
+            name: 'ジャールカンド州',
             code: 'JH',
           },
           {
-            name: 'Karnataka',
+            name: 'カルナータカ州',
             code: 'KA',
           },
           {
-            name: 'Kerala',
+            name: 'ケーララ州',
             code: 'KL',
           },
           {
-            name: 'Lakshadweep',
+            name: 'Ladakh',
+            code: 'LA',
+          },
+          {
+            name: 'ラクシャディープ諸島',
             code: 'LD',
           },
           {
-            name: 'Madhya Pradesh',
+            name: 'マディヤ・プラデーシュ州',
             code: 'MP',
           },
           {
-            name: 'Maharashtra',
+            name: 'マハーラーシュトラ州',
             code: 'MH',
           },
           {
-            name: 'Manipur',
+            name: 'マニプル州',
             code: 'MN',
           },
           {
-            name: 'Meghalaya',
+            name: 'メーガーラヤ州',
             code: 'ML',
           },
           {
-            name: 'Mizoram',
+            name: 'ミゾラム州',
             code: 'MZ',
           },
           {
-            name: 'Nagaland',
+            name: 'ナガランド州',
             code: 'NL',
           },
           {
-            name: 'Orissa',
+            name: 'オリッサ州',
             code: 'OR',
           },
           {
-            name: 'Puducherry',
+            name: 'ポンディシェリ連邦直轄領',
             code: 'PY',
           },
           {
-            name: 'Punjab',
+            name: 'パンジャーブ州',
             code: 'PB',
           },
           {
-            name: 'Rajasthan',
+            name: 'ラージャスターン州',
             code: 'RJ',
           },
           {
-            name: 'Sikkim',
+            name: 'シッキム州',
             code: 'SK',
           },
           {
-            name: 'Tamil Nadu',
+            name: 'タミル・ナードゥ州',
             code: 'TN',
           },
           {
-            name: 'Telangana',
+            name: 'テランガナ',
             code: 'TS',
           },
           {
-            name: 'Tripura',
+            name: 'トリプラ州',
             code: 'TR',
           },
           {
-            name: 'Uttar Pradesh',
+            name: 'ウッタル・プラデーシュ州',
             code: 'UP',
           },
           {
-            name: 'Uttarakhand',
+            name: 'ウッタラーカンド州',
             code: 'UK',
           },
           {
-            name: 'West Bengal',
+            name: '西ベンガル州',
             code: 'WB',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'STATE',
       },
       {
         name: 'インドネシア',
@@ -1669,161 +1739,164 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
         },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{country}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}',
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'Aceh',
+            name: 'アチェ州',
             code: 'AC',
           },
           {
-            name: 'Bali',
+            name: 'バリ州',
             code: 'BA',
           },
           {
-            name: 'Bangka Belitung',
+            name: 'バンカ・ブリトゥン州',
             code: 'BB',
           },
           {
-            name: 'Banten',
+            name: 'バンテン州',
             code: 'BT',
           },
           {
-            name: 'Bengkulu',
+            name: 'ブンクル州',
             code: 'BE',
           },
           {
-            name: 'Gorontalo',
+            name: 'ゴロンタロ州',
             code: 'GO',
           },
           {
-            name: 'Jakarta',
+            name: 'ジャカルタ',
             code: 'JK',
           },
           {
-            name: 'Jambi',
+            name: 'ジャンビ州',
             code: 'JA',
           },
           {
-            name: 'Jawa Barat',
+            name: '西ジャワ州',
             code: 'JB',
           },
           {
-            name: 'Jawa Tengah',
+            name: '中部ジャワ州',
             code: 'JT',
           },
           {
-            name: 'Jawa Timur',
+            name: '東ジャワ州',
             code: 'JI',
           },
           {
-            name: 'Kalimantan Barat',
+            name: '西カリマンタン州',
             code: 'KB',
           },
           {
-            name: 'Kalimantan Selatan',
+            name: '南カリマンタン州',
             code: 'KS',
           },
           {
-            name: 'Kalimantan Tengah',
+            name: '中部カリマンタン州',
             code: 'KT',
           },
           {
-            name: 'Kalimantan Timur',
+            name: '東カリマンタン州',
             code: 'KI',
           },
           {
-            name: 'Kalimantan Utara',
+            name: '北カリマンタン州',
             code: 'KU',
           },
           {
-            name: 'Kepulauan Riau',
+            name: 'リアウ諸島州',
             code: 'KR',
           },
           {
-            name: 'Lampung',
+            name: 'ランプン州',
             code: 'LA',
           },
           {
-            name: 'Maluku',
+            name: 'マルク州',
             code: 'MA',
           },
           {
-            name: 'Maluku Utara',
+            name: '北マルク州',
             code: 'MU',
           },
           {
-            name: 'Nusa Tenggara Barat',
-            code: 'NB',
-          },
-          {
-            name: 'Nusa Tenggara Timur',
-            code: 'NT',
-          },
-          {
-            name: 'Papua',
-            code: 'PA',
-          },
-          {
-            name: 'Papua Barat',
-            code: 'PB',
-          },
-          {
-            name: 'Riau',
-            code: 'RI',
-          },
-          {
-            name: 'Sulawesi Barat',
-            code: 'SR',
-          },
-          {
-            name: 'Sulawesi Selatan',
-            code: 'SN',
-          },
-          {
-            name: 'Sulawesi Tengah',
-            code: 'ST',
-          },
-          {
-            name: 'Sulawesi Tenggara',
-            code: 'SG',
-          },
-          {
-            name: 'Sulawesi Utara',
-            code: 'SA',
-          },
-          {
-            name: 'Sumatra Barat',
-            code: 'SB',
-          },
-          {
-            name: 'Sumatra Selatan',
-            code: 'SS',
-          },
-          {
-            name: 'Sumatra Utara',
+            name: '北スマトラ州',
             code: 'SU',
           },
           {
-            name: 'Yogyakarta',
+            name: '西ヌサ・トゥンガラ州',
+            code: 'NB',
+          },
+          {
+            name: '東ヌサ・トゥンガラ州',
+            code: 'NT',
+          },
+          {
+            name: 'パプア州',
+            code: 'PA',
+          },
+          {
+            name: '西パプア州',
+            code: 'PB',
+          },
+          {
+            name: 'リアウ州',
+            code: 'RI',
+          },
+          {
+            name: '南スマトラ州',
+            code: 'SS',
+          },
+          {
+            name: '西スラウェシ州',
+            code: 'SR',
+          },
+          {
+            name: '南スラウェシ州',
+            code: 'SN',
+          },
+          {
+            name: '中部スラウェシ州',
+            code: 'ST',
+          },
+          {
+            name: '南東スラウェシ州',
+            code: 'SG',
+          },
+          {
+            name: '北スラウェシ州',
+            code: 'SA',
+          },
+          {
+            name: '西スマトラ州',
+            code: 'SB',
+          },
+          {
+            name: 'ジョグジャカルタ特別州',
             code: 'YO',
           },
         ],
-        provinceKey: 'STATE',
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'ウォリス・フツナ',
@@ -1833,24 +1906,27 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'ウガンダ',
@@ -1860,15 +1936,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -1887,15 +1966,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -1914,15 +1996,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -1941,24 +2026,27 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'エクアドル',
@@ -1968,19 +2056,22 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -1995,15 +2086,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '行政',
+          zone: '行政区域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2013,123 +2107,123 @@ const data = {
         },
         zones: [
           {
-            name: '6th of October',
+            name: '10月6日',
             code: 'SU',
           },
           {
-            name: 'Al Sharqia',
+            name: 'シャルキーヤ県',
             code: 'SHR',
           },
           {
-            name: 'Alexandria',
+            name: 'アレクサンドリア県',
             code: 'ALX',
           },
           {
-            name: 'Aswan',
+            name: 'アスワン県',
             code: 'ASN',
           },
           {
-            name: 'Asyut',
+            name: 'アシュート県',
             code: 'AST',
           },
           {
-            name: 'Beheira',
+            name: 'ブハイラ県',
             code: 'BH',
           },
           {
-            name: 'Beni Suef',
+            name: 'ベニ・スエフ県',
             code: 'BNS',
           },
           {
-            name: 'Cairo',
+            name: 'カイロ県',
             code: 'C',
           },
           {
-            name: 'Dakahlia',
+            name: 'ダカリーヤ県',
             code: 'DK',
           },
           {
-            name: 'Damietta',
+            name: 'ディムヤート県',
             code: 'DT',
           },
           {
-            name: 'Faiyum',
+            name: 'ファイユーム県',
             code: 'FYM',
           },
           {
-            name: 'Gharbia',
+            name: 'ガルビーヤ県',
             code: 'GH',
           },
           {
-            name: 'Giza',
+            name: 'ギーザ県',
             code: 'GZ',
           },
           {
-            name: 'Helwan',
+            name: 'ヘルワン',
             code: 'HU',
           },
           {
-            name: 'Ismailia',
+            name: 'イスマイリア県',
             code: 'IS',
           },
           {
-            name: 'Kafr el-Sheikh',
+            name: 'カフル・アッシャイフ県',
             code: 'KFS',
           },
           {
-            name: 'Luxor',
+            name: 'ルクソール県',
             code: 'LX',
           },
           {
-            name: 'Matrouh',
+            name: 'マトルーフ県',
             code: 'MT',
           },
           {
-            name: 'Minya',
+            name: 'ミニヤー県',
             code: 'MN',
           },
           {
-            name: 'Monufia',
+            name: 'ミヌーフィーヤ県',
             code: 'MNF',
           },
           {
-            name: 'New Valley',
+            name: 'ニューバレー県',
             code: 'WAD',
           },
           {
-            name: 'North Sinai',
+            name: '北シナイ県',
             code: 'SIN',
           },
           {
-            name: 'Port Said',
+            name: 'ポートサイド県',
             code: 'PTS',
           },
           {
-            name: 'Qalyubia',
+            name: 'カリュービーヤ県',
             code: 'KB',
           },
           {
-            name: 'Qena',
+            name: 'ケナ県',
             code: 'KN',
           },
           {
-            name: 'Red Sea',
+            name: '紅海県',
             code: 'BA',
           },
           {
-            name: 'Sohag',
+            name: 'ソハーグ県',
             code: 'SHG',
           },
           {
-            name: 'South Sinai',
+            name: '南シナイ県',
             code: 'JS',
           },
           {
-            name: 'Suez',
+            name: 'スエズ県',
             code: 'SUZ',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'GOVERNORATE',
       },
       {
         name: 'エストニア',
@@ -2139,24 +2233,57 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: 'エスワティニ',
+        code: 'SZ',
+        phoneNumberPrefix: 268,
+        autocompletionField: 'address1',
+        continent: 'Africa',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'GOVERNORATE',
+        provinceKey: 'REGION',
       },
       {
         name: 'エチオピア',
@@ -2166,15 +2293,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2193,15 +2323,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2220,15 +2353,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2247,19 +2383,22 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -2273,20 +2412,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2294,22 +2436,25 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'オランダ領アンティル',
+        name: 'オランダ領アンティル諸島',
         code: 'AN',
         phoneNumberPrefix: 599,
         autocompletionField: 'address1',
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2328,15 +2473,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2355,15 +2503,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
+          address2: '建物名、部屋番号など',
+          city: 'サバーブ',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州、準州',
+          zone: '州/地区',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2373,35 +2524,35 @@ const data = {
         },
         zones: [
           {
-            name: 'Australian Capital Territory',
+            name: 'オーストラリア首都特別地域',
             code: 'ACT',
           },
           {
-            name: 'New South Wales',
+            name: 'ニューサウスウェールズ州',
             code: 'NSW',
           },
           {
-            name: 'Northern Territory',
+            name: 'ノーザンテリトリー',
             code: 'NT',
           },
           {
-            name: 'Queensland',
+            name: 'クイーンズランド州',
             code: 'QLD',
           },
           {
-            name: 'South Australia',
+            name: '南オーストラリア州',
             code: 'SA',
           },
           {
-            name: 'Tasmania',
+            name: 'タスマニア州',
             code: 'TAS',
           },
           {
-            name: 'Victoria',
+            name: 'ビクトリア州',
             code: 'VIC',
           },
           {
-            name: 'Western Australia',
+            name: '西オーストラリア州',
             code: 'WA',
           },
         ],
@@ -2414,20 +2565,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '住所2',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '住所2 (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2442,19 +2596,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2469,15 +2626,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2496,15 +2656,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2523,15 +2686,18 @@ const data = {
         continent: 'North America',
         labels: {
           address1: '住所',
-          address2: 'アパート、ユニット番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2541,55 +2707,55 @@ const data = {
         },
         zones: [
           {
-            name: 'Alberta',
+            name: 'アルバータ州',
             code: 'AB',
           },
           {
-            name: 'British Columbia',
+            name: 'ブリティッシュコロンビア州',
             code: 'BC',
           },
           {
-            name: 'Manitoba',
+            name: 'マニトバ州',
             code: 'MB',
           },
           {
-            name: 'New Brunswick',
+            name: 'ニューブランズウィック州',
             code: 'NB',
           },
           {
-            name: 'Newfoundland and Labrador',
+            name: 'ニューファンドランド・ラブラドール州',
             code: 'NL',
           },
           {
-            name: 'Northwest Territories',
+            name: 'ノースウエスト準州',
             code: 'NT',
           },
           {
-            name: 'Nova Scotia',
+            name: 'ノバスコシア州',
             code: 'NS',
           },
           {
-            name: 'Nunavut',
+            name: 'ヌナブト準州',
             code: 'NU',
           },
           {
-            name: 'Ontario',
+            name: 'オンタリオ州',
             code: 'ON',
           },
           {
-            name: 'Prince Edward Island',
+            name: 'プリンスエドワードアイランド州',
             code: 'PE',
           },
           {
-            name: 'Quebec',
+            name: 'ケベック州',
             code: 'QC',
           },
           {
-            name: 'Saskatchewan',
+            name: 'サスカチュワン州',
             code: 'SK',
           },
           {
-            name: 'Yukon',
+            name: 'ユーコン準州',
             code: 'YT',
           },
         ],
@@ -2603,15 +2769,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2630,15 +2799,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2657,19 +2829,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2684,15 +2859,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2711,15 +2889,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2738,15 +2919,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2765,15 +2949,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2792,15 +2979,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2819,19 +3009,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2846,15 +3039,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2873,19 +3069,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -2900,15 +3099,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2927,19 +3129,22 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{zip}{city}_{address2}_{address1}_{company}_{firstName}{lastName}_{country}_{phone}',
           show:
             '{zip} {city}_{address2}_{address1}_{company}_{firstName} {lastName}_{country}_{phone}',
         },
@@ -2954,15 +3159,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -2981,19 +3189,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3008,19 +3219,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3035,15 +3249,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3062,15 +3279,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3089,15 +3309,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3116,19 +3339,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3143,15 +3369,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3161,91 +3390,91 @@ const data = {
         },
         zones: [
           {
-            name: 'Alta Verapaz',
+            name: 'アルタ・ベラパス県',
             code: 'AVE',
           },
           {
-            name: 'Baja Verapaz',
+            name: 'バハ・ベラパス県',
             code: 'BVE',
           },
           {
-            name: 'Chimaltenango',
+            name: 'チマルテナンゴ県',
             code: 'CMT',
           },
           {
-            name: 'Chiquimula',
+            name: 'チキムラ県',
             code: 'CQM',
           },
           {
-            name: 'El Progreso',
+            name: 'エル・プログレソ県',
             code: 'EPR',
           },
           {
-            name: 'Escuintla',
+            name: 'エスクィントラ県',
             code: 'ESC',
           },
           {
-            name: 'Guatemala',
+            name: 'グアテマラ県',
             code: 'GUA',
           },
           {
-            name: 'Huehuetenango',
+            name: 'ウェウェテナンゴ県',
             code: 'HUE',
           },
           {
-            name: 'Izabal',
+            name: 'イサバル県',
             code: 'IZA',
           },
           {
-            name: 'Jalapa',
+            name: 'ハラパ県',
             code: 'JAL',
           },
           {
-            name: 'Jutiapa',
+            name: 'フティアパ県',
             code: 'JUT',
           },
           {
-            name: 'Petén',
+            name: 'ペテン県',
             code: 'PET',
           },
           {
-            name: 'Quetzaltenango',
+            name: 'ケツァルテナンゴ県',
             code: 'QUE',
           },
           {
-            name: 'Quiché',
+            name: 'キチェ県',
             code: 'QUI',
           },
           {
-            name: 'Retalhuleu',
+            name: 'レタルレウ県',
             code: 'RET',
           },
           {
-            name: 'Sacatepéquez',
+            name: 'サカテペケス県',
             code: 'SAC',
           },
           {
-            name: 'San Marcos',
+            name: 'サン・マルコス県',
             code: 'SMA',
           },
           {
-            name: 'Santa Rosa',
+            name: 'サンタ・ローサ県',
             code: 'SRO',
           },
           {
-            name: 'Sololá',
+            name: 'ソロラ県',
             code: 'SOL',
           },
           {
-            name: 'Suchitepéquez',
+            name: 'スチテペケス県',
             code: 'SUC',
           },
           {
-            name: 'Totonicapán',
+            name: 'トトニカパン県',
             code: 'TOT',
           },
           {
-            name: 'Zacapa',
+            name: 'サカパ県',
             code: 'ZAC',
           },
         ],
@@ -3259,19 +3488,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3286,46 +3518,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
-      },
-      {
-        name: 'グルジア',
-        code: 'GE',
-        phoneNumberPrefix: 995,
-        autocompletionField: 'address1',
-        continent: 'Europe',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3340,15 +3548,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3367,15 +3578,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3394,15 +3608,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3421,15 +3638,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3448,15 +3668,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3475,19 +3698,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3502,15 +3728,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3519,7 +3748,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'コロンビア',
@@ -3529,15 +3758,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '県',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3547,55 +3779,55 @@ const data = {
         },
         zones: [
           {
-            name: 'Bogotá, D.C.',
+            name: 'ボゴタ',
             code: 'DC',
           },
           {
-            name: 'Amazonas',
+            name: 'アマソナス県',
             code: 'AMA',
           },
           {
-            name: 'Antioquia',
+            name: 'アンティオキア県',
             code: 'ANT',
           },
           {
-            name: 'Arauca',
+            name: 'アラウカ県',
             code: 'ARA',
           },
           {
-            name: 'Atlántico',
+            name: 'アトランティコ県',
             code: 'ATL',
           },
           {
-            name: 'Bolívar',
+            name: 'ボリーバル県',
             code: 'BOL',
           },
           {
-            name: 'Boyacá',
+            name: 'ボヤカ県',
             code: 'BOY',
           },
           {
-            name: 'Caldas',
+            name: 'カルダス県',
             code: 'CAL',
           },
           {
-            name: 'Caquetá',
+            name: 'カケタ県',
             code: 'CAQ',
           },
           {
-            name: 'Casanare',
+            name: 'カサナレ県',
             code: 'CAS',
           },
           {
-            name: 'Cauca',
+            name: 'カウカ県',
             code: 'CAU',
           },
           {
-            name: 'Cesar',
+            name: 'セサール県',
             code: 'CES',
           },
           {
-            name: 'Chocó',
+            name: 'チョコ県',
             code: 'CHO',
           },
           {
@@ -3603,83 +3835,83 @@ const data = {
             code: 'COR',
           },
           {
-            name: 'Cundinamarca',
+            name: 'クンディナマルカ県',
             code: 'CUN',
           },
           {
-            name: 'Guainía',
+            name: 'グアイニア県',
             code: 'GUA',
           },
           {
-            name: 'Guaviare',
+            name: 'グアビアーレ県',
             code: 'GUV',
           },
           {
-            name: 'Huila',
+            name: 'ウイラ県',
             code: 'HUI',
           },
           {
-            name: 'La Guajira',
+            name: 'ラ・グアヒーラ県',
             code: 'LAG',
           },
           {
-            name: 'Magdalena',
+            name: 'マグダレーナ県',
             code: 'MAG',
           },
           {
-            name: 'Meta',
+            name: 'メタ県',
             code: 'MET',
           },
           {
-            name: 'Nariño',
+            name: 'ナリーニョ県',
             code: 'NAR',
           },
           {
-            name: 'Norte de Santander',
+            name: 'ノルテ・デ・サンタンデール県',
             code: 'NSA',
           },
           {
-            name: 'Putumayo',
+            name: 'プトゥマヨ県',
             code: 'PUT',
           },
           {
-            name: 'Quindío',
+            name: 'キンディオ県',
             code: 'QUI',
           },
           {
-            name: 'Risaralda',
+            name: 'リサラルダ県',
             code: 'RIS',
           },
           {
-            name: 'San Andrés, Providencia y Santa Catalina',
+            name: 'サン・アンドレス・イ・プロビデンシア県',
             code: 'SAP',
           },
           {
-            name: 'Santander',
+            name: 'サンタンデール県',
             code: 'SAN',
           },
           {
-            name: 'Sucre',
+            name: 'スクレ県',
             code: 'SUC',
           },
           {
-            name: 'Tolima',
+            name: 'トリマ県',
             code: 'TOL',
           },
           {
-            name: 'Valle del Cauca',
+            name: 'バジェ・デル・カウカ県',
             code: 'VAC',
           },
           {
-            name: 'Vaupés',
+            name: 'バウペス県',
             code: 'VAU',
           },
           {
-            name: 'Vichada',
+            name: 'ビチャーダ県',
             code: 'VID',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'コンゴ共和国(ブラザビル)',
@@ -3689,15 +3921,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3716,15 +3951,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3743,15 +3981,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3770,21 +4011,54 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
+        },
+        zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: 'サウスジョージア・サウスサンドウィッチ諸島',
+        code: 'GS',
+        phoneNumberPrefix: 500,
+        autocompletionField: 'address1',
+        continent: 'Other',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
         provinceKey: 'REGION',
@@ -3797,15 +4071,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3824,15 +4101,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -3851,19 +4131,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3878,19 +4161,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3898,26 +4184,29 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'サン・バルテルミー島',
+        name: 'サン・バルテルミー',
         code: 'BL',
         phoneNumberPrefix: 590,
         autocompletionField: 'address1',
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3932,19 +4221,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3959,19 +4251,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -3986,15 +4281,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4013,15 +4311,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4040,15 +4341,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4067,15 +4371,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4094,15 +4401,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4121,15 +4431,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4148,15 +4461,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4175,19 +4491,52 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: 'ジョージア',
+        code: 'GE',
+        phoneNumberPrefix: 995,
+        autocompletionField: 'address1',
+        continent: 'Europe',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4202,15 +4551,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4228,20 +4580,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '住所2',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '住所2 (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4255,20 +4610,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
+          city: '市/町',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4283,19 +4641,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4309,234 +4670,237 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
         },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'A Coruña',
+            name: 'ア・コルーニャ県',
             code: 'C',
           },
           {
-            name: 'Álava',
+            name: 'アラバ県',
             code: 'VI',
           },
           {
-            name: 'Albacete',
+            name: 'アルバセテ県',
             code: 'AB',
           },
           {
-            name: 'Alicante',
+            name: 'アリカンテ県',
             code: 'A',
           },
           {
-            name: 'Almería',
+            name: 'アルメリア県',
             code: 'AL',
           },
           {
-            name: 'Asturias',
+            name: 'Asturias Province',
             code: 'O',
           },
           {
-            name: 'Ávila',
+            name: 'アビラ県',
             code: 'AV',
           },
           {
-            name: 'Badajoz',
+            name: 'バダホス県',
             code: 'BA',
           },
           {
-            name: 'Balears',
+            name: 'バレアレス諸島²',
             code: 'PM',
           },
           {
-            name: 'Barcelona',
+            name: 'バルセロナ県',
             code: 'B',
           },
           {
-            name: 'Burgos',
+            name: 'ブルゴス県',
             code: 'BU',
           },
           {
-            name: 'Cáceres',
+            name: 'カセレス県',
             code: 'CC',
           },
           {
-            name: 'Cádiz',
+            name: 'カディス県',
             code: 'CA',
           },
           {
-            name: 'Cantabria',
+            name: 'カンタブリア州²',
             code: 'S',
           },
           {
-            name: 'Castellón',
+            name: 'カステリョン県',
             code: 'CS',
           },
           {
-            name: 'Ceuta',
+            name: 'セウタ',
             code: 'CE',
           },
           {
-            name: 'Ciudad Real',
+            name: 'シウダ・レアル県',
             code: 'CR',
           },
           {
-            name: 'Córdoba',
+            name: 'コルドバ県',
             code: 'CO',
           },
           {
-            name: 'Cuenca',
+            name: 'クエンカ県',
             code: 'CU',
           },
           {
-            name: 'Girona',
+            name: 'ジローナ県',
             code: 'GI',
           },
           {
-            name: 'Granada',
+            name: 'グラナダ県',
             code: 'GR',
           },
           {
-            name: 'Guadalajara',
+            name: 'グアダラハラ県',
             code: 'GU',
           },
           {
-            name: 'Guipúzcoa',
+            name: 'ギプスコア県',
             code: 'SS',
           },
           {
-            name: 'Huelva',
+            name: 'ウエルバ県',
             code: 'H',
           },
           {
-            name: 'Huesca',
+            name: 'ウエスカ県',
             code: 'HU',
           },
           {
-            name: 'Jaén',
+            name: 'ハエン県',
             code: 'J',
           },
           {
-            name: 'La Rioja',
+            name: 'ラ・リオハ州',
             code: 'LO',
           },
           {
-            name: 'Las Palmas',
+            name: 'ラス・パルマス県',
             code: 'GC',
           },
           {
-            name: 'León',
+            name: 'レオン県',
             code: 'LE',
           },
           {
-            name: 'Lleida',
+            name: 'リェイダ県',
             code: 'L',
           },
           {
-            name: 'Lugo',
+            name: 'ルーゴ県',
             code: 'LU',
           },
           {
-            name: 'Madrid',
+            name: 'マドリード県',
             code: 'M',
           },
           {
-            name: 'Málaga',
+            name: 'マラガ県',
             code: 'MA',
           },
           {
-            name: 'Melilla',
+            name: 'メリリャ',
             code: 'ML',
           },
           {
-            name: 'Murcia',
+            name: 'ムルシア県',
             code: 'MU',
           },
           {
-            name: 'Navarra',
+            name: 'ナバラ州²',
             code: 'NA',
           },
           {
-            name: 'Ourense',
+            name: 'オウレンセ県',
             code: 'OR',
           },
           {
-            name: 'Palencia',
+            name: 'パレンシア県',
             code: 'P',
           },
           {
-            name: 'Pontevedra',
+            name: 'ポンテベドラ県',
             code: 'PO',
           },
           {
-            name: 'Salamanca',
+            name: 'サラマンカ県',
             code: 'SA',
           },
           {
-            name: 'Santa Cruz de Tenerife',
+            name: 'サンタ・クルス・デ・テネリフェ県',
             code: 'TF',
           },
           {
-            name: 'Segovia',
+            name: 'セゴビア県',
             code: 'SG',
           },
           {
-            name: 'Sevilla',
+            name: 'セビリア県',
             code: 'SE',
           },
           {
-            name: 'Soria',
+            name: 'ソリア県',
             code: 'SO',
           },
           {
-            name: 'Tarragona',
+            name: 'タラゴナ県',
             code: 'T',
           },
           {
-            name: 'Teruel',
+            name: 'テルエル県',
             code: 'TE',
           },
           {
-            name: 'Toledo',
+            name: 'トレド県',
             code: 'TO',
           },
           {
-            name: 'Valencia',
+            name: 'バレンシア県',
             code: 'V',
           },
           {
-            name: 'Valladolid',
+            name: 'バリャドリッド県',
             code: 'VA',
           },
           {
-            name: 'Vizcaya',
+            name: 'ビスカヤ県',
             code: 'BI',
           },
           {
-            name: 'Zamora',
+            name: 'サモラ県',
             code: 'ZA',
           },
           {
-            name: 'Zaragoza',
+            name: 'サラゴサ県',
             code: 'Z',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'スリナム',
@@ -4546,15 +4910,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4563,7 +4930,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'スリランカ',
@@ -4573,15 +4940,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4600,19 +4970,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4627,48 +5000,24 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
-      },
-      {
-        name: 'スワジランド',
-        code: 'SZ',
-        phoneNumberPrefix: 268,
-        autocompletionField: 'address1',
-        continent: 'Africa',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}',
         },
         zones: [],
         provinceKey: 'REGION',
@@ -4681,19 +5030,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -4708,19 +5060,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4735,19 +5090,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -4755,22 +5113,25 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'セントクリストファー・ネイビス',
+        name: 'セントクリストファー・ネーヴィス',
         code: 'KN',
         phoneNumberPrefix: 1,
         autocompletionField: 'address1',
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4782,22 +5143,25 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'セントビンセント・グレナディーン諸島',
+        name: 'セントビンセント及びグレナディーン諸島',
         code: 'VC',
         phoneNumberPrefix: 1,
         autocompletionField: 'address1',
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4816,15 +5180,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4843,15 +5210,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4870,15 +5240,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4897,15 +5270,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4924,15 +5300,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4951,15 +5330,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '県',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -4969,319 +5351,319 @@ const data = {
         },
         zones: [
           {
-            name: 'Amnat Charoen',
+            name: 'アムナートチャルーン県',
             code: 'TH-37',
           },
           {
-            name: 'Ang Thong',
+            name: 'アーントーン県',
             code: 'TH-15',
           },
           {
-            name: 'Bangkok',
+            name: 'バンコク',
             code: 'TH-10',
           },
           {
-            name: 'Bueng Kan',
+            name: 'ブンカーン県',
             code: 'TH-38',
           },
           {
-            name: 'Buriram',
+            name: 'ブリーラム県',
             code: 'TH-31',
           },
           {
-            name: 'Chachoengsao',
+            name: 'チャチューンサオ県',
             code: 'TH-24',
           },
           {
-            name: 'Chai Nat',
+            name: 'チャイナート県',
             code: 'TH-18',
           },
           {
-            name: 'Chaiyaphum',
+            name: 'チャイヤプーム県',
             code: 'TH-36',
           },
           {
-            name: 'Chanthaburi',
+            name: 'チャンタブリー県',
             code: 'TH-22',
           },
           {
-            name: 'Chiang Mai',
+            name: 'チエンマイ県',
             code: 'TH-50',
           },
           {
-            name: 'Chiang Rai',
+            name: 'チエンラーイ県',
             code: 'TH-57',
           },
           {
-            name: 'Chon Buri',
+            name: 'チョンブリー県',
             code: 'TH-20',
           },
           {
-            name: 'Chumphon',
+            name: 'チュムポーン県',
             code: 'TH-86',
           },
           {
-            name: 'Kalasin',
+            name: 'カーラシン県',
             code: 'TH-46',
           },
           {
-            name: 'Kamphaeng Phet',
+            name: 'カムペーンペット県',
             code: 'TH-62',
           },
           {
-            name: 'Kanchanaburi',
+            name: 'カーンチャナブリー県',
             code: 'TH-71',
           },
           {
-            name: 'Khon Kaen',
+            name: 'コーンケン県',
             code: 'TH-40',
           },
           {
-            name: 'Krabi',
+            name: 'クラビー県',
             code: 'TH-81',
           },
           {
-            name: 'Lampang',
+            name: 'ラムパーン県',
             code: 'TH-52',
           },
           {
-            name: 'Lamphun',
+            name: 'ラムプーン県',
             code: 'TH-51',
           },
           {
-            name: 'Loei',
+            name: 'ルーイ県',
             code: 'TH-42',
           },
           {
-            name: 'Lopburi',
+            name: 'ロッブリー県',
             code: 'TH-16',
           },
           {
-            name: 'Mae Hong Son',
+            name: 'メーホンソーン県',
             code: 'TH-58',
           },
           {
-            name: 'Maha Sarakham',
+            name: 'マハーサーラカーム県',
             code: 'TH-44',
           },
           {
-            name: 'Mukdahan',
+            name: 'ムックダーハーン県',
             code: 'TH-49',
           },
           {
-            name: 'Nakhon Nayok',
+            name: 'ナコーンナーヨック県',
             code: 'TH-26',
           },
           {
-            name: 'Nakhon Pathom',
+            name: 'ナコーンパトム県',
             code: 'TH-73',
           },
           {
-            name: 'Nakhon Phanom',
+            name: 'ナコーンパノム県',
             code: 'TH-48',
           },
           {
-            name: 'Nakhon Ratchasima',
+            name: 'ナコーンラーチャシーマー県',
             code: 'TH-30',
           },
           {
-            name: 'Nakhon Sawan',
+            name: 'ナコーンサワン県',
             code: 'TH-60',
           },
           {
-            name: 'Nakhon Si Thammarat',
+            name: 'ナコーンシータンマラート県',
             code: 'TH-80',
           },
           {
-            name: 'Nan',
+            name: 'ナーン県',
             code: 'TH-55',
           },
           {
-            name: 'Narathiwat',
+            name: 'ナラーティワート県',
             code: 'TH-96',
           },
           {
-            name: 'Nong Bua Lam Phu',
+            name: 'ノーンブワラムプー県',
             code: 'TH-39',
           },
           {
-            name: 'Nong Khai',
+            name: 'ノーンカーイ県',
             code: 'TH-43',
           },
           {
-            name: 'Nonthaburi',
+            name: 'ノンタブリー県',
             code: 'TH-12',
           },
           {
-            name: 'Pathum Thani',
+            name: 'パトゥムターニー県',
             code: 'TH-13',
           },
           {
-            name: 'Pattani',
+            name: 'パッターニー県',
             code: 'TH-94',
           },
           {
-            name: 'Pattaya',
+            name: 'パッタヤー',
             code: 'TH-S',
           },
           {
-            name: 'Phangnga',
+            name: 'パンガー県',
             code: 'TH-82',
           },
           {
-            name: 'Phatthalung',
+            name: 'パッタルン県',
             code: 'TH-93',
           },
           {
-            name: 'Phayao',
+            name: 'パヤオ県',
             code: 'TH-56',
           },
           {
-            name: 'Phetchabun',
+            name: 'ペッチャブーン県',
             code: 'TH-67',
           },
           {
-            name: 'Phetchaburi',
+            name: 'ペッチャブリー県',
             code: 'TH-76',
           },
           {
-            name: 'Phichit',
+            name: 'ピチット県',
             code: 'TH-66',
           },
           {
-            name: 'Phitsanulok',
+            name: 'ピッサヌローク県',
             code: 'TH-65',
           },
           {
-            name: 'Phra Nakhon Si Ayutthaya',
+            name: 'アユタヤ県',
             code: 'TH-14',
           },
           {
-            name: 'Phrae',
+            name: 'プレー県',
             code: 'TH-54',
           },
           {
-            name: 'Phuket',
+            name: 'プーケット県',
             code: 'TH-83',
           },
           {
-            name: 'Prachin Buri',
+            name: 'プラーチーンブリー県',
             code: 'TH-25',
           },
           {
-            name: 'Prachuap Khiri Khan',
+            name: 'プラチュワップキーリーカン県',
             code: 'TH-77',
           },
           {
-            name: 'Ranong',
+            name: 'ラノーン県',
             code: 'TH-85',
           },
           {
-            name: 'Ratchaburi',
+            name: 'ラーチャブリー県',
             code: 'TH-70',
           },
           {
-            name: 'Rayong',
+            name: 'ラヨーン県',
             code: 'TH-21',
           },
           {
-            name: 'Roi Et',
+            name: 'ローイエット県',
             code: 'TH-45',
           },
           {
-            name: 'Sa Kaeo',
+            name: 'サケーオ県',
             code: 'TH-27',
           },
           {
-            name: 'Sakon Nakhon',
+            name: 'サコンナコーン県',
             code: 'TH-47',
           },
           {
-            name: 'Samut Prakan',
+            name: 'サムットプラーカーン県',
             code: 'TH-11',
           },
           {
-            name: 'Samut Sakhon',
+            name: 'サムットサーコーン県',
             code: 'TH-74',
           },
           {
-            name: 'Samut Songkhram',
+            name: 'サムットソンクラーム県',
             code: 'TH-75',
           },
           {
-            name: 'Saraburi',
+            name: 'サラブリー県',
             code: 'TH-19',
           },
           {
-            name: 'Satun',
+            name: 'サトゥーン県',
             code: 'TH-91',
           },
           {
-            name: 'Sing Buri',
+            name: 'シンブリー県',
             code: 'TH-17',
           },
           {
-            name: 'Sisaket',
+            name: 'シーサケート県',
             code: 'TH-33',
           },
           {
-            name: 'Songkhla',
+            name: 'ソンクラー県',
             code: 'TH-90',
           },
           {
-            name: 'Sukhothai',
+            name: 'スコータイ県',
             code: 'TH-64',
           },
           {
-            name: 'Suphan Buri',
+            name: 'スパンブリー県',
             code: 'TH-72',
           },
           {
-            name: 'Surat Thani',
+            name: 'スラートターニー県',
             code: 'TH-84',
           },
           {
-            name: 'Surin',
+            name: 'スリン県',
             code: 'TH-32',
           },
           {
-            name: 'Tak',
+            name: 'ターク県',
             code: 'TH-63',
           },
           {
-            name: 'Trang',
+            name: 'トラン県',
             code: 'TH-92',
           },
           {
-            name: 'Trat',
+            name: 'トラート県',
             code: 'TH-23',
           },
           {
-            name: 'Ubon Ratchathani',
+            name: 'ウボンラーチャターニー県',
             code: 'TH-34',
           },
           {
-            name: 'Udon Thani',
+            name: 'ウドーンターニー県',
             code: 'TH-41',
           },
           {
-            name: 'Uthai Thani',
+            name: 'ウタイターニー県',
             code: 'TH-61',
           },
           {
-            name: 'Uttaradit',
+            name: 'ウッタラディット県',
             code: 'TH-53',
           },
           {
-            name: 'Yala',
+            name: 'ヤラー県',
             code: 'TH-95',
           },
           {
-            name: 'Yasothon',
+            name: 'ヤソートーン県',
             code: 'TH-35',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'タジキスタン',
@@ -5291,24 +5673,27 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'タンザニア',
@@ -5318,19 +5703,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5345,15 +5733,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5365,26 +5756,29 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'チェコ共和国',
+        name: 'チェコ',
         code: 'CZ',
         phoneNumberPrefix: 420,
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5399,15 +5793,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5426,19 +5823,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5453,23 +5853,92 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{country}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
         },
-        zones: [],
+        zones: [
+          {
+            name: 'アリカ・イ・パリナコータ州',
+            code: 'AP',
+          },
+          {
+            name: 'タラパカ州',
+            code: 'TA',
+          },
+          {
+            name: 'アントファガスタ州',
+            code: 'AN',
+          },
+          {
+            name: 'アタカマ州',
+            code: 'AT',
+          },
+          {
+            name: 'コキンボ州',
+            code: 'CO',
+          },
+          {
+            name: 'バルパライソ州',
+            code: 'VS',
+          },
+          {
+            name: '首都州',
+            code: 'RM',
+          },
+          {
+            name: 'リベルタドール・ベルナルド・オイギンス州',
+            code: 'LI',
+          },
+          {
+            name: 'マウレ州',
+            code: 'ML',
+          },
+          {
+            name: 'ニュブレ州',
+            code: 'NB',
+          },
+          {
+            name: 'ビオビオ州',
+            code: 'BI',
+          },
+          {
+            name: 'ラ・アラウカニア州',
+            code: 'AR',
+          },
+          {
+            name: 'ロス・リオス州',
+            code: 'LR',
+          },
+          {
+            name: 'ロス・ラゴス州',
+            code: 'LL',
+          },
+          {
+            name:
+              'アイセン・デル・ヘネラル・カルロス・イバニェス・デル・カンポ州',
+            code: 'AI',
+          },
+          {
+            name: 'マガジャネス・イ・デ・ラ・アンタルティカ・チレーナ州',
+            code: 'MA',
+          },
+        ],
         provinceKey: 'REGION',
       },
       {
@@ -5480,15 +5949,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5497,7 +5969,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'STATE',
+        provinceKey: 'REGION',
       },
       {
         name: 'デンマーク',
@@ -5506,20 +5978,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5534,15 +6009,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5561,15 +6039,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5588,21 +6069,24 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{zip}{city}_{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+            '{zip}{city}_{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{phone}',
         },
         zones: [],
         provinceKey: 'REGION',
@@ -5615,19 +6099,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5642,15 +6129,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5669,15 +6159,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5696,19 +6189,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{country}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5723,19 +6219,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -5750,15 +6249,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5777,15 +6279,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -5795,155 +6300,155 @@ const data = {
         },
         zones: [
           {
-            name: 'Abia',
+            name: 'アビア州',
             code: 'AB',
           },
           {
-            name: 'Abuja Federal Capital Territory',
+            name: '連邦首都地区',
             code: 'FC',
           },
           {
-            name: 'Adamawa',
+            name: 'アダマワ州',
             code: 'AD',
           },
           {
-            name: 'Akwa Ibom',
+            name: 'アクワ・イボム州',
             code: 'AK',
           },
           {
-            name: 'Anambra',
+            name: 'アナンブラ州',
             code: 'AN',
           },
           {
-            name: 'Bauchi',
+            name: 'バウチ州',
             code: 'BA',
           },
           {
-            name: 'Bayelsa',
+            name: 'バイエルサ州',
             code: 'BY',
           },
           {
-            name: 'Benue',
+            name: 'ベヌエ州',
             code: 'BE',
           },
           {
-            name: 'Borno',
+            name: 'ボルノ州',
             code: 'BO',
           },
           {
-            name: 'Cross River',
+            name: 'クロスリバー州',
             code: 'CR',
           },
           {
-            name: 'Delta',
+            name: 'デルタ州',
             code: 'DE',
           },
           {
-            name: 'Ebonyi',
+            name: 'エボニ州',
             code: 'EB',
           },
           {
-            name: 'Edo',
+            name: 'エド州',
             code: 'ED',
           },
           {
-            name: 'Ekiti',
+            name: 'エキティ州',
             code: 'EK',
           },
           {
-            name: 'Enugu',
+            name: 'エヌグ州',
             code: 'EN',
           },
           {
-            name: 'Gombe',
+            name: 'ゴンベ州',
             code: 'GO',
           },
           {
-            name: 'Imo',
+            name: 'イモ州',
             code: 'IM',
           },
           {
-            name: 'Jigawa',
+            name: 'ジガワ州',
             code: 'JI',
           },
           {
-            name: 'Kaduna',
+            name: 'カドゥナ州',
             code: 'KD',
           },
           {
-            name: 'Kano',
+            name: 'カノ州',
             code: 'KN',
           },
           {
-            name: 'Katsina',
+            name: 'カツィナ州',
             code: 'KT',
           },
           {
-            name: 'Kebbi',
+            name: 'ケビ州',
             code: 'KE',
           },
           {
-            name: 'Kogi',
+            name: 'コギ州',
             code: 'KO',
           },
           {
-            name: 'Kwara',
+            name: 'クワラ州',
             code: 'KW',
           },
           {
-            name: 'Lagos',
+            name: 'レゴス州',
             code: 'LA',
           },
           {
-            name: 'Nasarawa',
+            name: 'ナサラワ州',
             code: 'NA',
           },
           {
-            name: 'Niger',
+            name: 'ナイジャ州',
             code: 'NI',
           },
           {
-            name: 'Ogun',
+            name: 'オグン州',
             code: 'OG',
           },
           {
-            name: 'Ondo',
+            name: 'オンド州',
             code: 'ON',
           },
           {
-            name: 'Osun',
+            name: 'オスン州',
             code: 'OS',
           },
           {
-            name: 'Oyo',
+            name: 'オヨ州',
             code: 'OY',
           },
           {
-            name: 'Plateau',
+            name: 'プラトー州',
             code: 'PL',
           },
           {
-            name: 'Rivers',
+            name: 'リバーズ州',
             code: 'RI',
           },
           {
-            name: 'Sokoto',
+            name: 'ソコト州',
             code: 'SO',
           },
           {
-            name: 'Taraba',
+            name: 'タラバ州',
             code: 'TA',
           },
           {
-            name: 'Yobe',
+            name: 'ヨベ州',
             code: 'YO',
           },
           {
-            name: 'Zamfara',
+            name: 'ザムファラ州',
             code: 'ZA',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'STATE',
       },
       {
         name: 'ナウル',
@@ -5953,42 +6458,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
         },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'STATE',
-      },
-      {
-        name: 'ナミビア',
-        code: 'NA',
-        phoneNumberPrefix: 264,
-        autocompletionField: 'address1',
-        continent: 'Africa',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6000,22 +6481,55 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'ニウエ島',
+        name: 'ナミビア',
+        code: 'NA',
+        phoneNumberPrefix: 264,
+        autocompletionField: 'address1',
+        continent: 'Africa',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: 'ニウエ',
         code: 'NU',
         phoneNumberPrefix: 683,
         autocompletionField: 'address1',
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6034,19 +6548,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}',
         },
@@ -6061,19 +6578,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6088,19 +6608,22 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6115,15 +6638,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6133,67 +6659,67 @@ const data = {
         },
         zones: [
           {
-            name: 'Auckland',
+            name: 'オークランド地方',
             code: 'AUK',
           },
           {
-            name: 'Bay of Plenty',
+            name: 'ベイ・オブ・プレンティ地方',
             code: 'BOP',
           },
           {
-            name: 'Canterbury',
+            name: 'カンタベリー地方',
             code: 'CAN',
           },
           {
-            name: 'Gisborne',
+            name: 'ギズボーン地方',
             code: 'GIS',
           },
           {
-            name: "Hawke's Bay",
+            name: 'ホークス・ベイ地方',
             code: 'HKB',
           },
           {
-            name: 'Manawatu-Wanganui',
+            name: 'マナワツ・ワンガヌイ地方',
             code: 'MWT',
           },
           {
-            name: 'Marlborough',
+            name: 'マールボロ地方',
             code: 'MBH',
           },
           {
-            name: 'Nelson',
+            name: 'ネルソン地方',
             code: 'NSN',
           },
           {
-            name: 'Northland',
+            name: 'ノースランド地方',
             code: 'NTL',
           },
           {
-            name: 'Otago',
+            name: 'オタゴ地方',
             code: 'OTA',
           },
           {
-            name: 'Southland',
+            name: 'サウスランド地方',
             code: 'STL',
           },
           {
-            name: 'Taranaki',
+            name: 'タラナキ地方',
             code: 'TKI',
           },
           {
-            name: 'Tasman',
+            name: 'タスマン地方',
             code: 'TAS',
           },
           {
-            name: 'Waikato',
+            name: 'ワイカト地方',
             code: 'WKO',
           },
           {
-            name: 'Wellington',
+            name: 'ウェリントン地方',
             code: 'WGN',
           },
           {
-            name: 'West Coast',
+            name: 'ウェスト・コースト地方',
             code: 'WTC',
           },
         ],
@@ -6207,15 +6733,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6233,20 +6762,23 @@ const data = {
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6261,15 +6793,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6288,19 +6823,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6315,15 +6853,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6342,15 +6883,18 @@ const data = {
         continent: 'Other',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6369,19 +6913,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6396,15 +6943,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6423,15 +6973,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6450,15 +7003,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6477,15 +7033,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6504,15 +7063,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6531,15 +7093,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6558,15 +7123,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6585,15 +7153,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6603,55 +7174,55 @@ const data = {
         },
         zones: [
           {
-            name: 'Bocas del Toro',
+            name: 'ボカス・デル・トーロ県',
             code: 'PA-1',
           },
           {
-            name: 'Chiriquí',
+            name: 'チリキ県',
             code: 'PA-4',
           },
           {
-            name: 'Coclé',
+            name: 'コクレ県',
             code: 'PA-2',
           },
           {
-            name: 'Colón',
+            name: 'コロン県',
             code: 'PA-3',
           },
           {
-            name: 'Darién',
+            name: 'ダリエン県',
             code: 'PA-5',
           },
           {
-            name: 'Emberá',
+            name: 'エンベラ自治区',
             code: 'PA-EM',
           },
           {
-            name: 'Herrera',
+            name: 'エレーラ県',
             code: 'PA-6',
           },
           {
-            name: 'Kuna Yala',
+            name: 'クナ・ヤラ自治区',
             code: 'PA-KY',
           },
           {
-            name: 'Los Santos',
+            name: 'ロス・サントス県',
             code: 'PA-7',
           },
           {
-            name: 'Ngöbe-Buglé',
+            name: 'ノベ・ブグレ自治区',
             code: 'PA-NB',
           },
           {
-            name: 'Panamá',
+            name: 'パナマ県',
             code: 'PA-8',
           },
           {
-            name: 'Panamá Oeste',
+            name: '西パナマ県',
             code: 'PA-10',
           },
           {
-            name: 'Veraguas',
+            name: 'ベラグアス県',
             code: 'PA-9',
           },
         ],
@@ -6665,15 +7236,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6692,19 +7266,22 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6712,22 +7289,25 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'パレスチナ',
+        name: 'パレスチナ自治区',
         code: 'PS',
         phoneNumberPrefix: 970,
         autocompletionField: 'address1',
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6746,19 +7326,22 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6773,15 +7356,18 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6800,19 +7386,22 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6827,19 +7416,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6854,19 +7446,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -6881,15 +7476,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6908,15 +7506,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6934,16 +7535,19 @@ const data = {
         autocompletionField: 'address1',
         continent: 'South America',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -6953,115 +7557,115 @@ const data = {
         },
         zones: [
           {
-            name: 'Acre',
+            name: 'アクレ州',
             code: 'AC',
           },
           {
-            name: 'Alagoas',
+            name: 'アラゴアス州',
             code: 'AL',
           },
           {
-            name: 'Amapá',
+            name: 'アマパー州',
             code: 'AP',
           },
           {
-            name: 'Amazonas',
+            name: 'アマゾナス州',
             code: 'AM',
           },
           {
-            name: 'Bahia',
+            name: 'バイーア州',
             code: 'BA',
           },
           {
-            name: 'Ceará',
+            name: 'セアラー州',
             code: 'CE',
           },
           {
-            name: 'Distrito Federal',
+            name: 'ブラジリア連邦直轄区',
             code: 'DF',
           },
           {
-            name: 'Espírito Santo',
+            name: 'エスピリトサント州',
             code: 'ES',
           },
           {
-            name: 'Goiás',
+            name: 'ゴイアス州',
             code: 'GO',
           },
           {
-            name: 'Maranhão',
+            name: 'マラニョン州',
             code: 'MA',
           },
           {
-            name: 'Mato Grosso',
+            name: 'マットグロッソ州',
             code: 'MT',
           },
           {
-            name: 'Mato Grosso do Sul',
+            name: 'マットグロッソ・ド・スル州',
             code: 'MS',
           },
           {
-            name: 'Minas Gerais',
+            name: 'ミナスジェライス州',
             code: 'MG',
           },
           {
-            name: 'Pará',
+            name: 'パラー州',
             code: 'PA',
           },
           {
-            name: 'Paraíba',
+            name: 'パライバ州',
             code: 'PB',
           },
           {
-            name: 'Paraná',
+            name: 'パラナ州',
             code: 'PR',
           },
           {
-            name: 'Pernambuco',
+            name: 'ペルナンブーコ州',
             code: 'PE',
           },
           {
-            name: 'Piauí',
+            name: 'ピアウイ州',
             code: 'PI',
           },
           {
-            name: 'Rio Grande do Norte',
+            name: 'リオグランデ・ド・ノルテ州',
             code: 'RN',
           },
           {
-            name: 'Rio Grande do Sul',
+            name: 'リオグランデ・ド・スル州',
             code: 'RS',
           },
           {
-            name: 'Rio de Janeiro',
+            name: 'リオデジャネイロ州',
             code: 'RJ',
           },
           {
-            name: 'Rondônia',
+            name: 'ロンドニア州',
             code: 'RO',
           },
           {
-            name: 'Roraima',
+            name: 'ロライマ州',
             code: 'RR',
           },
           {
-            name: 'Santa Catarina',
+            name: 'サンタカタリーナ州',
             code: 'SC',
           },
           {
-            name: 'São Paulo',
+            name: 'サンパウロ州',
             code: 'SP',
           },
           {
-            name: 'Sergipe',
+            name: 'セルジッペ州',
             code: 'SE',
           },
           {
-            name: 'Tocantins',
+            name: 'トカンティンス州',
             code: 'TO',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'STATE',
       },
       {
         name: 'ブルガリア',
@@ -7071,24 +7675,27 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'STATE',
+        provinceKey: 'REGION',
       },
       {
         name: 'ブルキナファソ',
@@ -7098,15 +7705,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7125,15 +7735,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7152,15 +7765,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7179,15 +7795,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7206,15 +7825,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7233,15 +7855,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7260,15 +7885,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7287,15 +7915,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7314,19 +7945,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7341,15 +7975,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7358,7 +7995,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'ベルギー',
@@ -7368,19 +8005,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7395,15 +8035,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7413,107 +8056,107 @@ const data = {
         },
         zones: [
           {
-            name: 'Amazonas',
+            name: 'アマソナス県',
             code: 'PE-AMA',
           },
           {
-            name: 'Áncash',
+            name: 'アンカシュ県',
             code: 'PE-ANC',
           },
           {
-            name: 'Apurímac',
+            name: 'アプリマク県',
             code: 'PE-APU',
           },
           {
-            name: 'Arequipa',
+            name: 'アレキパ県',
             code: 'PE-ARE',
           },
           {
-            name: 'Ayacucho',
+            name: 'アヤクーチョ県',
             code: 'PE-AYA',
           },
           {
-            name: 'Cajamarca',
+            name: 'カハマルカ県',
             code: 'PE-CAJ',
           },
           {
-            name: 'Callao',
+            name: 'カヤオ特別区',
             code: 'PE-CAL',
           },
           {
-            name: 'Cuzco',
+            name: 'クスコ県',
             code: 'PE-CUS',
           },
           {
-            name: 'Huancavelica',
+            name: 'ワンカベリカ県',
             code: 'PE-HUV',
           },
           {
-            name: 'Huánuco',
+            name: 'ワヌコ県',
             code: 'PE-HUC',
           },
           {
-            name: 'Ica',
+            name: 'イカ県',
             code: 'PE-ICA',
           },
           {
-            name: 'Junín',
+            name: 'フニン県',
             code: 'PE-JUN',
           },
           {
-            name: 'La Libertad',
+            name: 'ラ・リベルタ県',
             code: 'PE-LAL',
           },
           {
-            name: 'Lambayeque',
+            name: 'ランバイエケ県',
             code: 'PE-LAM',
           },
           {
-            name: 'Lima (departamento)',
+            name: 'リマ県',
             code: 'PE-LIM',
           },
           {
-            name: 'Lima (provincia)',
+            name: 'リマ郡',
             code: 'PE-LMA',
           },
           {
-            name: 'Loreto',
+            name: 'ロレート県',
             code: 'PE-LOR',
           },
           {
-            name: 'Madre de Dios',
+            name: 'マードレ・デ・ディオス県',
             code: 'PE-MDD',
           },
           {
-            name: 'Moquegua',
+            name: 'モケグア県',
             code: 'PE-MOQ',
           },
           {
-            name: 'Pasco',
+            name: 'パスコ県',
             code: 'PE-PAS',
           },
           {
-            name: 'Piura',
+            name: 'ピウラ県',
             code: 'PE-PIU',
           },
           {
-            name: 'Puno',
+            name: 'プーノ県',
             code: 'PE-PUN',
           },
           {
-            name: 'San Martín',
+            name: 'サン・マルティン県',
             code: 'PE-SAM',
           },
           {
-            name: 'Tacna',
+            name: 'タクナ県',
             code: 'PE-TAC',
           },
           {
-            name: 'Tumbes',
+            name: 'トゥンベス県',
             code: 'PE-TUM',
           },
           {
-            name: 'Ucayali',
+            name: 'ウカヤリ県',
             code: 'PE-UCA',
           },
         ],
@@ -7527,19 +8170,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7554,19 +8200,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7581,15 +8230,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7608,15 +8260,18 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7635,15 +8290,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7653,83 +8311,83 @@ const data = {
         },
         zones: [
           {
-            name: 'Açores',
+            name: 'アゾレス諸島',
             code: 'PT-20',
           },
           {
-            name: 'Aveiro',
+            name: 'アヴェイロ県',
             code: 'PT-01',
           },
           {
-            name: 'Beja',
+            name: 'ベージャ県',
             code: 'PT-02',
           },
           {
-            name: 'Braga',
+            name: 'ブラガ県',
             code: 'PT-03',
           },
           {
-            name: 'Bragança',
+            name: 'ブラガンサ県',
             code: 'PT-04',
           },
           {
-            name: 'Castelo Branco',
+            name: 'カステロ・ブランコ県',
             code: 'PT-05',
           },
           {
-            name: 'Coimbra',
+            name: 'コインブラ県',
             code: 'PT-06',
           },
           {
-            name: 'Évora',
+            name: 'エヴォラ県',
             code: 'PT-07',
           },
           {
-            name: 'Faro',
+            name: 'ファーロ県',
             code: 'PT-08',
           },
           {
-            name: 'Guarda',
+            name: 'グアルダ県',
             code: 'PT-09',
           },
           {
-            name: 'Leiria',
+            name: 'レイリア県',
             code: 'PT-10',
           },
           {
-            name: 'Lisboa',
+            name: 'リスボン県',
             code: 'PT-11',
           },
           {
-            name: 'Madeira',
+            name: 'マデイラ諸島',
             code: 'PT-30',
           },
           {
-            name: 'Portalegre',
+            name: 'ポルタレグレ県',
             code: 'PT-12',
           },
           {
-            name: 'Porto',
+            name: 'ポルト県',
             code: 'PT-13',
           },
           {
-            name: 'Santarém',
+            name: 'サンタレン県',
             code: 'PT-14',
           },
           {
-            name: 'Setúbal',
+            name: 'セトゥーバル県',
             code: 'PT-15',
           },
           {
-            name: 'Viana do Castelo',
+            name: 'ヴィアナ・ド・カステロ県',
             code: 'PT-16',
           },
           {
-            name: 'Vila Real',
+            name: 'ヴィラ・レアル県',
             code: 'PT-17',
           },
           {
-            name: 'Viseu',
+            name: 'ヴィゼウ県',
             code: 'PT-18',
           },
         ],
@@ -7743,46 +8401,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
-      },
-      {
-        name: 'マケドニア',
-        code: 'MK',
-        phoneNumberPrefix: 389,
-        autocompletionField: 'address1',
-        continent: 'Europe',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7797,19 +8431,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7817,26 +8454,29 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'マヨット島',
+        name: 'マヨット',
         code: 'YT',
         phoneNumberPrefix: 262,
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7851,15 +8491,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7878,15 +8521,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7905,15 +8551,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -7932,19 +8581,22 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -7959,89 +8611,92 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州、準州',
+          zone: '州/地区',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'Johor',
+            name: 'ジョホール州',
             code: 'JHR',
           },
           {
-            name: 'Kedah',
+            name: 'ケダ州',
             code: 'KDH',
           },
           {
-            name: 'Kelantan',
+            name: 'クランタン州',
             code: 'KTN',
           },
           {
-            name: 'Kuala Lumpur',
+            name: 'クアラルンプール',
             code: 'KUL',
           },
           {
-            name: 'Labuan',
+            name: 'ラブアン',
             code: 'LBN',
           },
           {
-            name: 'Melaka',
+            name: 'ムラカ州',
             code: 'MLK',
           },
           {
-            name: 'Negeri Sembilan',
+            name: 'ヌグリ・スンビラン州',
             code: 'NSN',
           },
           {
-            name: 'Pahang',
+            name: 'パハン州',
             code: 'PHG',
           },
           {
-            name: 'Perak',
-            code: 'PRK',
-          },
-          {
-            name: 'Perlis',
-            code: 'PLS',
-          },
-          {
-            name: 'Pulau Pinang',
+            name: 'ペナン州',
             code: 'PNG',
           },
           {
-            name: 'Putrajaya',
+            name: 'ペラ州',
+            code: 'PRK',
+          },
+          {
+            name: 'プルリス州',
+            code: 'PLS',
+          },
+          {
+            name: 'プトラジャヤ',
             code: 'PJY',
           },
           {
-            name: 'Sabah',
+            name: 'サバ州',
             code: 'SBH',
           },
           {
-            name: 'Sarawak',
+            name: 'サラワク州',
             code: 'SWK',
           },
           {
-            name: 'Selangor',
+            name: 'セランゴール州',
             code: 'SGR',
           },
           {
-            name: 'Terengganu',
+            name: 'トレンガヌ州',
             code: 'TRG',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'STATE_AND_TERRITORY',
       },
       {
         name: 'マン島',
@@ -8051,15 +8706,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8068,25 +8726,28 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'STATE_AND_TERRITORY',
+        provinceKey: 'REGION',
       },
       {
-        name: 'ミャンマー',
+        name: 'ミャンマー (ビルマ)',
         code: 'MM',
         phoneNumberPrefix: 95,
         autocompletionField: 'address1',
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8104,154 +8765,157 @@ const data = {
         autocompletionField: 'address1',
         continent: 'North America',
         labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address1: '住所および部屋番号',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
         },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'Aguascalientes',
+            name: 'アグアスカリエンテス州',
             code: 'AGS',
           },
           {
-            name: 'Baja California',
+            name: 'バハ・カリフォルニア州',
             code: 'BC',
           },
           {
-            name: 'Baja California Sur',
+            name: 'バハ・カリフォルニア・スル州',
             code: 'BCS',
           },
           {
-            name: 'Campeche',
+            name: 'カンペチェ州',
             code: 'CAMP',
           },
           {
-            name: 'Chiapas',
+            name: 'チアパス州',
             code: 'CHIS',
           },
           {
-            name: 'Chihuahua',
+            name: 'チワワ州',
             code: 'CHIH',
           },
           {
-            name: 'Ciudad de México',
+            name: 'メキシコシティ',
             code: 'DF',
           },
           {
-            name: 'Coahuila',
+            name: 'コアウイラ州',
             code: 'COAH',
           },
           {
-            name: 'Colima',
+            name: 'コリマ州',
             code: 'COL',
           },
           {
-            name: 'Durango',
+            name: 'ドゥランゴ州',
             code: 'DGO',
           },
           {
-            name: 'Guanajuato',
+            name: 'グアナフアト州',
             code: 'GTO',
           },
           {
-            name: 'Guerrero',
+            name: 'ゲレーロ州',
             code: 'GRO',
           },
           {
-            name: 'Hidalgo',
+            name: 'イダルゴ州',
             code: 'HGO',
           },
           {
-            name: 'Jalisco',
+            name: 'ハリスコ州',
             code: 'JAL',
           },
           {
-            name: 'México',
+            name: 'メヒコ州',
             code: 'MEX',
           },
           {
-            name: 'Michoacán',
+            name: 'ミチョアカン州',
             code: 'MICH',
           },
           {
-            name: 'Morelos',
+            name: 'モレロス州',
             code: 'MOR',
           },
           {
-            name: 'Nayarit',
+            name: 'ナヤリット州',
             code: 'NAY',
           },
           {
-            name: 'Nuevo León',
+            name: 'ヌエボ・レオン州',
             code: 'NL',
           },
           {
-            name: 'Oaxaca',
+            name: 'オアハカ州',
             code: 'OAX',
           },
           {
-            name: 'Puebla',
+            name: 'プエブラ州',
             code: 'PUE',
           },
           {
-            name: 'Querétaro',
+            name: 'ケレタロ州',
             code: 'QRO',
           },
           {
-            name: 'Quintana Roo',
+            name: 'キンタナ・ロー州',
             code: 'Q ROO',
           },
           {
-            name: 'San Luis Potosí',
+            name: 'サン・ルイス・ポトシ州',
             code: 'SLP',
           },
           {
-            name: 'Sinaloa',
+            name: 'シナロア州',
             code: 'SIN',
           },
           {
-            name: 'Sonora',
+            name: 'ソノラ州',
             code: 'SON',
           },
           {
-            name: 'Tabasco',
+            name: 'タバスコ州',
             code: 'TAB',
           },
           {
-            name: 'Tamaulipas',
+            name: 'タマウリパス州',
             code: 'TAMPS',
           },
           {
-            name: 'Tlaxcala',
+            name: 'トラスカラ州',
             code: 'TLAX',
           },
           {
-            name: 'Veracruz',
+            name: 'ベラクルス州',
             code: 'VER',
           },
           {
-            name: 'Yucatán',
+            name: 'ユカタン州',
             code: 'YUC',
           },
           {
-            name: 'Zacatecas',
+            name: 'サカテカス州',
             code: 'ZAC',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'STATE',
       },
       {
         name: 'モザンビーク',
@@ -8261,24 +8925,27 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'STATE',
+        provinceKey: 'REGION',
       },
       {
         name: 'モナコ',
@@ -8288,19 +8955,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -8315,15 +8985,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8342,19 +9015,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -8369,19 +9045,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -8396,15 +9075,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8423,19 +9105,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -8450,15 +9135,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8477,15 +9165,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8504,15 +9195,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8531,15 +9225,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8558,15 +9255,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '県',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8575,7 +9275,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'REGION',
+        provinceKey: 'PROVINCE',
       },
       {
         name: 'ラトビア',
@@ -8585,15 +9285,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8602,7 +9305,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: 'リトアニア',
@@ -8612,15 +9315,18 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8639,19 +9345,22 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -8666,15 +9375,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8693,19 +9405,22 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -8713,26 +9428,29 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'ルクセンブルグ',
+        name: 'ルクセンブルク',
         code: 'LU',
         phoneNumberPrefix: 352,
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -8747,15 +9465,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -8774,65 +9495,68 @@ const data = {
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '郡',
+          zone: '県',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}',
         },
         zones: [
           {
-            name: 'Alba',
+            name: 'アルバ県',
             code: 'AB',
           },
           {
-            name: 'Arad',
+            name: 'アラド県',
             code: 'AR',
           },
           {
-            name: 'Argeș',
+            name: 'アルジェシュ県',
             code: 'AG',
           },
           {
-            name: 'Bacău',
+            name: 'バカウ県',
             code: 'BC',
           },
           {
-            name: 'Bihor',
+            name: 'ビホル県',
             code: 'BH',
           },
           {
-            name: 'Bistrița-Năsăud',
+            name: 'Bistriţa-Năsăud',
             code: 'BN',
           },
           {
-            name: 'Botoșani',
+            name: 'ボトシャニ県',
             code: 'BT',
           },
           {
-            name: 'Brăila',
+            name: 'ブライラ県',
             code: 'BR',
           },
           {
-            name: 'Brașov',
+            name: 'ブラショフ県',
             code: 'BV',
           },
           {
-            name: 'București',
+            name: 'ブカレスト',
             code: 'B',
           },
           {
-            name: 'Buzău',
+            name: 'ブザウ県',
             code: 'BZ',
           },
           {
@@ -8840,127 +9564,127 @@ const data = {
             code: 'CS',
           },
           {
-            name: 'Cluj',
+            name: 'クルジュ県',
             code: 'CJ',
           },
           {
-            name: 'Constanța',
+            name: 'コンスタンツァ県',
             code: 'CT',
           },
           {
-            name: 'Covasna',
+            name: 'コヴァスナ県',
             code: 'CV',
           },
           {
-            name: 'Călărași',
+            name: 'カララシ県',
             code: 'CL',
           },
           {
-            name: 'Dolj',
+            name: 'ドルジュ県',
             code: 'DJ',
           },
           {
-            name: 'Dâmbovița',
+            name: 'ドゥンボヴィツァ県',
             code: 'DB',
           },
           {
-            name: 'Galați',
+            name: 'ガラツィ県',
             code: 'GL',
           },
           {
-            name: 'Giurgiu',
+            name: 'ジュルジュ県',
             code: 'GR',
           },
           {
-            name: 'Gorj',
+            name: 'ゴルジュ県',
             code: 'GJ',
           },
           {
-            name: 'Harghita',
+            name: 'ハルギタ県',
             code: 'HR',
           },
           {
-            name: 'Hunedoara',
+            name: 'フネドアラ県',
             code: 'HD',
           },
           {
-            name: 'Ialomița',
+            name: 'ヤロミツァ県',
             code: 'IL',
           },
           {
-            name: 'Iași',
+            name: 'ヤシ県',
             code: 'IS',
           },
           {
-            name: 'Ilfov',
+            name: 'イルフォヴ県',
             code: 'IF',
           },
           {
-            name: 'Maramureș',
+            name: 'マラムレシュ県',
             code: 'MM',
           },
           {
-            name: 'Mehedinți',
+            name: 'メヘディンチ県',
             code: 'MH',
           },
           {
-            name: 'Mureș',
+            name: 'ムレシュ県',
             code: 'MS',
           },
           {
-            name: 'Neamț',
+            name: 'ネアムツ県',
             code: 'NT',
           },
           {
-            name: 'Olt',
+            name: 'オルト県',
             code: 'OT',
           },
           {
-            name: 'Prahova',
+            name: 'プラホヴァ県',
             code: 'PH',
           },
           {
-            name: 'Sălaj',
+            name: 'サラージュ県',
             code: 'SJ',
           },
           {
-            name: 'Satu Mare',
+            name: 'サトゥ・マーレ県',
             code: 'SM',
           },
           {
-            name: 'Sibiu',
+            name: 'シビウ県',
             code: 'SB',
           },
           {
-            name: 'Suceava',
+            name: 'スチャヴァ県',
             code: 'SV',
           },
           {
-            name: 'Teleorman',
+            name: 'テレオルマン県',
             code: 'TR',
           },
           {
-            name: 'Timiș',
+            name: 'ティミシュ県',
             code: 'TM',
           },
           {
-            name: 'Tulcea',
+            name: 'トゥルチャ県',
             code: 'TL',
           },
           {
-            name: 'Vâlcea',
+            name: 'ヴルチャ県',
             code: 'VL',
           },
           {
-            name: 'Vaslui',
+            name: 'ヴァスルイ県',
             code: 'VS',
           },
           {
-            name: 'Vrancea',
+            name: 'ヴランチャ県',
             code: 'VN',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'COUNTY',
       },
       {
         name: 'レソト',
@@ -8970,42 +9694,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
         },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'COUNTY',
-      },
-      {
-        name: 'レバノン',
-        code: 'LB',
-        phoneNumberPrefix: 961,
-        autocompletionField: 'address1',
-        continent: 'Asia',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9017,26 +9717,59 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: 'レユニオン島',
+        name: 'レバノン',
+        code: 'LB',
+        phoneNumberPrefix: 961,
+        autocompletionField: 'address1',
+        continent: 'Asia',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
+        },
+        zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: 'レユニオン',
         code: 'RE',
         phoneNumberPrefix: 262,
         autocompletionField: 'address1',
         continent: 'Europe',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -9051,15 +9784,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9069,331 +9805,331 @@ const data = {
         },
         zones: [
           {
-            name: 'Altai Krai',
+            name: 'アルタイ地方',
             code: 'ALT',
           },
           {
-            name: 'Altai Republic',
+            name: 'アルタイ共和国',
             code: 'AL',
           },
           {
-            name: 'Amur Oblast',
+            name: 'アムール州',
             code: 'AMU',
           },
           {
-            name: 'Arkhangelsk Oblast',
+            name: 'アルハンゲリスク州',
             code: 'ARK',
           },
           {
-            name: 'Astrakhan Oblast',
+            name: 'アストラハン州',
             code: 'AST',
           },
           {
-            name: 'Belgorod Oblast',
+            name: 'ベルゴロド州',
             code: 'BEL',
           },
           {
-            name: 'Bryansk Oblast',
+            name: 'ブリャンスク州',
             code: 'BRY',
           },
           {
-            name: 'Chechen Republic',
+            name: 'チェチェン共和国',
             code: 'CE',
           },
           {
-            name: 'Chelyabinsk Oblast',
+            name: 'チェリャビンスク州',
             code: 'CHE',
           },
           {
-            name: 'Chukotka Autonomous Okrug',
+            name: 'チュクチ自治管区',
             code: 'CHU',
           },
           {
-            name: 'Chuvash Republic',
+            name: 'チュヴァシ共和国',
             code: 'CU',
           },
           {
-            name: 'Irkutsk Oblast',
+            name: 'イルクーツク州',
             code: 'IRK',
           },
           {
-            name: 'Ivanovo Oblast',
+            name: 'イヴァノヴォ州',
             code: 'IVA',
           },
           {
-            name: 'Jewish Autonomous Oblast',
+            name: 'ユダヤ自治州',
             code: 'YEV',
           },
           {
-            name: 'Kabardino-Balkarian Republic',
+            name: 'カバルダ・バルカル共和国',
             code: 'KB',
           },
           {
-            name: 'Kaliningrad Oblast',
+            name: 'カリーニングラード州',
             code: 'KGD',
           },
           {
-            name: 'Kaluga Oblast',
+            name: 'カルーガ州',
             code: 'KLU',
           },
           {
-            name: 'Kamchatka Krai',
+            name: 'カムチャツカ地方',
             code: 'KAM',
           },
           {
-            name: 'Karachay–Cherkess Republic',
+            name: 'カラチャイ・チェルケス共和国',
             code: 'KC',
           },
           {
-            name: 'Kemerovo Oblast',
+            name: 'ケメロヴォ州',
             code: 'KEM',
           },
           {
-            name: 'Khabarovsk Krai',
+            name: 'ハバロフスク地方',
             code: 'KHA',
           },
           {
-            name: 'Khanty-Mansi Autonomous Okrug',
+            name: 'ハンティ・マンシ自治管区・ユグラ',
             code: 'KHM',
           },
           {
-            name: 'Kirov Oblast',
+            name: 'キーロフ州',
             code: 'KIR',
           },
           {
-            name: 'Komi Republic',
+            name: 'コミ共和国',
             code: 'KO',
           },
           {
-            name: 'Kostroma Oblast',
+            name: 'コストロマ州',
             code: 'KOS',
           },
           {
-            name: 'Krasnodar Krai',
+            name: 'クラスノダール地方',
             code: 'KDA',
           },
           {
-            name: 'Krasnoyarsk Krai',
+            name: 'クラスノヤルスク地方',
             code: 'KYA',
           },
           {
-            name: 'Kurgan Oblast',
+            name: 'クルガン州',
             code: 'KGN',
           },
           {
-            name: 'Kursk Oblast',
+            name: 'クルスク州',
             code: 'KRS',
           },
           {
-            name: 'Leningrad Oblast',
+            name: 'レニングラード州',
             code: 'LEN',
           },
           {
-            name: 'Lipetsk Oblast',
+            name: 'リペツク州',
             code: 'LIP',
           },
           {
-            name: 'Magadan Oblast',
+            name: 'マガダン州',
             code: 'MAG',
           },
           {
-            name: 'Mari El Republic',
+            name: 'マリ・エル共和国',
             code: 'ME',
           },
           {
-            name: 'Moscow',
+            name: 'モスクワ',
             code: 'MOW',
           },
           {
-            name: 'Moscow Oblast',
+            name: 'モスクワ州',
             code: 'MOS',
           },
           {
-            name: 'Murmansk Oblast',
+            name: 'ムルマンスク州',
             code: 'MUR',
           },
           {
-            name: 'Nizhny Novgorod Oblast',
+            name: 'ニジニ・ノヴゴロド州',
             code: 'NIZ',
           },
           {
-            name: 'Novgorod Oblast',
+            name: 'ノヴゴロド州',
             code: 'NGR',
           },
           {
-            name: 'Novosibirsk Oblast',
+            name: 'ノヴォシビルスク州',
             code: 'NVS',
           },
           {
-            name: 'Omsk Oblast',
+            name: 'オムスク州',
             code: 'OMS',
           },
           {
-            name: 'Orenburg Oblast',
+            name: 'オレンブルク州',
             code: 'ORE',
           },
           {
-            name: 'Oryol Oblast',
+            name: 'オリョール州',
             code: 'ORL',
           },
           {
-            name: 'Penza Oblast',
+            name: 'ペンザ州',
             code: 'PNZ',
           },
           {
-            name: 'Perm Krai',
+            name: 'ペルミ地方',
             code: 'PER',
           },
           {
-            name: 'Primorsky Krai',
+            name: '沿海地方',
             code: 'PRI',
           },
           {
-            name: 'Pskov Oblast',
+            name: 'プスコフ州',
             code: 'PSK',
           },
           {
-            name: 'Republic of Adygeya',
+            name: 'アディゲ共和国',
             code: 'AD',
           },
           {
-            name: 'Republic of Bashkortostan',
+            name: 'バシコルトスタン共和国',
             code: 'BA',
           },
           {
-            name: 'Republic of Buryatia',
+            name: 'ブリヤート共和国',
             code: 'BU',
           },
           {
-            name: 'Republic of Dagestan',
+            name: 'ダゲスタン共和国',
             code: 'DA',
           },
           {
-            name: 'Republic of Ingushetia',
+            name: 'イングーシ共和国',
             code: 'IN',
           },
           {
-            name: 'Republic of Kalmykia',
+            name: 'カルムイク共和国',
             code: 'KL',
           },
           {
-            name: 'Republic of Karelia',
+            name: 'カレリア共和国',
             code: 'KR',
           },
           {
-            name: 'Republic of Khakassia',
+            name: 'ハカス共和国',
             code: 'KK',
           },
           {
-            name: 'Republic of Mordovia',
+            name: 'モルドヴィア共和国',
             code: 'MO',
           },
           {
-            name: 'Republic of North Ossetia–Alania',
+            name: '北オセチア共和国',
             code: 'SE',
           },
           {
-            name: 'Republic of Tatarstan',
+            name: 'タタールスタン共和国',
             code: 'TA',
           },
           {
-            name: 'Rostov Oblast',
+            name: 'ロストフ州',
             code: 'ROS',
           },
           {
-            name: 'Ryazan Oblast',
+            name: 'リャザン州',
             code: 'RYA',
           },
           {
-            name: 'Saint Petersburg',
+            name: 'サンクトペテルブルク',
             code: 'SPE',
           },
           {
-            name: 'Sakha Republic (Yakutia)',
+            name: 'サハ共和国',
             code: 'SA',
           },
           {
-            name: 'Sakhalin Oblast',
+            name: 'サハリン州',
             code: 'SAK',
           },
           {
-            name: 'Samara Oblast',
+            name: 'サマラ州',
             code: 'SAM',
           },
           {
-            name: 'Saratov Oblast',
+            name: 'サラトフ州',
             code: 'SAR',
           },
           {
-            name: 'Smolensk Oblast',
+            name: 'スモレンスク州',
             code: 'SMO',
           },
           {
-            name: 'Stavropol Krai',
+            name: 'スタヴロポリ地方',
             code: 'STA',
           },
           {
-            name: 'Sverdlovsk Oblast',
+            name: 'スヴェルドロフスク州',
             code: 'SVE',
           },
           {
-            name: 'Tambov Oblast',
+            name: 'タンボフ州',
             code: 'TAM',
           },
           {
-            name: 'Tomsk Oblast',
+            name: 'トムスク州',
             code: 'TOM',
           },
           {
-            name: 'Tula Oblast',
+            name: 'トゥーラ州',
             code: 'TUL',
           },
           {
-            name: 'Tver Oblast',
+            name: 'トヴェリ州',
             code: 'TVE',
           },
           {
-            name: 'Tyumen Oblast',
+            name: 'チュメニ州',
             code: 'TYU',
           },
           {
-            name: 'Tyva Republic',
+            name: 'トゥヴァ共和国',
             code: 'TY',
           },
           {
-            name: 'Udmurtia',
+            name: 'ウドムルト共和国',
             code: 'UD',
           },
           {
-            name: 'Ulyanovsk Oblast',
+            name: 'ウリヤノフスク州',
             code: 'ULY',
           },
           {
-            name: 'Vladimir Oblast',
+            name: 'ヴラジーミル州',
             code: 'VLA',
           },
           {
-            name: 'Volgograd Oblast',
+            name: 'ヴォルゴグラード州',
             code: 'VGG',
           },
           {
-            name: 'Vologda Oblast',
+            name: 'ヴォログダ州',
             code: 'VLG',
           },
           {
-            name: 'Voronezh Oblast',
+            name: 'ヴォロネジ州',
             code: 'VOR',
           },
           {
-            name: 'Yamalo-Nenets Autonomous Okrug',
+            name: 'ヤマロ・ネネツ自治管区',
             code: 'YAN',
           },
           {
-            name: 'Yaroslavl Oblast',
+            name: 'ヤロスラヴリ州',
             code: 'YAR',
           },
           {
-            name: 'Zabaykalsky Krai',
+            name: 'ザバイカリエ地方',
             code: 'ZAB',
           },
         ],
@@ -9407,15 +10143,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '省',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9425,131 +10164,131 @@ const data = {
         },
         zones: [
           {
-            name: 'Anhui',
+            name: '安徽省',
             code: 'AH',
           },
           {
-            name: 'Beijing',
+            name: '北京市',
             code: 'BJ',
           },
           {
-            name: 'Chongqing',
+            name: '重慶市',
             code: 'CQ',
           },
           {
-            name: 'Fujian',
+            name: '福建省',
             code: 'FJ',
           },
           {
-            name: 'Gansu',
+            name: '甘粛省',
             code: 'GS',
           },
           {
-            name: 'Guangdong',
+            name: '広東省',
             code: 'GD',
           },
           {
-            name: 'Guangxi',
+            name: '広西チワン族自治区',
             code: 'GX',
           },
           {
-            name: 'Guizhou',
+            name: '貴州省',
             code: 'GZ',
           },
           {
-            name: 'Hainan',
+            name: '海南省',
             code: 'HI',
           },
           {
-            name: 'Hebei',
+            name: '河北省',
             code: 'HE',
           },
           {
-            name: 'Heilongjiang',
+            name: '黒竜江省',
             code: 'HL',
           },
           {
-            name: 'Henan',
+            name: '河南省',
             code: 'HA',
           },
           {
-            name: 'Hubei',
+            name: '湖北省',
             code: 'HB',
           },
           {
-            name: 'Hunan',
+            name: '湖南省',
             code: 'HN',
           },
           {
-            name: 'Inner Mongolia',
+            name: '内モンゴル自治区',
             code: 'NM',
           },
           {
-            name: 'Jiangsu',
+            name: '江蘇省',
             code: 'JS',
           },
           {
-            name: 'Jiangxi',
+            name: '江西省',
             code: 'JX',
           },
           {
-            name: 'Jilin',
+            name: '吉林省',
             code: 'JL',
           },
           {
-            name: 'Liaoning',
+            name: '遼寧省',
             code: 'LN',
           },
           {
-            name: 'Ningxia',
+            name: '寧夏回族自治区',
             code: 'NX',
           },
           {
-            name: 'Qinghai',
+            name: '青海省',
             code: 'QH',
           },
           {
-            name: 'Shaanxi',
+            name: '陝西省',
             code: 'SN',
           },
           {
-            name: 'Shandong',
+            name: '山東省',
             code: 'SD',
           },
           {
-            name: 'Shanghai',
+            name: '上海市',
             code: 'SH',
           },
           {
-            name: 'Shanxi',
+            name: '山西省',
             code: 'SX',
           },
           {
-            name: 'Sichuan',
+            name: '四川省',
             code: 'SC',
           },
           {
-            name: 'Tianjin',
+            name: '天津市',
             code: 'TJ',
           },
           {
-            name: 'Xinjiang',
+            name: '新疆ウイグル自治区',
             code: 'XJ',
           },
           {
-            name: 'Xizang',
+            name: 'チベット自治区',
             code: 'YZ',
           },
           {
-            name: 'Yunnan',
+            name: '雲南省',
             code: 'YN',
           },
           {
-            name: 'Zhejiang',
+            name: '浙江省',
             code: 'ZJ',
           },
         ],
-        provinceKey: 'REGION',
+        provinceKey: 'PROVINCE',
       },
       {
         name: '中央アフリカ共和国',
@@ -9559,15 +10298,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9576,7 +10318,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: '中華人民共和国マカオ特別行政区',
@@ -9586,15 +10328,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9613,15 +10358,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
+          address2: '建物名、部屋番号など',
+          city: '地区',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9631,15 +10379,15 @@ const data = {
         },
         zones: [
           {
-            name: 'Hong Kong Island',
+            name: '香港島',
             code: 'HK',
           },
           {
-            name: 'Kowloon',
+            name: '九龍',
             code: 'KL',
           },
           {
-            name: 'New Territories',
+            name: '新しい地域',
             code: 'NT',
           },
         ],
@@ -9653,19 +10401,22 @@ const data = {
         continent: 'South America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -9680,19 +10431,22 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
@@ -9707,15 +10461,78 @@ const data = {
         continent: 'Other',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: '北マケドニア',
+        code: 'MK',
+        phoneNumberPrefix: 389,
+        autocompletionField: 'address1',
+        continent: 'Europe',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{country}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
+        },
+        zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: '北朝鮮',
+        code: 'KP',
+        phoneNumberPrefix: 82,
+        autocompletionField: 'address1',
+        continent: 'Asia',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9734,15 +10551,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9752,70 +10572,43 @@ const data = {
         },
         zones: [
           {
-            name: 'Eastern Cape',
+            name: '東ケープ州',
             code: 'EC',
           },
           {
-            name: 'Free State',
+            name: 'フリーステイト州',
             code: 'FS',
           },
           {
-            name: 'Gauteng',
+            name: 'ハウテン州',
             code: 'GT',
           },
           {
-            name: 'KwaZulu-Natal',
+            name: 'クワズール・ナタール州',
             code: 'NL',
           },
           {
-            name: 'Limpopo',
+            name: 'リンポポ州',
             code: 'LP',
           },
           {
-            name: 'Mpumalanga',
+            name: 'ムプマランガ州',
             code: 'MP',
           },
           {
-            name: 'North West',
+            name: '北西州',
             code: 'NW',
           },
           {
-            name: 'Northern Cape',
+            name: '北ケープ州',
             code: 'NC',
           },
           {
-            name: 'Western Cape',
+            name: '西ケープ州',
             code: 'WC',
           },
         ],
-        provinceKey: 'REGION',
-      },
-      {
-        name: '南ジョージア島・南サンドイッチ諸島',
-        code: 'GS',
-        phoneNumberPrefix: 500,
-        autocompletionField: 'address1',
-        continent: 'Other',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
+        provinceKey: 'PROVINCE',
       },
       {
         name: '南スーダン',
@@ -9825,15 +10618,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9842,7 +10638,7 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
         },
         zones: [],
-        provinceKey: 'PROVINCE',
+        provinceKey: 'REGION',
       },
       {
         name: '台湾',
@@ -9852,15 +10648,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -9872,100 +10671,34 @@ const data = {
         provinceKey: 'REGION',
       },
       {
-        name: '大韓民国',
-        code: 'KR',
-        phoneNumberPrefix: 82,
-        autocompletionField: 'zip',
-        continent: 'Asia',
+        name: '合衆国領有小離島',
+        code: 'UM',
+        phoneNumberPrefix: 1,
+        autocompletionField: 'address1',
+        continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '州',
         },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
         formatting: {
           edit:
-            '{company}_{lastName}{firstName}_{zip}_{country}_{province}{city}_{address1}_{address2}_{phone}',
+            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
           show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
-        zones: [
-          {
-            name: 'Busan',
-            code: 'KR-26',
-          },
-          {
-            name: 'Chungbuk',
-            code: 'KR-43',
-          },
-          {
-            name: 'Chungnam',
-            code: 'KR-44',
-          },
-          {
-            name: 'Daegu',
-            code: 'KR-27',
-          },
-          {
-            name: 'Daejeon',
-            code: 'KR-30',
-          },
-          {
-            name: 'Gangwon',
-            code: 'KR-42',
-          },
-          {
-            name: 'Gwangju',
-            code: 'KR-29',
-          },
-          {
-            name: 'Gyeongbuk',
-            code: 'KR-47',
-          },
-          {
-            name: 'Gyeonggi',
-            code: 'KR-41',
-          },
-          {
-            name: 'Gyeongnam',
-            code: 'KR-48',
-          },
-          {
-            name: 'Incheon',
-            code: 'KR-28',
-          },
-          {
-            name: 'Jeju',
-            code: 'KR-49',
-          },
-          {
-            name: 'Jeonbuk',
-            code: 'KR-45',
-          },
-          {
-            name: 'Jeonnam',
-            code: 'KR-46',
-          },
-          {
-            name: 'Sejong',
-            code: 'KR-50',
-          },
-          {
-            name: 'Seoul',
-            code: 'KR-11',
-          },
-          {
-            name: 'Ulsan',
-            code: 'KR-31',
-          },
-        ],
-        provinceKey: 'REGION',
+        zones: [],
+        provinceKey: 'STATE',
       },
       {
         name: '日本',
@@ -9975,15 +10708,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
           zone: '都道府県',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -10181,33 +10917,6 @@ const data = {
             code: 'JP-47',
           },
         ],
-        provinceKey: 'STATE',
-      },
-      {
-        name: '朝鮮民主主義人民共和国',
-        code: 'KP',
-        phoneNumberPrefix: 82,
-        autocompletionField: 'address1',
-        continent: 'Asia',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
         provinceKey: 'PREFECTURE',
       },
       {
@@ -10218,48 +10927,24 @@ const data = {
         continent: 'Oceania',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
             '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
           show:
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
-        },
-        zones: [],
-        provinceKey: 'REGION',
-      },
-      {
-        name: '米領太平洋諸島',
-        code: 'UM',
-        phoneNumberPrefix: 1,
-        autocompletionField: 'address1',
-        continent: 'Central America',
-        labels: {
-          address1: '住所',
-          address2: 'アパート、部屋番号など',
-          city: '市区町村',
-          company: '会社',
-          country: '国',
-          firstName: '名',
-          lastName: '姓',
-          phone: '電話番号',
-          postalCode: '郵便番号',
-          zone: '州',
-        },
-        formatting: {
-          edit:
-            '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{zip}_{phone}',
-          show:
-            '{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}',
         },
         zones: [],
         provinceKey: 'REGION',
@@ -10272,15 +10957,18 @@ const data = {
         continent: 'Asia',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -10299,15 +10987,18 @@ const data = {
         continent: 'Central America',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -10326,15 +11017,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -10353,15 +11047,18 @@ const data = {
         continent: 'Africa',
         labels: {
           address1: '住所',
-          address2: 'アパート、部屋番号など',
+          address2: '建物名、部屋番号など',
           city: '市区町村',
           company: '会社',
-          country: '国',
+          country: '国/地域',
           firstName: '名',
           lastName: '姓',
           phone: '電話番号',
           postalCode: '郵便番号',
-          zone: '州',
+          zone: '地域',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
         },
         formatting: {
           edit:
@@ -10370,10 +11067,108 @@ const data = {
             '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}',
         },
         zones: [],
+        provinceKey: 'REGION',
+      },
+      {
+        name: '韓国',
+        code: 'KR',
+        phoneNumberPrefix: 82,
+        autocompletionField: 'zip',
+        continent: 'Asia',
+        labels: {
+          address1: '住所',
+          address2: '建物名、部屋番号など',
+          city: '市区町村',
+          company: '会社',
+          country: '国/地域',
+          firstName: '名',
+          lastName: '姓',
+          phone: '電話番号',
+          postalCode: '郵便番号',
+          zone: '行政区',
+        },
+        optionalLabels: {
+          address2: '建物名、部屋番号など (任意)',
+        },
+        formatting: {
+          edit:
+            '{company}_{lastName}{firstName}_{zip}_{country}_{province}{city}_{address1}_{address2}_{phone}',
+          show:
+            '{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}',
+        },
+        zones: [
+          {
+            name: '釜山広域市',
+            code: 'KR-26',
+          },
+          {
+            name: '忠清北道',
+            code: 'KR-43',
+          },
+          {
+            name: '忠清南道',
+            code: 'KR-44',
+          },
+          {
+            name: '大邱広域市',
+            code: 'KR-27',
+          },
+          {
+            name: '大田広域市',
+            code: 'KR-30',
+          },
+          {
+            name: '江原道 (南)',
+            code: 'KR-42',
+          },
+          {
+            name: '光州広域市',
+            code: 'KR-29',
+          },
+          {
+            name: '慶尚北道',
+            code: 'KR-47',
+          },
+          {
+            name: '京畿道',
+            code: 'KR-41',
+          },
+          {
+            name: '慶尚南道',
+            code: 'KR-48',
+          },
+          {
+            name: '仁川広域市',
+            code: 'KR-28',
+          },
+          {
+            name: '済州特別自治道',
+            code: 'KR-49',
+          },
+          {
+            name: '全羅北道',
+            code: 'KR-45',
+          },
+          {
+            name: '全羅南道',
+            code: 'KR-46',
+          },
+          {
+            name: '世宗特別自治市',
+            code: 'KR-50',
+          },
+          {
+            name: 'ソウル特別市',
+            code: 'KR-11',
+          },
+          {
+            name: '蔚山広域市',
+            code: 'KR-31',
+          },
+        ],
         provinceKey: 'PROVINCE',
       },
     ],
   },
 };
-
 export default data;

--- a/packages/address-mocks/src/fixtures/country_ca_af.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_af.ts
@@ -19,6 +19,9 @@ const data = {
         postalCode: 'Postal code',
         zone: 'Province',
       },
+      optionalLabels: {
+        address2: 'Apt./Unit No. (optional)',
+      },
       formatting: {
         edit:
           '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',

--- a/packages/address-mocks/src/fixtures/country_ca_en.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_en.ts
@@ -18,6 +18,9 @@ const data = {
         postalCode: 'Postal code',
         zone: 'Province',
       },
+      optionalLabels: {
+        address2: 'Apt./Unit No. (optional)',
+      },
       formatting: {
         edit:
           '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',

--- a/packages/address-mocks/src/fixtures/country_ca_fr.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_fr.ts
@@ -18,6 +18,9 @@ const data = {
         postalCode: 'Code postal',
         zone: 'Province',
       },
+      optionalLabels: {
+        address2: 'Appartement, suite, etc. (facultatif)',
+      },
       formatting: {
         edit:
           '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',

--- a/packages/address-mocks/src/fixtures/country_ca_ja.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_ja.ts
@@ -18,6 +18,9 @@ const data = {
         postalCode: '郵便番号',
         zone: '州',
       },
+      optionalLabels: {
+        address2: '建物名、部屋番号など (任意)',
+      },
       formatting: {
         edit:
           '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}',

--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Added `optionalLabels` to GraphQL query for countries and for country [(#1610)](https://github.com/Shopify/quilt/pull/1610)
+- Minor update to `@shopify/address-consts` and minor update to `@shopify/address-mocks`. [(#1610)](https://github.com/Shopify/quilt/pull/1610)
 
 ## [2.8.0] - 2020-03-10
 

--- a/packages/address/src/graphqlQuery.ts
+++ b/packages/address/src/graphqlQuery.ts
@@ -19,6 +19,9 @@ query countries($locale: SupportedLocale!) {
       postalCode
       zone
     }
+    optionalLabels {
+      address2
+    }
     formatting {
       edit
       show
@@ -49,6 +52,9 @@ query country($countryCode: SupportedCountry!, $locale: SupportedLocale!) {
       phone
       postalCode
       zone
+    }
+    optionalLabels {
+      address2
     }
     formatting {
       edit

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -47,6 +47,7 @@ describe('AddressFormatter', () => {
         'autocompletionField',
         'continent',
         'labels',
+        'optionalLabels',
         'formatting',
         'zones',
         'provinceKey',


### PR DESCRIPTION
## Description

The original problem i'm trying to solve is in [this issue](https://github.com/Shopify/intl-broken-experiences/issues/176)

The idea is to allow the `AddressForm` component in `web` to choose between optional labels and the required labels for its fields.

Ex: for address 2 I want to use the version:

`Apartment, suite, etc. (optional)` instead of just `Apartment, suite, etc.`

The different labels for each country and locale come from [country service.](https://github.com/Shopify/country-service) 

`web` interacts with `country service` through the `address` package here in quilt. `address` fetches the data from `country service` using a GraphQL call.

In order to make this change I need to do the following:

1. Allow Country Service to return optional labels in its GraphQL endpoint. [This has already been done in this PR.](https://github.com/Shopify/country-service/pull/520)
2. Modify the `address` package in quilt to query for the new optionalLabels field I added in `country service`. Thats what this PR is for. 
3. Modify `web` to make use of the newly returned optionalLabels and allow the `AddressForm` component to decide whether to display the optional label or the regular one. Another PR will be made after this one has been merged, but the work is already done and can be viewed in [this commit](https://github.com/Shopify/web/commit/7a9438da91d384d393b73789fb2a8c00ff46b620). 

## Changes

What I've done here is change the GraphQL call in `address` to include optionalLabels. I've chosen to only include `address2` in the query to avoid over-fetching. If in the future other fields are required then this package will need to be changed again.

The tests and their mocks have also been changed to include optionalLabels.

## Type of change

- [x] <--address--> Minor: New feature (Changed the GraphQL query)
- [x] <--address-consts--> Minor: New feature (Added optionalLabels to the `Country` interface)
- [x] <--address-mocks--> Minor: New feature (Changed the mocks to include the newly fetched optionalLabels)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)

## Tophatting

These changes can be tested locally by cherry-picking [this commit](https://github.com/Shopify/web/commit/7a9438da91d384d393b73789fb2a8c00ff46b620) from web.

You then need to build and tophat the address package using `yarn tophat`

You can then navigate to `admin/billing/settings` in your local setup and click on `Add Payment Method`. If all goes well the optional label for address2 will be there rather than the regular one.


## Other notes

* This is my first time contributing to quilt so I'm not entirely sure whether the changes are major or minor so some feedback would be appreciated there.

* The mocks for the `countries` call were created by doing a call to the live service. 