### PR TITLE
[React I18n] Allow React 16+

### DIFF
--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -51,7 +51,7 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": ">= 16.0.0"
   },
   "optionalDependencies": {
     "@babel/template": "^7.0.0",


### PR DESCRIPTION
## Description

https://github.com/Shopify/quilt/issues/1740

Relaxes react constraint for `react-i18n`. Is this safe, or do we not support React 17 yet?

## Type of change
- [x] `@shopify/react-i18n` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
