### PR TITLE
Load async webpack assets after sync ones

### DIFF
--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -167,18 +167,7 @@ function getAssetsFromManifest(
     return entrypointAssets;
   }
 
-  const bundleTester = new RegExp(`\\b${name}[^\\.]*\\.${kind}`);
-
-  const nonVendorEntrypointIndex = entrypointAssets.findIndex(bundle =>
-    bundleTester.test(bundle.path),
-  );
-
-  if (nonVendorEntrypointIndex) {
-    entrypointAssets.splice(nonVendorEntrypointIndex, 0, ...asyncAssets);
-    return entrypointAssets;
-  }
-
-  return [...asyncAssets, ...entrypointAssets];
+  return [...entrypointAssets, ...asyncAssets];
 }
 
 function getAsyncAssetsFromManifest(

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -78,7 +78,7 @@ describe('Assets', () => {
       ]);
     });
 
-    it('prefixes async assets matching the passed IDs', async () => {
+    it('appends async assets matching the passed IDs', async () => {
       const js = '/custom.js';
       const asyncJs = '/used.js';
 
@@ -100,7 +100,7 @@ describe('Assets', () => {
 
       expect(
         await assets.scripts({name: 'custom', asyncAssets: ['used']}),
-      ).toStrictEqual([{path: asyncJs}, {path: js}]);
+      ).toStrictEqual([{path: js}, {path: asyncJs}]);
     });
 
     it('throws an error when no scripts exist for the passed entrypoint', async () => {
@@ -185,7 +185,7 @@ describe('Assets', () => {
       ]);
     });
 
-    it('prefixes async assets matching the passed IDs', async () => {
+    it('appends async assets matching the passed IDs', async () => {
       const css = '/custom.css';
       const asyncCss = '/used.css';
 
@@ -207,7 +207,7 @@ describe('Assets', () => {
 
       expect(
         await assets.styles({name: 'custom', asyncAssets: ['used']}),
-      ).toStrictEqual([{path: asyncCss}, {path: css}]);
+      ).toStrictEqual([{path: css}, {path: asyncCss}]);
     });
 
     it('throws an error when no styles exist for the passed entrypoint', async () => {
@@ -245,9 +245,9 @@ describe('Assets', () => {
         await assets.assets({name: 'custom', asyncAssets: ['mypage']}),
       ).toStrictEqual([
         {path: css},
+        {path: js},
         {path: asyncCss},
         {path: asyncJs},
-        {path: js},
       ]);
     });
   });


### PR DESCRIPTION
## Description

This mimics how assets are loaded in development. This shouldn't have
any effect for JS files which are marshaled by the webpack runtime, but
CSS content will now be loaded in a similar order to development.

Fixes #1652

I think this does the job, but I've not currently got the time to thoroughly investigate the ordering in complex applications. It'd be amazing if somebody from web foundations could finish this investigation and take this over the line.

I'm not quite sure of the effect of the `nonVendorEntrypointIndex` stuff and I think it might be buggy anyway as in the event of no result `nonVendorEntrypointIndex` will be set to -1 and you'd end up going into that if clause which doesn't seem right.

## Type of change

- [] @shopify/sewing-kit-koa Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
