### PR TITLE
Fix FormMapping for array of FieldDictionaries

### DIFF
--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -115,6 +115,6 @@ type FieldProp<T, K extends keyof Field<any>> = T extends Field<any>
 */
 export type FormMapping<Bag, FieldKey extends keyof Field<any>> = {
   [Key in keyof Bag]: Bag[Key] extends any[]
-    ? {[Index in keyof Bag[Key]]: FieldProp<Bag[Key][Index], FieldKey>}
+    ? FieldProp<Bag[Key][number], FieldKey>[]
     : FieldProp<Bag[Key], FieldKey>;
 };


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1794

See description in linked issue above.

The changed line is responsible for mapping a list of FieldDictionaries (e.g. `FieldDictionary<{body: string}>[]`) to a list of plain dictionary values (`{body: string}[]`). I think that the original type resulted in bugs because every key (including method names) was mapped over, resulting in incorrect argument types for Array methods such as `map`.

I've updated the type with explicit array syntax, and replaced `Index` with the more generic `number` type.

🎩 locally using `yalc` on my original branch in shopify/web showed no more TS errors, although I needed to add an explicit return type of `Promise<SubmitResult>` to the function declaration version.

## Type of change

- [X] react-form Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
