### PR TITLE
✨ add options to disabled some of the links in GraphQLUniversalProvider

### DIFF
--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -7,6 +7,14 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Change the request id header name from `X-Request-ID` to `X-Initiated-By-Request-ID` [#1738](https://github.com/Shopify/quilt/pull/1738)
+
+### Added
+
+- Added the ability to disabled csrfLink or requestIdLink. [#1738](https://github.com/Shopify/quilt/pull/1738)
+
 ## [3.5.0] - 2021-01-21
 
 ### Added

--- a/packages/react-graphql-universal-provider/src/csrf-link.ts
+++ b/packages/react-graphql-universal-provider/src/csrf-link.ts
@@ -3,11 +3,11 @@ import {setContext} from 'apollo-link-context';
 export const SAME_SITE_HEADER = 'x-shopify-react-xhr';
 export const SAME_SITE_VALUE = '1';
 
-export const csrfLink = setContext((_, {headers}) => {
-  return {
+export function createCsrfLink() {
+  return setContext((_, {headers}) => ({
     headers: {
       ...headers,
       [SAME_SITE_HEADER]: SAME_SITE_VALUE,
     },
-  };
-});
+  }));
+}

--- a/packages/react-graphql-universal-provider/src/request-id-link.ts
+++ b/packages/react-graphql-universal-provider/src/request-id-link.ts
@@ -4,7 +4,7 @@ export function createRequestIdLink(requestId: string) {
   return setContext((_, {headers}) => ({
     headers: {
       ...headers,
-      'X-Request-ID': requestId,
+      'X-Initiated-By-Request-ID': requestId,
     },
   }));
 }

--- a/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/test/GraphQLUniversalProvider.test.tsx
@@ -32,6 +32,12 @@ jest.mock('../request-id-link', () => ({
 }));
 const {createRequestIdLink} = jest.requireMock('../request-id-link');
 
+jest.mock('../csrf-link', () => ({
+  ...jest.requireActual('../csrf-link'),
+  createCsrfLink: jest.fn(),
+}));
+const {createCsrfLink} = jest.requireMock('../csrf-link');
+
 const ApolloClient = jest.requireMock('apollo-client').default;
 
 describe('<GraphQLUniversalProvider />', () => {
@@ -41,6 +47,7 @@ describe('<GraphQLUniversalProvider />', () => {
 
     ApolloClient.mockClear();
     createRequestIdLink.mockClear();
+    createCsrfLink.mockClear();
   });
 
   it('renders an ApolloProvider with a client created by the factory', () => {
@@ -322,6 +329,44 @@ describe('<GraphQLUniversalProvider />', () => {
       );
 
       expect(createRequestIdLink).not.toHaveBeenCalled();
+    });
+
+    it('does not call createRequestIdLink if addRequestId is false', () => {
+      const mockRequestId = 'request-id-value';
+
+      const graphQL = mount(
+        <NetworkContext.Provider
+          value={new NetworkManager({headers: {'X-Request-ID': mockRequestId}})}
+        >
+          <GraphQLUniversalProvider
+            createClientOptions={() => ({})}
+            addRequestId={false}
+          />
+        </NetworkContext.Provider>,
+      );
+
+      expect(createRequestIdLink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createCsrfLink', () => {
+    it('calls createCsrfLink if quiltRails is true', () => {
+      const graphQL = mount(
+        <GraphQLUniversalProvider createClientOptions={() => ({})} />,
+      );
+
+      expect(createCsrfLink).toHaveBeenCalledWith();
+    });
+
+    it('does not call createCsrfLink if quiltRails is false', () => {
+      const graphQL = mount(
+        <GraphQLUniversalProvider
+          createClientOptions={() => ({})}
+          quiltRails={false}
+        />,
+      );
+
+      expect(createCsrfLink).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-graphql-universal-provider/src/test/request-id-link.test.ts
+++ b/packages/react-graphql-universal-provider/src/test/request-id-link.test.ts
@@ -8,7 +8,9 @@ describe('createRequestIdLink()', () => {
     const requestIdLink = createRequestIdLink(mockRequestId);
 
     const mockLink = new ApolloLink(operation => {
-      expect(operation.getContext().header['X-Request-ID']).toBe(mockRequestId);
+      expect(operation.getContext().header['X-Initiated-By-Request-ID']).toBe(
+        mockRequestId,
+      );
 
       return Observable.of({data: {foo: {bar: true}}});
     });


### PR DESCRIPTION
## Description

1. breaking change: changing the header from `X-Request-ID` to `X-Initiated-By-Request-ID`, this is what web uses and actually does make more sense.
2. add in two options: quiltRails and addRequestId, both can be use to disabled certain link if not needed. Planning on using `quiltRails=false` in web to turn off csrf header. 

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [x] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
