### PR TITLE
Update minemagic to 0.3.6

### DIFF
--- a/gems/quilt_rails/Gemfile.lock
+++ b/gems/quilt_rails/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.1)


### PR DESCRIPTION
## Description
`minemagic` `0.3.5` was removed. This PR updates to `0.3.6`.

This only impacts the Ruby test fixture.