### PR TITLE
Fix accidental edit to changelog

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
-##  - 2020-11-04
+## [5.1.4] - 2020-11-04
 
 - Fix bug in `getTranslationTree` when having multiple translation dictionaries. [#1662](https://github.com/Shopify/quilt/pull/1662)
 - Remove unused `noop` util helper [#1669](https://github.com/Shopify/quilt/pull/1669)


### PR DESCRIPTION
## Description

https://github.com/Shopify/quilt/commit/993b3dcaabc7c8089a3585a273b5a6441c92d1c1#diff-360b49b297dba59227ffd850b606e12e3aa8a7a57c6d15f891c69b6a0e3ba91eL10 removed line in a changelog that caused the tests to fail.

Bringing it back fixes it.

To test: run `yarn test consistent-changelogs` and see that it now passes