### PR TITLE
allow host to be overridden by env

### DIFF
--- a/packages/koa-shopify-auth/src/auth/create-top-level-redirect.ts
+++ b/packages/koa-shopify-auth/src/auth/create-top-level-redirect.ts
@@ -14,7 +14,7 @@ export default function createTopLevelRedirect(apiKey: string, path: string) {
 
     ctx.body = redirectionPage({
       origin: shop,
-      redirectTo: `https://${host}${path}?${queryString}`,
+      redirectTo: `https://${process.env.SHOPIFY_CALLBACK_HOST || host}${path}?${queryString}`,
       apiKey,
     });
   };

--- a/packages/koa-shopify-auth/src/auth/oauth-query-string.ts
+++ b/packages/koa-shopify-auth/src/auth/oauth-query-string.ts
@@ -25,7 +25,9 @@ export default function oAuthQueryString(
     state: requestNonce,
     scope: scopes.join(', '),
     client_id: apiKey,
-    redirect_uri: `https://${host}${callbackPath}`,
+    redirect_uri: `https://${
+      process.env.SHOPIFY_CALLBACK_HOST || host
+    }${callbackPath}`,
   };
   /* eslint-enable @typescript-eslint/camelcase */
 


### PR DESCRIPTION
## Description

Allow overriding of auth callback host via environmental variable `SHOPIFY_CALLBACK_HOST`.

In proxied environments for local development, not having the ability to do this caused issues for me.

## Type of change

- [@shopify/koa-shopify-auth] Patch

