### PR TITLE
Order asynchronous assets _after_ normal entrypoints

### DIFF
--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -178,7 +178,7 @@ function getAssetsFromManifest(
     return entrypointAssets;
   }
 
-  return [...asyncAssets, ...entrypointAssets];
+  return [...entrypointAssets, ...asyncAssets];
 }
 
 function getAsyncAssetsFromManifest(

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -100,7 +100,7 @@ describe('Assets', () => {
 
       expect(
         await assets.scripts({name: 'custom', asyncAssets: ['used']}),
-      ).toStrictEqual([{path: asyncJs}, {path: js}]);
+      ).toStrictEqual([{path: js}, {path: asyncJs}]);
     });
 
     it('throws an error when no scripts exist for the passed entrypoint', async () => {
@@ -207,7 +207,7 @@ describe('Assets', () => {
 
       expect(
         await assets.styles({name: 'custom', asyncAssets: ['used']}),
-      ).toStrictEqual([{path: asyncCss}, {path: css}]);
+      ).toStrictEqual([{path: css}, {path: asyncCss}]);
     });
 
     it('throws an error when no styles exist for the passed entrypoint', async () => {


### PR DESCRIPTION
## Description

Orders asynchronous assets after normal entrypoints.

Asset order for requests to a react server via sewing-kit is currently incorrect. The first request works because there are no async assets. Subsequent reloads result in `webpackHotUpdate` not defined in the console because async hot reload assets are being loaded first. This patch makes sure the react server is ordering asset entrypoints correctly, by placing async ones last.

## Type of change

- [x] `@shopify/sewing-kit-koa` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
