### PR TITLE
Replace deprecated `babel-polyfills` in favor of `core-js` and `regenerator-runtime`

### DIFF
--- a/packages/polyfills/CHANGELOG.md
+++ b/packages/polyfills/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- Replace deprecated `babel-polyfills` in favor of `core-js` and `regenerator-runtime`. [#1660](https://github.com/Shopify/quilt/pull/1660)
+
 ## [1.2.4] - 2020-10-20
 
 - Updated `tslib` dependency to `^1.14.1`. [#1657](https://github.com/Shopify/quilt/pull/1657)

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -24,15 +24,16 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/polyfills/README.md",
   "dependencies": {
-    "@babel/polyfill": "^7.10.1",
     "@shopify/useful-types": "^2.2.1",
     "browser-unhandled-rejection": "^1.0.2",
     "caniuse-api": "^3.0.0",
+    "core-js": "^3.6.5",
     "formdata-polyfill": "^3.0.18",
     "intersection-observer": "^0.5.1",
     "intl-pluralrules": "^0.2.1",
     "mutationobserver-shim": "^0.3.3",
     "node-fetch": "^2.3.0",
+    "regenerator-runtime": "^0.13.7",
     "tslib": "^1.14.1",
     "url-polyfill": "^1.1.7",
     "whatwg-fetch": "^3.0.0"

--- a/packages/polyfills/src/base.ts
+++ b/packages/polyfills/src/base.ts
@@ -1,1 +1,2 @@
-require('@babel/polyfill');
+require('core-js/stable');
+require('regenerator-runtime/runtime');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,14 +1292,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/polyfill@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.10.1.tgz#d56d4c8be8dd6ec4dce2649474e9b707089f739f"
-  integrity sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/preset-env@^7.10.4":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.11.5.tgz#18cb4b9379e3e92ffea92c07471a99a2914e4272"
@@ -5231,7 +5223,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.0.0, core-js@^2.4.0, core-js@^2.6.5:
+core-js@^2.0.0, core-js@^2.4.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -12164,6 +12156,11 @@ regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
+regenerator-runtime@^0.13.7:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"


### PR DESCRIPTION
## Description

Babel-polyfill is deprecated and shouldn't be used anymore. We should use core-js directly now.
https://babeljs.io/docs/en/babel-polyfill

I'm aware of [this issue](https://github.com/Shopify/quilt/pull/1518) that cause the revert somehow. But I think it was caused by a misconfiguration maybe? By using `core-js` v3. We should also update our babel preset to configure preset-env with corejs 3, and might prevent the size increase?

Currently, we still default on v2, but consumers can customize it. Once this PR is shipped, we should default on v3. https://github.com/Shopify/web-configs/blob/ba2c02cac3fc150c5603493506e7115774335e59/packages/babel-preset/web.js#L6

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
