### PR TITLE
Docs: add instructions on how to watch changes in a package

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,6 +61,22 @@ After making code changes within the quilt repo:
 1. Run `yarn build --root packages/<package-folder-name>` to rebuild the package
 1. Run `yalc publish --push packages/<package-folder-name>` to push the changes to the consuming repo
 
+You may also run this command to rebuild and publish every time a change is detected in a package:
+
+```console
+npx nodemon --watch packages/<package-folder-name> \
+  --exec 'yarn build --root packages/<package-folder-name> \
+  && npx yalc publish --push packages/<package-folder-name>'
+```
+
+For example:
+
+```console
+npx nodemon --watch packages/storybook-a11y-test \
+  --exec 'yarn build --root packages/storybook-a11y-test \
+  && npx yalc publish --push packages/storybook-a11y-test'
+```
+
 ### Emoji commits
 
 We have found that prefacing a commit message or PR title with an emoji can be a great way to improve the developer experience when browsing the repo code. Additionally, it is a terse way to convey information. Many of our contributors have found the guide at https://gitmoji.carloscuesta.me/ to be helpful in preserving this dynamic.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,7 +67,7 @@ You may also run this command to rebuild and publish every time a change is dete
 npx nodemon --watch packages/<package-folder-name> \
   --exec 'yarn build --root packages/<package-folder-name> \
   && npx yalc publish --push packages/<package-folder-name>' \
-  --ignore packages/<package-folder-name> \
+  --ignore packages/<package-folder-name>/build \
   --ext ts --ignore '*.d.ts'
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,7 +66,9 @@ You may also run this command to rebuild and publish every time a change is dete
 ```console
 npx nodemon --watch packages/<package-folder-name> \
   --exec 'yarn build --root packages/<package-folder-name> \
-  && npx yalc publish --push packages/<package-folder-name>'
+  && npx yalc publish --push packages/<package-folder-name>' \
+  --ignore packages/<package-folder-name> \
+  --ext ts --ignore '*.d.ts'
 ```
 
 For example:
@@ -74,7 +76,9 @@ For example:
 ```console
 npx nodemon --watch packages/storybook-a11y-test \
   --exec 'yarn build --root packages/storybook-a11y-test \
-  && npx yalc publish --push packages/storybook-a11y-test'
+  && npx yalc publish --push packages/storybook-a11y-test' \
+  --ignore packages/storybook-a11y-test/build \
+  --ext ts --ignore '*.d.ts'
 ```
 
 ### Emoji commits


### PR DESCRIPTION
This seems to work on my machine, other people's tests appreciated!

### Tophatting

1. Run `yarn build --root packages/storybook-a11y-test`
1. Run `yalc publish packages/storybook-a11y-test`
1. Inside `web`, run `yalc link --no-pure @shopify/storybook-a11y-test`
1. Run this newly recommended watcher:
```console
npx nodemon --watch packages/storybook-a11y-test \
  --exec 'yarn build --root packages/storybook-a11y-test \
  && npx yalc publish --push packages/storybook-a11y-test' \
  --ignore packages/storybook-a11y-test/build \
  --ext ts --ignore '*.d.ts'
```
5. Make changes to the `storybook-a11y-test` package, and verify that they're applied in `web`.

Ideally, try this workflow with a couple of other packages, see if it works elsewhere!