### PR TITLE
force the registry to be public

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -14,4 +14,6 @@ ci:
     - node-build (14.x)
 dependencies:
   post:
+    - npm config set @shopify:registry https://registry.yarnpkg.com
+    - npm config set registry https://registry.yarnpkg.com
     - yarn run build: {timeout: 1800}


### PR DESCRIPTION
## Description
Force the registry to be public. This prevents matching on old private packages.

Note there is a version of `@shopify/react-server` that has not been published yet. 