### PR TITLE
Add useProgressState hook

### DIFF
--- a/packages/react-hooks/src/hooks/progress-state.ts
+++ b/packages/react-hooks/src/hooks/progress-state.ts
@@ -1,0 +1,16 @@
+import {useState} from 'react';
+
+export function useProgressState<T>(
+  event: () => Promise<T>,
+): [boolean, () => Promise<T>] {
+  const [inProgress, setInProgress] = useState(false);
+  async function handleEvent() {
+    try {
+      setInProgress(true);
+      return await event();
+    } finally {
+      setInProgress(false);
+    }
+  }
+  return [inProgress, handleEvent];
+}

--- a/packages/react-hooks/src/hooks/tests/progress-state.test.ts
+++ b/packages/react-hooks/src/hooks/tests/progress-state.test.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {useProgressState} from '../progress-state';
+
+describe('useProgressState', () => {
+  function MockComponent({method = (() => new Promise(null)) {
+    const [value, methodHandler] = useProgressState(method);
+
+    const inProgress = value ? 'true' : 'false';
+
+    return (
+      <>
+        <p>Progress: {inProgress}</p>
+        <button type="button" id="method" onClick={methodHandler} />
+      </>
+    );
+  }
+
+  it('sets progress to false', () => {
+    const wrapper = mount(<MockComponent />);
+    expect(wrapper).toContainReactText('Progress: false');
+  });
+
+  it('sets progress to true when method is called', () => {
+    const wrapper = mount(<MockComponent />);
+    expect(wrapper).toContainReactText('Value: false');
+
+    wrapper.find('button', {id: 'method'}).trigger('onClick');
+    expect(wrapper).toContainReactText('Progress: true');
+
+    wrapper.find('button', {id: 'toggle'}).trigger('onClick');
+    expect(wrapper).toContainReactText('Progress: false');
+  });
+});


### PR DESCRIPTION
## Description
There is a common use case when you want to provide feedback to the user that an action is happening and usually that requires defining some state as false and wrapping your method in a couple setters. This can be simplified with a hook. 
Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
