### PR TITLE
(Draft) ✨ automatically convert SimpleDocument into DocumentNode

### DIFF
--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -46,6 +46,7 @@
     "index.d.ts"
   ],
   "peerDependencies": {
+    "graphql": ">=15.0.0 <16.0.0",
     "react": ">=16.8.0 <17.0.0"
   },
   "module": "index.mjs",

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -48,7 +48,7 @@ export default function useGraphQLDocument<
         }
       })();
     }
-  }, [document]);
+  }, [document, documentOrAsyncDocument, mounted]);
 
   useAsyncAsset(
     isAsync(documentOrAsyncDocument)

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -62,6 +62,7 @@ export default function useGraphQLDocument<
 export function normalizeDocument<Data, Variables, DeepPartial = {}>(
   document: QueryDocument<Data, Variables, DeepPartial>,
 ) {
+  console.log('normalizing document', document);
   if (isSimpleDocument(document)) {
     return desimplify(document);
   } else {

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -72,9 +72,20 @@ export function normalizeDocument<Data, Variables, DeepPartial = {}>(
 function desimplify<Data, Variables, DeepPartial = {}>(
   doc: SimpleDocument<Data, Variables, DeepPartial>,
 ): DocumentNode<Data, Variables, DeepPartial> {
+  const start = performance.now();
+  const parsedDoc = parse(doc.source);
+  const interval = performance.now() - start;
+  console.log(
+    'Parsing document',
+    doc.name || 'anonymous',
+    'took',
+    interval,
+    'ms',
+  );
+
   return {
     id: doc.id,
-    ...parse(doc.source),
+    ...parsedDoc,
   };
 }
 

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -73,21 +73,30 @@ export function normalizeDocument<Data, Variables, DeepPartial = {}>(
 function desimplify<Data, Variables, DeepPartial = {}>(
   doc: SimpleDocument<Data, Variables, DeepPartial>,
 ): DocumentNode<Data, Variables, DeepPartial> {
-  const start = performance.now();
-  const parsedDoc = parse(doc.source);
-  const interval = performance.now() - start;
-  console.log(
-    'Parsing document',
-    doc.name || 'anonymous',
-    'took',
-    interval,
-    'ms',
-  );
+  if (typeof window === 'undefined') {
+    const parsedDoc = parse(doc.source);
 
-  return {
-    id: doc.id,
-    ...parsedDoc,
-  };
+    return {
+      id: doc.id,
+      ...parsedDoc,
+    };
+  } else {
+    const start = performance.now();
+    const parsedDoc = parse(doc.source);
+    const interval = performance.now() - start;
+    console.log(
+      'Parsing document',
+      doc.name || 'anonymous',
+      'took',
+      interval,
+      'ms',
+    );
+
+    return {
+      id: doc.id,
+      ...parsedDoc,
+    };
+  }
 }
 
 function isAsync<Data, Variables, DeepPartial = {}>(

--- a/packages/react-graphql/src/hooks/mutation.ts
+++ b/packages/react-graphql/src/hooks/mutation.ts
@@ -1,13 +1,14 @@
+import {useCallback, useMemo} from 'react';
 import {OperationVariables} from 'apollo-client';
-import {DocumentNode} from 'graphql-typed';
-import {useCallback} from 'react';
 import {NoInfer} from '@shopify/useful-types';
 
+import {QueryDocument} from '../types';
 import {MutationHookOptions, MutationHookResult} from './types';
 import useApolloClient from './apollo-client';
+import {normalizeDocument} from './graphql-document';
 
 export default function useMutation<Data = any, Variables = OperationVariables>(
-  mutation: DocumentNode<Data, Variables>,
+  mutation: QueryDocument<Data, Variables>,
   options: MutationHookOptions<Data, NoInfer<Partial<Variables>>> = {} as any,
 ): MutationHookResult<Data, Variables> {
   const {
@@ -22,6 +23,7 @@ export default function useMutation<Data = any, Variables = OperationVariables>(
   } = options;
 
   const client = useApolloClient(overrideClient);
+  const document = useMemo(() => normalizeDocument(mutation), [mutation]);
 
   const runMutation = useCallback(
     (perMutationOptions: MutationHookOptions<Data, Variables> = {} as any) => {
@@ -32,7 +34,7 @@ export default function useMutation<Data = any, Variables = OperationVariables>(
       delete perMutationOptions.variables;
 
       return client.mutate({
-        mutation,
+        mutation: document,
         variables: mutateVariables as any,
         optimisticResponse,
         refetchQueries,

--- a/packages/react-graphql/src/hooks/mutation.ts
+++ b/packages/react-graphql/src/hooks/mutation.ts
@@ -3,6 +3,7 @@ import {OperationVariables} from 'apollo-client';
 import {NoInfer} from '@shopify/useful-types';
 
 import {QueryDocument} from '../types';
+
 import {MutationHookOptions, MutationHookResult} from './types';
 import useApolloClient from './apollo-client';
 import {normalizeDocument} from './graphql-document';

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -12,6 +12,7 @@ import {useServerEffect} from '@shopify/react-effect';
 import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
 
 import {PossiblyAsyncQuery} from '../types';
+
 import {QueryHookOptions, QueryHookResult} from './types';
 import useApolloClient from './apollo-client';
 import useGraphQLDocument from './graphql-document';

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -8,12 +8,10 @@ import {
   WatchQueryOptions,
   ObservableQuery,
 } from 'apollo-client';
-import {DocumentNode} from 'graphql-typed';
 import {useServerEffect} from '@shopify/react-effect';
 import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
 
-import {AsyncDocumentNode} from '../types';
-
+import {PossiblyAsyncQuery} from '../types';
 import {QueryHookOptions, QueryHookResult} from './types';
 import useApolloClient from './apollo-client';
 import useGraphQLDocument from './graphql-document';
@@ -23,9 +21,7 @@ export default function useQuery<
   Variables = OperationVariables,
   DeepPartial = {}
 >(
-  queryOrAsyncQuery:
-    | DocumentNode<Data, Variables, DeepPartial>
-    | AsyncDocumentNode<Data, Variables, DeepPartial>,
+  queryOrAsyncQuery: PossiblyAsyncQuery<Data, Variables, DeepPartial>,
   ...optionsPart: IfAllNullableKeys<
     Variables,
     [QueryHookOptions<Data, NoInfer<Variables>>?],

--- a/packages/react-graphql/src/index.ts
+++ b/packages/react-graphql/src/index.ts
@@ -8,6 +8,7 @@ export type {
   GraphQLData,
   GraphQLVariables,
   GraphQLDeepPartial,
+  PossiblyAsyncQuery,
   QueryProps,
 } from './types';
 

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -5,6 +5,7 @@ import {
   GraphQLData,
   GraphQLVariables,
   GraphQLDeepPartial,
+  SimpleDocument,
 } from 'graphql-typed';
 import {QueryResult} from '@apollo/react-common';
 import {
@@ -49,10 +50,18 @@ export type QueryProps<Data = any, Variables = OperationVariables> = {
   onError?: (error: ApolloError) => void;
 } & VariableOptions<Variables>;
 
+export type PossiblyAsyncQuery<Data = {}, Variables = {}, DeepPartial = {}> =
+  | QueryDocument<Data, Variables>
+  | AsyncDocumentNode<Data, Variables, DeepPartial>;
+
+export type QueryDocument<Data = {}, Variables = {}, DeepPartial = {}> =
+  | DocumentNode<Data, Variables, DeepPartial>
+  | SimpleDocument<Data, Variables, DeepPartial>;
+
 export interface AsyncDocumentNode<Data, Variables, DeepPartial>
   extends GraphQLOperation<Data, Variables, DeepPartial>,
     AsyncHookTarget<
-      DocumentNode<Data, Variables, DeepPartial>,
+      QueryDocument<Data, Variables, DeepPartial>,
       {},
       VariableOptions<Variables>,
       VariableOptions<Variables> &
@@ -62,7 +71,7 @@ export interface AsyncDocumentNode<Data, Variables, DeepPartial>
 export interface AsyncQueryComponentType<Data, Variables, DeepPartial>
   extends GraphQLOperation<Data, Variables, DeepPartial>,
     AsyncComponentType<
-      DocumentNode<Data, Variables, DeepPartial>,
+      QueryDocument<Data, Variables, DeepPartial>,
       QueryHookOptions<Data, Variables> &
         Pick<QueryProps<Data, Variables>, 'children'>,
       {},


### PR DESCRIPTION
This PR will be used as a proof of concept beta to see what effect turning on `simple: true` in a large app has (and how much of a trade-off bringing in a parser is instead).

Initial estimates have total AST size in some of our largest apps at 500kb+ minzipped, vs `parse` being only about 8kb. We will use our automated tooling with a beta to see how much savings we can glean in a real app.