### PR TITLE
Pass caught server error to custom error component

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Assign `ctx.state.quiltError` to exception caught after server error. ([#1667](https://github.com/Shopify/quilt/pull/1667))
 
 ## [0.20.0] - 2020-11-04
 

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -173,6 +173,7 @@ export function createRender(
 
       logger.log(errorMessage);
       ctx.status = StatusCode.InternalServerError;
+      ctx.state.quiltError = error;
 
       if (renderRawErrorMessage) {
         ctx.body = errorMessage;


### PR DESCRIPTION
## Description

For custom error components, there's the server error that is supposed to be passed in as a [prop](https://github.com/Shopify/quilt/blob/master/packages/react-server/src/webpack-plugin/webpack-plugin.ts#L105) that's currently undefined at the moment. This sets that value to the same error as what's caught and logged in the react server.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] React-server Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
