### PR TITLE
[react-hooks] Fix mutating refs during render phase or asynchronously

### DIFF
--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Added `useIsomorphicLayoutEffect` hook [#1813](https://github.com/Shopify/quilt/pull/1813).
+- Updated `useLazyRef` hook implementation to avoid mutating refs directly during the render phase, which is unsafe [#1813](https://github.com/Shopify/quilt/pull/1813).
+- Updated `useTimeout` and `useInterval` hooks. Both of these hooks use mutable ref to hold on to the latest callback function. Now updating this ref synchronously to avoid stale callbacks being invoked [#1813](https://github.com/Shopify/quilt/pull/1813).
+
 ## [1.12.2] - 2021-03-03
 
 ### Fixed

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -18,6 +18,7 @@ $ yarn add @shopify/react-hooks
 - [useDelayedCallback()](#usedelayedcallback)
 - [useForceUpdate()](#useforceupdate)
 - [useInterval()](#useinterval)
+- [useIsomorphicLayoutEffect()](#useisomorphiclayouteffect)
 - [useLazyRef()](#uselazyref)
 - [useMedia() & useMediaLayout()](#usemedia--usemedialayout)
 - [useMountedRef()](#usemountedref)
@@ -153,6 +154,12 @@ function MyComponent() {
 ```
 
 This is a TypeScript implementation of @gaeron's `useInterval` hook from the [Overreacted blog post](https://overreacted.io/making-setinterval-declarative-with-react-hooks/#just-show-me-the-code).
+
+### `useIsomorphicLayoutEffect()`
+
+This hook is a drop-in replacement for `useLayoutEffect` that can be used safely in a server-side rendered app. It resolves to `useEffect` on the server and `useLayoutEffect` on the client (since `useLayoutEffect` cannot be used in a server-side environment).
+
+Refer to the [`useLayoutEffect` documentation to learn more](https://reactjs.org/docs/hooks-reference.html#uselayouteffect).
 
 ### `useLazyRef()`
 

--- a/packages/react-hooks/src/hooks/index.ts
+++ b/packages/react-hooks/src/hooks/index.ts
@@ -9,3 +9,4 @@ export {useTimeout} from './timeout';
 export {useToggle} from './toggle';
 export {useForceUpdate} from './force-update';
 export {useDelayedCallback} from './delayed-callback';
+export {useIsomorphicLayoutEffect} from './isomorphic-layout-effect';

--- a/packages/react-hooks/src/hooks/interval.ts
+++ b/packages/react-hooks/src/hooks/interval.ts
@@ -1,5 +1,7 @@
 import {useEffect, useRef} from 'react';
 
+import {useIsomorphicLayoutEffect} from './isomorphic-layout-effect';
+
 type IntervalCallback = () => void;
 type IntervalDelay = number | null;
 
@@ -11,7 +13,8 @@ type IntervalDelay = number | null;
 export function useInterval(callback: IntervalCallback, delay: IntervalDelay) {
   const savedCallback = useRef(callback);
 
-  useEffect(() => {
+  // Need to use a layout effect to force the saved callback to be synchronously updated during a commit
+  useIsomorphicLayoutEffect(() => {
     savedCallback.current = callback;
   }, [callback]);
 

--- a/packages/react-hooks/src/hooks/isomorphic-layout-effect.ts
+++ b/packages/react-hooks/src/hooks/isomorphic-layout-effect.ts
@@ -1,0 +1,14 @@
+import {useEffect, useLayoutEffect} from 'react';
+
+// https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js
+const canUseDOM =
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined';
+
+/**
+ * A hook that resolves to useEffect on the server and useLayoutEffect on the client
+ */
+export const useIsomorphicLayoutEffect = canUseDOM
+  ? useLayoutEffect
+  : useEffect;

--- a/packages/react-hooks/src/hooks/lazy-ref.ts
+++ b/packages/react-hooks/src/hooks/lazy-ref.ts
@@ -1,13 +1,8 @@
-import {useRef, MutableRefObject} from 'react';
-
-const UNSET = Symbol('unset');
+import {useRef, useState, MutableRefObject} from 'react';
 
 export function useLazyRef<T>(getValue: () => T): MutableRefObject<T> {
-  const ref = useRef<T | typeof UNSET>(UNSET);
-
-  if (ref.current === UNSET) {
-    ref.current = getValue();
-  }
+  const [value] = useState<T>(getValue);
+  const ref = useRef<T>(value);
 
   return ref as MutableRefObject<T>;
 }

--- a/packages/react-hooks/src/hooks/timeout.ts
+++ b/packages/react-hooks/src/hooks/timeout.ts
@@ -1,12 +1,15 @@
 import {useEffect, useRef} from 'react';
 
+import {useIsomorphicLayoutEffect} from './isomorphic-layout-effect';
+
 type IntervalCallback = () => void;
 type IntervalDelay = number | null;
 
 export function useTimeout(callback: IntervalCallback, delay: IntervalDelay) {
   const savedCallback = useRef(callback);
 
-  useEffect(() => {
+  // Need to use a layout effect to force the saved callback to be synchronously updated during a commit
+  useIsomorphicLayoutEffect(() => {
     savedCallback.current = callback;
   }, [callback]);
 


### PR DESCRIPTION
## Description

### Updating mutable references to callbacks

The `useEffect` hook runs asynchronously, after the rendering phase of a component is complete. When storing values in a mutable ref that should point to the latest argument passed to a component or hook, there can be a window of time between when the commit phase is kicked off and when the async `useEffect` function is called where it points to a stale callback.

To avoid this, we need to use `useLayoutEffect` to make sure to synchronously update the ref to the latest value during the commit phase.

`useLayoutEffect` cannot be used in a server-side environment, so we need to also introduce the `useIsomorphicLayoutEffect` hook to safely be able to use this strategy in a server-side rendered application.

We need to do this inside `useLayoutEffect` rather than directly in the body of the component for reasons described below.

### Mutating refs in the render phase

Refs should never be mutated while rendering. The `useLazyRef` component has been updated to a different strategy that does not involve mutating refs during the render phase of a component.

This is currently more of a technicality, as with current versions of React it is technically safe to do this, but this will no longer be safe with some of the upcoming changes that are coming to React.

As a rule of thumb, React components should be pure. They should only calculate the output of the next render or invoke hooks. Updating a ref (as well as updating state) shouldn’t be performed inside the immediate scope of a component’s render cycle for that reason.

In the future, React could decide to pause rendering a component, and potentially abort completely and re-start from scratch. Other examples include the `useTransition` hook of the Suspense API and future work around built-in animations.

Rendering should be treated as something that needs to be sandboxed and have no side-effects. You don't want the fact that React tried rendering something to leak out and have side-effects on mutable refs, for the same reason why you don't want to write to mutable state in a multithreaded environment. Exactly because it's hard to think about what can go wrong.

## Next steps

We should create a linting rule against mutating refs in the body of functional components.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `@shopify/react-hooks` Patch: Bug (non-breaking change which fixes an issue)
- [x]  `@shopify/react-hooks` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
