### PR TITLE
[dynamicList] add ability to add multiple items with factory

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.9.0] - 2020-12-03
 
+- Added new functionality to `useDynamicList`. Added the ability to dynamically add more than one list item and the ability to pass in an argument into the dynamic list factory.
 - Added `useDynamicList` functionality. `useDynamicList` adds the ability to dynamically add and remove list items.
 
 ## [0.8.1] - 2020-10-20

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -637,7 +637,7 @@ function MyComponent() {
 
 #### `useDynamicList()`
 
-This offers the same functionality as useList. `useDynamicList` is a hook that adds on `useList` by adding the ability to dynamically add and remove list items. The same way you would utilize `useList` is the same way you would utilize `useDynamicList` except some differences such as the `addField`, and the `removeField` function. We also have to pass in a factory into this hook (telling the hook the exact type of object to add and how it should be initialized).
+This offers the same functionality as useList. `useDynamicList` is a hook that adds on `useList` by adding the ability to dynamically add and remove list items. The same way you would utilize `useList` is the same way you would utilize `useDynamicList` except some differences such as the `addItem`, and the `removeItem` function. We also have to pass in a factory into this hook (telling the hook the exact type of object to add and how it should be initialized).
 
 ##### Using `useDynamicList`
 
@@ -657,7 +657,27 @@ const {fields, addItem, removeItem} = useDynamicList(
 );
 ```
 
-You can choose to initialize it with an existing number of cards or no card.
+We can also have a factory that produces multiple cards such as
+
+```tsx
+const emptyCardFactory = (): Card[] => [
+  {
+    cardNumber: '',
+    cvv: '',
+  },
+  {
+    cardNumber: '',
+    cvv: '',
+  },
+];
+
+const {fields, addItem, removeItem} = useDynamicList(
+  [{cardNumber: '4242 4242 4242 4242', cvv: '000'}],
+  emptyCardFactory,
+);
+```
+
+You can choose to initialize the list with an existing number of cards or no card.
 
 2. Displaying your list and attaching the handlers `useDynamicList` provides
 
@@ -688,7 +708,18 @@ You can choose to initialize it with an existing number of cards or no card.
 
 We render our UI representation of the fields by utilizing the `fields.map` function. For each field, we can use the handlers such as onChange, value, onBlur. These are the same handlers that useList provides.
 
-We can also utilize the `removeItem`, and `addItem` functions. In this example, these functions are attached to a button press. When we remove a field we pass in the index (to indicate what field to remove). When we add a field, we utilize the factory we passed in when initializing `useDynamicList`.
+We can also utilize the `removeItem`, and `addItem` functions. In this example, these functions are attached to a button press. When we remove an item we pass in the index (to indicate what field item to remove). When we add a item, we utilize the factory we passed in when initializing `useDynamicList`.
+
+Note that addItem can also take in an argument which can then be passed onto the factory. In this case, the factory can be
+
+```tsx
+const emptyCardFactory = (factoryArgument: any): Card => ([{
+  cardNumber: '',
+  cvv: '',
+});
+```
+
+You can then use this argument to do as you wish :).
 
 #### Does this work with useForm?
 

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -5,11 +5,13 @@ import {useBaseList, FieldListConfig} from './baselist';
 
 interface DynamicList<Item extends object> {
   fields: FieldDictionary<Item>[];
-  addItem(): void;
+  addItem(factoryArgument?: any): void;
   removeItem(index: number): void;
 }
 
-type FactoryFunction<Item> = () => Item;
+type FactoryFunction<Item extends object> = (
+  factoryArgument?: any,
+) => Item | Item[];
 
 /*
   A custom hook for dynamically adding and removing field items. This utilizes the base functionality of useBaseList.
@@ -27,8 +29,14 @@ export function useDynamicList<Item extends object>(
 ): DynamicList<Item> {
   const {fields, dispatch} = useBaseList(listOrConfig, validationDependencies);
 
-  function addItem() {
-    dispatch(addFieldItemAction([fieldFactory()]));
+  function addItem(factoryArgument?: any) {
+    const itemToAdd = fieldFactory(factoryArgument);
+
+    if (Array.isArray(itemToAdd)) {
+      dispatch(addFieldItemAction(itemToAdd));
+    } else {
+      dispatch(addFieldItemAction([itemToAdd]));
+    }
   }
 
   function removeItem(index: number) {

--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -7,12 +7,11 @@ import {FieldListConfig} from '../baselist';
 
 import {Variant, randomVariants, clickEvent, TextField} from './utils';
 
-const factory = () => {
-  return {price: '', optionName: '', optionValue: ''};
-};
-
 describe('useDynamicList', () => {
   describe('add and remove fields', () => {
+    const factory = () => {
+      return {price: '', optionName: '', optionValue: ''};
+    };
     function DynamicListComponent(config: FieldListConfig<Variant>) {
       const {fields, addItem, removeItem} = useDynamicList<Variant>(
         config,
@@ -99,6 +98,79 @@ describe('useDynamicList', () => {
       expect(wrapper).toContainReactComponent(TextField, {
         name: 'price0',
         value: variants[0].price,
+      });
+    });
+
+    it('cannot remove field when there are no items', () => {
+      const variants: Variant[] = [];
+
+      const wrapper = mount(<DynamicListComponent list={variants} />);
+
+      expect(
+        wrapper.findAll('button', {children: 'Remove Variant'}),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('add mulitiple items with payload', () => {
+    const factory = (argument: any) => {
+      const {price, optionName, optionValue} = argument;
+      return [
+        {price, optionName, optionValue},
+        {price: '', optionName: '', optionValue: ''},
+      ];
+    };
+
+    const payload = {
+      price: '1000',
+      optionName: 'option1',
+      optionValue: '1000',
+    };
+    function DynamicListComponent(config: FieldListConfig<Variant>) {
+      const {fields, addItem} = useDynamicList<Variant>(config, factory);
+
+      return (
+        <ul>
+          {fields.map((fields, index) => (
+            <li key={index}>
+              <TextField
+                label="price"
+                name={`price${index}`}
+                {...fields.price}
+              />
+            </li>
+          ))}
+          <button type="button" onClick={() => addItem(payload)}>
+            Add Variant
+          </button>
+        </ul>
+      );
+    }
+
+    it('adds multiple items from factory', () => {
+      const variants: Variant[] = randomVariants(1);
+
+      const wrapper = mount(<DynamicListComponent list={variants} />);
+
+      wrapper
+        .find('button', {children: 'Add Variant'})!
+        .trigger('onClick', clickEvent());
+
+      expect(wrapper.findAll(TextField)).toHaveLength(3);
+    });
+
+    it('calls factory with payload', () => {
+      const variants: Variant[] = [];
+
+      const wrapper = mount(<DynamicListComponent list={variants} />);
+
+      wrapper
+        .find('button', {children: 'Add Variant'})!
+        .trigger('onClick', clickEvent());
+
+      expect(wrapper).toContainReactComponent(TextField, {
+        name: 'price0',
+        value: payload.price,
       });
     });
   });


### PR DESCRIPTION
## Description

Adds ability to add multiple items dynamically and also pass in an argument

## Tophat

https://codesandbox.io/s/fervent-chaum-bogfr?fontsize=14&hidenavigation=1&theme=dark

You should be able to add more than one item through the factory.

You should be able to pass in a `factoryArgument` into addItem which is passed to the factory. This way the factory can be used for something like pagination. There are a lot of possibilities for this.

## Type of change

`react-form` - DynamicList

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
