### PR TITLE
Add `updated` command to list updated packages

### DIFF
--- a/documentation/guides/release-and-deploy.md
+++ b/documentation/guides/release-and-deploy.md
@@ -14,6 +14,7 @@ git checkout main && git pull
 
 ## 2. Updating `CHANGELOG.md`
 
+- Run `yarn updated` to a get list of packaged that have changed since the last release.
 - Go into every package that is being released. Edit `CHANGELOG.md` by moving any line items from `Unreleased` section into a new release with the new section with the new version number and today's date as title. (eg. `1.0.0 - 2019-07-24`).
 
 - Stage the `CHANGELOG.md` changes using:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean": "rimraf ./packages/*/build ./packages/*/*.{d.ts,js,esnext,mjs} .sewing-kit",
     "generate": "plop",
     "generate:package": "plop package && yarn plop docs",
-    "yalc": "yalc"
+    "yalc": "yalc",
+    "updated": "lerna updated"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Adds an `updated` command to list packages updated since the last release. This will make it easier to go into each package to update their CHANGELOGs:

```
➜  quilt git:(main) ✗ yarn updated
yarn run v1.19.1
$ lerna updated
lerna info version 2.11.0
lerna info versioning independent
lerna info ignore [ '**/*.md', '**/tests/**', '**/test/**' ]
lerna info Checking for updated packages...
lerna info Comparing with @shopify/react-network@3.6.8.
lerna info Checking for prereleased packages...
lerna info result
- @shopify/react-app-bridge-universal-provider
- @shopify/react-cookie
- @shopify/react-csrf-universal-provider
- @shopify/react-google-analytics
- @shopify/react-graphql-universal-provider
- @shopify/react-graphql
- @shopify/react-html
- @shopify/react-i18n-universal-provider
- @shopify/react-import-remote
- @shopify/react-network
- @shopify/react-router
- @shopify/react-server
- @shopify/react-testing
- @shopify/react-tracking-pixel
- @shopify/react-universal-provider
✨  Done in 1.84s.
```


## Type of change

Adds a new package.json script

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] ~~I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)~~
