### PR TITLE
EncodeURI origin app-bridge

### DIFF
--- a/packages/koa-shopify-auth/CHANGELOG.md
+++ b/packages/koa-shopify-auth/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- URI encode `config` on redirection page [1612](https://github.com/Shopify/quilt/pull/1612)
 
 ## [3.1.65] - 2020-07-06
 

--- a/packages/koa-shopify-auth/src/auth/redirection-page.ts
+++ b/packages/koa-shopify-auth/src/auth/redirection-page.ts
@@ -12,7 +12,7 @@ export default function redirectionScript({origin, redirectTo, apiKey}) {
           var Redirect = AppBridge.actions.Redirect;
           var app = createApp({
             apiKey: '${apiKey}',
-            shopOrigin: '${origin}',
+            shopOrigin: "${encodeURI(origin)}",
           });
           var redirect = Redirect.create(app);
           redirect.dispatch(Redirect.Action.REMOTE, '${redirectTo}');

--- a/packages/koa-shopify-auth/src/auth/test/redirection-page.test.ts
+++ b/packages/koa-shopify-auth/src/auth/test/redirection-page.test.ts
@@ -1,0 +1,15 @@
+import redirectionScript from '../redirection-page';
+
+const origin = 'https://shopify.com/?x=шеллы';
+const redirectTo = 'shop1.myshopify.io';
+const apiKey = 'fakekey';
+
+describe('redirectionScript', () => {
+  it('returns a script tag with formatted data', () => {
+    const script = redirectionScript({origin, redirectTo, apiKey});
+
+    expect(script).toContain(
+      'shopOrigin: "https://shopify.com/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"',
+    );
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://hackerone.shopifycloud.com/reports/966419

Encode the `origin` parameter to block XSS vulnerabilities

## Type of change

- [x] `koa-shopify-auth` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
