### PR TITLE
Refresh the react server on current page

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- The `react_render_error` now refreshes on current page. ([#1611](https://github.com/Shopify/quilt/pull/1664))
+
 <!-- ## [Unreleased] -->
 
 ### Changed

--- a/gems/quilt_rails/app/views/quilt/ui/react_render_error.html
+++ b/gems/quilt_rails/app/views/quilt/ui/react_render_error.html
@@ -3,7 +3,7 @@
 <head>
   <title>React Render Error</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta http-equiv="refresh" content="3;URL='/'" />
+  <meta http-equiv="refresh" content="3" />
   <link rel="stylesheet" href="https://unpkg.com/@shopify/polaris@5.1.0/dist/styles.css" />
 </head>
 <body>

--- a/gems/quilt_rails/test/quilt_rails/controllers/quilt/ui_controller_test.rb
+++ b/gems/quilt_rails/test/quilt_rails/controllers/quilt/ui_controller_test.rb
@@ -15,7 +15,7 @@ module QuiltRails
 
         assert_select("h1", "Waiting for React Sever to boot up.")
         assert_select("meta[http-equiv='refresh']") do |selector, *|
-          assert_equal("3;URL='/'", selector[:content])
+          assert_equal("3", selector[:content])
         end
       end
 


### PR DESCRIPTION
## Description

When the node react server is re-starting and not yet booted up you'll see the react_render_error page, which tries to refresh until the server is up. The refresh currently always tries to re-direct to '/', which throws you out of the page you were just developing. This removes the hardcoded path to refresh to and instead refreshes the current page.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] Quilt-rails Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
