### PR TITLE
[React-HTML] Exposing some useful server components

### DIFF
--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Exposing the `Style`, `Script` and `Stylesheet` component from the `@shopify/react-html/server`. [#1829](https://github.com/Shopify/quilt/pull/1884)
 
 ## 10.2.7 - 2021-04-13
 

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -202,15 +202,15 @@ import {Stylesheet} from '@shopify/react-html/server';
 />;
 ```
 
-### `<InlineStyle />`
+### `<Style />`
 
-The `<InlineStyle />` component lets you render `<style>` tags in your document dynamically as part of your react app. It supports all of the props of a basic `style` tag, but forces some properties to be the values needed for an inline style. In general, prefer the `inlineStyles` prop of the `Html` component instead of using this component explicitly.
+The `<Style />` component lets you render `<style>` tags in your document dynamically as part of your react app. It supports all of the props of a basic `style` tag, but forces some properties to be the values needed for an inline style. In general, prefer the `inlineStyles` prop of the `Html` component instead of using this component explicitly.
 
 ```tsx
-import {InlineStyle} from '@shopify/react-html/server';
+import {Style} from '@shopify/react-html/server';
 
 const css = '.foo {color: red}';
-<InlineStyle>{css}</InlineStyle>;
+<Style>{css}</Style>;
 ```
 
 ### `<Script />`

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -6,10 +6,10 @@ import {HtmlManager} from '../../manager';
 import {HtmlContext} from '../../context';
 import {MANAGED_ATTRIBUTE, removeDuplicate} from '../../utilities';
 
+import {Style} from './Style';
 import {Script} from './Script';
 import Serialize from './Serialize';
 import {Stylesheet} from './Stylesheet';
-import {InlineStyle} from './InlineStyle';
 
 export interface Asset {
   path: string;
@@ -101,9 +101,7 @@ export default function Html({
   });
 
   const inlineStylesMarkup = inlineStyles.map(inlineStyle => {
-    return (
-      <InlineStyle key={inlineStyle.content}>{inlineStyle.content}</InlineStyle>
-    );
+    return <Style key={inlineStyle.content}>{inlineStyle.content}</Style>;
   });
 
   const blockingScriptsMarkup = blockingScripts.map(script => {

--- a/packages/react-html/src/server/components/Style.tsx
+++ b/packages/react-html/src/server/components/Style.tsx
@@ -4,6 +4,6 @@ export interface Props extends React.StyleHTMLAttributes<HTMLStyleElement> {
   children: string;
 }
 
-export function InlineStyle(props: Props) {
+export function Style(props: Props) {
   return <style type="text/css" {...props} />;
 }

--- a/packages/react-html/src/server/components/index.ts
+++ b/packages/react-html/src/server/components/index.ts
@@ -1,3 +1,6 @@
 export {default as Serialize} from './Serialize';
 export {default as Html} from './Html';
 export type {HtmlProps} from './Html';
+export {Style} from './Style';
+export {Script} from './Script';
+export {Stylesheet} from './Stylesheet';

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import withEnv from '@shopify/with-env';
 import {mount} from '@shopify/react-testing';
 
+import {Style} from '../Style';
 import {Script} from '../Script';
 import {Stylesheet} from '../Stylesheet';
-import {InlineStyle} from '../InlineStyle';
 import {HtmlManager} from '../../../manager';
 import {MANAGED_ATTRIBUTE} from '../../../utilities';
 import Html from '../Html';
@@ -143,7 +143,7 @@ describe('<Html />', () => {
       const head = html.find('head')!;
 
       for (const inlineStyle of inlineStyles) {
-        expect(head).toContainReactComponent(InlineStyle, {
+        expect(head).toContainReactComponent(Style, {
           children: inlineStyle.content,
         });
       }


### PR DESCRIPTION
## Description
- Renaming the `InlineStyle` component from the server folder to `Style` to avoid conflict in exports.
- Exporting the `Style`, `Script` and `Stylesheet` components from the server folder.

## Type of change

It's a patch because the `InlineStyle` component was not exposed before.

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
