### PR TITLE
Use requestBody, not body in docs example

### DIFF
--- a/packages/jest-koa-mocks/README.md
+++ b/packages/jest-koa-mocks/README.md
@@ -120,7 +120,7 @@ describe('oauthStart', () => {
 
 #### Testing apps using common koa libraries
 
-`createContext` allows you to pass a `body` and `session` key by default, so you should be able to test applications using the common body parsing or session libraries simply and quickly.
+`createMockContext` allows you to pass a `requestBody` and `session` key by default, so you should be able to test applications using the common body parsing or session libraries simply and quickly.
 
 ```javascript
 import login from '../login';
@@ -130,7 +130,7 @@ describe('password-validator', () => {
   it('sets session.user if body contains a valid password and username', async () => {
     const ctx = createMockContext({
       url: '/login',
-      body: {
+      requestBody: {
         username: 'valid',
         password: 'valid',
       },


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1659

Updates docs to use the correct key in mock context example.

## Type of change

Docs

- [x] @shopify/jest-koa-mocks Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] ~I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)~
