### PR TITLE
Use @shopify/typescript-configs as a base

### DIFF
--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -1,33 +1,15 @@
 {
-  "compileOnSave": false,
+  "extends": "@shopify/typescript-configs/library.json",
   "compilerOptions": {
     "composite": true,
-    "declaration": true,
-    "declarationMap": true,
-    "pretty": true,
-    "moduleResolution": "node",
-    "target": "es5",
-    "downlevelIteration": true,
-    "esModuleInterop": true,
-    "jsx": "react",
-    "isolatedModules": true,
-    "strictNullChecks": true,
+    // Strict mode enables these strict* and noImplicit* options.
+    // Disable them temporarily while we fix up problematic behaviour from
+    // the time before we wanted strict mode
+    "strictBindCallApply": false,
+    "strictFunctionTypes": false,
+    "strictPropertyInitialization": false,
     "noImplicitAny": false,
-    "sourceMap": false,
-    "noEmitOnError": false,
-    "experimentalDecorators": true,
-    "noUnusedParameters": true,
-    "noUnusedLocals": true,
-    "importHelpers": true,
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "es2015",
-      "es2016",
-      "es2017",
-      "es2018",
-      "esnext.asynciterable"
-    ],
+    "noImplicitThis": false,
     "typeRoots": ["../../node_modules/@types"]
   }
 }

--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -2,9 +2,8 @@
   "extends": "@shopify/typescript-configs/library.json",
   "compilerOptions": {
     "composite": true,
-    // Strict mode enables these strict* and noImplicit* options.
-    // Disable them temporarily while we fix up problematic behaviour from
-    // the time before we wanted strict mode
+    "__TODOCOMMENT1": "Strict mode enables these strict* and noImplicit* options.",
+    "__TODOCOMMENT2": "Disable them temporarily while we fix up problematic behaviour from the time before we wanted strict mode",
     "strictBindCallApply": false,
     "strictFunctionTypes": false,
     "strictPropertyInitialization": false,

--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -2,8 +2,9 @@
   "extends": "@shopify/typescript-configs/library.json",
   "compilerOptions": {
     "composite": true,
-    "__TODOCOMMENT1": "Strict mode enables these strict* and noImplicit* options.",
-    "__TODOCOMMENT2": "Disable them temporarily while we fix up problematic behaviour from the time before we wanted strict mode",
+    // Strict mode enables these strict* and noImplicit* options.
+    // Disable them temporarily while we fix up problematic behaviour from
+    // the time before we wanted strict mode
     "strictBindCallApply": false,
     "strictFunctionTypes": false,
     "strictPropertyInitialization": false,

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@shopify/app-bridge": "^0.7.3",
     "@shopify/babel-preset": "^23.1.1",
     "@shopify/eslint-plugin": "^36.0.2",
+    "@shopify/typescript-configs": "^4.0.0",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/faker": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,6 +1821,11 @@
     pkg-dir "4.2.0"
     pluralize "^8.0.0"
 
+"@shopify/typescript-configs@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/typescript-configs/-/typescript-configs-4.0.0.tgz#56624b897014a49212924ba867c23d50093f3f4c"
+  integrity sha512-pHCdcOjKlHnuLC5xJtL83fWCknVZ/Im7lVBtBaAl1MRmtVpi5OpZL1FDEAWDFc0RGPpHBnurrxtbcusHUtrbVQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"


### PR DESCRIPTION
## Description

Simplify our to tsconfig.base.json by inheriting from the pan-org ts configs.

The pan org config enables strict mode but we're not compliant yet, so opt out of the currently problematic sub-checks for now. We can come back to enabling these items in follow up PRs
