### PR TITLE
🐛 ✨ [react-i18n][i18n.unformatNumber] handle negative numbers

### DIFF
--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -371,6 +371,23 @@ export class I18n {
     return Boolean(easternNameOrderFormatter);
   }
 
+  @memoize()
+  numberSymbols() {
+    const formattedNumber = this.formatNumber(123456.7, {
+      maximumFractionDigits: 1,
+      minimumFractionDigits: 1,
+    });
+    let thousandSymbol;
+    let decimalSymbol;
+    for (const char of formattedNumber) {
+      if (isNaN(parseInt(char, 10))) {
+        if (thousandSymbol) decimalSymbol = char;
+        else thousandSymbol = char;
+      }
+    }
+    return {thousandSymbol, decimalSymbol};
+  }
+
   private formatCurrencyAuto(
     amount: number,
     options: Intl.NumberFormatOptions = {},
@@ -571,23 +588,6 @@ export class I18n {
 
     return decimal.length === 0 ? DECIMAL_NOT_SUPPORTED : decimal;
   }
-
-  @memoize()
-  private numberSymbols() {
-    const formattedNumber = this.formatNumber(123456.7, {
-      maximumFractionDigits: 1,
-      minimumFractionDigits: 1,
-    });
-    let thousandSymbol;
-    let decimalSymbol;
-    for (const char of formattedNumber) {
-      if (isNaN(parseInt(char, 10))) {
-        if (thousandSymbol) decimalSymbol = char;
-        else thousandSymbol = char;
-      }
-    }
-    return {thousandSymbol, decimalSymbol};
-  }
 }
 
 function normalizedNumber(
@@ -615,8 +615,11 @@ function normalizedNumber(
     .substring(lastDecimalIndex + 1)
     .replace(nonDigits, '');
 
+  const isNegative = input.trim().startsWith('-');
+  const negativeSign = isNegative ? '-' : '';
+
   const normalizedDecimal = lastDecimalIndex === -1 ? '' : PERIOD;
-  const normalizedValue = `${integerValue}${normalizedDecimal}${decimalValue}`;
+  const normalizedValue = `${negativeSign}${integerValue}${normalizedDecimal}${decimalValue}`;
 
   return normalizedValue === '' || normalizedValue === PERIOD
     ? ''

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -583,66 +583,82 @@ describe('I18n', () => {
   });
 
   describe('#unformatNumber()', () => {
-    let formatNumber: jest.SpyInstance;
-    let i18n: I18n;
+    const getI18n = (locale = 'en-ca') =>
+      new I18n(defaultTranslations, {...defaultDetails, locale});
 
-    beforeAll(() => {
-      formatNumber = jest.spyOn(I18n.prototype, 'formatNumber');
-    });
-
-    beforeEach(() => {
-      i18n = new I18n(defaultTranslations, defaultDetails);
-    });
-
-    afterEach(() => {
-      formatNumber.mockClear();
-    });
-
-    afterAll(() => {
-      formatNumber.mockRestore();
-    });
-
-    const input = 123456.7891;
+    const expected = '123456.7891';
 
     it('handles number with period decimal symbol', () => {
-      formatNumber.mockImplementationOnce(() => '123,456.7');
-
       const formatted = '123,456.7891';
 
-      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+      expect(getI18n().unformatNumber(formatted)).toBe(expected);
     });
 
     it('handles number with comma decimal symbol', () => {
-      formatNumber.mockImplementationOnce(() => '123.456,7');
-
       const formatted = '123.456,7891';
 
-      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+      expect(getI18n('es-es').unformatNumber(formatted)).toBe(expected);
     });
 
     it('handles number with space as the thousand symbol', () => {
-      formatNumber.mockImplementationOnce(() => '123 456,7');
-
       const formatted = '123 456,7891';
 
-      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+      expect(getI18n('de-de').unformatNumber(formatted)).toBe(expected);
     });
 
     it('handles number with unusual comma separators and period decimal symbol', () => {
-      formatNumber.mockImplementationOnce(() => '123,456.7');
-
       const formatted = '1,23,456.7891';
 
-      expect(i18n.unformatNumber(formatted)).toBe(input.toString());
+      expect(getI18n().unformatNumber(formatted)).toBe(expected);
     });
 
     it('handles invalid value', () => {
-      formatNumber.mockImplementationOnce(() => '123,456.7');
-
       const formatted = 'foobar';
 
-      expect(i18n.unformatNumber(formatted)).toBe('');
+      expect(getI18n().unformatNumber(formatted)).toBe('');
     });
+
+    it('handles negative value', () => {
+      const formatted = '-123,343.34';
+
+      expect(getI18n().unformatNumber(formatted)).toBe('-123343.34');
+    });
+
+    it('ignores negative sign not in first position', () => {
+      const formatted = '123-232.34';
+
+      expect(getI18n().unformatNumber(formatted)).toBe('123232.34');
+    });
+
+    it('handles leading/trailing spaces', () => {
+      const formatted = '  -34,455.5  ';
+
+      expect(getI18n().unformatNumber(formatted)).toBe('-34455.5');
+    });
+  });
+
+  describe('#numberSymbols()', () => {
+    const tests: [string, string, string][] = [
+      // [locale, decimal, thousands]
+      ['en', '.', ','],
+      ['es', ',', '.'],
+      ['fr', ',', '\u202F'],
+      ['sv', ',', '\u00A0'],
+      ['hi', '.', ','],
+      ['ko', '.', ','],
+      ['jp', '.', ','],
+    ];
+    it.each(tests)(
+      'locale %s decimal is "%s" and thousands is "%s"',
+      (locale, decimalSymbol, thousandSymbol) => {
+        const i18n = new I18n(defaultTranslations, {...defaultDetails, locale});
+
+        expect(i18n.numberSymbols()).toStrictEqual({
+          decimalSymbol,
+          thousandSymbol,
+        });
+      },
+    );
   });
 
   describe('#formatCurrency()', () => {


### PR DESCRIPTION
## Description

Fixes bug with `i18n.unformatNumber()` stripping the negative sign `-` from negative numbers.

Exposes `i18n.numberSymbols()` as a public method.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] `react-i18n` Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
