### PR TITLE
Improve types and exports of react-router

### DIFF
--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Fix typing of Link so it supports the same props as react-router's Link. [1645](https://github.com/Shopify/quilt/pull/1645)
+- Export `MemoryRouter`. [1645](https://github.com/Shopify/quilt/pull/1645)
 
 ## [0.0.31] - 2019-08-18
 

--- a/packages/react-router/src/components/Link/Link.tsx
+++ b/packages/react-router/src/components/Link/Link.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import {Link as ReactRouterLink} from 'react-router-dom';
+import {Link as ReactRouterLink, LinkProps} from 'react-router-dom';
 
-export interface Props {
+type ReactRouterLinkProps = Omit<LinkProps, 'to'>;
+
+export interface Props extends ReactRouterLinkProps {
   external?: boolean;
   url: string;
-  children?: React.ReactNode;
 }
 
 export default function Link({url, external, children, ...rest}: Props) {

--- a/packages/react-router/src/components/Link/tests/Link.test.tsx
+++ b/packages/react-router/src/components/Link/tests/Link.test.tsx
@@ -43,10 +43,9 @@ describe('<Link />', () => {
 
     it('sets the `to` prop and passes along other props to ReactRouterLink', () => {
       const url = '/home';
-      const props = {className: 'foo'};
-      const link = mount(<Link url={url} {...props} />);
+      const link = mount(<Link url={url} className="foo" />);
       expect(link).toContainReactComponent(ReactRouterLink, {
-        ...props,
+        className: 'foo',
         to: url,
       });
     });

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -5,5 +5,6 @@ export {
   RouteComponentProps,
   withRouter,
   RouterChildContext,
+  MemoryRouter,
 } from 'react-router-dom';
 export {Router, Redirect, Link} from './components';


### PR DESCRIPTION
##  Description

When attempting to migrate a codebase from using react-router to using @shopify/react-router I found two shortcomings:

- The Props on `Link` did not inherit from the props on react-router's `Link` even though we passed everything through. This meant that `<Link className="foo">` did what was expected at runtime but typescript claimed className was not a valid prop.
- I used MemoryRouter for some of my tests, and I want it to be exposed via @shopify/react-router so that I don't have to reference a transitive dependency.

This PR does the following:

- Update Link's Props so can handle passing in props defined on
  react-router-dom's link props
- Tweak test so typescript will check validity of Link props
- Reexport MemoryRouter for usage in tests


## Type of change

- [x] @shopify/react-router Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
