### PR TITLE
[react-form] reset dynamic list

### DIFF
--- a/packages/react-form/src/hooks/list/baselist.ts
+++ b/packages/react-form/src/hooks/list/baselist.ts
@@ -47,6 +47,7 @@ interface BaseList<Item extends object> {
 export function useBaseList<Item extends object>(
   listOrConfig: FieldListConfig<Item> | Item[],
   validationDependencies: unknown[] = [],
+  isDynamic = false,
 ): BaseList<Item> {
   const list = Array.isArray(listOrConfig) ? listOrConfig : listOrConfig.list;
   const validates: FieldListConfig<Item>['validates'] = Array.isArray(
@@ -55,7 +56,7 @@ export function useBaseList<Item extends object>(
     ? {}
     : listOrConfig.validates || {};
 
-  const [state, dispatch] = useListReducer(list);
+  const [state, dispatch] = useListReducer(list, isDynamic);
 
   useEffect(() => {
     if (!isEqual(list, state.initial)) {

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -32,7 +32,11 @@ export function useDynamicList<Item extends object>(
   fieldFactory: FactoryFunction<Item>,
   validationDependencies: unknown[] = [],
 ): DynamicList<Item> {
-  const {fields, dispatch} = useBaseList(listOrConfig, validationDependencies);
+  const {fields, dispatch} = useBaseList(
+    listOrConfig,
+    validationDependencies,
+    true,
+  );
 
   function addItem(factoryArgument?: any) {
     const itemToAdd = fieldFactory(factoryArgument);

--- a/packages/react-form/src/hooks/list/hooks/handlers.ts
+++ b/packages/react-form/src/hooks/list/hooks/handlers.ts
@@ -13,6 +13,7 @@ import {
   updateErrorAction,
   newDefaultAction,
   resetAction,
+  resetListAction,
   ListState,
   ListAction,
 } from './index';
@@ -69,7 +70,11 @@ export function useHandlers<Item extends object>(
               }
             },
             reset() {
-              dispatch(resetAction({target}));
+              if (state.isDynamic) {
+                dispatch(resetListAction());
+              } else {
+                dispatch(resetAction({target}));
+              }
             },
             newDefaultValue(value: Item[Key]) {
               dispatch(newDefaultAction({target, value}));
@@ -90,5 +95,5 @@ export function useHandlers<Item extends object>(
         },
       );
     });
-  }, [dispatch, state.list, validationConfigs]);
+  }, [dispatch, state.isDynamic, state.list, validationConfigs]);
 }

--- a/packages/react-form/src/hooks/list/hooks/index.ts
+++ b/packages/react-form/src/hooks/list/hooks/index.ts
@@ -6,6 +6,7 @@ export {
   updateErrorAction,
   newDefaultAction,
   resetAction,
+  resetListAction,
   addFieldItemAction,
   moveFieldItemAction,
   removeFieldItemAction,


### PR DESCRIPTION
## Description

Fixes #1830

Inspired by https://github.com/Shopify/quilt/pull/1828

## Type of change

It does a full reset of a dynamic list instead of resetting each existing field.
So items that have been removed will reappear and items that have been added will disappear. 

- [x] `react-form` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
