### PR TITLE
Disable flaky test that takes a long time to run/fail

### DIFF
--- a/packages/web-worker/src/test/e2e.test.ts
+++ b/packages/web-worker/src/test/e2e.test.ts
@@ -954,6 +954,7 @@ describe('web-worker', () => {
     );
   });
 
+  // Disabled because it's flaky and takes about a minute to run
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('allows for multiple workers to be created without naming collisions', async () => {
     const workerOneMessage = 'Hello';

--- a/packages/web-worker/src/test/e2e.test.ts
+++ b/packages/web-worker/src/test/e2e.test.ts
@@ -954,7 +954,8 @@ describe('web-worker', () => {
     );
   });
 
-  it('allows for multiple workers to be created without naming collisions', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('allows for multiple workers to be created without naming collisions', async () => {
     const workerOneMessage = 'Hello';
     const workerTwoMessage = 'world';
     const testId = 'WorkerResult';


### PR DESCRIPTION
## Description

Skip a flaky e2e test that takes a long time to run & fail.

## Type of change

Skipping a test

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] ~~I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)~~
