### PR TITLE
Fix to get broken graphql libs out the door

### DIFF
--- a/packages/graphql-config-utilities/CHANGELOG.md
+++ b/packages/graphql-config-utilities/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Refactor `getGraphQLProjects` to take default projects into consideration. [#1894](https://github.com/Shopify/quilt/pull/1894)
 
 ## 2.0.1 - 2021-05-07
 

--- a/packages/graphql-config-utilities/src/config.ts
+++ b/packages/graphql-config-utilities/src/config.ts
@@ -64,11 +64,6 @@ export function resolveSchemaPath(
 }
 
 export function getGraphQLProjects(config: GraphQLConfig) {
-  // eslint-disable-next-line no-console
-  console.warn(
-    'Deprecation: Use of `getGraphQLProjects` has been deprecated. Please use `config.projects` instead.',
-  );
-
   const projects = Object.values(config?.projects || {});
 
   if (projects.length > 1) {
@@ -81,8 +76,15 @@ export function getGraphQLProjects(config: GraphQLConfig) {
     return projects;
   }
 
-  // invalid project configuration
-  throw new Error(`No projects defined in '${config.filepath}'`);
+  let defaultProject: GraphQLProjectConfig;
+
+  try {
+    defaultProject = config.getDefault();
+    return [defaultProject];
+  } catch {
+    // invalid project configuration
+    throw new Error(`No projects defined in '${config.filepath}'`);
+  }
 }
 
 export function getGraphQLSchemaPaths(config: GraphQLConfig) {

--- a/packages/graphql-typescript-definitions/CHANGELOG.md
+++ b/packages/graphql-typescript-definitions/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fix broken file exports. [#1894](https://github.com/Shopify/quilt/pull/1894)
 
 ## 1.0.1 - 2021-05-07
 

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -48,6 +48,7 @@
     "graphql-typed": "^0.4.0"
   },
   "files": [
+    "bin/*",
     "build/*",
     "!*.tsbuildinfo",
     "index.js",

--- a/packages/graphql-validate-fixtures/CHANGELOG.md
+++ b/packages/graphql-validate-fixtures/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fix broken file exports. [#1894](https://github.com/Shopify/quilt/pull/1894)
 
 ## 1.0.1 - 2021-05-07
 

--- a/packages/graphql-validate-fixtures/package.json
+++ b/packages/graphql-validate-fixtures/package.json
@@ -32,6 +32,7 @@
     "yargs": "^15.3.1"
   },
   "files": [
+    "bin/*",
     "build/*",
     "!*.tsbuildinfo",
     "index.js",

--- a/tests/consistent-package-json.test.ts
+++ b/tests/consistent-package-json.test.ts
@@ -75,6 +75,11 @@ packages.forEach(
             // We want to make sure the first set of items are always in a fixed
             // order. Most importantly, the `!*.tsbuildinfo` exclusion must be
             // after `build/*`.
+            /* eslint-disable jest/no-if */
+            if (packageJSON?.bin) {
+              expectedPackageJSON.files.unshift('bin/*');
+            }
+            /* eslint-enable */
             expect(
               packageJSON.files.slice(0, expectedPackageJSON.files.length),
             ).toStrictEqual(expectedPackageJSON.files);


### PR DESCRIPTION
## Description

Fixes the issue with the missing bins in `graphql-typescript-definitions` and `graphql-validate-fixtures`.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
