### PR TITLE
Export StringMapper interface

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Fixed
+
+- Export `StringMapper` interface [#1655](https://github.com/Shopify/quilt/pull/1655)
+
 ## [0.11.27] - 2020-10-20
 
 - Updated `tslib` dependency to `^1.14.1`. [#1657](https://github.com/Shopify/quilt/pull/1657)

--- a/packages/react-form-state/src/types.ts
+++ b/packages/react-form-state/src/types.ts
@@ -27,3 +27,7 @@ export interface ValueMapper<Value> {
 export type FieldStates<Fields> = {
   [FieldPath in keyof Fields]: FieldState<Fields[FieldPath]>;
 };
+
+export interface StringMapper {
+  (input: string): any;
+}

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -9,14 +9,11 @@ import {
   isPositiveNumericString,
 } from '@shopify/predicates';
 
+import {StringMapper} from './types';
 import {mapObject} from './utilities';
 
 interface Matcher<Input, Fields = any> {
   (input: Input, fields: Fields): boolean;
-}
-
-interface StringMapper {
-  (input: string): any;
 }
 
 type ErrorContent = string | StringMapper;


### PR DESCRIPTION
## Description

While adding project references in Web, I ran into this error

```
app/sections/Products/utilities/validators.ts:25:17 - error TS4058: Return type of exported function has or is using name 'StringMapper' from external module "/app/node_modules/@shopify/react-form-state/dist/validators" but cannot be named.
```

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `@shopify/react-form-state` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
