### PR TITLE
🐛Fix behaviour of makeCleanAfterSubmit

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed a bug in `makeCleanAfterSubmit` for `useForm` [#1762](https://github.com/Shopify/quilt/pull/1762)
 
 ## [0.12.1] - 2021-03-30
 

--- a/packages/react-form/src/hooks/submit.ts
+++ b/packages/react-form/src/hooks/submit.ts
@@ -58,10 +58,9 @@ export function useSubmit<T extends FieldBag>(
         setErrors(result.errors);
       } else {
         setSubmitErrors([]);
-      }
-
-      if (makeCleanAfterSubmit) {
-        makeCleanFields(fields);
+        if (makeCleanAfterSubmit) {
+          makeCleanFields(fields);
+        }
       }
     },
     [mounted, onSubmit, setErrors, makeCleanAfterSubmit],

--- a/packages/react-form/src/hooks/test/form.test.tsx
+++ b/packages/react-form/src/hooks/test/form.test.tsx
@@ -352,7 +352,7 @@ describe('useForm', () => {
       it('does not undirty fields after if makeCleanAfterSubmit is true but submit is unsuccessful', async () => {
         const promise = Promise.resolve(submitFail());
         const wrapper = mount(
-          <ProductForm data={fakeProduct()} makeCleanAfterSubmit={false} />,
+          <ProductForm data={fakeProduct()} makeCleanAfterSubmit />,
         );
 
         changeTitle(wrapper, '');


### PR DESCRIPTION
## Description

Fixes #1717
Fixing the code so that `makeCleanAfterSubmit`, if true, should only "undirty" the form after a successful submission, not on a failed submission. 
Update the tests to correctly test this condition. 
<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
