### PR TITLE
Add helper function to wrap content with language disclaimers

### DIFF
--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -7,6 +7,7 @@ import {
   getCurrencySymbol,
   memoizedNumberFormatter,
   memoizedPluralRules,
+  wrapWithDisclaimer,
 } from '../utilities';
 
 const {pseudotranslate} = require.requireMock('@shopify/i18n') as {
@@ -396,6 +397,20 @@ describe('translate()', () => {
         symbol: '€',
         prefixed: true,
       });
+    });
+  });
+
+  describe('wrapWithDisclaimer', () => {
+    const translations = {
+      disclaimer: {language: {en: '{content}', de: '{content} (in German)'}},
+    };
+    it('wraps the content in the translation', () => {
+      expect(wrapWithDisclaimer('Learn more', 'en', translations, locale)).toBe(
+        'Learn more',
+      );
+      expect(wrapWithDisclaimer('Learn more', 'de', translations, locale)).toBe(
+        'Learn more (in German)',
+      );
     });
   });
 });

--- a/packages/react-i18n/src/utilities/disclaimer.ts
+++ b/packages/react-i18n/src/utilities/disclaimer.ts
@@ -1,0 +1,18 @@
+import {TranslationDictionary} from '../types';
+
+import {translate} from './translate';
+
+export function wrapWithDisclaimer(
+  content: string,
+  language: string,
+  translations: TranslationDictionary | TranslationDictionary[],
+  locale: string,
+): string {
+  const scope = 'disclaimer.language';
+  return translate(
+    language,
+    {scope, replacements: {content}},
+    translations,
+    locale,
+  );
+}

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -1,4 +1,5 @@
 import {getCurrencySymbol} from './money';
+import {wrapWithDisclaimer} from './disclaimer';
 import {noop} from './noop';
 import {
   PSEUDOTRANSLATE_OPTIONS,
@@ -11,6 +12,7 @@ import {
 
 export {
   getCurrencySymbol,
+  wrapWithDisclaimer,
   noop,
   PSEUDOTRANSLATE_OPTIONS,
   translate,


### PR DESCRIPTION
## Description

In some scenarios we show users links with text like `Learn more`, and those links are managed by third-party and often don't provide content in the users language. For those cases, we would like to show a disclaimer to inform users that the content is not on their language, like `Learn more (in German)` or similar. The example in `utilities.test.tsx` shows this example.

I'm first adding this PR as a spike/draft to discuss if/how we should proceed with this approach.

## Type of change

- [ ] react-i18n Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
