### PR TITLE
Filter out stories with a11y: disabled

### DIFF
--- a/packages/storybook-a11y-test/CHANGELOG.md
+++ b/packages/storybook-a11y-test/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+- Added back the filtering of stories with `a11y: {disable: true}` parameter [#1866](https://github.com/Shopify/quilt/pull/1866)
+
 ## 0.0.5 - 2021-04-23
 
 ### Added

--- a/packages/storybook-a11y-test/src/index.ts
+++ b/packages/storybook-a11y-test/src/index.ts
@@ -29,10 +29,19 @@ export const getStoryIds = async (iframePath: string) => {
     Object.keys(window.__STORYBOOK_STORY_STORE__.extract()),
   );
 
+  const disabledStoryIds = await page.evaluate(() =>
+    window.__STORYBOOK_STORY_STORE__
+      .raw()
+      .filter(story => story.parameters.a11y && story.parameters.a11y.disable)
+      .map(story => story.id),
+  );
+
+  console.log(disabledStoryIds);
+
   await page.close();
   await browser.close();
 
-  return storyIds;
+  return storyIds.filter(storyId => !disabledStoryIds.includes(storyId));
 };
 
 const removeSkippedStories = (skippedStoryIds: string[]) => {

--- a/packages/storybook-a11y-test/src/index.ts
+++ b/packages/storybook-a11y-test/src/index.ts
@@ -36,8 +36,6 @@ export const getStoryIds = async (iframePath: string) => {
       .map(story => story.id),
   );
 
-  console.log(disabledStoryIds);
-
   await page.close();
   await browser.close();
 


### PR DESCRIPTION
## Description

This adds back the filtering of stories that have `a11y: {disable: true}` set in their story parameters.

## Type of change

Minor change for storybook-a11y-test

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
