### PR TITLE
[React Form] Enable reordering of Dynamic Lists 

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Add ability to sort dynamic lists [#1785](https://github.com/Shopify/quilt/pull/1785)
+- Add ability to reorder dynamic lists [#1785](https://github.com/Shopify/quilt/pull/1785)
 
 ## [0.11.2] - 2021-03-03
 

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Added
+
+- Add ability to sort dynamic lists [#1785](https://github.com/Shopify/quilt/pull/1785)
+
 ## [0.11.2] - 2021-03-03
 
 ### Fixed

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -652,7 +652,7 @@ const emptyCardFactory = (): Card => ({
   cvv: '',
 });
 
-const {fields, addItem, removeItem} = useDynamicList(
+const {fields, addItem, removeItem, moveItem} = useDynamicList(
   [{cardNumber: '4242 4242 4242 4242', cvv: '000'}],
   emptyCardFactory,
 );
@@ -672,7 +672,7 @@ const emptyCardFactory = (): Card[] => [
   },
 ];
 
-const {fields, addItem, removeItem} = useDynamicList(
+const {fields, addItem, removeItem, moveItem} = useDynamicList(
   [{cardNumber: '4242 4242 4242 4242', cvv: '000'}],
   emptyCardFactory,
 );
@@ -700,6 +700,16 @@ You can choose to initialize the list with an existing number of cards or no car
       />
       <div>
         <Button onClick={() => removeItem(index)}>Remove</Button>
+      </div>
+      <div>
+        <Button onClick={() => moveItem(field, index, index - 1)}>
+          Move Item Up
+        </Button>
+      </div>
+      <div>
+        <Button onClick={() => moveItem(field, index, index + 1)}>
+          Move Item Down
+        </Button>
       </div>
     </FormLayout.Group>
   ));

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -702,12 +702,12 @@ You can choose to initialize the list with an existing number of cards or no car
         <Button onClick={() => removeItem(index)}>Remove</Button>
       </div>
       <div>
-        <Button onClick={() => moveItem(field, index, index - 1)}>
+        <Button onClick={() => moveItem(index, index - 1)}>
           Move Item Up
         </Button>
       </div>
       <div>
-        <Button onClick={() => moveItem(field, index, index + 1)}>
+        <Button onClick={() => moveItem(index, index + 1)}>
           Move Item Down
         </Button>
       </div>

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -702,12 +702,18 @@ You can choose to initialize the list with an existing number of cards or no car
         <Button onClick={() => removeItem(index)}>Remove</Button>
       </div>
       <div>
-        <Button onClick={() => moveItem(index, index - 1)}>
+        <Button
+          disabled={index === 0}
+          onClick={() => moveItem(index, index - 1)}
+        >
           Move Item Up
         </Button>
       </div>
       <div>
-        <Button onClick={() => moveItem(index, index + 1)}>
+        <Button
+          disabled={index === fields.length}
+          onClick={() => moveItem(index, index + 1)}
+        >
           Move Item Down
         </Button>
       </div>

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -1,12 +1,13 @@
 import {FieldDictionary} from '../../types';
 
-import {addFieldItemAction, removeFieldItemAction} from './hooks';
+import {addFieldItemAction, removeFieldItemAction, moveFieldItemAction} from './hooks';
 import {useBaseList, FieldListConfig} from './baselist';
 
 interface DynamicList<Item extends object> {
   fields: FieldDictionary<Item>[];
   addItem(factoryArgument?: any): void;
   removeItem(index: number): void;
+  moveItem(item: Item, oldIndex: number, newIndex: number): void;
 }
 
 type FactoryFunction<Item extends object> = (
@@ -39,9 +40,15 @@ export function useDynamicList<Item extends object>(
     }
   }
 
+  function moveItem(item, oldIndex, newIndex) {
+    console.log('moving item in array');
+    dispatch(moveFieldItemAction(item, oldIndex, newIndex))
+  }
+
   function removeItem(index: number) {
     dispatch(removeFieldItemAction(index));
   }
 
-  return {fields, addItem, removeItem};
+  return {fields, addItem, removeItem, moveItem};
 }
+

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -40,8 +40,7 @@ export function useDynamicList<Item extends object>(
     }
   }
 
-  function moveItem(item, oldIndex, newIndex) {
-    console.log('moving item in array');
+  function moveItem(item: Item, oldIndex: number, newIndex: number) {
     dispatch(moveFieldItemAction(item, oldIndex, newIndex))
   }
 

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -11,7 +11,7 @@ interface DynamicList<Item extends object> {
   fields: FieldDictionary<Item>[];
   addItem(factoryArgument?: any): void;
   removeItem(index: number): void;
-  moveItem(item: Item, oldIndex: number, newIndex: number): void;
+  moveItem(oldIndex: number, newIndex: number): void;
 }
 
 type FactoryFunction<Item extends object> = (
@@ -44,8 +44,8 @@ export function useDynamicList<Item extends object>(
     }
   }
 
-  function moveItem(item: Item, oldIndex: number, newIndex: number) {
-    dispatch(moveFieldItemAction(item, oldIndex, newIndex));
+  function moveItem(oldIndex: number, newIndex: number) {
+    dispatch(moveFieldItemAction(oldIndex, newIndex));
   }
 
   function removeItem(index: number) {

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -11,7 +11,7 @@ interface DynamicList<Item extends object> {
   fields: FieldDictionary<Item>[];
   addItem(factoryArgument?: any): void;
   removeItem(index: number): void;
-  moveItem(oldIndex: number, newIndex: number): void;
+  moveItem(fromIndex: number, toIndex: number): void;
 }
 
 type FactoryFunction<Item extends object> = (
@@ -44,8 +44,8 @@ export function useDynamicList<Item extends object>(
     }
   }
 
-  function moveItem(oldIndex: number, newIndex: number) {
-    dispatch(moveFieldItemAction(oldIndex, newIndex));
+  function moveItem(fromIndex: number, toIndex: number) {
+    dispatch(moveFieldItemAction(fromIndex, toIndex));
   }
 
   function removeItem(index: number) {

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -1,6 +1,10 @@
 import {FieldDictionary} from '../../types';
 
-import {addFieldItemAction, removeFieldItemAction, moveFieldItemAction} from './hooks';
+import {
+  addFieldItemAction,
+  removeFieldItemAction,
+  moveFieldItemAction,
+} from './hooks';
 import {useBaseList, FieldListConfig} from './baselist';
 
 interface DynamicList<Item extends object> {
@@ -41,13 +45,11 @@ export function useDynamicList<Item extends object>(
   }
 
   function moveItem(item: Item, oldIndex: number, newIndex: number) {
-    dispatch(moveFieldItemAction(item, oldIndex, newIndex))
+    dispatch(moveFieldItemAction(item, oldIndex, newIndex));
   }
 
   function removeItem(index: number) {
     dispatch(removeFieldItemAction(index));
   }
-
   return {fields, addItem, removeItem, moveItem};
 }
-

--- a/packages/react-form/src/hooks/list/hooks/index.ts
+++ b/packages/react-form/src/hooks/list/hooks/index.ts
@@ -7,6 +7,7 @@ export {
   newDefaultAction,
   resetAction,
   addFieldItemAction,
+  moveFieldItemAction,
   removeFieldItemAction,
 } from './reducer';
 

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -31,7 +31,7 @@ interface AddFieldItemAction<Item> {
 
 interface MoveFieldItemAction<Item> {
   type: 'moveFieldItem';
-  payload: {item: Item, oldIndex: number, newIndex: number};
+  payload: {item: Item; oldIndex: number; newIndex: number};
 }
 
 interface RemoveFieldItemAction {
@@ -103,7 +103,7 @@ export function moveFieldItemAction<Item>(
 ): MoveFieldItemAction<Item> {
   return {
     type: 'moveFieldItem',
-    payload: {item, oldIndex, newIndex}
+    payload: {item, oldIndex, newIndex},
   };
 }
 
@@ -178,7 +178,11 @@ function reduceList<Item extends object>(
     case 'moveFieldItem': {
       const newList = [...state.list];
       newList.splice(action.payload.oldIndex, 1);
-      newList.splice(action.payload.newIndex, 0, action.payload.item as FieldStates<Item>);
+      newList.splice(
+        action.payload.newIndex,
+        0,
+        action.payload.item as FieldStates<Item>,
+      );
 
       return {
         ...state,

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -31,7 +31,7 @@ interface AddFieldItemAction<Item> {
 
 interface MoveFieldItemAction {
   type: 'moveFieldItem';
-  payload: {oldIndex: number; newIndex: number};
+  payload: {fromIndex: number; toIndex: number};
 }
 
 interface RemoveFieldItemAction {
@@ -97,12 +97,12 @@ export function addFieldItemAction<Item>(
 }
 
 export function moveFieldItemAction(
-  oldIndex: number,
-  newIndex: number,
+  fromIndex: number,
+  toIndex: number,
 ): MoveFieldItemAction {
   return {
     type: 'moveFieldItem',
-    payload: {oldIndex, newIndex},
+    payload: {fromIndex, toIndex},
   };
 }
 
@@ -181,7 +181,7 @@ function reduceList<Item extends object>(
 
       return {
         ...state,
-        list: newList,
+        list: state.list,
       };
     }
     case 'addFieldItem': {

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -12,6 +12,7 @@ import {mapObject} from '../../../utilities';
 export type ListAction<Item> =
   | ReinitializeAction<Item>
   | AddFieldItemAction<Item>
+  | MoveFieldItemAction<Item>
   | RemoveFieldItemAction
   | UpdateErrorAction<Item>
   | UpdateAction<Item, keyof Item>
@@ -26,6 +27,11 @@ interface ReinitializeAction<Item> {
 interface AddFieldItemAction<Item> {
   type: 'addFieldItem';
   payload: {list: Item[]};
+}
+
+interface MoveFieldItemAction<Item> {
+  type: 'moveFieldItem';
+  payload: {item: Item, oldIndex: number, newIndex: number};
 }
 
 interface RemoveFieldItemAction {
@@ -87,6 +93,17 @@ export function addFieldItemAction<Item>(
   return {
     type: 'addFieldItem',
     payload: {list},
+  };
+}
+
+export function moveFieldItemAction<Item>(
+  item: Item,
+  oldIndex: number,
+  newIndex: number,
+): MoveFieldItemAction<Item> {
+  return {
+    type: 'moveFieldItem',
+    payload: {item, oldIndex, newIndex}
   };
 }
 
@@ -156,6 +173,16 @@ function reduceList<Item extends object>(
       return {
         initial: action.payload.list,
         list: action.payload.list.map(initialListItemState),
+      };
+    }
+    case 'moveFieldItem': {
+      const newList = [...state.list];
+      newList.splice(action.payload.oldIndex, 1);
+      newList.splice(action.payload.newIndex, 0, action.payload.item as FieldStates<Item>);
+
+      return {
+        ...state,
+        list: newList,
       };
     }
     case 'addFieldItem': {

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -176,8 +176,7 @@ function reduceList<Item extends object>(
     }
     case 'moveFieldItem': {
       const newList = [...state.list];
-      const item = newList[action.payload.oldIndex];
-      newList.splice(action.payload.oldIndex, 1);
+      const [item] = newList.splice(action.payload.oldIndex, 1);
       newList.splice(action.payload.newIndex, 0, item);
 
       return {

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -175,13 +175,23 @@ function reduceList<Item extends object>(
       };
     }
     case 'moveFieldItem': {
+      const {fromIndex, toIndex} = action.payload;
+      if (
+        fromIndex >= state.list.length ||
+        fromIndex < 0 ||
+        toIndex >= state.list.length ||
+        toIndex < 0
+      ) {
+        throw new Error(`Failed to move item from ${fromIndex} to ${toIndex}`);
+      }
+
       const newList = [...state.list];
-      const [item] = newList.splice(action.payload.oldIndex, 1);
-      newList.splice(action.payload.newIndex, 0, item);
+      const [item] = newList.splice(action.payload.fromIndex, 1);
+      newList.splice(action.payload.toIndex, 0, item);
 
       return {
         ...state,
-        list: state.list,
+        list: newList,
       };
     }
     case 'addFieldItem': {

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -12,7 +12,7 @@ import {mapObject} from '../../../utilities';
 export type ListAction<Item> =
   | ReinitializeAction<Item>
   | AddFieldItemAction<Item>
-  | MoveFieldItemAction<Item>
+  | MoveFieldItemAction
   | RemoveFieldItemAction
   | UpdateErrorAction<Item>
   | UpdateAction<Item, keyof Item>
@@ -29,9 +29,9 @@ interface AddFieldItemAction<Item> {
   payload: {list: Item[]};
 }
 
-interface MoveFieldItemAction<Item> {
+interface MoveFieldItemAction {
   type: 'moveFieldItem';
-  payload: {item: Item; oldIndex: number; newIndex: number};
+  payload: {oldIndex: number; newIndex: number};
 }
 
 interface RemoveFieldItemAction {
@@ -96,14 +96,13 @@ export function addFieldItemAction<Item>(
   };
 }
 
-export function moveFieldItemAction<Item>(
-  item: Item,
+export function moveFieldItemAction(
   oldIndex: number,
   newIndex: number,
-): MoveFieldItemAction<Item> {
+): MoveFieldItemAction {
   return {
     type: 'moveFieldItem',
-    payload: {item, oldIndex, newIndex},
+    payload: {oldIndex, newIndex},
   };
 }
 
@@ -177,12 +176,9 @@ function reduceList<Item extends object>(
     }
     case 'moveFieldItem': {
       const newList = [...state.list];
+      const item = newList[action.payload.oldIndex];
       newList.splice(action.payload.oldIndex, 1);
-      newList.splice(
-        action.payload.newIndex,
-        0,
-        action.payload.item as FieldStates<Item>,
-      );
+      newList.splice(action.payload.newIndex, 0, item);
 
       return {
         ...state,

--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -34,7 +34,7 @@ describe('useDynamicList', () => {
                 type="button"
                 title="move up"
                 onClick={() => {
-                  moveItem((fields as unknown) as Variant, index, index - 1);
+                  moveItem(index, index - 1);
                 }}
               >
                 Move Variant up
@@ -43,7 +43,7 @@ describe('useDynamicList', () => {
                 type="button"
                 title="move down"
                 onClick={() => {
-                  moveItem((fields as unknown) as Variant, index, index + 1);
+                  moveItem(index, index + 1);
                 }}
               >
                 Move Variant down

--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -13,7 +13,7 @@ describe('useDynamicList', () => {
       return {price: '', optionName: '', optionValue: ''};
     };
     function DynamicListComponent(config: FieldListConfig<Variant>) {
-      const {fields, addItem, removeItem} = useDynamicList<Variant>(
+      const {fields, addItem, removeItem, moveItem} = useDynamicList<Variant>(
         config,
         factory,
       );
@@ -30,6 +30,24 @@ describe('useDynamicList', () => {
               <button type="button" onClick={() => removeItem(index)}>
                 Remove Variant
               </button>
+              <button
+                type="button"
+                title="move up"
+                onClick={() => {
+                  moveItem((fields as unknown) as Variant, index, index - 1);
+                }}
+              >
+                Move Variant up
+              </button>
+              <button
+                type="button"
+                title="move down"
+                onClick={() => {
+                  moveItem((fields as unknown) as Variant, index, index + 1);
+                }}
+              >
+                Move Variant down
+              </button>
             </li>
           ))}
           <button type="button" onClick={() => addItem()}>
@@ -38,6 +56,36 @@ describe('useDynamicList', () => {
         </ul>
       );
     }
+
+    it('can move field to a new position', () => {
+      const variants: Variant[] = [
+        {price: 'A', optionName: 'A', optionValue: 'A'},
+        {price: 'B', optionName: 'B', optionValue: 'B'},
+        {price: 'C', optionName: 'C', optionValue: 'C'},
+      ];
+
+      const wrapper = mount(<DynamicListComponent list={variants} />);
+
+      wrapper
+        .findAll('button', {children: 'Move Variant up'})![2]
+        .trigger('onClick');
+
+      const sort1 = wrapper
+        .findAll('li')
+        .map(i => i.find(TextField).props.value);
+
+      expect(sort1).toStrictEqual(['A', 'C', 'B']);
+
+      wrapper
+        .findAll('button', {children: 'Move Variant down'})![0]
+        .trigger('onClick');
+
+      const sort2 = wrapper
+        .findAll('li')
+        .map(i => i.find(TextField).props.value);
+
+      expect(sort2).toStrictEqual(['C', 'A', 'B']);
+    });
 
     it('can remove field', () => {
       const variants: Variant[] = randomVariants(1);

--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -39,15 +39,6 @@ describe('useDynamicList', () => {
               >
                 Move Variant up
               </button>
-              <button
-                type="button"
-                title="move down"
-                onClick={() => {
-                  moveItem(index, index + 1);
-                }}
-              >
-                Move Variant down
-              </button>
             </li>
           ))}
           <button type="button" onClick={() => addItem()}>
@@ -75,16 +66,6 @@ describe('useDynamicList', () => {
         .map(i => i.find(TextField).props.value);
 
       expect(sort1).toStrictEqual(['A', 'C', 'B']);
-
-      wrapper
-        .findAll('button', {children: 'Move Variant down'})![0]
-        .trigger('onClick');
-
-      const sort2 = wrapper
-        .findAll('li')
-        .map(i => i.find(TextField).props.value);
-
-      expect(sort2).toStrictEqual(['C', 'A', 'B']);
     });
 
     it('can remove field', () => {

--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -68,6 +68,22 @@ describe('useDynamicList', () => {
       expect(sort1).toStrictEqual(['A', 'C', 'B']);
     });
 
+    it('will throw an error if new position is out of index range', () => {
+      const variants: Variant[] = [
+        {price: 'A', optionName: 'A', optionValue: 'A'},
+        {price: 'B', optionName: 'B', optionValue: 'B'},
+        {price: 'C', optionName: 'C', optionValue: 'C'},
+      ];
+
+      const wrapper = mount(<DynamicListComponent list={variants} />);
+
+      expect(() => {
+        wrapper
+          .findAll('button', {children: 'Move Variant up'})![0]
+          .trigger('onClick');
+      }).toThrow('Failed to move item from 0 to -1');
+    });
+
     it('can remove field', () => {
       const variants: Variant[] = randomVariants(1);
 


### PR DESCRIPTION
## Description
This PR will enable sorting of [dynamic lists](https://www.npmjs.com/package/@shopify/react-form#usedynamiclist) via an additional `moveItem` method

Fixes (issue #1765)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
