### PR TITLE
Add empty index for ast-utilities

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Removed dependency on tslib, as we no-longer compile with `tsc`. [#1829](https://github.com/Shopify/quilt/pull/1829)
+- Added an empty file to use as the index entrypoint, instead of causing a file-not-found error. [#1834](https://github.com/Shopify/quilt/pull/1834)
 
 ## 0.2.2 - 2021-03-03
 

--- a/packages/ast-utilities/src/index.ts
+++ b/packages/ast-utilities/src/index.ts
@@ -1,0 +1,3 @@
+// Deliberately empty.
+// Import from /javascript or /markdown instead.
+export {};


### PR DESCRIPTION
## Description

When investigating rollup stuff I found a case where we configure an index entrypoint but no source file actually exists.

In the current world, this compiles, but is an error at runtime if you try and import `@shopify/ast-utilities` as it would try to import a non-existent file.
In the rollup build world this a build-time error as it tries to load a file that does not exist.

This PR adds an empty file that gets used as the index entrypoint.

Adding an empty index entrypoint feels more idiomatic than removing configuration for the index file (as that will require messing with the consistent-package-json tests.

## Type of change

- [x] ast-utilities Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
