### PR TITLE
Update docs for quilt_rails disable automount

### DIFF
--- a/gems/quilt_rails/README.md
+++ b/gems/quilt_rails/README.md
@@ -147,7 +147,7 @@ class ReactController < ApplicationController
 end
 ```
 
-🗒️ if you don't have a controller. Follow the [instruction](./docs/manual-installation#add-a-react-controller-and-routes) to setup `quilt_rails` in a controller instead of using the engine.
+🗒️ if you don't have a controller. Follow the [instruction](./docs/manual-installation.md#option-2-add-a-react-controller-and-routes) to setup `quilt_rails` in a controller instead of using the engine.
 
 Headers can be accessed during server-side-rendering with the `useRequestHeader` hook from `@shopify/react-network`.
 
@@ -183,7 +183,7 @@ class ReactController < ApplicationController
 end
 ```
 
-🗒️ if you don't have a controller. Follow the [instruction](./docs/manual-installation#add-a-react-controller-and-routes) to setup `quilt_rails` in a controller instead of using the engine.
+🗒️ if you don't have a controller. Follow the [instruction](./docs/manual-installation.md#option-2-add-a-react-controller-and-routes) to setup `quilt_rails` in a controller instead of using the engine.
 
 If using `react-server` without a customized server & client file, this will be automatically passed into your application as the `data` prop. If `react-server` is not being used or a customized server / client file was provided, check out [`react-server/webpack-plugin`](../../packages/react-server/src/webpack-plugin/webpack-plugin.ts) on how to pass the data to React.
 

--- a/gems/quilt_rails/docs/manual-installation.md
+++ b/gems/quilt_rails/docs/manual-installation.md
@@ -94,6 +94,8 @@ Add routes to default to the `ReactController`.
   root 'react#index'
 ```
 
+Set `Quilt.configuration.mount = false` in your app config.
+
 #### Add JavaScript
 
 `sewing_kit` looks for the top level component of your React app in `app/ui/index`. The component exported from this component (and any imported JS/CSS) will be built into a `main` bundle, and used to render the initial server-rendered markup.


### PR DESCRIPTION
## Description

Follow-up to https://github.com/Shopify/quilt/pull/1605. Update the manual installation / manual controller setup to also disable the mount of the engine. Also fix some broken links.

## Type of change

Documentation change.

## Checklist

- [x] Only doc change, no changelog.
