### PR TITLE
[Do Not Merge] drop node 10 from quilt

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
     timeout-minutes: 10
 
     steps:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/dev.yml
+++ b/dev.yml
@@ -2,8 +2,8 @@ name: quilt
 type: node
 up:
   - node:
-      version: v10.18.1
-      yarn: 1.19.1
+      version: v12.21.0
+      yarn: 1.22.5
 commands:
   __default__: start
   build: yarnpkg build

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,15 +1,12 @@
 ci:
   require:
-    - node-unit-tests (10.x)
     - node-unit-tests (12.x)
     - node-unit-tests (14.x)
     - node-e2e-tests (10.x)
     - node-e2e-tests (12.x)
     - node-e2e-tests (14.x)
-    - node-lint (10.x)
     - node-lint (12.x)
     - node-lint (14.x)
-    - node-build (10.x)
     - node-build (12.x)
     - node-build (14.x)
 dependencies:


### PR DESCRIPTION
https://github.com/Shopify/shopify-events/issues/1163

> Node.js 10 will be reaching its End of Life on April 30th. We have already seen dependency bumps breaking our Node.js 10 checks in our CI. Repos should be moving to at least Node.js 12 and should have a plan to move to 14 over the next year.