### PR TITLE
Update Graphql Config => v3

### DIFF
--- a/packages/graphql-config-utilities/package.json
+++ b/packages/graphql-config-utilities/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/Shopify/quilt/blob/main/packages/graphql-config-utilities/README.md",
   "dependencies": {
     "glob": "^7.1.6",
-    "graphql-config": "^2.0.0"
+    "graphql-config": "^3.2.0"
   },
   "files": [
     "build/*",

--- a/packages/graphql-config-utilities/src/config.ts
+++ b/packages/graphql-config-utilities/src/config.ts
@@ -1,5 +1,6 @@
 import {existsSync} from 'fs';
 import {promisify} from 'util';
+import {resolve} from 'path';
 
 import {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
 // we need to use an import/require here because it does not force consumers to
@@ -14,48 +15,47 @@ export function resolvePathRelativeToConfig(
   project: GraphQLProjectConfig,
   relativePath: string,
 ) {
-  return project.resolveConfigPath(relativePath);
+  return resolve(project.dirpath, relativePath);
 }
 
 export function resolveProjectName(
   project: GraphQLProjectConfig,
   defaultName = defaultGraphQLProjectName,
 ) {
-  return project.projectName || defaultName;
+  // eslint-disable-next-line no-console
+  console.warn(
+    'Deprecation: Use of `resolveProjectName` has been deprecated. Please use `project.name` instead.',
+  );
+  return project.name || defaultName;
 }
 
 export function resolveSchemaPath(
   project: GraphQLProjectConfig,
   ignoreMissing = false,
 ) {
-  // schemaPath is nullable in graphq-config even though it cannot actually be
-  // omitted. This function simplifies access to the schemaPath without
+  // schemaPath is nullable in graphql-config even though it cannot actually be
+  // omitted. This function simplifies access to the schema without
   // requiring a type guard.
-  if (!project.schemaPath) {
+  if (!project.schema) {
     // this case should never happen with a properly formatted config file.
     // graphql-config currently does not perform any validation so it's possible
     // for a mal-formed schema to be loaded at runtime.
-    throw new Error(
-      `Missing GraphQL schemaPath for project '${resolveProjectName(project)}'`,
-    );
+    throw new Error(`Missing GraphQL schema for project '${project.name}'`);
   }
 
   // resolve fully qualified schemaPath
-  const schemaPath = project.resolveConfigPath(project.schemaPath);
-
+  const schemaPath = resolve(project.dirpath, project.schema as string);
   if (ignoreMissing) {
     return schemaPath;
   }
 
   if (!existsSync(schemaPath)) {
-    const forProject = project.projectName
-      ? ` for project '${project.projectName}'`
-      : '';
+    const forProject = project.name ? ` for project '${project.name}'` : '';
     throw new Error(
       [
         `Schema not found${forProject}.`,
         `Expected to find the schema at '${schemaPath}' but the path does not exist.`,
-        `Check '${project.configPath}' and verify that schemaPath is configured correctly${forProject}.`,
+        `Check '${project.filepath}' and verify that schemaPath is configured correctly${forProject}.`,
       ].join(' '),
     );
   }
@@ -64,22 +64,25 @@ export function resolveSchemaPath(
 }
 
 export function getGraphQLProjects(config: GraphQLConfig) {
-  const projects = config.getProjects();
+  // eslint-disable-next-line no-console
+  console.warn(
+    'Deprecation: Use of `getGraphQLProjects` has been deprecated. Please use `config.projects` instead.',
+  );
 
-  if (projects) {
+  const projects = Object.values(config?.projects || {});
+
+  if (projects.length > 1) {
     // multi-project configuration, return an array of projects
-    return Object.values(projects);
+    return projects;
   }
 
-  const project = config.getProjectConfig();
-
-  if (project && project.schemaPath) {
+  if (projects[0] && projects[0]?.schema) {
     // single project configuration, return an array of the single project
-    return [project];
+    return projects;
   }
 
   // invalid project configuration
-  throw new Error(`No projects defined in '${config.configPath}'`);
+  throw new Error(`No projects defined in '${config.filepath}'`);
 }
 
 export function getGraphQLSchemaPaths(config: GraphQLConfig) {
@@ -91,11 +94,12 @@ export function getGraphQLSchemaPaths(config: GraphQLConfig) {
 export async function getGraphQLProjectIncludedFilePaths(
   projectConfig: GraphQLProjectConfig,
 ) {
+  const [includes, excludes] = getIncludesExcludesFromConfig(projectConfig);
   return (
     await Promise.all(
-      projectConfig.includes.map(include =>
+      includes.map(include =>
         promisify(glob)(resolvePathRelativeToConfig(projectConfig, include), {
-          ignore: projectConfig.excludes.map(exclude =>
+          ignore: excludes.map(exclude =>
             resolvePathRelativeToConfig(projectConfig, exclude),
           ),
         }),
@@ -110,14 +114,38 @@ export function getGraphQLProjectForSchemaPath(
 ) {
   const project =
     getGraphQLProjects(config)
-      .filter(project => project.schemaPath === schemaPath)
-      .shift() || config.getProjectConfig();
+      .filter(project => {
+        return resolveSchemaPath(project, true) === schemaPath;
+      })
+      .shift() || config.projects[0];
 
-  if (!project || project.schemaPath !== schemaPath) {
+  if (
+    !project ||
+    !(project as GraphQLProjectConfig).schema ||
+    `${(project as GraphQLProjectConfig).dirpath}/${
+      (project as GraphQLProjectConfig).schema
+    }` !== schemaPath
+  ) {
     throw new Error(
       `No project defined in graphql config for schema '${schemaPath}'`,
     );
   }
-
   return project;
+}
+
+export function getIncludesExcludesFromConfig(
+  projectConfig: GraphQLProjectConfig,
+): [string[], string[]] {
+  if (!projectConfig.include) {
+    return [[], []];
+  }
+
+  const excludes = projectConfig.exclude || [];
+
+  const includes =
+    typeof projectConfig.include === 'string'
+      ? [projectConfig.include as string]
+      : projectConfig.include;
+  const ignore = typeof excludes === 'string' ? [excludes as string] : excludes;
+  return [includes, ignore];
 }

--- a/packages/graphql-config-utilities/src/tests/fixtures/default/.graphqlconfig
+++ b/packages/graphql-config-utilities/src/tests/fixtures/default/.graphqlconfig
@@ -1,0 +1,3 @@
+{
+  "schemaPath": "schema.graphql",
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/default/schema.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/default/schema.graphql
@@ -1,0 +1,19 @@
+enum Generation {
+  MILLENIAL
+  GEN_X
+}
+
+type Person {
+  id: ID!
+  name: String!
+  generation: Generation!
+  relatives: [Person!]!
+}
+
+type Query {
+  person: Person
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/error/.graphqlconfig
+++ b/packages/graphql-config-utilities/src/tests/fixtures/error/.graphqlconfig
@@ -1,0 +1,1 @@
+{ "name": "error-test", "schemaPath": "undefined"}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-multi/.graphqlconfig
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-multi/.graphqlconfig
@@ -1,0 +1,17 @@
+{
+  "name": "this-is-a-test",
+  "schemaPath": "schema.graphql",
+  "includes": ["documents/**/*.graphql"],
+  "projects": {
+    "project-one": {
+      "name": "project-one",
+      "schemaPath": "project-one/schema.graphql",
+      "includes": ["documents/**/*.graphql"],
+    },
+    "project-two": {
+      "name": "project-two",
+      "schemaPath": "project-two/schema.graphql",
+      "includes": ["documents/**/*.graphql"],
+    }
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-multi/documents/Fragment.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-multi/documents/Fragment.graphql
@@ -1,0 +1,7 @@
+fragment PersonFields on Person {
+  name
+  generation
+  relatives {
+    name
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-multi/documents/Query.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-multi/documents/Query.graphql
@@ -1,0 +1,6 @@
+query FindPerson {
+  person {
+    id
+    ...PersonFields
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-multi/schema.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-multi/schema.graphql
@@ -1,0 +1,19 @@
+enum Generation {
+  MILLENIAL
+  GEN_X
+}
+
+type Person {
+  id: ID!
+  name: String!
+  generation: Generation!
+  relatives: [Person!]!
+}
+
+type Query {
+  person: Person
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-multi/types/Generation.ts
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-multi/types/Generation.ts
@@ -1,0 +1,4 @@
+export enum Generation {
+  Millenial = 'MILLENIAL',
+  GenX = 'GEN_X',
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-multi/types/index.ts
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-multi/types/index.ts
@@ -1,0 +1,1 @@
+export {Generation} from './Generation';

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/.graphqlconfig
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/.graphqlconfig
@@ -1,0 +1,12 @@
+{
+  "name": "this-is-a-test",
+  "schemaPath": "schema.graphql",
+  "includes": ["documents/**/*.graphql"],
+  "projects": {
+    "project-one": {
+      "name": "project-one",
+      "schemaPath": "schema.graphql",
+      "includes": ["documents/**/*.graphql", "new-documents/**/*.graphql"],
+    }
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/documents/Fragment.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/documents/Fragment.graphql
@@ -1,0 +1,7 @@
+fragment PersonFields on Person {
+  name
+  generation
+  relatives {
+    name
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/documents/Query.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/documents/Query.graphql
@@ -1,0 +1,6 @@
+query FindPerson {
+  person {
+    id
+    ...PersonFields
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/new-documents/Fragment.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/new-documents/Fragment.graphql
@@ -1,0 +1,7 @@
+fragment PersonFields on Person {
+  name
+  generation
+  relatives {
+    name
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/new-documents/Query.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/new-documents/Query.graphql
@@ -1,0 +1,6 @@
+query FindPerson {
+  person {
+    id
+    ...PersonFields
+  }
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/schema.graphql
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/schema.graphql
@@ -1,0 +1,19 @@
+enum Generation {
+  MILLENIAL
+  GEN_X
+}
+
+type Person {
+  id: ID!
+  name: String!
+  generation: Generation!
+  relatives: [Person!]!
+}
+
+type Query {
+  person: Person
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/types/Generation.ts
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/types/Generation.ts
@@ -1,0 +1,4 @@
+export enum Generation {
+  Millenial = 'MILLENIAL',
+  GenX = 'GEN_X',
+}

--- a/packages/graphql-config-utilities/src/tests/fixtures/project-one/types/index.ts
+++ b/packages/graphql-config-utilities/src/tests/fixtures/project-one/types/index.ts
@@ -1,0 +1,1 @@
+export {Generation} from './Generation';

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -33,7 +33,7 @@
     "fs-extra": "^9.0.0",
     "glob": "^7.1.2",
     "graphql": ">=14.5.0 <15.0.0",
-    "graphql-config": "^2.2.1",
+    "graphql-config": "^3.2.0",
     "graphql-config-utilities": "^1.3.2",
     "graphql-tool-utilities": "^1.4.4",
     "upper-case-first": "^2.0.1",

--- a/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
@@ -5,6 +5,7 @@ import {
   getGraphQLProjects,
   getGraphQLSchemaPaths,
   resolvePathRelativeToConfig,
+  getIncludesExcludesFromConfig,
 } from 'graphql-config-utilities';
 
 import {AbstractGraphQLFilesystem} from './graphql-filesystem';
@@ -41,14 +42,20 @@ export class DefaultGraphQLFilesystem extends AbstractGraphQLFilesystem {
 
   private setupDocumentWatchers(config: GraphQLConfig) {
     return getGraphQLProjects(config)
-      .filter(({includes}) => includes.length > 0)
+      .filter(projectConfig => {
+        const [includes] = getIncludesExcludesFromConfig(projectConfig);
+        return includes.length > 0;
+      })
       .map(projectConfig => {
+        const [includes, excludes] = getIncludesExcludesFromConfig(
+          projectConfig,
+        );
         return watch(
-          projectConfig.includes.map(include =>
+          includes.map(include =>
             resolvePathRelativeToConfig(projectConfig, include),
           ),
           {
-            ignored: projectConfig.excludes.map(exclude =>
+            ignored: excludes.map(exclude =>
               resolvePathRelativeToConfig(projectConfig, exclude),
             ),
             ignoreInitial: true,

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -13,7 +13,7 @@ import {
 import chalk from 'chalk';
 import {mkdirp, readFile, writeFile} from 'fs-extra';
 import {
-  getGraphQLConfig,
+  loadConfigSync,
   GraphQLProjectConfig,
   GraphQLConfig,
 } from 'graphql-config';
@@ -97,9 +97,11 @@ export class Builder extends EventEmitter {
     super();
     this.options = options;
 
+    const configPath = cwd ? resolve(cwd) : undefined;
+
     this.config = options.config
       ? options.config
-      : getGraphQLConfig(cwd ? resolve(cwd) : undefined);
+      : loadConfigSync({rootDir: configPath});
   }
 
   once(event: 'error', handler: (error: Error) => void): this;
@@ -186,7 +188,7 @@ export class Builder extends EventEmitter {
   }
 
   stop() {
-    if (this.filesystem) {
+    if (this.filesystem && typeof this.filesystem.dispose === 'function') {
       this.filesystem.dispose();
     }
   }
@@ -209,7 +211,7 @@ export class Builder extends EventEmitter {
     filePath: string,
     projectConfig: GraphQLProjectConfig,
   ) => {
-    const documents = this.documentMapByProject.get(projectConfig.projectName);
+    const documents = this.documentMapByProject.get(projectConfig.name);
 
     if (documents) {
       documents.delete(filePath);
@@ -235,10 +237,9 @@ export class Builder extends EventEmitter {
       this.config,
       schemaPath,
     );
-
     const schemaTypesPath = getSchemaTypesPath(projectConfig, this.options);
     const definitions = generateSchemaTypes(
-      projectConfig.getSchema(),
+      await projectConfig.getSchema(),
       this.options,
     );
     await mkdirp(schemaTypesPath);
@@ -264,7 +265,7 @@ export class Builder extends EventEmitter {
         this.documentMapByProject.entries(),
       ).map(([projectName, documents]) =>
         this.generateDocumentTypesForProject(
-          this.config.getProjectConfig(projectName),
+          this.config.getProject(projectName),
           documents,
         ),
       ),
@@ -317,7 +318,7 @@ export class Builder extends EventEmitter {
 
     try {
       ast = compile(
-        projectConfig.getSchema(),
+        await projectConfig.getSchema(),
         concatAST(Array.from(documents.values())),
       );
     } catch (error) {
@@ -406,11 +407,11 @@ export class Builder extends EventEmitter {
     projectConfig: GraphQLProjectConfig,
     contents: string,
   ) {
-    let documents = this.documentMapByProject.get(projectConfig.projectName);
+    let documents = this.documentMapByProject.get(projectConfig.name);
 
     if (!documents) {
       documents = new Map<string, DocumentNode>();
-      this.documentMapByProject.set(projectConfig.projectName, documents);
+      this.documentMapByProject.set(projectConfig.name, documents);
     }
 
     if (contents.trim().length === 0) {
@@ -439,9 +440,7 @@ function getSchemaTypesPath(
     projectConfig,
     join(
       options.schemaTypesPath,
-      `${
-        projectConfig.projectName ? `${projectConfig.projectName}-` : ''
-      }types`,
+      `${projectConfig.name ? `${projectConfig.name}-` : ''}types`,
     ),
   );
 }

--- a/packages/graphql-typescript-definitions/test/fixtures/all-clear/default-types/Generation.ts
+++ b/packages/graphql-typescript-definitions/test/fixtures/all-clear/default-types/Generation.ts
@@ -1,0 +1,4 @@
+export enum Generation {
+  MILLENIAL = "MILLENIAL",
+  GEN_X = "GEN_X",
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/all-clear/default-types/index.ts
+++ b/packages/graphql-typescript-definitions/test/fixtures/all-clear/default-types/index.ts
@@ -1,0 +1,2 @@
+import { Generation } from "./Generation";
+export { Generation };

--- a/packages/graphql-validate-fixtures/package.json
+++ b/packages/graphql-validate-fixtures/package.json
@@ -26,7 +26,7 @@
     "fs-extra": "^9.0.0",
     "glob": "^7.1.2",
     "graphql": ">=14.5.0 <15.0.0",
-    "graphql-config": "^2.2.1",
+    "graphql-config": "^3.2.0",
     "graphql-config-utilities": "^1.3.2",
     "graphql-tool-utilities": "^1.4.4",
     "yargs": "^15.3.1"

--- a/packages/graphql-validate-fixtures/test/__snapshots__/index.test.ts.snap
+++ b/packages/graphql-validate-fixtures/test/__snapshots__/index.test.ts.snap
@@ -126,9 +126,13 @@ Array [
 `;
 
 exports[`evaluateFixtures() throws an error when the schema is not found 1`] = `
-[Error: Error parsing 'packages/graphql-validate-fixtures/test/fixtures/missing-schema/schema.json':
+[Error: Error parsing 'schema.json':
 
-ENOENT: no such file or directory, open 'packages/graphql-validate-fixtures/test/fixtures/missing-schema/schema.json']
+
+      Unable to find any GraphQL type definitions for the following pointers:
+        
+          - schema.json
+          ]
 `;
 
 exports[`evaluateFixtures() throws an error when there are malformed GraphQL documents 1`] = `

--- a/packages/graphql-validate-fixtures/test/validate.test.ts
+++ b/packages/graphql-validate-fixtures/test/validate.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @shopify/jest/no-snapshots */
 
-import {join} from 'path';
+import {join, resolve} from 'path';
 
 // eslint-disable-next-line @shopify/typescript/prefer-build-client-schema
 import {buildSchema, parse, concatAST} from 'graphql';
-import {GraphQLProjectConfig} from 'graphql-config';
+import {GraphQLProjectConfig, loadConfigSync} from 'graphql-config';
 import {AST, compile} from 'graphql-tool-utilities';
 
 import {
@@ -513,13 +513,9 @@ describe('validate', () => {
   });
 });
 
-const mockGraphQLConfig = new GraphQLProjectConfig(
-  {
-    schemaPath: '.',
-  },
-  '.',
-  'test',
-);
+const mockGraphQLConfig = loadConfigSync({
+  rootDir: resolve(__dirname, 'fixtures', 'all-clear'),
+});
 
 function validateAgainstAST(fixtureContent: any, ast: AST) {
   const projectOperations: GraphQLProjectAST = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6121,14 +6121,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
-  integrity sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=
-  dependencies:
-    node-fetch "2.1.2"
-    whatwg-fetch "2.0.4"
-
 cross-fetch@3.1.4, cross-fetch@^3.0.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
@@ -8469,18 +8461,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-config@^2.0.0, graphql-config@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-2.2.2.tgz#a4b577826bba9b83e7b0f6cd617be43ca67da045"
-  integrity sha512-mtv1ejPyyR2mJUUZNhljggU+B/Xl8tJJWf+h145hB+1Y48acSghFalhNtXfPBcYl2tJzpb+lGxfj3O7OjaiMgw==
-  dependencies:
-    graphql-import "^0.7.1"
-    graphql-request "^1.5.0"
-    js-yaml "^3.10.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-
-graphql-config@^3.0.2:
+graphql-config@^3.0.2, graphql-config@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-3.2.0.tgz#3ec3a7e319792086b80e54db4b37372ad4a79a32"
   integrity sha512-ygEKDeQNZKpm4137560n2oY3bGM0D5zyRsQVaJntKkufWdgPg6sb9/4J1zJW2y/yC1ortAbhNho09qmeJeLa9g==
@@ -8497,21 +8478,6 @@ graphql-config@^3.0.2:
     minimatch "3.0.4"
     string-env-interpolation "1.0.1"
     tslib "^2.0.0"
-
-graphql-import@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/graphql-import/-/graphql-import-0.7.1.tgz#4add8d91a5f752d764b0a4a7a461fcd93136f223"
-  integrity sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==
-  dependencies:
-    lodash "^4.17.4"
-    resolve-from "^4.0.0"
-
-graphql-request@^1.5.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
-  integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
-  dependencies:
-    cross-fetch "2.2.2"
 
 graphql-tag@^2.10.1, graphql-tag@^2.10.3:
   version "2.10.3"
@@ -8831,7 +8797,7 @@ http-cache-semantics@^3.8.1:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
 
-http-errors@1.7.3, http-errors@^1.6.3, http-errors@~1.7.2:
+http-errors@1.7.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -8842,7 +8808,7 @@ http-errors@1.7.3, http-errors@^1.6.3, http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@^1.7.3:
+http-errors@^1.6.3, http-errors@^1.7.3:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
   integrity sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==
@@ -10311,7 +10277,7 @@ jest@^26.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.10.0, js-yaml@^3.13.1:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -10968,7 +10934,7 @@ lodash.xorby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
-lodash@^4.15.0, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.7.0:
+lodash@^4.15.0, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11784,11 +11750,6 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
-
-node-fetch@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
 node-fetch@2.6.1, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
@@ -16866,11 +16827,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
-  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Fixes security updates regarding `node-fetch` by updating `graphql-config` to vs 3 as this version strips `graphql-response` which ends up using `node-fetch`.

Once this PR is in: https://github.com/Shopify/quilt/pull/1880 I will rebase.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `graphql-config-utilities`  Minor: New feature (non-breaking change which adds functionality)
expected)
- [x] `graphql-typescript-definitions`  Minor
expected)
- [x] `graphql-validate-fixtures`  Minor
expected)


## 🎩 

CI passes in sewing-kit (with beta releases): https://github.com/Shopify/sewing-kit/pull/2649

Tested locally on hydrox and builds and serves correctly 

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
