### PR TITLE
[Dates] Calculate DST offset for days where we jump forward or back

### DIFF
--- a/packages/dates/CHANGELOG.md
+++ b/packages/dates/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [0.4.4] - 2020-11-01
+
+- Updated `apply-time-zone-offest.ts` to check for offset in days dst is applied. fixes web issue [#18493](https://github.com/Shopify/store/issues/18493)
+
 ## [0.4.3] - 2020-10-20
 
 - Updated `tslib` dependency to `^1.14.1`. [#1657](https://github.com/Shopify/quilt/pull/1657)

--- a/packages/dates/src/apply-time-zone-offset.ts
+++ b/packages/dates/src/apply-time-zone-offset.ts
@@ -12,7 +12,7 @@ export function applyTimeZoneOffset(
   const initialOffset = getTimeZoneOffset(date, timeZone1, timeZone2);
   const adjustedDate = new Date(date.valueOf() - initialOffset * 60 * 1000);
   const targetOffset = getTimeZoneOffset(adjustedDate, timeZone1, timeZone2);
-  const offsetDiff = targetOffset - initialOffset - Math.abs(dstOffsetDiff);
+  const offsetDiff = targetOffset - initialOffset + dstOffsetDiff;
 
   return new Date(adjustedDate.valueOf() - offsetDiff * 60 * 1000);
 }

--- a/packages/dates/src/apply-time-zone-offset.ts
+++ b/packages/dates/src/apply-time-zone-offset.ts
@@ -7,12 +7,13 @@ export function applyTimeZoneOffset(
 ) {
   const dateToCheckForDSTOffset = new Date(date);
   dateToCheckForDSTOffset.setHours(2);
+  const needsDSTOffset = date.getTimezoneOffset() !== dateToCheckForDSTOffset.getTimezoneOffset();
+  const dstOffset = needsDSTOffset ? 60 : 0;
 
-  const dstOffsetDiff = date.getTimezoneOffset() - dateToCheckForDSTOffset.getTimezoneOffset();
   const initialOffset = getTimeZoneOffset(date, timeZone1, timeZone2);
   const adjustedDate = new Date(date.valueOf() - initialOffset * 60 * 1000);
   const targetOffset = getTimeZoneOffset(adjustedDate, timeZone1, timeZone2);
-  const offsetDiff = targetOffset - initialOffset + dstOffsetDiff;
+  const offsetDiff = targetOffset - initialOffset - dstOffset;
 
   return new Date(adjustedDate.valueOf() - offsetDiff * 60 * 1000);
 }

--- a/packages/dates/src/apply-time-zone-offset.ts
+++ b/packages/dates/src/apply-time-zone-offset.ts
@@ -5,10 +5,14 @@ export function applyTimeZoneOffset(
   timeZone1?: string,
   timeZone2?: string,
 ) {
+  const dateToCheckForDSTOffset = new Date(date);
+  dateToCheckForDSTOffset.setHours(2);
+
+  const dstOffsetDiff = date.getTimezoneOffset() - dateToCheckForDSTOffset.getTimezoneOffset();
   const initialOffset = getTimeZoneOffset(date, timeZone1, timeZone2);
   const adjustedDate = new Date(date.valueOf() - initialOffset * 60 * 1000);
   const targetOffset = getTimeZoneOffset(adjustedDate, timeZone1, timeZone2);
-  const offsetDiff = targetOffset - initialOffset;
+  const offsetDiff = targetOffset - initialOffset - Math.abs(dstOffsetDiff);
 
   return new Date(adjustedDate.valueOf() - offsetDiff * 60 * 1000);
 }

--- a/packages/dates/src/tests/apply-time-zone-offset.test.ts
+++ b/packages/dates/src/tests/apply-time-zone-offset.test.ts
@@ -58,9 +58,9 @@ describe('applyTimeZoneOffset()', () => {
       ).toStrictEqual(expected);
     });
 
-    it('applies extra dst offset for days where DST is applied or reverted', () => {
-      const date = new Date('2020-11-01T04:00:00.000Z');
-      const expected = new Date('2020-11-01T06:00:00.000Z');
+    it.only('applies extra dst offset for days where DST is applied or reverted', () => {
+      const date = new Date('2020-11-01T00:00:00.000Z');
+      const expected = new Date('2020-11-01T02:00:00.000Z');
 
       expect(
         applyTimeZoneOffset(date, 'America/Denver', 'America/Toronto'),

--- a/packages/dates/src/tests/apply-time-zone-offset.test.ts
+++ b/packages/dates/src/tests/apply-time-zone-offset.test.ts
@@ -57,5 +57,14 @@ describe('applyTimeZoneOffset()', () => {
         applyTimeZoneOffset(date, 'Australia/Sydney', 'UTC'),
       ).toStrictEqual(expected);
     });
+
+    it('applies extra dst offset for days where DST is applied or reverted', () => {
+      const date = new Date('Sun Nov 01 2020 00:00:00 GMT-0400');
+      const expected = new Date('Sun Nov 01 2020 01:00:00 GMT-0500');
+
+      expect(
+        applyTimeZoneOffset(date, 'America/Denver', undefined),
+      ).toStrictEqual(expected);
+    });
   });
 });

--- a/packages/dates/src/tests/apply-time-zone-offset.test.ts
+++ b/packages/dates/src/tests/apply-time-zone-offset.test.ts
@@ -59,8 +59,8 @@ describe('applyTimeZoneOffset()', () => {
     });
 
     it('applies extra dst offset for days where DST is applied or reverted', () => {
-      const date = new Date('Sun Nov 01 2020 00:00:00 GMT-0400');
-      const expected = new Date('Sun Nov 01 2020 01:00:00 GMT-0500');
+      const date = new Date('2020-11-01T04:00:00.000Z');
+      const expected = new Date('2020-11-01T06:00:00.000Z');
 
       expect(
         applyTimeZoneOffset(date, 'America/Denver', undefined),

--- a/packages/dates/src/tests/apply-time-zone-offset.test.ts
+++ b/packages/dates/src/tests/apply-time-zone-offset.test.ts
@@ -63,7 +63,7 @@ describe('applyTimeZoneOffset()', () => {
       const expected = new Date('2020-11-01T06:00:00.000Z');
 
       expect(
-        applyTimeZoneOffset(date, 'America/Denver', undefined),
+        applyTimeZoneOffset(date, 'America/Denver', 'America/Toronto'),
       ).toStrictEqual(expected);
     });
   });


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/store/issues/18493

Currently, there is an issue where if you are in a different timezone locally than your shops timezone, you cannot select the days where the time jumps forward or falls back. 

This PR adds a value for the offset of the DST changes made on those days. Any other day will have an offset of 0 but days where the time changes will get an offset of however much that change is, and will be applied to the target date, allowing you to select it properly.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

This change exists only in `applyTimeZoneOffset()` and only updates the `Dates` package.

## Type of change

Adds a field to check for DST change in a given day

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [x] Dates - Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
