### PR TITLE
Fix react form state mjs

### DIFF
--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- [Patch] Remove TypeScript type from distributed mjs [#1838](https://github.com/Shopify/quilt/pull/1838)
 
 ## 0.12.4 - 2021-04-13
 

--- a/packages/react-form-state/src/index.ts
+++ b/packages/react-form-state/src/index.ts
@@ -1,11 +1,6 @@
 import FormState from './FormState';
-import {
-  asChoiceField,
-  ChoiceFieldDescriptor,
-  push,
-  replace,
-  remove,
-} from './utilities';
+import type {ChoiceFieldDescriptor} from './utilities';
+import {asChoiceField, push, replace, remove} from './utilities';
 
 export {asChoiceField};
 export type {ChoiceFieldDescriptor};


### PR DESCRIPTION
## Description
Fix parsing of rect-form-state's index.mjs. esbuild is throwing:
```
Error: Client generation failed with errors: [{"location":{"column":24,"file":"node_modules/@shopify/react-form-state/build/esm/index.mjs","length":21,"line":2,"lineText":"import { asChoiceField, ChoiceFieldDescriptor, push, replace, remove } from \"./utilities.mjs\";","namespace":"","suggestion":""},"notes":[],"text":"No matching export in \"node_modules/@shopify/react-form-state/build/esm/utilities.mjs\" for import \"ChoiceFieldDescriptor\""}]
```

To confirm that a stale type is lingering around in the distributed mjs file, [here's unpkg's view of this](https://unpkg.com/browse/@shopify/react-form-state@0.12.4/build/esm/index.mjs):
```ts
import { asChoiceField, ChoiceFieldDescriptor, push, replace, remove } from "./utilities.mjs";
```

## Type of change
- [x] react-form-state Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
