### PR TITLE
undo request animation frame

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Undoing blur event change due to additional issues [#1809](https://github.com/Shopify/quilt/pull/1809)
+
 ## [0.12.4] - 2021-04-01
 
 ### Fixed

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -129,14 +129,11 @@ export function useField<Value = string>(
 
       if (errors && errors.length > 0) {
         const [firstError] = errors;
-        requestAnimationFrame(() => {
-          dispatch(updateErrorAction(errors));
-        });
+        dispatch(updateErrorAction(errors));
         return firstError;
       }
-      requestAnimationFrame(() => {
-        dispatch(updateErrorAction(undefined));
-      });
+
+      dispatch(updateErrorAction(undefined));
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [state.value, ...dependencies],

--- a/packages/react-form/src/hooks/field/test/field.test.tsx
+++ b/packages/react-form/src/hooks/field/test/field.test.tsx
@@ -7,17 +7,6 @@ import {FieldState} from '../../../types';
 import {FieldAction, reduceField, makeFieldReducer} from '../reducer';
 
 describe('useField', () => {
-  let rafSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    rafSpy = jest.spyOn(window, 'requestAnimationFrame');
-    rafSpy.mockImplementation(callback => callback());
-  });
-
-  afterEach(() => {
-    rafSpy.mockRestore();
-  });
-
   function TestField({config}: {config: string | FieldConfig<string>}) {
     const field = useField(config);
     const text = 'Test field';


### PR DESCRIPTION
## Description

This PR is to undo the requestAnimationframe that was added to onBlur.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
