### PR TITLE
[react-form, react-form-state] Update `fast-deep-equal` to `^3.1.3`

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Updated `fast-deep-equal` dependency to `^3.1.3` [#1710](https://github.com/Shopify/quilt/pull/1710)
 
 ## [0.11.28] - 2020-10-23
 

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/master/packages/react-form-state/README.md",
   "dependencies": {
     "@shopify/predicates": "^1.2.7",
-    "fast-deep-equal": "^2.0.1",
+    "fast-deep-equal": "^3.1.3",
     "tslib": "^1.14.1"
   },
   "peerDependencies": {

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Updated `fast-deep-equal` dependency to `^3.1.3` [#1710](https://github.com/Shopify/quilt/pull/1710)
+
 ## [0.10.0] - 2020-12-08
 
 - Added new functionality to `useDynamicList`. Added the ability to dynamically add more than one list item and the ability to pass in an argument into the dynamic list factory. [#1679](https://github.com/Shopify/quilt/pull/1679)

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@shopify/predicates": "^1.2.7",
     "@shopify/react-hooks": "^1.11.2",
-    "fast-deep-equal": "^2.0.1",
+    "fast-deep-equal": "^3.1.3",
     "get-value": "^3.0.1",
     "tslib": "^1.14.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6725,7 +6725,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
## Description

Keeps packages relying on `fast-deep-equal` ([CHANGELOG](https://github.com/epoberezkin/fast-deep-equal/releases)) up to date with the latest version.

This is useful because I'm introducing a new devDependency in Shopify/web that relies on `fast-deep-equal@3`, and this will prevent having to add this dependency to the list of ignored packages in `failOnDuplicateDependencies` ([as set up in Shopify/web’s `sewing-kit.config.js`](https://github.com/Shopify/web/blob/4b536816071de3db29f31af72dcc47e1a541c7e2/sewing-kit.config.ts#L341-L344)).

## Type of change

- [ ] react-form Patch: dependency update
- [ ] react-form-state Minor: dependency update

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
