### PR TITLE
🐛 Use import type to fix sewing-kit-koa mjs compilation

### DIFF
--- a/packages/sewing-kit-koa/CHANGELOG.md
+++ b/packages/sewing-kit-koa/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Removed dependency on tslib, as we no-longer compile with `tsc`. [#1829](https://github.com/Shopify/quilt/pull/1829)
+- [Patch] Remove TypeScript type from distributed mjs [#1835](https://github.com/Shopify/quilt/pull/1835)
 
 ## 6.4.3 - 2021-03-03
 

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -7,7 +7,8 @@ import mount from 'koa-mount';
 import appRoot from 'app-root-path';
 import {Header} from '@shopify/network';
 
-import Assets, {Asset} from './assets';
+import type {Asset} from './assets';
+import Assets from './assets';
 
 export {Assets};
 export type {Asset};


### PR DESCRIPTION
## Description
esbuild can't compile the mjs build of sewing-kit-koa because it references a TypeScript type. This switches `Assets` to be imported via `import type`, which gets it stripped out of the mjs build.

## Type of change

- [x] sewing-kit-koa Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
