### PR TITLE
Add Origin header to Header enum

### DIFF
--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [1.6.0] - 2020-10-22
+
+- Added `Origin` header [#1658](https://github.com/Shopify/quilt/pull/1658)
+
 ## [1.5.1] - 2020-10-20
 
 - Updated `tslib` dependency to `^1.14.1`. [#1657](https://github.com/Shopify/quilt/pull/1657)

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -84,7 +84,7 @@ export enum Header {
   ContentTypeOptions = 'X-Content-Type-Options',
   StrictTransportSecurity = 'Strict-Transport-Security',
   ReferrerPolicy = 'Referrer-Policy',
-  Origin = 'Origin'
+  Origin = 'Origin',
 }
 
 export enum CspDirective {

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -84,6 +84,7 @@ export enum Header {
   ContentTypeOptions = 'X-Content-Type-Options',
   StrictTransportSecurity = 'Strict-Transport-Security',
   ReferrerPolicy = 'Referrer-Policy',
+  Origin = 'Origin'
 }
 
 export enum CspDirective {


### PR DESCRIPTION
## Description

We need the `Origin` header to detect if we should perform server side rendering.  This adds it to the `Header` enum in `@shopify/network`.

## Type of change

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
