### PR TITLE
storybook-a11y-test Allow the timeout to be set

### DIFF
--- a/packages/storybook-a11y-test/CHANGELOG.md
+++ b/packages/storybook-a11y-test/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Added
+
+- Added timeout option [[#1859](https://github.com/Shopify/quilt/pull/1859)]
+
 ## 0.0.3 - 2021-04-13
 
 ### Changed

--- a/packages/storybook-a11y-test/README.md
+++ b/packages/storybook-a11y-test/README.md
@@ -19,7 +19,7 @@ Make sure you have built your storybook instance and there is an `iframe.html` f
 ```js
 const {storybookA11yTest} = require('./built-a11y-package');
 
-(async() => {
+(async () => {
   const options = {
     iframePath: `file://${__dirname}/../build/storybook/static/iframe.html`,
     skippedStoryIds: [],
@@ -52,3 +52,7 @@ An array of storybook id's to skip.
 #### concurrentCount `number` (optional)
 
 The number of tabs to open in chromium. The default option is based off the number of CPU cores available `os.cpus().length`.
+
+#### timeout `number` (optional)
+
+The goto timeout for the provided url. Defaults to 3000 (puppeteer default)

--- a/packages/storybook-a11y-test/src/index.ts
+++ b/packages/storybook-a11y-test/src/index.ts
@@ -78,6 +78,7 @@ export async function storybookA11yTest({
   iframePath,
   skippedStoryIds = [],
   concurrentCount = os.cpus().length,
+  timeout = 3000,
 }) {
   try {
     // Open a browser
@@ -98,7 +99,7 @@ export async function storybookA11yTest({
 
       try {
         const page = await browser.newPage();
-        await page.goto(url);
+        await page.goto(url, {timeout});
         const result = await page.evaluate(() =>
           window.axe.run(document.getElementById('root'), {}),
         );

--- a/packages/storybook-a11y-test/src/index.ts
+++ b/packages/storybook-a11y-test/src/index.ts
@@ -99,7 +99,7 @@ export async function storybookA11yTest({
 
       try {
         const page = await browser.newPage();
-        await page.goto(url, {timeout});
+        await page.goto(url, {waitUntil: 'load', timeout});
         const result = await page.evaluate(() =>
           window.axe.run(document.getElementById('root'), {}),
         );


### PR DESCRIPTION
## Description
Allow the timeout to be set. Some larger projects need more time. Adding a timeout option that defaults to puppeteers default of 3000.

Solution for:
```
please retry => file:/app/build/storybook/static/iframe.html?id=components-exportmodal-components-asynchronousexportbanner--basic:
--
  | - Navigation timeout of 30000 ms exceeded
  | please retry => file:/app/build/storybook/static/iframe.html?id=components-exportmodal-components-asynchronousexportbanner--draft-orders:
  | - Navigation timeout of 30000 ms exceeded
  | please retry => file:/app/build/storybook/static/iframe.html?id=polaris-next-multiprogressbar--without-specifying-total-items-explicitly:
  | - Navigation timeout of 30000 ms exceeded
  | please retry => file:/app/build/storybook/static/iframe.html?id=sections-orders-components-ordersanalyticsincontext--daily-orders:
  | - Navigation timeout of 30000 ms exceeded
  | To re-run these tests run `yarn run storybook:a11y`
  | error Command failed with exit code 1.
```

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [X] `@shopify/storybook-a11y-test`<!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
