### PR TITLE
Add module.exports to jest and jest-simple

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/graphql-mini-transforms/CHANGELOG.md
+++ b/packages/graphql-mini-transforms/CHANGELOG.md
@@ -8,6 +8,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 <!-- ## [Unreleased] -->
 
 ## [2.0.0] - 2021-03-11
+- Updated `jest` and `jest-simple` to be compatible with jest [[#133](https://github.com/Shopify/quilt/pull/133)]
+
+## [2.0.0] - 2021-03-11
 
 ### Changed
 

--- a/packages/graphql-mini-transforms/CHANGELOG.md
+++ b/packages/graphql-mini-transforms/CHANGELOG.md
@@ -8,7 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 <!-- ## [Unreleased] -->
 
 ## [2.0.0] - 2021-03-11
-- Updated `jest` and `jest-simple` to be compatible with jest [[#133](https://github.com/Shopify/quilt/pull/133)]
+- Updated `jest` and `jest-simple` to be compatible with jest [[#1787](https://github.com/Shopify/quilt/pull/1787)]
 
 ## [2.0.0] - 2021-03-11
 

--- a/packages/graphql-mini-transforms/CHANGELOG.md
+++ b/packages/graphql-mini-transforms/CHANGELOG.md
@@ -7,7 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
-## [2.0.0] - 2021-03-11
+### Changed
+
 - Updated `jest` and `jest-simple` to be compatible with jest [[#1787](https://github.com/Shopify/quilt/pull/1787)]
 
 ## [2.0.0] - 2021-03-11

--- a/packages/graphql-mini-transforms/src/jest-simple.ts
+++ b/packages/graphql-mini-transforms/src/jest-simple.ts
@@ -54,3 +54,5 @@ export const transformer: Transformer = {
     `;
   },
 };
+
+export default transformer;

--- a/packages/graphql-mini-transforms/src/jest-simple.ts
+++ b/packages/graphql-mini-transforms/src/jest-simple.ts
@@ -55,4 +55,4 @@ export const transformer: Transformer = {
   },
 };
 
-export default transformer;
+module.exports = transformer;

--- a/packages/graphql-mini-transforms/src/jest.ts
+++ b/packages/graphql-mini-transforms/src/jest.ts
@@ -54,3 +54,5 @@ export const transformer: Transformer = {
     `;
   },
 };
+
+export default transformer;

--- a/packages/graphql-mini-transforms/src/jest.ts
+++ b/packages/graphql-mini-transforms/src/jest.ts
@@ -55,4 +55,4 @@ export const transformer: Transformer = {
   },
 };
 
-export default transformer;
+module.exports = transformer;


### PR DESCRIPTION
## Description
This PR fixes a bug where `jest` and `jest-simple` won't run by default when referenced as a customTransformer in jest.
Fixes (issue #)

I confirmed the fix by running `yarn build`. and copying the `build/cjs/jest` and `build/cjs/jest-simple` files to another project and running the tests.

This PR also adds a timeout to the node tests of 10 minutes.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `graphql-mini-transforms` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
