### PR TITLE
[react-testing] improved performance by making descendants calculations lazy for element children

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Improved the performance of Root wrapper updates [#1812](https://github.com/Shopify/quilt/pull/1812)
+
 ## [2.2.2] - 2021-03-03
 
 ### Fixed

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -253,10 +253,12 @@ export class Root<Props> implements Node<Props> {
     if (this.wrapper == null) {
       this.root = null;
     } else {
-      const topElement = flatten(
-        ((this.wrapper as unknown) as ReactInstance)._reactInternalFiber,
+      const topElement = fiberToElement(
+        findCurrentFiberUsingSlowPath(
+          ((this.wrapper as unknown) as ReactInstance)._reactInternalFiber,
+        ),
         this,
-      )[0];
+      );
 
       this.root = this.resolveRoot(topElement as any) as any;
     }
@@ -284,52 +286,40 @@ function defaultRender(element: React.ReactElement<unknown>) {
   return element;
 }
 
-function flatten(
-  element: Fiber,
+function fiberToElement(
+  node: Fiber,
   root: Root<unknown>,
-): (Element<unknown> | string)[] {
-  const node: Fiber = findCurrentFiberUsingSlowPath(element);
-
+): Element<unknown> | string {
   if (node.tag === Tag.HostText) {
-    return [node.memoizedProps as string];
+    return node.memoizedProps as string;
   }
 
-  const props = {...((node.memoizedProps as any) || {})};
-  const {children, descendants} = childrenToTree(node.child, root);
+  const props = node.memoizedProps as any;
+  const children = childrenToTree(node.child, root);
 
-  return [
-    new Element(
-      {
-        tag: node.tag,
-        type: node.type,
-        props,
-        instance: node.stateNode,
-      },
-      children,
-      descendants,
-      root,
-    ),
-    ...descendants,
-  ];
+  return new Element(
+    {
+      tag: node.tag,
+      type: node.type,
+      props,
+      instance: node.stateNode,
+    },
+    children,
+    root,
+  );
 }
 
 function childrenToTree(fiber: Fiber | null, root: Root<unknown>) {
   let currentFiber = fiber;
   const children: (string | Element<unknown>)[] = [];
-  const descendants: (string | Element<unknown>)[] = [];
 
   while (currentFiber != null) {
-    const result = flatten(currentFiber, root);
-
-    if (result.length > 0) {
-      children.push(result[0]);
-      descendants.push(...result);
-    }
-
+    const result = fiberToElement(currentFiber, root);
+    children.push(result);
     currentFiber = currentFiber.sibling;
   }
 
-  return {children, descendants};
+  return children;
 }
 
 function isPromise<T>(promise: T | Promise<T>): promise is Promise<T> {

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -15,19 +15,6 @@ const defaultTree = {
 };
 
 const defaultRoot = new Root(<DummyComponent />);
-
-const divOne = new Element(
-  {
-    ...defaultTree,
-    type: 'div',
-    tag: Tag.HostComponent,
-    instance: document.createElement('div'),
-  },
-  [],
-  [],
-  defaultRoot,
-);
-
 const divTwo = new Element(
   {
     ...defaultTree,
@@ -36,21 +23,29 @@ const divTwo = new Element(
     instance: document.createElement('div'),
   },
   [],
-  [],
   defaultRoot,
 );
 
-const componentOne = new Element(
-  {...defaultTree, type: DummyComponent},
-  [],
-  [],
+const divOne = new Element(
+  {
+    ...defaultTree,
+    type: 'div',
+    tag: Tag.HostComponent,
+    instance: document.createElement('div'),
+  },
+  [divTwo],
   defaultRoot,
 );
 
 const componentTwo = new Element(
   {...defaultTree, type: DummyComponent},
   [],
-  [],
+  defaultRoot,
+);
+
+const componentOne = new Element(
+  {...defaultTree, type: DummyComponent},
+  [divOne, componentTwo],
   defaultRoot,
 );
 
@@ -58,7 +53,7 @@ describe('Element', () => {
   describe('#props', () => {
     it('returns the props from the tree', () => {
       const props = {foo: 'bar'};
-      const element = new Element({...defaultTree, props}, [], [], defaultRoot);
+      const element = new Element({...defaultTree, props}, [], defaultRoot);
       expect(element).toHaveProperty('props', props);
     });
   });
@@ -66,7 +61,7 @@ describe('Element', () => {
   describe('#type', () => {
     it('returns the type from the tree', () => {
       const type = DummyComponent;
-      const element = new Element({...defaultTree, type}, [], [], defaultRoot);
+      const element = new Element({...defaultTree, type}, [], defaultRoot);
       expect(element).toHaveProperty('type', type);
     });
   });
@@ -74,12 +69,7 @@ describe('Element', () => {
   describe('#instance', () => {
     it('returns the type from the tree', () => {
       const instance = {};
-      const element = new Element(
-        {...defaultTree, instance},
-        [],
-        [],
-        defaultRoot,
-      );
+      const element = new Element({...defaultTree, instance}, [], defaultRoot);
       expect(element).toHaveProperty('instance', instance);
     });
   });
@@ -88,7 +78,6 @@ describe('Element', () => {
     it('is false for non-host components', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.MemoComponent},
-        [],
         [],
         defaultRoot,
       );
@@ -99,7 +88,6 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent},
         [],
-        [],
         defaultRoot,
       );
       expect(element).toHaveProperty('isDOM', true);
@@ -108,12 +96,7 @@ describe('Element', () => {
 
   describe('#children', () => {
     it('returns element children', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne, divTwo],
-        [divOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne, divTwo], defaultRoot);
 
       expect(element).toHaveProperty('children', [divOne, divTwo]);
     });
@@ -121,7 +104,6 @@ describe('Element', () => {
     it('does not return string children', () => {
       const element = new Element(
         defaultTree,
-        [divOne, 'Some text', divTwo],
         [divOne, 'Some text', divTwo],
         defaultRoot,
       );
@@ -132,23 +114,7 @@ describe('Element', () => {
 
   describe('#descendants', () => {
     it('returns element descendants', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne],
-        [divOne, divTwo],
-        defaultRoot,
-      );
-
-      expect(element).toHaveProperty('descendants', [divOne, divTwo]);
-    });
-
-    it('does not return string descendants', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne],
-        [divOne, 'Some text', divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne], defaultRoot);
 
       expect(element).toHaveProperty('descendants', [divOne, divTwo]);
     });
@@ -160,12 +126,7 @@ describe('Element', () => {
     });
 
     it('returns the instances associated with each child DOM element', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne, divTwo],
-        [divOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne, divTwo], defaultRoot);
 
       expect(element.domNodes).toStrictEqual([
         divOne.instance,
@@ -174,23 +135,13 @@ describe('Element', () => {
     });
 
     it('does not return descendant DOM nodes', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne],
-        [divOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne], defaultRoot);
 
       expect(element.domNodes).not.toContain(divTwo.instance);
     });
 
     it('does not return instances for non-DOM nodes', () => {
-      const element = new Element(
-        defaultTree,
-        [componentOne],
-        [componentOne],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [componentOne], defaultRoot);
 
       expect(element.domNodes).not.toContain(componentOne.instance);
     });
@@ -202,34 +153,19 @@ describe('Element', () => {
     });
 
     it('returns null if there is no direct child DOM node', () => {
-      const element = new Element(
-        defaultTree,
-        [componentOne],
-        [componentOne],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [componentOne], defaultRoot);
 
       expect(element.domNode).toBeNull();
     });
 
     it('returns the DOM node if there is a single DOM child', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne],
-        [divOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne], defaultRoot);
 
       expect(element.domNode).toBe(divOne.instance);
     });
 
     it('throws an error if there are multiple top-level DOM nodes', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne, divTwo],
-        [divOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne, divTwo], defaultRoot);
 
       expect(() => element.domNode).toThrow(/multiple HTML elements/);
     });
@@ -238,7 +174,7 @@ describe('Element', () => {
   describe('#prop()', () => {
     it('returns the prop value for the specified key', () => {
       const props = {foo: 'bar'};
-      const element = new Element({...defaultTree, props}, [], [], defaultRoot);
+      const element = new Element({...defaultTree, props}, [], defaultRoot);
       expect(element.prop('foo')).toBe(props.foo);
     });
   });
@@ -253,7 +189,6 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent, type: 'div', instance: div},
         [],
-        [],
         defaultRoot,
       );
 
@@ -265,13 +200,12 @@ describe('Element', () => {
       const childTextTwo = 'bar';
       const descendantText = ' baz?';
 
-      const elementChild = new Element(defaultTree, [], [], defaultRoot);
+      const elementChild = new Element(defaultTree, [], defaultRoot);
       jest.spyOn(elementChild, 'text').mockImplementation(() => childTextOne);
 
       const element = new Element(
         {...defaultTree, tag: Tag.FunctionComponent, type: DummyComponent},
         [elementChild, childTextTwo],
-        [elementChild, childTextTwo, descendantText],
         defaultRoot,
       );
 
@@ -281,7 +215,6 @@ describe('Element', () => {
     it('returns an empty string for portals', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostPortal, type: DummyComponent},
-        ['Hello world'],
         ['Hello world'],
         defaultRoot,
       );
@@ -300,7 +233,6 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent, type: 'div', instance: div},
         [],
-        [],
         defaultRoot,
       );
 
@@ -310,15 +242,13 @@ describe('Element', () => {
     it('concatenates the HTML contents of all child elements and child text', () => {
       const childHtml = 'foo ';
       const childText = 'bar';
-      const descendantText = ' baz?';
 
-      const elementChild = new Element(defaultTree, [], [], defaultRoot);
+      const elementChild = new Element(defaultTree, [], defaultRoot);
       jest.spyOn(elementChild, 'text').mockImplementation(() => childHtml);
 
       const element = new Element(
         {...defaultTree, tag: Tag.FunctionComponent, type: DummyComponent},
         [elementChild, childText],
-        [elementChild, childText, descendantText],
         defaultRoot,
       );
 
@@ -328,7 +258,6 @@ describe('Element', () => {
     it('returns an empty string for portals', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostPortal, type: DummyComponent},
-        ['Hello world'],
         ['Hello world'],
         defaultRoot,
       );
@@ -342,7 +271,6 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent, type: 'div'},
         [],
-        [],
         defaultRoot,
       );
 
@@ -353,7 +281,6 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.FunctionComponent, type: DummyComponent},
         [],
-        [],
         defaultRoot,
       );
 
@@ -363,12 +290,7 @@ describe('Element', () => {
 
   describe('#find()', () => {
     it('finds the first matching DOM node', () => {
-      const element = new Element(
-        defaultTree,
-        [componentOne],
-        [componentOne, divOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [componentOne], defaultRoot);
 
       expect(element.find('div')).toBe(divOne);
     });
@@ -376,8 +298,7 @@ describe('Element', () => {
     it('finds the first matching component', () => {
       const element = new Element(
         defaultTree,
-        [divOne],
-        [divOne, componentOne, componentTwo],
+        [divOne, componentOne],
         defaultRoot,
       );
 
@@ -394,7 +315,6 @@ describe('Element', () => {
           instance: document.createElement('div'),
         },
         [],
-        [],
         defaultRoot,
       );
 
@@ -406,7 +326,6 @@ describe('Element', () => {
           tag: Tag.HostComponent,
           instance: document.createElement('div'),
         },
-        [],
         [],
         defaultRoot,
       );
@@ -420,13 +339,11 @@ describe('Element', () => {
           instance: document.createElement('span'),
         },
         [],
-        [],
         defaultRoot,
       );
 
       const element = new Element(
         defaultTree,
-        [divOne, divTwo, span],
         [divOne, divTwo, span],
         defaultRoot,
       );
@@ -439,30 +356,20 @@ describe('Element', () => {
     });
 
     it('returns null when no match is found', () => {
-      const element = new Element(defaultTree, [], [], defaultRoot);
+      const element = new Element(defaultTree, [], defaultRoot);
       expect(element.find(DummyComponent)).toBeNull();
     });
   });
 
   describe('#findAll()', () => {
     it('finds all matching DOM nodes', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne],
-        [divOne, componentOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne], defaultRoot);
 
       expect(element.findAll('div')).toStrictEqual([divOne, divTwo]);
     });
 
     it('finds all matching components', () => {
-      const element = new Element(
-        defaultTree,
-        [componentOne],
-        [componentOne, divOne, componentTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [componentOne], defaultRoot);
 
       expect(element.findAll(DummyComponent)).toStrictEqual([
         componentOne,
@@ -480,7 +387,6 @@ describe('Element', () => {
           instance: document.createElement('div'),
         },
         [],
-        [],
         defaultRoot,
       );
 
@@ -492,7 +398,6 @@ describe('Element', () => {
           tag: Tag.HostComponent,
           instance: document.createElement('div'),
         },
-        [],
         [],
         defaultRoot,
       );
@@ -506,13 +411,11 @@ describe('Element', () => {
           instance: document.createElement('span'),
         },
         [],
-        [],
         defaultRoot,
       );
 
       const element = new Element(
         defaultTree,
-        [divOne, divTwo, span],
         [divOne, divTwo, span],
         defaultRoot,
       );
@@ -527,7 +430,7 @@ describe('Element', () => {
     });
 
     it('returns an empty array when no matches are found', () => {
-      const element = new Element(defaultTree, [], [], defaultRoot);
+      const element = new Element(defaultTree, [], defaultRoot);
       expect(element.findAll(DummyComponent)).toHaveLength(0);
     });
   });
@@ -538,12 +441,7 @@ describe('Element', () => {
         (element: Element<unknown>) => element === divTwo,
       );
 
-      const element = new Element(
-        defaultTree,
-        [componentOne],
-        [componentOne, divOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [componentOne], defaultRoot);
 
       expect(element.findWhere(matches)).toBe(divTwo);
       expect(matches).toHaveBeenCalledWith(componentOne);
@@ -552,24 +450,14 @@ describe('Element', () => {
     });
 
     it('returns null when no match is found', () => {
-      const element = new Element(
-        defaultTree,
-        [componentOne],
-        [componentOne],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [componentOne], defaultRoot);
       expect(element.findWhere(() => false)).toBeNull();
     });
   });
 
   describe('#findAllWhere()', () => {
     it('finds all matching nodes', () => {
-      const element = new Element(
-        defaultTree,
-        [divOne],
-        [divOne, componentOne, divTwo],
-        defaultRoot,
-      );
+      const element = new Element(defaultTree, [divOne], defaultRoot);
 
       expect(
         element.findAllWhere(element => element === componentTwo),
@@ -594,7 +482,6 @@ describe('Element', () => {
       const element = new Element<Props>(
         {...defaultTree, type: TriggerableComponent, props: {}},
         [],
-        [],
         defaultRoot,
       );
 
@@ -607,7 +494,6 @@ describe('Element', () => {
       const onClick = jest.fn(() => '');
       const element = new Element<Props>(
         {...defaultTree, type: TriggerableComponent, props: {onClick}},
-        [],
         [],
         defaultRoot,
       );
@@ -626,7 +512,6 @@ describe('Element', () => {
           props: {onClick: () => ''},
         },
         [],
-        [],
         defaultRoot,
       );
 
@@ -643,7 +528,6 @@ describe('Element', () => {
           props: {onClick: () => returnValue},
         },
         [],
-        [],
         defaultRoot,
       );
 
@@ -658,7 +542,6 @@ describe('Element', () => {
           type: TriggerableComponent,
           props: {onClick: jest.fn()},
         },
-        [],
         [],
         defaultRoot,
       );
@@ -688,7 +571,6 @@ describe('Element', () => {
           props: {actions: []},
         },
         [],
-        [],
         defaultRoot,
       );
 
@@ -704,7 +586,6 @@ describe('Element', () => {
           type: TriggerableComponent,
           props: {actions: []},
         },
-        [],
         [],
         defaultRoot,
       );
@@ -725,7 +606,6 @@ describe('Element', () => {
           props: {actions: [{onAction}]},
         },
         [],
-        [],
         defaultRoot,
       );
 
@@ -742,7 +622,6 @@ describe('Element', () => {
           type: TriggerableComponent,
           props: {actions: [{onAction: () => returnValue}]},
         },
-        [],
         [],
         defaultRoot,
       );

--- a/packages/react-testing/src/tests/root.test.tsx
+++ b/packages/react-testing/src/tests/root.test.tsx
@@ -23,7 +23,6 @@ describe('Root', () => {
         instance: childInstance,
       },
       [],
-      [],
       root,
     );
 
@@ -39,7 +38,6 @@ describe('Root', () => {
         },
         instance,
       },
-      [childElement],
       [childElement],
       root,
     );


### PR DESCRIPTION
## Description

Fixes (issue #)

N/A

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

I've been looking into a flaky slow test and doing some profiling and noticed that one of the significant bottlenecks is found in `react-testing` specifically when  attempting to flatten a react fiber linked list into an array of elements. It seems like determining the descendants of each child is an exponential time algorithm. This has a pretty big impact on tests with big fiber trees. I've changed the descendants to be lazily evaluated and derived from the children though grabbing the root descendants still goes through the entire tree which is slow. Additionally I hand optimized some code, for example the spread operator when compiled with typescript to es5 into a `spread` call seems to be a rather big culprit of performance issues in this computational heavy process.  

Performing the above optimization made a significant improvement to the test in question (which had a really big fiber tree ~80 in depth) :

Before:
<img width="895" alt="Screen Shot 2021-04-01 at 9 18 39 AM" src="https://user-images.githubusercontent.com/3513040/113317970-f6254f00-92dd-11eb-8a7f-e074d9a2cbc2.png">

After:

<img width="895" alt="Screen Shot 2021-04-01 at 9 19 47 AM" src="https://user-images.githubusercontent.com/3513040/113318007-fe7d8a00-92dd-11eb-9a93-1abb43b17dd6.png">

For other tests with smaller fiber trees the improvement is a more modest 10-20%.

Before:
<img width="895" alt="Screen Shot 2021-04-01 at 9 35 06 AM" src="https://user-images.githubusercontent.com/3513040/113318272-4c928d80-92de-11eb-84b0-71aaa78efe96.png">

After:
<img width="895" alt="Screen Shot 2021-04-01 at 9 36 02 AM" src="https://user-images.githubusercontent.com/3513040/113318344-6207b780-92de-11eb-8c85-0765a9a1901e.png">

This should improve unit tests times across the board.

Note: A change in descendants order is a breaking one. I sketched out the order in this PR and it seems to be the same as before, but something worth verifying for the reviewers.

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
