### PR TITLE
Fix invalid peer dep range on magic-entries-webpack-plugin

### DIFF
--- a/packages/magic-entries-webpack-plugin/CHANGELOG.md
+++ b/packages/magic-entries-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Fixed invalid version constraint on `webpack` peer dependency. [#1743](https://github.com/Shopify/quilt/pull/1743)
+
 ## [0.2.0] - 2020-12-18
 
 ### Added

--- a/packages/magic-entries-webpack-plugin/package.json
+++ b/packages/magic-entries-webpack-plugin/package.json
@@ -29,7 +29,7 @@
     "tslib": "^1.14.1"
   },
   "peerDependencies": {
-    "webpack": ">4.25.1, <=4.5.0"
+    "webpack": "^4.25.1"
   },
   "files": [
     "build/*",


### PR DESCRIPTION
## Description

I think the version constraint on the `webpack` peer dependency of `magic-entries-webpack-plugin` is incorrect. According to https://semver.npmjs.com/, there should be no comma.

## Type of change

- [x] `@shopify/magic-entries-webpack-plugin` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
