### PR TITLE
Export referenceTime from performance package

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [1.2.3] - 2020-9-16
+
+### Changed
+
+- Change `@shopify/performance` package to export the `referenceTime` util
+
 ## [1.2.2] - 2019-10-16
 
 ### Fixed

--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -7,11 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
-## [1.2.3] - 2020-9-16
+### Added
 
-### Changed
-
-- Change `@shopify/performance` package to export the `referenceTime` util
+- Added `timeOrigin` util as an export of `@shopify/performance` so it can be reused outside this package
 
 ## [1.2.2] - 2019-10-16
 

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -78,6 +78,8 @@ performance.event({
 performance.finish();
 ```
 
+This package also exports a `timeOrigin` util. This util can be used instead of using `performance.timeOrigin` directly. The `timeOrigin` util provides a fallback for browsers that don't support `performance.timeOrigin`, such as Safari, but will still use the higher-resolution `performance.timeOrigin` when available.
+
 ### `Navigation`
 
 The `Navigation` object represents a full navigation, either from a full-page refresh, or between two pages. It has the following key details about the navigation:

--- a/packages/performance/src/index.ts
+++ b/packages/performance/src/index.ts
@@ -1,4 +1,4 @@
 export {Performance} from './performance';
 export {Navigation} from './navigation';
 export * from './types';
-export {now} from './utilities';
+export {now, referenceTime} from './utilities';

--- a/packages/performance/src/index.ts
+++ b/packages/performance/src/index.ts
@@ -1,4 +1,4 @@
 export {Performance} from './performance';
 export {Navigation} from './navigation';
 export * from './types';
-export {now, referenceTime} from './utilities';
+export {now, timeOrigin} from './utilities';

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -6,7 +6,7 @@ import {
   withNavigation,
   withTiming,
   supportsPerformanceObserver,
-  referenceTime,
+  timeOrigin as referenceTime,
   hasGlobal,
 } from './utilities';
 import {

--- a/packages/performance/src/utilities.ts
+++ b/packages/performance/src/utilities.ts
@@ -1,4 +1,4 @@
-export function referenceTime() {
+export function timeOrigin() {
   // If no performance, then we always used Date.now(), which is a full
   // (if inaccurate) timestamp
   if (typeof performance === 'undefined') {


### PR DESCRIPTION
## Description

Yesterday I encountered an issue where Safari didn't support the performance.timeOrigin Web API. After posting on Slack I was pointed to https://github.com/Shopify/quilt/blob/d3720fd2380feac38c575fc42edf8271992e885b/packages/performance/src/utilities.ts#L8 which is a workaround used in `@shopify/performance`.

I've since copied this solution into my own PR but I think it would make sense to have this exported from this package.

My related PR where we're using this https://github.com/Shopify/online-store-web/pull/8080#discussion_r489412172

We're using this in an embedded Shopify admin app to get the `timeOrigin` of when the Shopify/web browser context begins to measure the full loading time of our new React app.


## Type of change

Minor/non-breaking

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)