### PR TITLE
Option for rendering raw stack or custom error page for SSR errors

### DIFF
--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Added `renderRawErrorMessage` to the options for `createRender` and `createServer`, controls rendering of raw stack or custom error page for SSR errors. Defaults to old behaviour, which is raw stack for development only.
 
 ## [0.19.0] - 2020-10-26
 

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -87,6 +87,8 @@ interface Options {
   debug?: boolean;
   // a function similar to the render option but specifically used to render error pages for production SSR errors
   renderError: RenderFunction;
+  // Control when to render raw stack trace, defaults to development only.
+  renderRawErrorMessage?: boolean;
   // additional props to pass into the Html component, or a function that takes a Koa.Context and returns a props object
   // See https://github.com/Shopify/quilt/blob/master/packages/react-html/README.md#html-
   htmlProps?: HtmlProps | (ctx: Context) => HtmlProps

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -174,7 +174,6 @@ export function createRender(
       logger.log(errorMessage);
       ctx.status = StatusCode.InternalServerError;
 
-      // eslint-disable-next-line no-process-env
       if (renderRawErrorMessage) {
         ctx.body = errorMessage;
       } else {

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -54,6 +54,7 @@ export type RenderOptions = Pick<
   assetPrefix?: string;
   assetName?: string | ValueFromContext<string>;
   renderError?: RenderFunction;
+  renderRawErrorMessage?: boolean;
   htmlProps?: HtmlProps | ValueFromContext<HtmlProps>;
 };
 
@@ -71,6 +72,7 @@ export function createRender(
     assetPrefix,
     assetName: assetNameInput = 'main',
     renderError,
+    renderRawErrorMessage,
     htmlProps: htmlPropsInput = {},
   } = options;
 
@@ -173,7 +175,7 @@ export function createRender(
       ctx.status = StatusCode.InternalServerError;
 
       // eslint-disable-next-line no-process-env
-      if (process.env.NODE_ENV === 'development') {
+      if (renderRawErrorMessage) {
         ctx.body = errorMessage;
       } else {
         if (renderError) {

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -69,7 +69,13 @@ export function createServer(options: Options): Server {
   }
 
   app.use(
-    createRender(render, {assetPrefix, assetName, renderError, renderRawErrorMessage, htmlProps}),
+    createRender(render, {
+      assetPrefix,
+      assetName,
+      renderError,
+      renderRawErrorMessage,
+      htmlProps,
+    }),
   );
 
   return app.listen(port, ip, () => {

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -46,10 +46,10 @@ export function createServer(options: Options): Server {
     assetPrefix = process.env.CDN_URL && process.env.CDN_URL !== 'undefined'
       ? process.env.CDN_URL
       : undefined,
-    /* eslint-enable no-process-env */
     render,
     renderError,
     renderRawErrorMessage = process.env.NODE_ENV === 'development',
+    /* eslint-enable no-process-env */
     serverMiddleware,
     assetName,
     htmlProps,

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -22,6 +22,7 @@ interface Options {
   serverMiddleware?: compose.Middleware<Context>[];
   render: RenderFunction;
   renderError?: RenderOptions['renderError'];
+  renderRawErrorMessage?: boolean;
   app?: Koa;
 }
 
@@ -48,6 +49,7 @@ export function createServer(options: Options): Server {
     /* eslint-enable no-process-env */
     render,
     renderError,
+    renderRawErrorMessage = process.env.NODE_ENV === 'development',
     serverMiddleware,
     assetName,
     htmlProps,
@@ -67,7 +69,7 @@ export function createServer(options: Options): Server {
   }
 
   app.use(
-    createRender(render, {assetPrefix, assetName, renderError, htmlProps}),
+    createRender(render, {assetPrefix, assetName, renderError, renderRawErrorMessage, htmlProps}),
   );
 
   return app.listen(port, ip, () => {


### PR DESCRIPTION
## Description

In #1490 we added support for a custom `renderError` function to react-server SSR. But this function will only run outside dev, making it hard to test the behaviour. This PR adds another option for controlling the raw stack dump which is now only outputted in dev. This will allow the user to control behaviour for any environment.

The boolean defaults to the old behaviour for backward compatibility.

## Type of change

- [x] react-server Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
