### PR TITLE
Run node CI on pull requests

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,6 +1,10 @@
 name: Node-CI
 
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   node-lint:


### PR DESCRIPTION
## Description

Node CI doesn't seem to be running on pull requests from forks. See https://github.com/Shopify/quilt/pull/1725

## Type of change

CI

## Checklist

- [ ] ~I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)~
