### PR TITLE
Forward ref of component rendered by Async

### DIFF
--- a/packages/react-async/CHANGELOG.md
+++ b/packages/react-async/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Now forwarding the ref of the component rendered via `createAsyncComponent` [#1833](https://github.com/Shopify/quilt/pull/1833)
+
 ## 3.2.2 - 2021-03-03
 
 ### Fixed

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -1,4 +1,5 @@
 import React, {
+  forwardRef,
   useEffect,
   useRef,
   useCallback,
@@ -51,7 +52,8 @@ export function createAsyncComponent<
   Props extends object,
   PreloadOptions extends object = {},
   PrefetchOptions extends object = {},
-  KeepFreshOptions extends object = {}
+  KeepFreshOptions extends object = {},
+  Ref extends object = {}
 >({
   id,
   load,
@@ -87,7 +89,7 @@ export function createAsyncComponent<
     ? AssetTiming.CurrentPage
     : AssetTiming.Immediate;
 
-  function Async(props: Props) {
+  const Async = forwardRef<Ref | undefined, Props>((props, ref) => {
     const {resolved: Component, load, loading, error} = useAsync(resolver, {
       scripts: scriptTiming,
       styles: stylesTiming,
@@ -97,7 +99,7 @@ export function createAsyncComponent<
     const {current: startedHydrated} = useRef(useHydrationManager().hydrated);
 
     if (error) {
-      return renderError(error);
+      return <>{renderError(error)}</>;
     }
 
     let loadingMarkup: ReactNode | null = null;
@@ -111,7 +113,7 @@ export function createAsyncComponent<
     }
 
     let contentMarkup: ReactNode | null = null;
-    const rendered = Component ? <Component {...props} /> : null;
+    const rendered = Component ? <Component {...props} ref={ref} /> : null;
 
     if (progressivelyHydrated && !startedHydrated) {
       contentMarkup = rendered ? (
@@ -131,7 +133,7 @@ export function createAsyncComponent<
         {loadingMarkup}
       </>
     );
-  }
+  });
 
   Async.displayName = `Async(${componentName})`;
 


### PR DESCRIPTION
## Description

This PR adds ref forwarding for the component rendered by `Async` that is returned by the `createAsyncComponent` function. 

## Type of change

It's somewhat debatable whether this is a new feature or a bug fix. I'd tend to categorize the fact that refs are not being properly forwarded currently as a bug (unexpected behaviour for most consumers).

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
