### PR TITLE
[koa-performance] Adds @babel/runtime as a dependency

### DIFF
--- a/packages/koa-performance/package.json
+++ b/packages/koa-performance/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/Shopify/quilt/blob/main/packages/koa-performance/README.md",
   "dependencies": {
+    "@babel/runtime": "^7.13.10",
     "@shopify/network": "^1.6.3",
     "@shopify/performance": "^1.3.3",
     "@shopify/statsd": "^2.1.3",


### PR DESCRIPTION
## Description
I'm using `@shopify/koa-performance` `1.4.0` on a project and am running in to this error:

```
Error: Cannot find module '@babel/runtime/regenerator'
Require stack:
- /Users/darrenhebner/src/github.com/Shopify/checkout-one-web-stats/node_modules/@shopify/koa-performance/build/cjs/middleware.js
- /Users/darrenhebner/src/github.com/Shopify/checkout-one-web-stats/node_modules/@shopify/koa-performance/build/cjs/index.js
- /Users/darrenhebner/src/github.com/Shopify/checkout-one-web-stats/node_modules/@shopify/koa-performance/index.js
- /Users/darrenhebner/src/github.com/Shopify/checkout-one-web-stats/build/app/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:957:15)
    at Function.Module._load (internal/modules/cjs/loader.js:840:27)
    at Module.require (internal/modules/cjs/loader.js:1019:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (/Users/darrenhebner/src/github.com/Shopify/checkout-one-web-stats/node_modules/@shopify/koa-performance/build/cjs/middleware.js:8:43)
    at Module._compile (internal/modules/cjs/loader.js:1133:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Module.require (internal/modules/cjs/loader.js:1019:19)
```

It looks like `@babel/runtime` is missing as a dependency on `koa-performance`.


## Type of change
- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
