### PR TITLE
[koa-performance] Include custom tags for navigation metrics

### DIFF
--- a/packages/koa-performance/CHANGELOG.md
+++ b/packages/koa-performance/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.4.0] - 2021-03-19
+## [Unreleased]
 
 ### Added
 

--- a/packages/koa-performance/CHANGELOG.md
+++ b/packages/koa-performance/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2021-03-19
+
+### Added
+
+- Adds the ability to pass custom tags to additional navigation metrics [#1792](https://github.com/Shopify/quilt/pull/1792)
+
 ## [1.3.2] - 2021-03-03
 
 ### Fixed


### PR DESCRIPTION
## Description
This PR adds the ability to add custom tags to additional navigation metrics. We currently tag these metrics with the same navigation tags as the base navigation metrics (complete, usable). There are some cases where tags specific to the type of additional metric could be useful.

Here's an example. In Checkout One, we want to track that our GraphQL client is effectively hydrating. To do this, we want to add an additional `failed_hydration` metric. In order to know which query is failing, we will use a custom tag.

```ts
navigation.eventsByType(EventType.graphql).filter(({metadata}) =>
  serverSideQueries.includes(metadata.name),
).forEach(({metadata}) => {
  metrics.push({
    name: 'failed_hydration',
    value: 1,
    tags: {
      name: metadata.name
    }
  })
})
```

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
