### PR TITLE
add missed changelog updates

### DIFF
--- a/packages/graphql-config-utilities/CHANGELOG.md
+++ b/packages/graphql-config-utilities/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Update `graphql-config` to version 3. [#1883](https://github.com/Shopify/quilt/pull/1883)
 
 ## 1.3.2 - 2021-04-13
 

--- a/packages/graphql-typescript-definitions/CHANGELOG.md
+++ b/packages/graphql-typescript-definitions/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Update `graphql-config` to version 3. Update `graphql-config-utilities`. [#1883](https://github.com/Shopify/quilt/pull/1883)
 
 ## 0.24.0 - 2021-04-13
 

--- a/packages/graphql-validate-fixtures/CHANGELOG.md
+++ b/packages/graphql-validate-fixtures/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Update `graphql-config` to version 3. Update `graphql-config-utilities`. [#1883](https://github.com/Shopify/quilt/pull/1883)
 
 ## 0.14.3 - 2021-04-13
 


### PR DESCRIPTION
## Description

Updates missed changelog updates for:
- graphql-config-utilities
- graphql-typescript-definitions
- graphql-validate-fixtures

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
