### PR TITLE
Add react hook useSteps

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2021-03-18
+
+### Added
+
+- Added `useSteps` hook ([#1791](https://github.com/Shopify/quilt/pull/1791))
+
 ## [1.12.2] - 2021-03-03
 
 ### Fixed

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -25,6 +25,7 @@ $ yarn add @shopify/react-hooks
 - [usePrevious()](#useprevious)
 - [useTimeout()](#usetimeout)
 - [useToggle()](#usetoggle)
+- [useSteps()](#usesteps)
 
 ## Usage
 
@@ -253,6 +254,24 @@ function MyComponent() {
       <button onClick={toggleIsActive}>Toggle isActive state</button>
       <button onClick={setIsActiveTrue}>Set isActive state to true</button>
       <button onClick={setIsActiveFalse}>Set isActive state to false</button>
+    </>
+  );
+}
+```
+
+### `useSteps()`
+
+This hook provides an object that contains a numeric state value for the current step and two memoized callbacks to manipulate it (nextStep, previousStep). It accepts two arguments: the total number of steps possible, and the initial step (optional - defaults to 1). This is useful for paged modals or anything that has a finite set of steps to walkthrough.
+
+```tsx
+function MyComponent() {
+  const {currentStep, nextStep, previousStep} = useSteps(5, 2);
+
+  return (
+    <>
+      <p>Step: {currentStep}</p>
+      <button onClick={nextStep}>Go to next step</button>
+      <button onClick={previousStep}>Go to previous step</button>
     </>
   );
 }

--- a/packages/react-hooks/src/hooks/steps.ts
+++ b/packages/react-hooks/src/hooks/steps.ts
@@ -1,0 +1,19 @@
+import {useState, useCallback} from 'react';
+
+export function useSteps(steps: number, initialStep = 1) {
+  const [currentStep, setCurrentStep] = useState(initialStep);
+
+  return {
+    currentStep,
+    nextStep: useCallback(() => {
+      if (currentStep < steps) {
+        setCurrentStep(currentStep + 1);
+      }
+    }, [currentStep, steps]),
+    previousStep: useCallback(() => {
+      if (currentStep > 1) {
+        setCurrentStep(currentStep - 1);
+      }
+    }, [currentStep]),
+  };
+}

--- a/packages/react-hooks/src/hooks/tests/steps.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/steps.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {useSteps} from '../steps';
+
+describe('useSteps', () => {
+  function TestMyProps(_props: any) {
+    return null;
+  }
+
+  function MockComponent({
+    steps,
+    initialStep,
+  }: {
+    steps: number;
+    initialStep?: number;
+  }) {
+    const props = useSteps(steps, initialStep);
+    return <TestMyProps {...props} />;
+  }
+
+  it('starts with current step set to 1', () => {
+    const wrapper = mount(<MockComponent steps={3} />);
+
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 1,
+    });
+  });
+
+  it('sets custom initial step when initialStep is provided', () => {
+    const wrapper = mount(<MockComponent steps={3} initialStep={2} />);
+
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 2,
+    });
+  });
+
+  it('sets the next step when nextStep is called', () => {
+    const wrapper = mount(<MockComponent steps={3} />);
+
+    wrapper.find(TestMyProps).trigger('nextStep');
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 2,
+    });
+
+    wrapper.find(TestMyProps).trigger('nextStep');
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 3,
+    });
+  });
+
+  it('sets the previous step when previousStep is called', () => {
+    const wrapper = mount(<MockComponent steps={3} initialStep={2} />);
+
+    wrapper.find(TestMyProps).trigger('previousStep');
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 1,
+    });
+
+    wrapper.find(TestMyProps).trigger('previousStep');
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 1,
+    });
+  });
+
+  it('does not set next step when current step is the last', () => {
+    const wrapper = mount(<MockComponent steps={2} initialStep={1} />);
+
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 1,
+    });
+
+    wrapper.find(TestMyProps).trigger('nextStep');
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 2,
+    });
+  });
+
+  it('does not set previous step when current step is the first', () => {
+    const wrapper = mount(<MockComponent steps={3} />);
+
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 1,
+    });
+
+    wrapper.find(TestMyProps).trigger('previousStep');
+    expect(wrapper).toContainReactComponent(TestMyProps, {
+      currentStep: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds `useSteps` to `react-hooks` package.

This hook provides an object that contains a numeric state value for the current step and two memoized callbacks to manipulate it (nextStep, previousStep). It accepts two arguments: the total number of steps possible, and the initial step (optional - defaults to 0). This is useful for paged modals or anything that has a finite set of steps to walkthrough.

```tsx
function MyComponent() {
  const {currentStep, nextStep, previousStep} = useSteps(5, 2);

  return (
    <>
      <p>Step: {currentStep}</p>
      <button onClick={nextStep}>Go to next step</button>
      <button onClick={previousStep}>Go to previous step</button>
    </>
  );
}
```

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
