### PR TITLE
export ErrorContent type from react-form

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Exporting type ErrorContent [#1818](https://github.com/Shopify/quilt/pull/1818)
 
 ## [0.12.5] - 2021-04-05
 

--- a/packages/react-form/src/validation/index.ts
+++ b/packages/react-form/src/validation/index.ts
@@ -1,2 +1,3 @@
+export type {ErrorContent} from './validator';
 export {validator} from './validator';
 export * from './validators';


### PR DESCRIPTION
## Description

Makes `ErrorContent` available for import directly from `@shopify/react-form`.

It's a useful type to have when building custom validators. In one case in web, it is already being imported by [reaching into dist](https://github.com/Shopify/web/blob/cf34d0b/app/sections/Payments/PaymentsSettings/ShopifyPaymentsDetails/formValidators.ts#L8)

## Type of change

- [X] react-form Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
