### PR TITLE
[react-form] Adding requestAnimationFrame onBlur

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [0.12.1] - 2021-03-30
+
+### Fixed
+
+- Fixed blur event causing fields to lose focus [#1803](https://github.com/Shopify/quilt/pull/1803)
+
 ## [0.12.0] - 2021-03-16
 
 ### Added

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -129,11 +129,14 @@ export function useField<Value = string>(
 
       if (errors && errors.length > 0) {
         const [firstError] = errors;
-        dispatch(updateErrorAction(errors));
+        requestAnimationFrame(() => {
+          dispatch(updateErrorAction(errors));
+        });
         return firstError;
       }
-
-      dispatch(updateErrorAction(undefined));
+      requestAnimationFrame(() => {
+        dispatch(updateErrorAction(undefined));
+      });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [state.value, ...dependencies],

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -7,6 +7,18 @@ import {FieldState} from '../../../types';
 import {FieldAction, reduceField, makeFieldReducer} from '../reducer';
 
 describe('useField', () => {
+
+  let rafSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    rafSpy = jest.spyOn(window, 'requestAnimationFrame');
+    rafSpy.mockImplementation((callback) => callback());
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+  });
+
   function TestField({config}: {config: string | FieldConfig<string>}) {
     const field = useField(config);
     const text = 'Test field';

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -7,12 +7,11 @@ import {FieldState} from '../../../types';
 import {FieldAction, reduceField, makeFieldReducer} from '../reducer';
 
 describe('useField', () => {
-
   let rafSpy: jest.SpyInstance;
 
   beforeEach(() => {
     rafSpy = jest.spyOn(window, 'requestAnimationFrame');
-    rafSpy.mockImplementation((callback) => callback());
+    rafSpy.mockImplementation(callback => callback());
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Description

Currently, forms that use the Polaris modal are broken when tabbing. This was originally reported as a [Polaris issue](https://github.com/Shopify/polaris-react/issues/4086) but upon further investigation, it appears to be a react-form bug.

Trapfocus enables and disables itself based on whether the [`document.activeElement`](https://github.com/Shopify/polaris-react/commit/6ef4c7f6ed9e8b94a5835651764fe503f1cea802#diff-7d1dd444b8ebe0bb6fbd51ca04924e95da371f2418791524767bba41bd2e3157R28) is part of its children. When tabbing through a form, that makes use of `useField`, the dispatch event causes a rerender which has a side effect that makes the field lose focus and breaks tabbing. Looking at the [docs](https://reactjs.org/docs/hooks-reference.html#bailing-out-of-a-dispatch) I believe this is because `useReducer` does not a guarantee that a re-render won't occur when you don't mutate the state.

In order to fix this I added a `requestAnimationFrame` around the dispatch calls which ensure focus is not lost. 

Note: even though this issue exists today, the fix is required for webification.

| Before  | After |
| ------------- | ------------- |
| https://user-images.githubusercontent.com/1229901/113002181-88dbb780-913f-11eb-8734-9f9c9dafeba8.mov  | https://user-images.githubusercontent.com/1229901/113002194-8bd6a800-913f-11eb-8a7c-063e3a086f54.mov |








## Type of change

- [x] React-form Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
