### PR TITLE
✨ Add support for getting example postal code format

### DIFF
--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -77,6 +77,7 @@ export interface Country {
     show: string;
   };
   zones: Zone[];
+  zipExample: string;
 }
 
 export interface ResponseError {

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -77,7 +77,7 @@ export interface Country {
     show: string;
   };
   zones: Zone[];
-  zipExample: string;
+  postalCodeExample: string;
 }
 
 export interface ResponseError {

--- a/packages/address/src/graphqlQuery.ts
+++ b/packages/address/src/graphqlQuery.ts
@@ -30,6 +30,7 @@ query countries($locale: SupportedLocale!) {
       name
       code
     }
+    zipExample
   }
 }
 
@@ -64,6 +65,7 @@ query country($countryCode: SupportedCountry!, $locale: SupportedLocale!) {
       name
       code
     }
+    zipExample
   }
 }
 `;

--- a/packages/address/src/graphqlQuery.ts
+++ b/packages/address/src/graphqlQuery.ts
@@ -30,7 +30,7 @@ query countries($locale: SupportedLocale!) {
       name
       code
     }
-    zipExample
+    postalCodeExample
   }
 }
 
@@ -65,7 +65,7 @@ query country($countryCode: SupportedCountry!, $locale: SupportedLocale!) {
       name
       code
     }
-    zipExample
+    postalCodeExample
   }
 }
 `;


### PR DESCRIPTION
## Description

The Address package supports queries to https://country-service.shopifycloud.com/graphql to pull down the list of countries. However a chunk of people who fill out the forms get the postal code format subtly wrong and get validation errors from the backend.

Today one of these validations returns the example zip in the error message from the backend. It would be great if we could include that on the front end and give the user a hint before they enter the value.

## Type of change

- [ ] `address-consts` Minor: New feature (now has a type that maps to the returned value from the API)
- [ ] `address` Minor: New feature (now queries the value from the API)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
