### PR TITLE
Support external urls with Link

### DIFF
--- a/packages/react-router/src/components/Link/Link.tsx
+++ b/packages/react-router/src/components/Link/Link.tsx
@@ -8,16 +8,20 @@ export interface Props extends ReactRouterLinkProps {
   url: string;
 }
 
-export default function Link({url, external, children, ...rest}: Props) {
-  let target: string | undefined;
-  let rel: string | undefined;
-  if (external) {
-    target = '_blank';
-    rel = 'noopener noreferrer';
+const IS_EXTERNAL_LINK_REGEX = /^(?:[a-z][a-z\d+.-]*:|\/\/)/;
+
+export default function Link(props: Props) {
+  const {url, external, children, ...rest} = props;
+  if (external || IS_EXTERNAL_LINK_REGEX.test(url)) {
+    return (
+      <a href={url} {...rest} target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    );
   }
 
   return (
-    <ReactRouterLink target={target} to={url} rel={rel} {...rest}>
+    <ReactRouterLink to={url} {...props}>
       {children}
     </ReactRouterLink>
   );

--- a/packages/react-router/src/components/Link/tests/Link.test.tsx
+++ b/packages/react-router/src/components/Link/tests/Link.test.tsx
@@ -36,9 +36,20 @@ describe('<Link />', () => {
   });
 
   describe('external', () => {
-    it('renders a react router link', () => {
+    it('does not render a react router link for external URL', () => {
       const link = mount(<Link url="https://shopify.com" />);
-      expect(link).toContainReactComponent(ReactRouterLink);
+      expect(link).not.toContainReactComponent(ReactRouterLink);
+      expect(link).toContainReactComponent('a', {
+        href: 'https://shopify.com',
+      });
+    });
+
+    it('does not render a react router link when external prop is provided', () => {
+      const link = mount(<Link external url="something-else" />);
+      expect(link).not.toContainReactComponent(ReactRouterLink);
+      expect(link).toContainReactComponent('a', {
+        href: 'something-else',
+      });
     });
 
     it('sets the `to` prop and passes along other props to ReactRouterLink', () => {
@@ -52,7 +63,7 @@ describe('<Link />', () => {
 
     it('sets default external attributes', () => {
       const link = mount(<Link url="https://shopify.com" external />);
-      expect(link).toContainReactComponent(ReactRouterLink, {
+      expect(link).toContainReactComponent('a', {
         target: '_blank',
         rel: 'noopener noreferrer',
       });


### PR DESCRIPTION
## Description

Fixes #1672 

Introduces support for external (ie. not relative) URLs to the `<Link>` component exported by the `@shopify/react-router` package.

When an external URL is rendered with the Link component, render it as a plain `<a>` tag rather than a `<ReactRouterLink>` if the URL is external (ie. not relative).

This ensures that we can continue to use the `<Link>` component without needing to provide workarounds in each service to first check the URL and resolve it differently.

This logic is taken from the [Polaris documentation](https://github.com/Shopify/polaris-react/blob/72748e3ddb7d60433ba6ed9d9895b390ffa7a283/src/components/AppProvider/README.md#using-linkcomponent) where it is a recommended code snippet, but I believe that it should be upstream.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->


- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
