### PR TITLE
i18n: fix pseudotranslate

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed pseudotranslate leaving out final part.
+
 ## [0.2.0] - 2020-12-18
 
 ### Added

--- a/packages/i18n/src/pseudotranslate.ts
+++ b/packages/i18n/src/pseudotranslate.ts
@@ -178,6 +178,8 @@ function createParts(
       lastTokenEndIndex = token.index + token[0].length;
       token = delimiterRegex.exec(string);
     }
+
+    parts.push(string.substring(lastTokenEndIndex, string.length));
   } else {
     parts.push(string);
   }

--- a/packages/i18n/src/test/pseudotranslate.test.ts
+++ b/packages/i18n/src/test/pseudotranslate.test.ts
@@ -32,6 +32,15 @@ describe('pseudotranslate()', () => {
       expect(pseudo).toContain('day');
     });
 
+    it('does not break strings without delimiters', () => {
+      const pseudoWithoutDelimiter = pseudotranslate('cat');
+      const pseudoWithDelimiter = pseudotranslate('cat', {
+        startDelimiter: '{',
+        endDelimiter: '}',
+      });
+      expect(pseudoWithoutDelimiter).toBe(pseudoWithDelimiter);
+    });
+
     it('uses the delimiter as both start and end', () => {
       expect(
         pseudotranslate('Hello, $name$.', {


### PR DESCRIPTION
Using the default options `psueduotranslate` was dropping the last part of a translation string after the last matched token (e.g. `{xyz}`). For strings without replacements, this was causing the entire string to be dropped instead of being added to the `parts` array.

## Description

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
