### PR TITLE
Allow custom id graphql universal provider

### DIFF
--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
-## Added
+### Added
 
 - Added the ability to use a custom serialized identifier for the apollo cache. [#1724](https://github.com/Shopify/quilt/pull/1724)
 

--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Added
+
+- Added the ability to use a custom serialized identifier for the apollo cache. [#X](https://github.com/Shopify/quilt/pull/X)
+
 ## [3.4.0] - 2020-12-18
 
 ### Added

--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Added
 
-- Added the ability to use a custom serialized identifier for the apollo cache. [#X](https://github.com/Shopify/quilt/pull/X)
+- Added the ability to use a custom serialized identifier for the apollo cache. [#1724](https://github.com/Shopify/quilt/pull/1724)
 
 ## [3.4.0] - 2020-12-18
 

--- a/packages/react-graphql-universal-provider/README.md
+++ b/packages/react-graphql-universal-provider/README.md
@@ -167,3 +167,40 @@ function GraphQL({url, children}: {url: URL; children?: React.ReactNode}) {
   );
 }
 ```
+
+#### Customizing the serialized id
+
+```tsx
+// GraphQL.tsx
+import React from 'react';
+import fetch from 'cross-fetch';
+import {createHttpLink} from 'apollo-link-http';
+import {GraphQLUniversalProvider} from '@shopify/react-graphql-universal-provider';
+
+export function GraphQL({
+  url,
+  children,
+}: {
+  url: URL;
+  children?: React.ReactNode;
+}) {
+  const createClientOptions = () => {
+    const link = createHttpLink({
+      // make sure to use absolute URL on the server
+      uri: `${url.origin}/graphql`,
+      fetch,
+    });
+
+    return {link};
+  };
+
+  return (
+    <GraphQLUniversalProvider
+      id="graphql-cache"
+      createClientOptions={createClientOptions}
+    >
+      {children}
+    </GraphQLUniversalProvider>
+  );
+}
+```

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -12,16 +12,15 @@ import {csrfLink} from './csrf-link';
 import {createRequestIdLink} from './request-id-link';
 
 interface Props<TCacheShape extends NormalizedCacheObject> {
+  id?: string;
   children?: React.ReactNode;
   createClientOptions(): Partial<ApolloClientOptions<TCacheShape>>;
 }
 
 export function GraphQLUniversalProvider<
   TCacheShape extends NormalizedCacheObject
->({children, createClientOptions}: Props<TCacheShape>) {
-  const [initialData, Serialize] = useSerialized<TCacheShape | undefined>(
-    'apollo',
-  );
+>({id = 'apollo', children, createClientOptions}: Props<TCacheShape>) {
+  const [initialData, Serialize] = useSerialized<TCacheShape | undefined>(id);
   const requestID = useRequestHeader('X-Request-ID');
 
   const [client, ssrLink] = useLazyRef<


### PR DESCRIPTION
## Description

This PR adds the ability to customize the data-id of the serialized apollo cache object. Today it is hardcoded to `apollo` in the case where you might have multiple graphql clients, this would result in collisions. This PR adds an `id` prop that defaults to `apollo` so there is no change in behavior.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [X] `@shopify/react-graphql-universal-provider` Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
