### PR TITLE
Support configuring Html props from react-server

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- Update `HtmlProps` to mark children as optional (same as any React component) and export it ([#1661](https://github.com/Shopify/quilt/pull/1661))
+
 ## [10.0.1] - 2020-10-20
 
 - Updated `tslib` dependency to `^1.14.1`. [#1657](https://github.com/Shopify/quilt/pull/1657)

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -20,10 +20,10 @@ export interface InlineStyle {
   content: string;
 }
 
-export interface Props {
+export interface HtmlProps {
   manager?: HtmlManager;
   hydrationManager?: HydrationManager;
-  children: React.ReactElement<any> | string;
+  children?: React.ReactElement<any> | string;
   locale?: string;
   styles?: Asset[];
   inlineStyles?: InlineStyle[];
@@ -37,7 +37,7 @@ export interface Props {
 export default function Html({
   manager,
   hydrationManager,
-  children,
+  children = '',
   locale = 'en',
   blockingScripts = [],
   scripts = [],
@@ -46,7 +46,7 @@ export default function Html({
   preloadAssets = [],
   headMarkup = null,
   bodyMarkup = null,
-}: Props) {
+}: HtmlProps) {
   const markup =
     typeof children === 'string'
       ? children

--- a/packages/react-html/src/server/components/index.ts
+++ b/packages/react-html/src/server/components/index.ts
@@ -1,2 +1,2 @@
 export {default as Serialize} from './Serialize';
-export {default as Html} from './Html';
+export {default as Html, HtmlProps} from './Html';

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
-- Add `htmlProps` to the options for `createRender` and `createServer`, these props will be passed into the call to `@shopify/react-html`'s `<Html>` component ([#1661](https://github.com/Shopify/quilt/pull/1661))
+- Added `htmlProps` to the options for `createRender` and `createServer`, these props will be passed into the call to `@shopify/react-html`'s `<Html>` component ([#1661](https://github.com/Shopify/quilt/pull/1661))
 
 ## [0.18.4] - 2020-10-20
 

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- Add `htmlProps` to the options for `createRender` and `createServer`, these props will be passed into the call to `@shopify/react-html`'s `<Html>` component ([#1661](https://github.com/Shopify/quilt/pull/1661))
+
 ## [0.18.4] - 2020-10-20
 
 - Added `tslib@^1.14.1` in the list of dependencies. [#1657](https://github.com/Shopify/quilt/pull/1657)

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -87,6 +87,9 @@ interface Options {
   debug?: boolean;
   // a function similar to the render option but specifically used to render error pages for production SSR errors
   renderError: RenderFunction;
+  // additional props to pass into the Html component, or a function that takes a Koa.Context and returns a props object.
+  // See https://github.com/Shopify/quilt/blob/master/packages/react-html/README.md#html-
+  htmlProps?: HtmlProps | (ctx: Context) => HtmlProps
 }
 ```
 

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -87,7 +87,7 @@ interface Options {
   debug?: boolean;
   // a function similar to the render option but specifically used to render error pages for production SSR errors
   renderError: RenderFunction;
-  // additional props to pass into the Html component, or a function that takes a Koa.Context and returns a props object.
+  // additional props to pass into the Html component, or a function that takes a Koa.Context and returns a props object
   // See https://github.com/Shopify/quilt/blob/master/packages/react-html/README.md#html-
   htmlProps?: HtmlProps | (ctx: Context) => HtmlProps
 }

--- a/packages/react-server/src/render/index.ts
+++ b/packages/react-server/src/render/index.ts
@@ -1,1 +1,1 @@
-export {createRender, Context, RenderFunction} from './render';
+export {createRender, Context, RenderFunction, RenderOptions} from './render';

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -5,11 +5,10 @@ import Koa, {Context} from 'koa';
 import compose from 'koa-compose';
 import mount from 'koa-mount';
 
-import {createRender, RenderFunction} from '../render';
+import {createRender, RenderFunction, RenderOptions} from '../render';
 import {requestLogger} from '../logger';
 import {metricsMiddleware as metrics} from '../metrics';
 import {ping} from '../ping';
-import {ValueFromContext} from '../types';
 
 const logger = console;
 
@@ -18,10 +17,11 @@ interface Options {
   port?: number;
   assetPrefix?: string;
   proxy?: boolean;
-  assetName?: string | ValueFromContext<string>;
+  assetName?: RenderOptions['assetName'];
+  htmlProps?: RenderOptions['htmlProps'];
   serverMiddleware?: compose.Middleware<Context>[];
   render: RenderFunction;
-  renderError?: RenderFunction;
+  renderError?: RenderOptions['renderError'];
   app?: Koa;
 }
 
@@ -50,6 +50,7 @@ export function createServer(options: Options): Server {
     renderError,
     serverMiddleware,
     assetName,
+    htmlProps,
     proxy = false,
     app = new Koa(),
   } = options;
@@ -65,7 +66,9 @@ export function createServer(options: Options): Server {
     app.use(compose(serverMiddleware));
   }
 
-  app.use(createRender(render, {assetPrefix, assetName, renderError}));
+  app.use(
+    createRender(render, {assetPrefix, assetName, renderError, htmlProps}),
+  );
 
   return app.listen(port, ip, () => {
     logger.log(`started react-server on ${ip}:${port}`);

--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -53,6 +53,37 @@ describe('createServer()', () => {
     );
   });
 
+  it('passes htmlProps through to the Html component', async () => {
+    function MockApp() {
+      return <div>markup</div>;
+    }
+
+    const wrapper = await saddle((port, host) =>
+      createServer({
+        port,
+        ip: host,
+        render: () => <MockApp />,
+        htmlProps: {
+          scripts: [{path: '/extraScript.js'}],
+          styles: [{path: '/extraStyle.css'}],
+          headMarkup: <script>let ScriptFromHeadMarkup = 1;</script>,
+        },
+      }),
+    );
+
+    const response = await wrapper.fetch('/');
+
+    await expect(response).toHaveBodyText(
+      `<script type="text/javascript" src="/extraScript.js" crossorigin="anonymous" defer="">`,
+    );
+    await expect(response).toHaveBodyText(
+      `<link rel="stylesheet" type="text/css" href="/extraStyle.css" crossorigin="anonymous"/>`,
+    );
+    await expect(response).toHaveBodyText(
+      `<script>let ScriptFromHeadMarkup = 1;</script>`,
+    );
+  });
+
   it('supports updatable meta components', async () => {
     const myTitle = 'Shopify Mock App';
 


### PR DESCRIPTION
## Description

react-html's `<Html>` component supports a bunch of props for configuring
content to inject into the head, however previously that was not exposed
from react-server's createRender and createServer functions.

This commit lets you pass a htmlProps option into createRender and
createServer that will then be applied when createRender calls `<Html>`.

This means you can use createServer, and inject arbitary content into
the head using `<Html>`'s headMarkup prop (and use any of `<Html>`'s other
props too):

```js
createServer({
  render: () => <MockApp />,
  htmlProps: {
    scripts: [{path: '/extraScript.js'}],
    styles: [{path: '/extraStyle.css'}],
    headMarkup:  <>
      <script>let ScriptFromHeadMarkup = 1;</script>
      <script>let ScriptFromSecondHeadMarkup = 1;</script>
    </>,
  },
}),
```

## To test

An hand-cranked end-to-end test of this might be hard as there probably aren't many demo apps lying around. 

Find an application that uses `createServer` within it's server entrypoint ([brand-registry](https://github.com/Shopify/brand-registry/blob/master/app/ui/server.ts#L28) does this but I'm otherwise unfamiliar with the app). Add 'htmlProps' to its list of options, and then note that the markup is injected into the head:

```
htmlProps: {
  headMarkup:  <>
    <script>let ScriptFromHeadMarkup = 1;</script>
  </>,
}
```

Fortunately the createServer tests act as automated end-to-end test by configuring the server and asserting what html gets returned. [this new unit test](https://github.com/Shopify/quilt/pull/1661/files#diff-0e3f16674e62102134dc2abefc47aeb1282f0d23213f96c2cada5c2886e763ddR56) demonstrates adding `htmlProps` to the call to `createServer` and asserting that the returned html includes that head markup.

So the real tophat instructions are "check tests pass, check the added unit tests showcase e2e behaviour" :D


## Type of change

- [x] @shopify/react-html Patch: Bug (non-breaking change which fixes an issue)
- [x] @shopify/react-server Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
