### PR TITLE
Use same name in text and example

### DIFF
--- a/gems/quilt_rails/docs/api.md
+++ b/gems/quilt_rails/docs/api.md
@@ -31,7 +31,7 @@ The `Quilt::Performance::Reportable` mixin is intended to be used in Rails contr
 > **Note** `Quilt::Performance::Reportable` does not require you to use the `React::Renderable` mixin, React-Server, or even any server-side-rendering solution at all. It should work perfectly fine for applications using something like `sewing_kit_script_tag` based client-side-rendering.
 
 ```ruby
-class PerformanceController < ApplicationController
+class PerformanceReportController < ApplicationController
   include Quilt::Performance::Reportable
 
   def create

--- a/gems/quilt_rails/docs/performance-tracking.md
+++ b/gems/quilt_rails/docs/performance-tracking.md
@@ -30,7 +30,7 @@ yarn add @shopify/react-performance
 
 If your application is not using `Quilt::Engine`, you will need to manually configure the server-side portion of performance tracking. If it _is_ using the engine, the following will be done automatically.
 
-1. Add a `PerformanceController` and the corresponding routes to your Rails app.
+1. Add a `PerformanceReportController` and the corresponding routes to your Rails app.
 
 ```ruby
 # app/controllers/performance_report_controller.rb


### PR DESCRIPTION
## Description

Tiny Instructions update, the description used a different name than the code examples.