### PR TITLE
Fix bin file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tmp
 # Sewing-Kit builds and entrypoints
 .sewing-kit
 packages/*/build
+packages/*/bin
 packages/*/*.esnext
 packages/*/*.mjs
 packages/*/*.d.ts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
     "**/.git": true,
     "**/node_modules": true,
     "**/.DS_Store": true,
-    "packages/*/{.sewing-kit,build}": true,
+    "packages/*/{.sewing-kit,build,bin}": true,
     ".{dev,shadowenv.d,sewing-kit}": true
   },
   "files.insertFinalNewline": true,

--- a/packages/graphql-typescript-definitions/bin/graphql-typescript-definitions
+++ b/packages/graphql-typescript-definitions/bin/graphql-typescript-definitions
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../lib/cli');

--- a/packages/graphql-typescript-definitions/sewing-kit.config.ts
+++ b/packages/graphql-typescript-definitions/sewing-kit.config.ts
@@ -4,5 +4,6 @@ import {quiltPackage} from '../../config/sewing-kit';
 
 export default createPackage(pkg => {
   pkg.entry({root: './src/index'});
+  pkg.binary({name: 'graphql-typescript-definitions', root: './src/cli'});
   pkg.use(quiltPackage());
 });

--- a/packages/graphql-validate-fixtures/bin/graphql-validate-fixtures
+++ b/packages/graphql-validate-fixtures/bin/graphql-validate-fixtures
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../lib/cli');

--- a/packages/graphql-validate-fixtures/sewing-kit.config.ts
+++ b/packages/graphql-validate-fixtures/sewing-kit.config.ts
@@ -4,5 +4,6 @@ import {quiltPackage} from '../../config/sewing-kit';
 
 export default createPackage(pkg => {
   pkg.entry({root: './src/index'});
+  pkg.binary({name: 'graphql-validate-fixtures', root: './src/cli'});
   pkg.use(quiltPackage());
 });


### PR DESCRIPTION

## Description

graphql-typescript-definitions and graphql-validate-fixtures have
binarys. Instead of manually writing the bin file content, we can
get sewing-kit to generate these bin folders for us.

- Deletes packages/*/bin (only affects graphql-typescript-definitions
  and graphql-validate-fixtures
- Add packages/*/bin to gitignore as this folder will be generated by SK
- Add pkg.binary() definitions for packages that have binarys

## To test

- Run `yarn sewing-kit build --root packages/graphql-validate-fixtures && yarn sewing-kit build --root packages/graphql-typescript-definitions`
- `ls packages/*/bin/*` and note graphql-typescript-definitions and graphql-validate-fixtures both have generated bin files.
- Open those two files and see they both point to '../build/node/cli'


## Type of change

- [x] graphql-typescript-definitions Patch: Bug (non-breaking change which fixes an issue)
- [x] graphql-validate-fixtures Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
