### PR TITLE
Fix getTranslationTree when having multiple dictionaries

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- Fix bug in `getTranslationTree` when having multiple translation dictionaries. [#1662](https://github.com/Shopify/quilt/pull/1662)
+
 ## [5.1.3] - 2020-10-20
 
 - Updated `tslib` dependency to `^1.14.1`. [#1657](https://github.com/Shopify/quilt/pull/1657)

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -108,6 +108,12 @@ describe('getTranslationTree()', () => {
     ).toBe('other');
   });
 
+  it('returns the translation keys even if they are hidden in a second dictionary', () => {
+    expect(
+      getTranslationTree('foobar.barfoo', [{foo: {bar: 'one'}}, {foobar: {barfoo: 'two '}}], locale),
+    ).toBe('two');
+  });
+
   it('throws a MissingTranslationError when no translation is found', () => {
     expect(() =>
       getTranslationTree('foo.bar.baz', {foo: {bar: 'one'}}, locale),

--- a/packages/react-i18n/src/test/utilities.test.tsx
+++ b/packages/react-i18n/src/test/utilities.test.tsx
@@ -110,7 +110,11 @@ describe('getTranslationTree()', () => {
 
   it('returns the translation keys even if they are hidden in a second dictionary', () => {
     expect(
-      getTranslationTree('foobar.barfoo', [{foo: {bar: 'one'}}, {foobar: {barfoo: 'two '}}], locale),
+      getTranslationTree(
+        'foobar.barfoo',
+        [{foo: {bar: 'one'}}, {foobar: {barfoo: 'two'}}],
+        locale,
+      ),
     ).toBe('two');
   });
 

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -80,6 +80,7 @@ export function getTranslationTree(
 
     for (const part of id.split(SEPARATOR)) {
       result = result[part];
+      if (!result) break;
     }
 
     if (result) {


### PR DESCRIPTION
Co-authored-by: Shalini Mekala <shalini.mekala@shopify.com>

## Description

When having multiple dictionaries, getTranslationTree was failing to retrieve results for a given key.
I guess it's also related to #1322

## Type of change

- [x] react-i18n Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
