### PR TITLE
Fix typo in react-bugsnag Readme

### DIFF
--- a/packages/react-bugsnag/README.md
+++ b/packages/react-bugsnag/README.md
@@ -39,7 +39,7 @@ const client = createBugsnagClient({apiKey: API_KEY});
 
 function App() {
   return (
-    <Bugsang client={client}>
+    <Bugsnag client={client}>
       {/* app code */}
     </Bugsnag>
   );


### PR DESCRIPTION

## Description

Fixes a tiny typo in the `@shopify/react-bugsnag` readme

Bugsang -> Bugsnag
