### PR TITLE
Disable the entire e2e worker test suite

### DIFF
--- a/packages/web-worker/src/test/e2e.test.ts
+++ b/packages/web-worker/src/test/e2e.test.ts
@@ -18,7 +18,9 @@ const secondWorkerFile = 'src/worker2.js';
 
 jest.setTimeout(30_000);
 
-describe('web-worker', () => {
+// @TODO: Disabled for now because these tests are flaky and take a long time to run
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('web-worker', () => {
   it('creates a worker factory that can produce workers that act like the original module', async () => {
     const greetingPrefix = 'Hello ';
     const greetingTarget = 'world';
@@ -954,9 +956,7 @@ describe('web-worker', () => {
     );
   });
 
-  // Disabled because it's flaky and takes about a minute to run
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('allows for multiple workers to be created without naming collisions', async () => {
+  it('allows for multiple workers to be created without naming collisions', async () => {
     const workerOneMessage = 'Hello';
     const workerTwoMessage = 'world';
     const testId = 'WorkerResult';


### PR DESCRIPTION
## Description

The e2e worker tests are flaky and take a long time to run. They've turned into a huge productivity killer.

Disabling the entire suite for now.

We should either:
a. Revise these tests
b. Move them to a different CI pipeline to unblock the regular unit test pipeline

## Type of change

Skipping tests

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] ~~I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)~~
