### PR TITLE
Fix copyright year to include the first year it was issued

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Shopify
+Copyright (c) 2018-present Shopify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
As per Shopify's development handbook OSS page: https://development.shopify.io/engineering/overview/approach/open_source

> And a LICENSE.md file in the root of the project containing the chosen open-source license with appropriate Shopify copyright header with a start year (for example: 2019-present)

Related to https://github.com/Shopify/web-foundations/issues/123