### PR TITLE
Remove noop util and export in react-i18n

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 <!-- ## [Unreleased] -->
 
 - Fix bug in `getTranslationTree` when having multiple translation dictionaries. [#1662](https://github.com/Shopify/quilt/pull/1662)
+- Remove unused `noop` util helper [#1669](https://github.com/Shopify/quilt/pull/1669)
 
 ## [5.1.3] - 2020-10-20
 

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -1,5 +1,4 @@
 import {getCurrencySymbol} from './money';
-import {noop} from './noop';
 import {
   PSEUDOTRANSLATE_OPTIONS,
   TranslateOptions,
@@ -11,7 +10,6 @@ import {
 
 export {
   getCurrencySymbol,
-  noop,
   PSEUDOTRANSLATE_OPTIONS,
   translate,
   getTranslationTree,

--- a/packages/react-i18n/src/utilities/noop.ts
+++ b/packages/react-i18n/src/utilities/noop.ts
@@ -1,1 +1,0 @@
-export function noop() {}


### PR DESCRIPTION
## Description

When working in a project with react-i18n and [`@shopify/javascript-utilities`](https://github.com/Shopify/javascript-utilities), it happens very often that the `noop` function from react-i18n is suggested instead of the one from the Js util repo and it's a bit annoying. Even if the noop is not exported from the root of the project.

Removing it is easy as it wasn't even used anyway :)

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
