### PR TITLE
Reexport hooks from react-router-dom

### DIFF
--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Fix typing of Link so it supports the same props as react-router's Link. [1645](https://github.com/Shopify/quilt/pull/1645)
 - Export `MemoryRouter`. [1645](https://github.com/Shopify/quilt/pull/1645)
+- Reexport `useRouteMatch`, `useParams`, `useLocation` and `useHistory` hooks. [1646](https://github.com/Shopify/quilt/pull/1646)
 
 ## [0.0.31] - 2019-08-18
 

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@shopify/react-network": "^3.5.5",
     "@types/react-router-dom": "*",
-    "react-router-dom": ">=5.0.0 <6.0.0"
+    "react-router-dom": ">=5.1.0 <6.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <17.0.0",

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -6,5 +6,9 @@ export {
   withRouter,
   RouterChildContext,
   MemoryRouter,
+  useRouteMatch,
+  useParams,
+  useLocation,
+  useHistory,
 } from 'react-router-dom';
 export {Router, Redirect, Link} from './components';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11882,7 +11882,7 @@ react-reconciler@^0.20.2:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-"react-router-dom@>=5.0.0 <6.0.0":
+"react-router-dom@>=5.1.0 <6.0.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
   integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==


### PR DESCRIPTION
## Description

React-router provides a set of 4 hooks to access its info if you don't want to go down the HOC `withRouter` approach. So consumers don't need to import from a transitive dependency, let's expose them here.

This bumps the minimum of react-router-dom from v5.0.0 to v5.1.0 as that is when the hooks were initroduced.

## Type of change

- [x] @shopify/react-router Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
