### PR TITLE
✨ <Html> now accepts `type` for scripts

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Better ES module support via `<Html />`'s `script` / `blockingScripts` accepting a `type` property
+
 ## [10.1.0] - 2020-12-18
 
 ### Added

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -16,6 +16,10 @@ export interface Asset {
   integrity?: string;
 }
 
+export interface ScriptAsset extends Asset {
+  type?: 'module' | 'text/javascript';
+}
+
 export interface InlineStyle {
   content: string;
 }
@@ -27,8 +31,8 @@ export interface HtmlProps {
   locale?: string;
   styles?: Asset[];
   inlineStyles?: InlineStyle[];
-  scripts?: Asset[];
-  blockingScripts?: Asset[];
+  scripts?: ScriptAsset[];
+  blockingScripts?: ScriptAsset[];
   preloadAssets?: Asset[];
   headMarkup?: React.ReactNode;
   bodyMarkup?: React.ReactNode;
@@ -108,6 +112,7 @@ export default function Html({
         key={script.path}
         src={script.path}
         integrity={script.integrity}
+        type={script.type}
         crossOrigin="anonymous"
       />
     );
@@ -119,6 +124,7 @@ export default function Html({
         key={script.path}
         src={script.path}
         integrity={script.integrity}
+        type={script.type}
         crossOrigin="anonymous"
         defer
       />

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -17,7 +17,7 @@ export interface Asset {
 }
 
 export interface ScriptAsset extends Asset {
-  type?: 'module' | 'text/javascript';
+  type?: 'module' | 'nomodule' | 'script';
 }
 
 export interface InlineStyle {

--- a/packages/react-html/src/server/components/Script.tsx
+++ b/packages/react-html/src/server/components/Script.tsx
@@ -5,5 +5,6 @@ export interface Props extends React.ScriptHTMLAttributes<HTMLScriptElement> {
 }
 
 export function Script(props: Props) {
-  return <script type="text/javascript" {...props} />;
+  const type = props.type ?? 'text/javascript';
+  return <script {...props} type={type} />;
 }

--- a/packages/react-html/src/server/components/Script.tsx
+++ b/packages/react-html/src/server/components/Script.tsx
@@ -5,6 +5,15 @@ export interface Props extends React.ScriptHTMLAttributes<HTMLScriptElement> {
 }
 
 export function Script(props: Props) {
-  const type = props.type ?? 'text/javascript';
-  return <script {...props} type={type} />;
+  const {type, defer, ...otherProps} = props;
+  const isNoModule = type === 'nomodule';
+
+  const attributes = {
+    ...otherProps,
+    type: !type || isNoModule ? 'text/javascript' : type,
+    defer: type === 'module' ? undefined : defer,
+    noModule: isNoModule ? true : undefined,
+  };
+
+  return <script {...attributes} />;
 }

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -83,6 +83,17 @@ describe('<Html />', () => {
         });
       }
     });
+
+    it('includes `type` attributes', () => {
+      const script = {path: 'foo.js', type: 'module' as const};
+      const html = mount(<Html {...mockProps} scripts={[script]} />);
+      const head = html.find('head')!;
+
+      expect(head).toContainReactComponent(Script, {
+        defer: true,
+        type: script.type,
+      });
+    });
   });
 
   describe('blockingScripts', () => {
@@ -96,6 +107,16 @@ describe('<Html />', () => {
           src: script.path,
         });
       }
+    });
+
+    it('includes `type` attributes', () => {
+      const script = {path: 'foo.js', type: 'text/javascript' as const};
+      const html = mount(<Html {...mockProps} blockingScripts={[script]} />);
+      const head = html.find('head')!;
+
+      expect(head).toContainReactComponent(Script, {
+        type: 'text/javascript',
+      });
     });
   });
 

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -85,13 +85,12 @@ describe('<Html />', () => {
     });
 
     it('includes `type` attributes', () => {
-      const script = {path: 'foo.js', type: 'module' as const};
+      const script = {path: 'foo.js', type: 'nomodule' as const};
       const html = mount(<Html {...mockProps} scripts={[script]} />);
       const head = html.find('head')!;
 
       expect(head).toContainReactComponent(Script, {
-        defer: true,
-        type: script.type,
+        type: 'nomodule',
       });
     });
   });
@@ -110,12 +109,12 @@ describe('<Html />', () => {
     });
 
     it('includes `type` attributes', () => {
-      const script = {path: 'foo.js', type: 'text/javascript' as const};
+      const script = {path: 'foo.js', type: 'module' as const};
       const html = mount(<Html {...mockProps} blockingScripts={[script]} />);
       const head = html.find('head')!;
 
       expect(head).toContainReactComponent(Script, {
-        type: 'text/javascript',
+        type: 'module',
       });
     });
   });

--- a/packages/react-html/src/server/components/tests/Script.test.tsx
+++ b/packages/react-html/src/server/components/tests/Script.test.tsx
@@ -22,18 +22,48 @@ describe('<Script />', () => {
     });
   });
 
-  it('defaults to text/javascript', () => {
-    const script = mount(<Script src="foo.js" />);
+  describe('type', () => {
+    it('defaults to text/javascript', () => {
+      const script = mount(<Script src="foo.js" />);
 
-    expect(script).toContainReactComponent('script', {
-      type: 'text/javascript',
+      expect(script).toContainReactComponent('script', {
+        type: 'text/javascript',
+      });
+      expect(script).not.toContainReactComponent('script', {
+        nomodule: expect.anything(),
+      });
     });
-  });
 
-  it('renders provided types', () => {
-    const moduleScript = mount(<Script src="foo.js" type="module" />);
-    expect(moduleScript).toContainReactComponent('script', {
-      type: 'module',
+    it('renders noModule when specified', () => {
+      const script = mount(<Script src="foo.js" type="nomodule" />);
+      expect(script).toContainReactComponent('script', {
+        type: 'text/javascript',
+        noModule: true,
+      });
+    });
+
+    it('renders module when specified', () => {
+      const script = mount(<Script src="foo.js" type="module" />);
+      expect(script).toContainReactComponent('script', {
+        type: 'module',
+      });
+      expect(script).not.toContainReactComponent('script', {
+        noModule: expect.anything(),
+      });
+    });
+
+    it('omits defer attribute for modules', () => {
+      const script = mount(<Script src="foo.js" type="module" defer />);
+      expect(script).not.toContainReactComponent('script', {
+        defer: expect.anything(),
+      });
+    });
+
+    it('renders arbitrary types', () => {
+      const script = mount(<Script src="foo.js" type="bar" />);
+      expect(script).toContainReactComponent('script', {
+        type: 'bar',
+      });
     });
   });
 });

--- a/packages/react-html/src/server/components/tests/Script.test.tsx
+++ b/packages/react-html/src/server/components/tests/Script.test.tsx
@@ -16,10 +16,24 @@ describe('<Script />', () => {
 
     expect(script).toContainReactComponent('script', {
       src: 'foo.js',
-      type: 'text/javascript',
       integrity: '00000000',
       crossOrigin: 'anonymous',
       defer: true,
+    });
+  });
+
+  it('defaults to text/javascript', () => {
+    const script = mount(<Script src="foo.js" />);
+
+    expect(script).toContainReactComponent('script', {
+      type: 'text/javascript',
+    });
+  });
+
+  it('renders provided types', () => {
+    const moduleScript = mount(<Script src="foo.js" type="module" />);
+    expect(moduleScript).toContainReactComponent('script', {
+      type: 'module',
     });
   });
 });

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -68,7 +68,7 @@ describe('createRender', () => {
 
       // Assets from manifest are still present
       expect(bodyResult).toContain(
-        '<script type="text/javascript" src="main.js" crossorigin="anonymous" defer=""></script>',
+        '<script src="main.js" type="text/javascript" crossorigin="anonymous" defer=""></script>',
       );
       expect(bodyResult).toContain(
         '<link rel="stylesheet" type="text/css" href="main.css" crossorigin="anonymous"/>',
@@ -76,7 +76,7 @@ describe('createRender', () => {
 
       // Additional script/style assets are added
       expect(bodyResult).toContain(
-        '<script type="text/javascript" src="/extraScript.js" crossorigin="anonymous" defer=""></script>',
+        '<script src="/extraScript.js" type="text/javascript" crossorigin="anonymous" defer=""></script>',
       );
       expect(bodyResult).toContain(
         '<link rel="stylesheet" type="text/css" href="/extraStyle.css" crossorigin="anonymous"/>',

--- a/packages/react-server/src/render/test/render.test.tsx
+++ b/packages/react-server/src/render/test/render.test.tsx
@@ -68,7 +68,7 @@ describe('createRender', () => {
 
       // Assets from manifest are still present
       expect(bodyResult).toContain(
-        '<script src="main.js" type="text/javascript" crossorigin="anonymous" defer=""></script>',
+        '<script src="main.js" crossorigin="anonymous" type="text/javascript" defer=""></script>',
       );
       expect(bodyResult).toContain(
         '<link rel="stylesheet" type="text/css" href="main.css" crossorigin="anonymous"/>',
@@ -76,7 +76,7 @@ describe('createRender', () => {
 
       // Additional script/style assets are added
       expect(bodyResult).toContain(
-        '<script src="/extraScript.js" type="text/javascript" crossorigin="anonymous" defer=""></script>',
+        '<script src="/extraScript.js" crossorigin="anonymous" type="text/javascript" defer=""></script>',
       );
       expect(bodyResult).toContain(
         '<link rel="stylesheet" type="text/css" href="/extraStyle.css" crossorigin="anonymous"/>',

--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -74,7 +74,7 @@ describe('createServer()', () => {
     const response = await wrapper.fetch('/');
 
     await expect(response).toHaveBodyText(
-      `<script type="text/javascript" src="/extraScript.js" crossorigin="anonymous" defer="">`,
+      `<script src="/extraScript.js" type="text/javascript" crossorigin="anonymous" defer="">`,
     );
     await expect(response).toHaveBodyText(
       `<link rel="stylesheet" type="text/css" href="/extraStyle.css" crossorigin="anonymous"/>`,

--- a/packages/react-server/src/server/test/server.test.tsx
+++ b/packages/react-server/src/server/test/server.test.tsx
@@ -74,7 +74,7 @@ describe('createServer()', () => {
     const response = await wrapper.fetch('/');
 
     await expect(response).toHaveBodyText(
-      `<script src="/extraScript.js" type="text/javascript" crossorigin="anonymous" defer="">`,
+      `<script src="/extraScript.js" crossorigin="anonymous" type="text/javascript" defer="">`,
     );
     await expect(response).toHaveBodyText(
       `<link rel="stylesheet" type="text/css" href="/extraStyle.css" crossorigin="anonymous"/>`,

--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Better ES module support via `Entrypoint`'s `js` assets containing an optional `type` key
+
 ## [6.4.0] - 2020-12-18
 
 ### Added

--- a/packages/sewing-kit-koa/src/types.ts
+++ b/packages/sewing-kit-koa/src/types.ts
@@ -3,8 +3,12 @@ export interface Asset {
   integrity?: string;
 }
 
+export interface ScriptAsset extends Asset {
+  type?: string;
+}
+
 export interface Entrypoint {
-  js: Asset[];
+  js: ScriptAsset[];
   css: Asset[];
 }
 


### PR DESCRIPTION
## Description
With various bundlers/frameworks providing much improved support for ES modules, it'd be nice if code like:
```ts
<Html scripts={[{path: '/foo.js', type: 'module'}] />
```

generated content like
```
<script src="/foo.js" type="module" />
```

## Type of change
- [x] `@shopify/react-html` Minor
- [x] `@shopify/sewing-kit-koa` Minor

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above