### PR TITLE
✨ custom watch/glob behaviour for graphql-typescript-definitions

### DIFF
--- a/packages/graphql-typescript-definitions/CHANGELOG.md
+++ b/packages/graphql-typescript-definitions/CHANGELOG.md
@@ -11,6 +11,11 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Removed dependency on tslib, as we no-longer compile with `tsc`. [#1829](https://github.com/Shopify/quilt/pull/1829)
 
+### Added
+
+- Minor: `Builder.run` now accepts an optional `graphQLFilesystem` property. Custom filesystems _must_ provide watch/glob functionality mandated by [`GraphQLFileSystem`](./src/filesystem/graphql-filesystem.ts) [[#1824](https://github.com/Shopify/quilt/pull/1824)]
+- Minor: `AbstractGraphQLFileSystem` provides emitter boilerplate for `GraphQLFileSystem`'s `change:schema` / `change:document` / `delete:document` events [[#1824](https://github.com/Shopify/quilt/pull/1824)]
+
 ## 0.23.2 - 2021-03-23
 
 ### Fixed

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -288,3 +288,34 @@ As with the CLI, you can pass options to customize the build and behavior:
 - `schemaTypesPath`
 - `customScalars`
 - `config` (custom `GraphQLConfig` instance)
+
+#### Customizing filesystem interactions
+
+In projects with thousands of GraphQL documents, `Builder` may take a few seconds to reach its ready state. Additionally, very large projects with deep file trees may exceed Node's default memory limits (especially in non-MacOS environments). To allow project/environment-specific customization, builders accept a [`GraphQLFilesystem`](./src/filesystem/graphql-filesystem.ts) object.
+
+```js
+const {
+  AbstractGraphQLFilesystem,
+  Builder,
+} = require('graphql-typescript-definitions');
+
+class CustomFilesystem extends AbstractGraphQLFilesystem {
+  watch(config) {
+    // Set up filesystem watchers, and emit change:schema / change:document / delete:document events.
+  }
+
+  getGraphQLProjectIncludedFilePaths(projectConfig) {
+    // Find all .graphql documents for the given project.
+  }
+
+  dispose() {
+    // Release any resources held by watchers.
+  }
+}
+
+const builder = new Builder({
+  graphQLFilesystem: new CustomFilesystem(),
+});
+
+builder.run({watch: true});
+```

--- a/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
@@ -1,0 +1,74 @@
+import {FSWatcher, watch} from 'chokidar';
+import {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
+import {
+  getGraphQLProjectIncludedFilePaths,
+  getGraphQLProjects,
+  getGraphQLSchemaPaths,
+  resolvePathRelativeToConfig,
+} from 'graphql-config-utilities';
+
+import {AbstractGraphQLFilesystem} from './graphql-filesystem';
+
+export class DefaultGraphQLFilesystem extends AbstractGraphQLFilesystem {
+  private readonly watchers: FSWatcher[] = [];
+
+  async watch(config: GraphQLConfig) {
+    this.watchers.push(
+      ...this.setupDocumentWatchers(config).concat(
+        this.setupSchemaWatcher(config),
+      ),
+    );
+
+    await Promise.all(
+      this.watchers.map(
+        watcher =>
+          new Promise<void>(resolve => watcher.on('ready', () => resolve())),
+      ),
+    );
+  }
+
+  dispose() {
+    this.watchers.forEach(watcher => {
+      watcher.close();
+    });
+
+    this.watchers.length = 0;
+  }
+
+  getGraphQLProjectIncludedFilePaths(projectConfig: GraphQLProjectConfig) {
+    return getGraphQLProjectIncludedFilePaths(projectConfig);
+  }
+
+  private setupDocumentWatchers(config: GraphQLConfig) {
+    return getGraphQLProjects(config)
+      .filter(({includes}) => includes.length > 0)
+      .map(projectConfig => {
+        return watch(
+          projectConfig.includes.map(include =>
+            resolvePathRelativeToConfig(projectConfig, include),
+          ),
+          {
+            ignored: projectConfig.excludes.map(exclude =>
+              resolvePathRelativeToConfig(projectConfig, exclude),
+            ),
+            ignoreInitial: true,
+          },
+        )
+          .on('add', (filePath: string) =>
+            this.emit('change:document', filePath, projectConfig),
+          )
+          .on('change', (filePath: string) =>
+            this.emit('change:document', filePath, projectConfig),
+          )
+          .on('unlink', (filePath: string) =>
+            this.emit('delete:document', filePath, projectConfig),
+          );
+      });
+  }
+
+  private setupSchemaWatcher(config: GraphQLConfig) {
+    return watch(getGraphQLSchemaPaths(config), {
+      ignoreInitial: true,
+    }).on('change', schemaPath => this.emit('change:schema', schemaPath));
+  }
+}

--- a/packages/graphql-typescript-definitions/src/filesystem/graphql-filesystem.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/graphql-filesystem.ts
@@ -1,0 +1,69 @@
+import {EventEmitter} from 'events';
+
+import {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
+
+export interface GraphQLFilesystem {
+  watch(config: GraphQLConfig): Promise<void>;
+  dispose(): void;
+
+  getGraphQLProjectIncludedFilePaths(
+    projectConfig: GraphQLProjectConfig,
+  ): Promise<string[]>;
+
+  once(event: 'error', handler: (error: Error) => void): this;
+  once(event: 'change:schema', handler: (path: string) => void): this;
+  once(
+    event: 'change:document' | 'delete:document',
+    handler: (path: string, project: GraphQLProjectConfig) => void,
+  ): this;
+
+  on(event: 'error', handler: (error: Error) => void): this;
+  on(event: 'change:schema', handler: (path: string) => void): this;
+  on(
+    event: 'change:document' | 'delete:document',
+    handler: (path: string, project: GraphQLProjectConfig) => void,
+  ): this;
+}
+
+export abstract class AbstractGraphQLFilesystem extends EventEmitter {
+  abstract watch(config: GraphQLConfig): Promise<void>;
+  abstract dispose(): void;
+
+  abstract getGraphQLProjectIncludedFilePaths(
+    projectConfig: GraphQLProjectConfig,
+  ): Promise<string[]>;
+
+  once(event: 'error', handler: (error: Error) => void): this;
+  once(event: 'change:schema', handler: (path: string) => void): this;
+  once(
+    event: 'change:document' | 'delete:document',
+    handler: (path: string, project: GraphQLProjectConfig) => void,
+  ): this;
+
+  once(event: string, handler: (...args: any[]) => void): this {
+    return super.once(event, handler);
+  }
+
+  on(event: 'error', handler: (error: Error) => void): this;
+  on(event: 'change:schema', handler: (path: string) => void): this;
+  on(
+    event: 'change:document' | 'delete:document',
+    handler: (path: string, project: GraphQLProjectConfig) => void,
+  ): this;
+
+  on(event: string, handler: (...args: any[]) => void): this {
+    return super.on(event, handler);
+  }
+
+  emit(event: 'error', error: Error): boolean;
+  emit(
+    event: 'change:document' | 'delete:document',
+    path: string,
+    config: GraphQLProjectConfig,
+  ): boolean;
+
+  emit(event: 'change:schema', path: string): boolean;
+  emit(event: string, ...args: any[]): boolean {
+    return super.emit(event, ...args);
+  }
+}

--- a/packages/graphql-typescript-definitions/src/filesystem/index.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/index.ts
@@ -1,0 +1,2 @@
+export type {GraphQLFilesystem} from './graphql-filesystem';
+export {AbstractGraphQLFilesystem} from './graphql-filesystem';


### PR DESCRIPTION
## Description
In Spin environments, graphql-typescript-definitions's chokidar / glob setup causes out of memory errors, and is extremely slow even when it does succeed. Bumping memory limits is off the table for me, so I'm experimenting with other tools. This PR gets the package into a state where I can switch out tools without forking quilt packages (currently looking into watchman and vscode's filesystem).

### Did you figure out why these changes are even necessary?
I believe the slowness / memory pressure isn't happening in local development because ([per chokidar's docs](https://github.com/paulmillr/chokidar#how)):

> On MacOS, chokidar by default uses a native extension exposing the Darwin FSEvents API. This provides very efficient recursive watching... [o]n most other platforms... chokidar will initiate watchers recursively for everything within scope of the paths that have been specified, so be judicious about not wasting system resources by watching much more than needed.

Native FS support aside, we can't assume ultra-fast SSDs are available in cloud environments.

## Type of change

- [x] graphql-typescript-definitions Minor: New feature

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above