### PR TITLE
[react-form | DynamicList] newDefaultValue and value props

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Adds a makeCleanDynamicLists function, which adds the ability to set [newDefaultValue, defaultValue] and get the value of a dynamic list. [#1871](https://github.com/Shopify/quilt/pull/1871)
 
 ## 0.13.1 - 2021-04-29
 

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -659,10 +659,17 @@ const emptyCardFactory = (): Card => ({
   cvv: '',
 });
 
-const {fields, addItem, removeItem, moveItem, reset, dirty} = useDynamicList(
-  [],
-  emptyCardFactory,
-);
+const {
+  fields,
+  addItem,
+  removeItem,
+  moveItem,
+  reset,
+  dirty,
+  value,
+  newDefaultValue,
+  defaultValue,
+} = useDynamicList([], emptyCardFactory);
 ```
 
 You can also have a factory that produces multiple cards such as:
@@ -679,10 +686,17 @@ const emptyCardFactory = (): Card[] => {
   ];
 };
 
-const {fields, addItem, removeItem, moveItem, reset, dirty} = useDynamicList(
-  [],
-  emptyCardFactory,
-);
+const {
+  fields,
+  addItem,
+  removeItem,
+  moveItem,
+  reset,
+  dirty,
+  value,
+  newDefaultValue,
+  defaultValue,
+} = useDynamicList([], emptyCardFactory);
 ```
 
 AddItem can accept an argument which will be passed to the factory. In this case, the factory could look like:
@@ -751,6 +765,33 @@ Rendering your dynamic list would look like this:
 </FormLayout>
 ```
 
+You can use the newDefaultValue function to change the defaultValue of the dynamicList. This will also set the value and defaultValue property of the dynamicList to the newValue passed in.
+
+```tsx
+const newValue = [
+  {id: '123456', cardNumber: '4242 4242 4242 4242', cvv: '000'},
+];
+newDefaultValue(newValue);
+```
+
+You can iterate through the values and defaultValues of the dynamicList
+
+```tsx
+value.map(card => (
+  <div>
+    <p>Card number: {card.cardNumber}</p>
+    <p>CVV : {card.cvv}</p>
+  </div>
+));
+
+defaultValue.map(card => (
+  <div>
+    <p>Card number: {card.cardNumber}</p>
+    <p>CVV : {card.cvv}</p>
+  </div>
+));
+```
+
 ##### How to use it with `useForm`
 
 You can use `useDynamicList` with `useForm` in two ways:
@@ -785,7 +826,7 @@ const form = useForm<typeof fields, typeof customerCards>({
   dynamicLists: {
     customerCards,
   },
-  onSubmit: async (fieldValues) => {
+  onSubmit: async fieldValues => {
     console.log(fieldValues);
     return submitSuccess();
   },

--- a/packages/react-form/src/hooks/form.ts
+++ b/packages/react-form/src/hooks/form.ts
@@ -10,7 +10,11 @@ import {
   FormWithDynamicLists,
   DynamicListBag,
 } from '../types';
-import {validateAll, makeCleanFields} from '../utilities';
+import {
+  validateAll,
+  makeCleanFields,
+  makeCleanDynamicLists,
+} from '../utilities';
 
 import {useDirty} from './dirty';
 import {useReset} from './reset';
@@ -109,6 +113,7 @@ export function useForm<T extends FieldBag, D extends DynamicListBag>({
     onSubmit,
     fieldsWithLists,
     makeCleanAfterSubmit,
+    dynamicLists,
   );
 
   const reset = useCallback(() => {
@@ -119,14 +124,16 @@ export function useForm<T extends FieldBag, D extends DynamicListBag>({
 
   const fieldsRef = useLazyRef(() => fieldsWithLists);
   fieldsRef.current = fieldsWithLists;
+  const dynamicListsRef = useLazyRef(() => dynamicLists);
 
   const validate = useCallback(() => {
     return validateAll(fieldsRef.current);
   }, [fieldsRef]);
 
-  const makeClean = useCallback(() => makeCleanFields(fieldsRef.current), [
-    fieldsRef,
-  ]);
+  const makeClean = useCallback(() => {
+    makeCleanFields(fieldsRef.current);
+    makeCleanDynamicLists(dynamicListsRef.current);
+  }, [dynamicListsRef, fieldsRef]);
 
   const form: Form<T> = {
     fields,

--- a/packages/react-form/src/hooks/list/baselist.ts
+++ b/packages/react-form/src/hooks/list/baselist.ts
@@ -46,6 +46,9 @@ interface BaseList<Item extends object> {
   dispatch: React.Dispatch<ListAction<Item>>;
   reset(): void;
   dirty: boolean;
+  defaultValue: Item[];
+  value: Item[];
+  newDefaultValue(newDefaultItems: Item[]): void;
 }
 
 export function useBaseList<Item extends object>(
@@ -63,7 +66,8 @@ export function useBaseList<Item extends object>(
     if (!isEqual(list, state.initial)) {
       dispatch(reinitializeAction(list));
     }
-  }, [list, state.initial, dispatch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [list, dispatch]);
 
   const validationConfigs = useMemo(
     () =>
@@ -77,6 +81,10 @@ export function useBaseList<Item extends object>(
 
   function reset() {
     dispatch(resetListAction());
+  }
+
+  function newDefaultValue(newDefaultItems: Item[]) {
+    dispatch(reinitializeAction(newDefaultItems));
   }
 
   const handlers = useHandlers(state, dispatch, validationConfigs);
@@ -105,5 +113,13 @@ export function useBaseList<Item extends object>(
 
   const fieldsDirty = useDirty({fields});
 
-  return {fields, dispatch, reset, dirty: fieldsDirty || isBaseListDirty};
+  return {
+    fields,
+    dispatch,
+    reset,
+    dirty: fieldsDirty || isBaseListDirty,
+    defaultValue: state.initial,
+    value: listWithoutFieldStates,
+    newDefaultValue,
+  };
 }

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -14,6 +14,9 @@ export interface DynamicList<Item extends object> {
   moveItem(fromIndex: number, toIndex: number): void;
   reset(): void;
   dirty: boolean;
+  value: Item[];
+  defaultValue: Item[];
+  newDefaultValue(newDefaultItems: Item[]): void;
 }
 
 type FactoryFunction<Item extends object> = (
@@ -34,10 +37,15 @@ export function useDynamicList<Item extends object>(
   fieldFactory: FactoryFunction<Item>,
   validationDependencies: unknown[] = [],
 ): DynamicList<Item> {
-  const {fields, dispatch, reset, dirty} = useBaseList(
-    listOrConfig,
-    validationDependencies,
-  );
+  const {
+    fields,
+    dispatch,
+    reset,
+    dirty,
+    newDefaultValue,
+    value,
+    defaultValue,
+  } = useBaseList(listOrConfig, validationDependencies);
 
   function addItem(factoryArgument?: any) {
     const itemToAdd = fieldFactory(factoryArgument);
@@ -57,5 +65,15 @@ export function useDynamicList<Item extends object>(
     dispatch(removeFieldItemAction(index));
   }
 
-  return {fields, addItem, removeItem, moveItem, reset, dirty};
+  return {
+    fields,
+    addItem,
+    removeItem,
+    moveItem,
+    reset,
+    dirty,
+    value,
+    newDefaultValue,
+    defaultValue,
+  };
 }

--- a/packages/react-form/src/hooks/list/test/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/baselist.test.tsx
@@ -768,4 +768,130 @@ describe('useBaseList', () => {
       });
     });
   });
+
+  describe('value, newDefaultValue and defaultValue', () => {
+    function TestListWithValue(config: FieldListConfig<Variant>) {
+      const {value, newDefaultValue, defaultValue} = useBaseList<Variant>(
+        config,
+      );
+
+      const onNewDefault = (value: Variant[]) => {
+        newDefaultValue(value);
+      };
+
+      return (
+        <>
+          {value.map(variant => (
+            <>
+              <p>Value: {variant.price}</p>
+              <p>Value: {variant.optionName}</p>
+              <p>Value: {variant.optionValue}</p>
+            </>
+          ))}
+
+          {defaultValue.map(variant => (
+            <>
+              <p>Default: {variant.price}</p>
+              <p>Default: {variant.optionName}</p>
+              <p>Default: {variant.optionValue}</p>
+            </>
+          ))}
+
+          <button type="button" onClick={onNewDefault} />
+        </>
+      );
+    }
+
+    it('returns the value of the baselist', () => {
+      const price = '1.00';
+      const optionName = 'material';
+      const optionValue = 'cotton';
+      const variants: Variant[] = [
+        {
+          price,
+          optionName,
+          optionValue,
+        },
+      ];
+
+      const wrapper = mount(<TestListWithValue list={variants} />);
+      expect(wrapper).toContainReactText(`Value: ${price}`);
+      expect(wrapper).toContainReactText(`Value: ${optionName}`);
+      expect(wrapper).toContainReactText(`Value: ${optionValue}`);
+    });
+
+    it('resets the list to a new default value', () => {
+      const price = '1.00';
+      const optionName = 'material';
+      const optionValue = 'cotton';
+      const variants: Variant[] = [
+        {
+          price,
+          optionName,
+          optionValue,
+        },
+      ];
+      const newDefaultPrice = '2.00';
+      const newDefaultOption = 'color';
+      const newDefaultOptionValue = 'blue';
+
+      const wrapper = mount(<TestListWithValue list={variants} />);
+
+      expect(wrapper).toContainReactText(`Default: ${price}`);
+      expect(wrapper).toContainReactText(`Default: ${optionName}`);
+      expect(wrapper).toContainReactText(`Default: ${optionValue}`);
+
+      wrapper.find('button')!.trigger('onClick', [
+        {
+          price: newDefaultPrice,
+          optionName: newDefaultOption,
+          optionValue: newDefaultOptionValue,
+        },
+      ]);
+
+      expect(wrapper).toContainReactText(`Default: ${newDefaultPrice}`);
+      expect(wrapper).toContainReactText(`Default: ${newDefaultOption}`);
+      expect(wrapper).toContainReactText(`Default: ${newDefaultOptionValue}`);
+    });
+
+    it('reinitializes the list when the list config has changed after changing the default value', () => {
+      const variants: Variant[] = [
+        {
+          price: '1.00',
+          optionName: 'material',
+          optionValue: 'cotton',
+        },
+      ];
+
+      const newDefaultPrice = '2.00';
+      const newDefaultOption = 'color';
+      const newDefaultOptionValue = 'blue';
+
+      const nextVariant = {
+        price: '1.00',
+        optionName: 'material',
+        optionValue: 'cotton',
+      };
+
+      const wrapper = mount(<TestListWithValue list={variants} />);
+
+      wrapper.find('button')!.trigger('onClick', [
+        {
+          price: newDefaultPrice,
+          optionName: newDefaultOption,
+          optionValue: newDefaultOptionValue,
+        },
+      ]);
+
+      expect(wrapper).toContainReactText(
+        `Default: ${newDefaultPrice}Default: ${newDefaultOption}Default: ${newDefaultOptionValue}`,
+      );
+
+      wrapper.setProps({list: [nextVariant]});
+
+      expect(wrapper).not.toContainReactText(
+        `Default: ${newDefaultPrice}Default: ${newDefaultOption}Default: ${newDefaultOptionValue}`,
+      );
+    });
+  });
 });

--- a/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/test/dynamiclist.test.tsx
@@ -336,4 +336,105 @@ describe('useDynamicList', () => {
       });
     });
   });
+
+  describe('value, newDefaultValue and defaultValue', () => {
+    function TestListWithValue(config: FieldListConfig<Variant>) {
+      const factory = () => {
+        return {price: '', optionName: '', optionValue: ''};
+      };
+      const {
+        value,
+        newDefaultValue,
+        dirty,
+        addItem,
+        defaultValue,
+      } = useDynamicList<Variant>(config, factory);
+
+      const onNewDefault = (value: Variant[]) => {
+        newDefaultValue(value);
+      };
+
+      return (
+        <>
+          {value.map(variants => (
+            <>
+              <p>Value: {variants.price}</p>
+              <p>Value: {variants.optionName}</p>
+              <p>Value: {variants.optionValue}</p>
+            </>
+          ))}
+
+          {defaultValue.map(variants => (
+            <>
+              <p>Default: {variants.price}</p>
+              <p>Default: {variants.optionName}</p>
+              <p>Default: {variants.optionValue}</p>
+            </>
+          ))}
+
+          <button type="button" onClick={onNewDefault}>
+            Default
+          </button>
+          <button type="button" onClick={() => addItem()}>
+            Add Variant
+          </button>
+          <button type="button" disabled={!dirty}>
+            Reset
+          </button>
+        </>
+      );
+    }
+
+    it('returns the value of the dynamiclist', () => {
+      const price = '1.00';
+      const optionName = 'material';
+      const optionValue = 'cotton';
+      const variants: Variant[] = [
+        {
+          price,
+          optionName,
+          optionValue,
+        },
+      ];
+
+      const wrapper = mount(<TestListWithValue list={variants} />);
+      expect(wrapper).toContainReactText(`Value: ${price}`);
+      expect(wrapper).toContainReactText(`Value: ${optionName}`);
+      expect(wrapper).toContainReactText(`Value: ${optionValue}`);
+    });
+
+    it('sets and returns the default value of the dynamic list', () => {
+      const price = '1.00';
+      const optionName = 'material';
+      const optionValue = 'cotton';
+      const variants: Variant[] = [
+        {
+          price,
+          optionName,
+          optionValue,
+        },
+      ];
+      const newDefaultPrice = '2.00';
+      const newDefaultOption = 'color';
+      const newDefaultOptionValue = 'blue';
+
+      const wrapper = mount(<TestListWithValue list={variants} />);
+
+      expect(wrapper).toContainReactText(`Default: ${price}`);
+      expect(wrapper).toContainReactText(`Default: ${optionName}`);
+      expect(wrapper).toContainReactText(`Default: ${optionValue}`);
+
+      wrapper.find('button', {children: 'Default'})!.trigger('onClick', [
+        {
+          price: newDefaultPrice,
+          optionName: newDefaultOption,
+          optionValue: newDefaultOptionValue,
+        },
+      ]);
+
+      expect(wrapper).toContainReactText(`Default: ${newDefaultPrice}`);
+      expect(wrapper).toContainReactText(`Default: ${newDefaultOption}`);
+      expect(wrapper).toContainReactText(`Default: ${newDefaultOptionValue}`);
+    });
+  });
 });

--- a/packages/react-form/src/hooks/test/utilities/index.ts
+++ b/packages/react-form/src/hooks/test/utilities/index.ts
@@ -1,4 +1,5 @@
 import faker from 'faker';
+import {Root} from '@shopify/react-testing';
 
 import {SimpleProduct, TextField} from './components';
 
@@ -65,4 +66,16 @@ export function fakeProduct(): SimpleProduct {
 export function clickEvent() {
   // we don't actually use these at all so it is ok to just return an empty object
   return {} as any;
+}
+
+export function fillRequiredFields(wrapper: Root<any>) {
+  const optionTextFields = wrapper.findAll(TextField, {label: 'option'});
+  optionTextFields.forEach(textField =>
+    textField.trigger('onChange', 'a value'),
+  );
+
+  const titleTextFields = wrapper.findAll(TextField, {label: 'title'});
+  titleTextFields.forEach(textField =>
+    textField.trigger('onChange', 'a value'),
+  );
 }

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -23,4 +23,5 @@ export {
   validateAll,
   reduceFields,
   makeCleanFields,
+  makeCleanDynamicLists,
 } from './utilities';

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -9,6 +9,7 @@ import {
   FormMapping,
   Field,
   FormError,
+  DynamicListBag,
 } from './types';
 
 export function isField<T extends Object>(input: any): input is Field<T> {
@@ -209,4 +210,12 @@ export function defaultDirtyComparator<Value>(
 
 export function makeCleanFields(fieldBag: FieldBag) {
   reduceFields(fieldBag, (_, field) => field.newDefaultValue(field.value));
+}
+
+export function makeCleanDynamicLists(dynamicLists?: DynamicListBag) {
+  if (dynamicLists) {
+    Object.values(dynamicLists).forEach(dynamicList => {
+      dynamicList.newDefaultValue(dynamicList.value);
+    });
+  }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/1855

## Summary
Adds a `makeCleanDynamicList` function, `newDefaultValue` function, `defaultValue`, and `value` properties to `useDynamicList`. This also helps fix the issue where the dynamic list is not cleaned when `makeCleanAfterSubmit` is specified. 

## Tophat

Codesandbox [here](https://codesandbox.io/s/nice-surf-f4kml)

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
