### PR TITLE
[react-async] Add reloadOnError prop to createAsyncComponent

### DIFF
--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -101,7 +101,9 @@ export function createAsyncComponent<
     if (error) {
       if (reloadOnError) {
         load();
+        return null;
       }
+
       return renderError(error);
     }
 

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -24,6 +24,7 @@ interface Options<
   displayName?: string;
   renderLoading?(props: Props): ReactNode;
   renderError?(error: Error): ReactNode;
+  reloadOnError?: boolean;
 
   /**
    * Custom logic to use for the usePreload hook of the new, async
@@ -60,6 +61,7 @@ export function createAsyncComponent<
   displayName,
   renderLoading = noopRender,
   renderError = defaultRenderError,
+  reloadOnError,
   usePreload: useCustomPreload = noopUse,
   usePrefetch: useCustomPrefetch = noopUse,
   useKeepFresh: useCustomKeepFresh = noopUse,
@@ -97,6 +99,9 @@ export function createAsyncComponent<
     const {current: startedHydrated} = useRef(useHydrationManager().hydrated);
 
     if (error) {
+      if (reloadOnError) {
+        load();
+      }
       return renderError(error);
     }
 


### PR DESCRIPTION
## Description

Hoping this reduces the number of Chunk load errors we see https://github.com/Shopify/online-store-web/issues/9758


## Type of change

- [ ] `react-async` - Minor: add `reloadOnError` prop to `createAsyncComponent`

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
