### PR TITLE
Fix timer flaky test

### DIFF
--- a/packages/koa-metrics/src/test/timer.test.ts
+++ b/packages/koa-metrics/src/test/timer.test.ts
@@ -8,8 +8,7 @@ describe('timer', () => {
     await delay(10);
     const durationMillis = timer.stop();
 
-    // Node 14 CI test are flaky with this test
-    expect(durationMillis).toBeGreaterThanOrEqual(isNode14() ? 9 : 10);
+    expect(durationMillis).toBeGreaterThanOrEqual(9);
   });
 });
 
@@ -17,8 +16,4 @@ function delay(milliseconds: number) {
   return new Promise(resolve => {
     setTimeout(resolve, milliseconds);
   });
-}
-
-function isNode14() {
-  return NODE_VERSION.includes('v14.');
 }


### PR DESCRIPTION
## Description

Fix flaky test on main. It appears to be flaky in any Node version, so changing the assert to >= 9 seems to make the most sense.

Commit with failed test: e7f51b91747614ae74f1ba8ba8adef34e2ee715e

`react-form-state packages/react-form-state/src/tests/FormState.test.tsx` also appears to be [flaky](https://github.com/Shopify/quilt/runs/1930232224), but I don't know why yet.

## Type of change

Flaky test in `@shopify/koa-metrics`

## Checklist

- [ ] ~I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)~
