### PR TITLE
improve dynamicLists typing

### DIFF
--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -13,9 +13,14 @@ describe('useDynamicList', () => {
       return {price: '', optionName: '', optionValue: ''};
     };
     function DynamicListComponent(config: FieldListConfig<Variant>) {
-      const {fields, addItem, removeItem, moveItem, reset} = useDynamicList<
-        Variant
-      >(config, factory);
+      const {
+        fields,
+        addItem,
+        removeItem,
+        moveItem,
+        reset,
+        dirty,
+      } = useDynamicList<Variant>(config, factory);
 
       return (
         <>
@@ -48,6 +53,7 @@ describe('useDynamicList', () => {
           <button type="button" onClick={reset}>
             Reset
           </button>
+          <p>Dirty: {dirty.toString()}</p>
         </>
       );
     }
@@ -112,8 +118,6 @@ describe('useDynamicList', () => {
       wrapper
         .find('button', {children: 'Add Variant'})!
         .trigger('onClick', clickEvent());
-
-      // const addedTextField = wrapper.findAll(TextField)![0];
 
       expect(wrapper).toContainReactComponent(TextField, {
         name: 'price1',
@@ -206,6 +210,66 @@ describe('useDynamicList', () => {
           .trigger('onClick', clickEvent());
 
         expect(wrapper).toContainReactComponent(TextField);
+      });
+    });
+
+    describe('dirty dynamic list', () => {
+      it('handles dirty state when adding a field and resetting it', () => {
+        const wrapper = mount(
+          <DynamicListComponent list={randomVariants(1)} />,
+        );
+
+        expect(wrapper).toContainReactText('Dirty: false');
+
+        wrapper
+          .find(TextField, {name: 'price0'})!
+          .trigger('onChange', 'new value');
+
+        expect(wrapper).toContainReactText('Dirty: true');
+
+        wrapper
+          .find('button', {children: 'Reset'})!
+          .trigger('onClick', clickEvent());
+
+        expect(wrapper).toContainReactText('Dirty: false');
+      });
+
+      it('handles dirty state when adding a field and resetting it', () => {
+        const wrapper = mount(<DynamicListComponent list={randomVariants()} />);
+
+        expect(wrapper).toContainReactText('Dirty: false');
+
+        wrapper
+          .find('button', {children: 'Add Variant'})!
+          .trigger('onClick', clickEvent());
+
+        expect(wrapper).toContainReactText('Dirty: true');
+
+        wrapper
+          .find('button', {children: 'Reset'})!
+          .trigger('onClick', clickEvent());
+
+        expect(wrapper).toContainReactText('Dirty: false');
+      });
+
+      it('handles dirty state when removing a field and resetting it', () => {
+        const wrapper = mount(
+          <DynamicListComponent list={randomVariants(1)} />,
+        );
+
+        expect(wrapper).toContainReactText('Dirty: false');
+
+        wrapper
+          .find('button', {children: 'Remove Variant'})!
+          .trigger('onClick', clickEvent());
+
+        expect(wrapper).toContainReactText('Dirty: true');
+
+        wrapper
+          .find('button', {children: 'Reset'})!
+          .trigger('onClick', clickEvent());
+
+        expect(wrapper).toContainReactText('Dirty: false');
       });
     });
   });

--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -73,6 +73,9 @@ describe('useDynamicList', () => {
     });
 
     it('will throw an error if new position is out of index range', () => {
+      const consoleErrorMock = jest.spyOn(console, 'error');
+      consoleErrorMock.mockImplementation();
+
       const variants: Variant[] = [
         {price: 'A', optionName: 'A', optionValue: 'A'},
         {price: 'B', optionName: 'B', optionValue: 'B'},
@@ -86,6 +89,8 @@ describe('useDynamicList', () => {
           .findAll('button', {children: 'Move Variant up'})![0]
           .trigger('onClick');
       }).toThrow('Failed to move item from 0 to -1');
+
+      consoleErrorMock.mockRestore();
     });
 
     it('can remove field', () => {

--- a/packages/react-form/src/hooks/test/form-with-dynamic-list.test.tsx
+++ b/packages/react-form/src/hooks/test/form-with-dynamic-list.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {
+  FormWithDynamicVariantList,
+  TextField,
+  isDirty,
+  fakeProduct,
+  hitSubmit,
+  hitReset,
+  waitForSubmit,
+} from './utilities';
+
+import {submitSuccess, submitFail} from '..';
+
+describe('useForm with dynamic list', () => {
+  describe('dirty state', () => {
+    it('dirty state is false when no field has been changed', () => {
+      const wrapper = mount(
+        <FormWithDynamicVariantList data={fakeProduct()} />,
+      );
+
+      expect(isDirty(wrapper)).toBe(false);
+    });
+
+    it('dirty state is true when a new variant item has been added', () => {
+      const wrapper = mount(
+        <FormWithDynamicVariantList data={fakeProduct()} />,
+      );
+
+      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+
+      expect(isDirty(wrapper)).toBe(true);
+    });
+
+    it('dirty state is true when a variant item has been removed', () => {
+      const wrapper = mount(
+        <FormWithDynamicVariantList data={fakeProduct()} />,
+      );
+
+      wrapper.find('button', {children: 'Remove item'}).trigger('onClick');
+
+      expect(isDirty(wrapper)).toBe(true);
+    });
+
+    it('dirty state is true when a variant item has been edited', () => {
+      const wrapper = mount(
+        <FormWithDynamicVariantList data={fakeProduct()} />,
+      );
+
+      wrapper
+        .find(TextField, {label: 'price'})
+        .trigger('onChange', 'next price');
+
+      expect(isDirty(wrapper)).toBe(true);
+    });
+  });
+
+  describe('submit', () => {
+    it('validates dynamic list fields with their latest values before submitting and bails out if any fail', () => {
+      const submitSpy = jest.fn(() => Promise.resolve(submitSuccess()));
+      const product = fakeProduct();
+      const wrapper = mount(
+        <FormWithDynamicVariantList data={product} onSubmit={submitSpy} />,
+      );
+
+      const textFields = wrapper.findAll(TextField, {label: 'option'});
+
+      textFields.forEach(textField => textField.trigger('onChange', ''));
+      hitSubmit(wrapper);
+
+      expect(submitSpy).not.toHaveBeenCalled();
+
+      expect(wrapper).toContainReactComponentTimes(
+        TextField,
+        textFields.length,
+        {
+          error: 'Option name is required!',
+        },
+      );
+    });
+
+    it('propagates remote submission errors to matching fields', async () => {
+      const errors = [
+        {
+          field: ['variants', '0', 'price'],
+          message: 'The server hates your price',
+        },
+      ];
+      const promise = Promise.resolve(submitFail(errors));
+      const wrapper = mount(
+        <FormWithDynamicVariantList
+          data={fakeProduct()}
+          onSubmit={() => promise}
+        />,
+      );
+
+      await waitForSubmit(wrapper, promise);
+
+      expect(wrapper).toContainReactComponent(TextField, {
+        error: errors[0].message,
+      });
+    });
+  });
+
+  describe('reset', () => {
+    it('reset dynamic list after adding new item', () => {
+      const wrapper = mount(
+        <FormWithDynamicVariantList data={fakeProduct()} />,
+      );
+
+      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+
+      expect(wrapper).toContainReactComponentTimes(TextField, 3, {
+        label: 'option',
+      });
+
+      hitReset(wrapper);
+
+      expect(wrapper).toContainReactComponentTimes(TextField, 2, {
+        label: 'option',
+      });
+      expect(isDirty(wrapper)).toBe(false);
+    });
+
+    it('reset dynamic list after removing item', () => {
+      const wrapper = mount(
+        <FormWithDynamicVariantList data={fakeProduct()} />,
+      );
+
+      wrapper.find('button', {children: 'Remove item'}).trigger('onClick');
+
+      expect(wrapper).toContainReactComponentTimes(TextField, 1, {
+        label: 'option',
+      });
+
+      hitReset(wrapper);
+
+      expect(wrapper).toContainReactComponentTimes(TextField, 2, {
+        label: 'option',
+      });
+      expect(isDirty(wrapper)).toBe(false);
+    });
+  });
+});

--- a/packages/react-form/src/hooks/test/form.test.tsx
+++ b/packages/react-form/src/hooks/test/form.test.tsx
@@ -5,14 +5,7 @@ import {mount} from '@shopify/react-testing';
 import {SubmitHandler} from '../../types';
 import {positiveNumericString, notEmpty} from '../../validation';
 
-import {
-  useList,
-  useField,
-  useForm,
-  submitSuccess,
-  submitFail,
-  useDynamicList,
-} from '..';
+import {useList, useField, useForm, submitSuccess, submitFail} from '..';
 
 interface SimpleProduct {
   title: string;
@@ -35,17 +28,11 @@ describe('useForm', () => {
     data,
     onSubmit,
     makeCleanAfterSubmit,
-    dynamicListEnabled = false,
   }: {
     data: SimpleProduct;
     onSubmit?: SubmitHandler<SimpleProduct>;
     makeCleanAfterSubmit?: boolean;
-    dynamicListEnabled: boolean;
   }) {
-    const variantsEmptyFactory = () => {
-      return {id: '', price: '', optionName: '', optionValue: ''};
-    };
-
     const title = useField({
       value: data.title,
       validates: notEmpty('Title is required!'),
@@ -68,34 +55,13 @@ describe('useForm', () => {
       },
     });
 
-    const dynamicVariants = useDynamicList(data.variants, variantsEmptyFactory);
-
-    const dynamicListProp = dynamicListEnabled
-      ? {
-          dynamicLists: {
-            defaultDynamicList: dynamicVariants,
-          },
-        }
-      : undefined;
-
-    const {
-      submit,
-      submitting,
-      dirty,
-      reset,
-      makeClean,
-      submitErrors,
-      dynamicLists,
-    } = useForm({
-      fields: {title, description, defaultVariant, variants},
-      ...dynamicListProp,
-      onSubmit: onSubmit as any,
-      makeCleanAfterSubmit,
-    });
-
-    const {
-      defaultDynamicList: {addItem, fields: dynamicListFields, removeItem},
-    } = dynamicLists;
+    const {submit, submitting, dirty, reset, makeClean, submitErrors} = useForm(
+      {
+        fields: {title, description, defaultVariant, variants},
+        onSubmit: onSubmit as any,
+        makeCleanAfterSubmit,
+      },
+    );
 
     return (
       <form onSubmit={submit}>
@@ -121,24 +87,6 @@ describe('useForm', () => {
             </fieldset>
           );
         })}
-        {dynamicListFields.map((field, index) => (
-          <>
-            <TextField
-              value={field.price.value}
-              key={field.id.value}
-              label={`dynamicField${index}`}
-              onChange={field.price.onChange}
-              onBlur={field.price.onBlur}
-            />
-            <button
-              type="button"
-              onClick={() => removeItem(index)}
-              key={`button${field.id.value}`}
-            >
-              Remove dynamic field
-            </button>
-          </>
-        ))}
         <button type="button" onClick={makeClean}>
           Clean
         </button>
@@ -147,9 +95,6 @@ describe('useForm', () => {
         </button>
         <button type="submit" disabled={!dirty} onClick={submit}>
           Submit
-        </button>
-        <button type="button" disabled={!dirty} onClick={addItem}>
-          Add Item
         </button>
       </form>
     );
@@ -498,60 +443,6 @@ describe('useForm', () => {
         .prop('onClick');
 
       expect(initialMakeCleanHandler).toBe(newMakeCleanHandler);
-    });
-  });
-
-  describe('dynamicLists', () => {
-    it('reflects dynamic list being dirty in forms dirty state', () => {
-      const wrapper = mount(
-        <ProductForm data={fakeProduct()} dynamicListEnabled />,
-      );
-
-      wrapper
-        .find('button', {
-          children: 'Add Item',
-        })!
-        .trigger('onClick', clickEvent());
-
-      expect(isDirty(wrapper)).toBe(true);
-
-      hitReset(wrapper);
-
-      expect(isDirty(wrapper)).toBe(false);
-    });
-
-    it('resets dynamic list fields when forms reset is called', () => {
-      const wrapper = mount(
-        <ProductForm data={fakeProduct()} dynamicListEnabled />,
-      );
-
-      wrapper
-        .find('button', {
-          children: 'Add Item',
-        })!
-        .trigger('onClick', clickEvent());
-
-      expect(wrapper).toContainReactComponent(TextField, {
-        value: '',
-        label: 'dynamicField2',
-      });
-
-      hitReset(wrapper);
-
-      expect(wrapper).not.toContainReactComponent(TextField, {
-        value: '',
-        label: 'dynamicField2',
-      });
-    });
-
-    it('renders empty dynamic list when dynamic list is not enabled', () => {
-      const wrapper = mount(<ProductForm data={fakeProduct()} />);
-
-      const dynamicListFieldsRemoveButtons = wrapper.findAll('button', {
-        children: 'Remove dynamic field',
-      });
-
-      expect(dynamicListFieldsRemoveButtons).toHaveLength(0);
     });
   });
 });

--- a/packages/react-form/src/hooks/test/utilities/components/FormWithDynamicVariantList.tsx
+++ b/packages/react-form/src/hooks/test/utilities/components/FormWithDynamicVariantList.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import {SubmitHandler} from '../../../../types';
+import {notEmpty} from '../../../../validation';
+import {useDynamicList, useField, useForm} from '../../..';
+
+import {SimpleProduct, Variant} from './types';
+import {TextField} from './TextField';
+
+export function FormWithDynamicVariantList({
+  data,
+  onSubmit,
+  makeCleanAfterSubmit,
+}: {
+  data: SimpleProduct;
+  onSubmit?: SubmitHandler<SimpleProduct>;
+  makeCleanAfterSubmit?: boolean;
+}) {
+  const variantFactory = () => {
+    return {
+      id: Date.now().toString(),
+      price: '',
+      optionName: '',
+      optionValue: '',
+    };
+  };
+
+  const {
+    fields: {title},
+    dynamicLists: {variants},
+    submit,
+    submitting,
+    dirty,
+    reset,
+    makeClean,
+    submitErrors,
+  } = useForm({
+    fields: {
+      title: useField({
+        value: data.title,
+        validates: notEmpty('Title is required!'),
+      }),
+    },
+    dynamicLists: {
+      variants: useDynamicList<Variant>(
+        {
+          list: data.variants,
+          validates: {
+            optionName: notEmpty('Option name is required!'),
+          },
+        },
+        variantFactory,
+      ),
+    },
+    onSubmit: onSubmit as any,
+    makeCleanAfterSubmit,
+  });
+
+  return (
+    <form onSubmit={submit}>
+      {submitting && <p>loading...</p>}
+      {submitErrors.length > 0 &&
+        // eslint-disable-next-line react/no-array-index-key
+        submitErrors.map(({message}, index) => <p key={index}>{message}</p>)}
+
+      <fieldset>
+        <TextField label="title" {...title} />
+      </fieldset>
+      {variants.fields.map(({price, optionName, optionValue, id}, index) => {
+        return (
+          <fieldset name="default-variant" key={id.value}>
+            <TextField label="price" {...price} />
+            <TextField label="option" {...optionName} />
+            <TextField label="value" {...optionValue} />
+            <button type="button" onClick={() => variants.removeItem(index)}>
+              Remove item
+            </button>
+          </fieldset>
+        );
+      })}
+      <button type="button" onClick={() => variants.addItem()}>
+        Add item
+      </button>
+      <button type="button" onClick={makeClean}>
+        Clean
+      </button>
+      <button type="reset" disabled={!dirty} onClick={reset}>
+        Reset
+      </button>
+      <button type="submit" disabled={!dirty} onClick={submit}>
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/packages/react-form/src/hooks/test/utilities/components/ProductForm.tsx
+++ b/packages/react-form/src/hooks/test/utilities/components/ProductForm.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import {SubmitHandler} from '../../../../types';
+import {positiveNumericString, notEmpty} from '../../../../validation';
+import {useList, useField, useForm} from '../../..';
+
+import {SimpleProduct} from './types';
+import {TextField} from './TextField';
+
+export function ProductForm({
+  data,
+  onSubmit,
+  makeCleanAfterSubmit,
+}: {
+  data: SimpleProduct;
+  onSubmit?: SubmitHandler<SimpleProduct>;
+  makeCleanAfterSubmit?: boolean;
+}) {
+  const title = useField({
+    value: data.title,
+    validates: notEmpty('Title is required!'),
+  });
+  const description = useField(data.description);
+
+  const defaultVariant = {
+    price: useField({
+      value: data.defaultVariant.price,
+      validates: positiveNumericString('price must be a number'),
+    }),
+    optionName: useField(data.defaultVariant.optionName),
+    optionValue: useField(data.defaultVariant.optionValue),
+  };
+
+  const variants = useList({
+    list: data.variants,
+    validates: {
+      price: positiveNumericString('price must be a number'),
+    },
+  });
+
+  const {submit, submitting, dirty, reset, makeClean, submitErrors} = useForm({
+    fields: {title, description, defaultVariant, variants},
+    onSubmit: onSubmit as any,
+    makeCleanAfterSubmit,
+  });
+
+  return (
+    <form onSubmit={submit}>
+      {submitting && <p>loading...</p>}
+      {submitErrors.length > 0 &&
+        submitErrors.map(({message}) => <p key={message}>{message}</p>)}
+
+      <fieldset>
+        <TextField label="title" {...title} />
+        <TextField label="description" {...description} />
+      </fieldset>
+      <fieldset name="default-variant">
+        <TextField label="price" {...defaultVariant.price} />
+        <TextField label="option" {...defaultVariant.optionName} />
+        <TextField label="value" {...defaultVariant.optionValue} />
+      </fieldset>
+      {variants.map(({price, optionName, optionValue, id}) => {
+        return (
+          <fieldset name="default-variant" key={id.value}>
+            <TextField label="price" {...price} />
+            <TextField label="option" {...optionName} />
+            <TextField label="value" {...optionValue} />
+          </fieldset>
+        );
+      })}
+      <button type="button" onClick={makeClean}>
+        Clean
+      </button>
+      <button type="reset" disabled={!dirty} onClick={reset}>
+        Reset
+      </button>
+      <button type="submit" disabled={!dirty} onClick={submit}>
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/packages/react-form/src/hooks/test/utilities/components/TextField.tsx
+++ b/packages/react-form/src/hooks/test/utilities/components/TextField.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface TextFieldProps {
+  value: string;
+  label: string;
+  name?: string;
+  error?: string;
+  onChange(value): void;
+  onBlur(): void;
+}
+
+export function TextField({
+  label,
+  name = label,
+  onChange,
+  onBlur,
+  value,
+  error,
+}: TextFieldProps) {
+  return (
+    <>
+      <label htmlFor={name}>
+        {label}
+        <input
+          id={name}
+          name={name}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </label>
+      {error && <p>{error}</p>}
+    </>
+  );
+}

--- a/packages/react-form/src/hooks/test/utilities/components/index.ts
+++ b/packages/react-form/src/hooks/test/utilities/components/index.ts
@@ -1,0 +1,4 @@
+export {FormWithDynamicVariantList} from './FormWithDynamicVariantList';
+export {ProductForm} from './ProductForm';
+export {TextField} from './TextField';
+export * from './types';

--- a/packages/react-form/src/hooks/test/utilities/components/types.ts
+++ b/packages/react-form/src/hooks/test/utilities/components/types.ts
@@ -1,0 +1,13 @@
+export interface Variant {
+  id: string;
+  optionName: string;
+  optionValue: string;
+  price: string;
+}
+
+export interface SimpleProduct {
+  title: string;
+  description: string;
+  defaultVariant: Omit<Variant, 'id'>;
+  variants: Variant[];
+}

--- a/packages/react-form/src/hooks/test/utilities/index.ts
+++ b/packages/react-form/src/hooks/test/utilities/index.ts
@@ -1,0 +1,68 @@
+import faker from 'faker';
+
+import {SimpleProduct, TextField} from './components';
+
+export * from './components';
+
+export function isDirty(wrapper) {
+  try {
+    expect(wrapper).toContainReactComponent('button', {
+      type: 'reset',
+      disabled: false,
+    });
+    expect(wrapper).toContainReactComponent('button', {
+      type: 'submit',
+      disabled: false,
+    });
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+export function changeTitle(wrapper, newTitle) {
+  wrapper.find(TextField, {label: 'title'})!.trigger('onChange', newTitle);
+}
+
+export function hitSubmit(wrapper) {
+  wrapper.find('button', {type: 'submit'})!.trigger('onClick', clickEvent());
+}
+
+export async function waitForSubmit(wrapper, successPromise) {
+  hitSubmit(wrapper);
+
+  await wrapper.act(async () => {
+    await successPromise;
+  });
+}
+
+export function hitReset(wrapper) {
+  wrapper.find('button', {type: 'reset'})!.trigger('onClick', clickEvent());
+}
+
+export function hitClean(wrapper) {
+  wrapper.find('button', {type: 'button'})!.trigger('onClick', clickEvent());
+}
+
+export function fakeProduct(): SimpleProduct {
+  return {
+    title: faker.commerce.product(),
+    description: faker.lorem.paragraph(),
+    defaultVariant: {
+      price: faker.commerce.price(),
+      optionName: 'material',
+      optionValue: faker.commerce.productMaterial(),
+    },
+    variants: Array.from({length: 2}).map(() => ({
+      id: faker.random.uuid(),
+      price: faker.commerce.price(),
+      optionName: faker.lorem.word(),
+      optionValue: faker.commerce.productMaterial(),
+    })),
+  };
+}
+
+export function clickEvent() {
+  // we don't actually use these at all so it is ok to just return an empty object
+  return {} as any;
+}

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -65,6 +65,24 @@ export type FieldDictionary<Record extends object> = {
   [Key in keyof Record]: Field<Record[Key]>;
 };
 
+export interface FormWithoutDynamicListsInput<T extends FieldBag> {
+  fields: T;
+  onSubmit?: SubmitHandler<FormMapping<T, 'value'>>;
+  makeCleanAfterSubmit?: boolean;
+}
+
+export interface FormWithDynamicListsInput<
+  T extends FieldBag,
+  D extends DynamicListBag
+> extends FormWithoutDynamicListsInput<T> {
+  dynamicLists: D;
+}
+
+export interface FormInput<T extends FieldBag, D extends DynamicListBag>
+  extends FormWithoutDynamicListsInput<T> {
+  dynamicLists?: D;
+}
+
 export interface Form<T extends FieldBag> {
   fields: T;
   dirty: boolean;
@@ -74,7 +92,13 @@ export interface Form<T extends FieldBag> {
   reset(): void;
   submit(event?: React.FormEvent): void;
   makeClean(): void;
-  dynamicLists: DynamicListBag;
+}
+
+export interface FormWithDynamicLists<
+  T extends FieldBag,
+  D extends DynamicListBag
+> extends Form<T> {
+  dynamicLists: D;
 }
 
 export interface FormError {


### PR DESCRIPTION
You can test with [this condesandbox](https://codesandbox.io/s/fancy-resonance-eh569?file=/src/App.tsx).
I am using function overloading to define two scenarios:

1. we have a classic `useForm` (like all existing ones) that does not use `dynamicLists`;
2. we can a `useForm` relying `dynamicLists`.

Result is:
- No more default value in our hook;
- In `App.tsx`: No need to use `!` or to check if `dynamicLists` is defined.

In the future we could do the same to also turn `fields` optional 🤔 