### PR TITLE
fix: resolve url to only be path and search

### DIFF
--- a/packages/jest-koa-mocks/CHANGELOG.md
+++ b/packages/jest-koa-mocks/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Fixed
+
+- `createMockContext` properly sets `ctx.url` and `ctx.originalUrl` so that it includes only the portions of URL that are present in the actual HTTP request [source](https://nodejs.org/api/http.html#http_message_url).
+
 ## 2.3.4 - 2021-04-13
 
 ### Changed

--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -1,4 +1,4 @@
-import {URL} from 'url';
+import {URL, format} from 'url';
 import stream from 'stream';
 
 import httpMocks, {RequestMethod} from 'node-mocks-http';
@@ -74,7 +74,10 @@ export default function createContext<
   const urlObject = new URL(url, `${protocolFallback}://${host}`);
 
   const req = httpMocks.createRequest({
-    url: urlObject.toString(),
+    url: format({
+      pathname: urlObject.pathname,
+      search: urlObject.search,
+    }),
     method,
     statusCode,
     session,

--- a/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/test/create-mock-context.test.ts
@@ -11,7 +11,7 @@ describe('create-mock-context', () => {
     const context = createContext({method, url});
 
     expect(context.method).toBe(method);
-    expect(context.url).toBe(url);
+    expect(context.url).toBe('/admin');
   });
 
   it('defaults status to 404', () => {
@@ -62,8 +62,8 @@ describe('create-mock-context', () => {
     const context = createContext({url: STORE_URL});
 
     const {url, originalUrl, host, origin, path, protocol} = context;
-    expect(url).toBe(STORE_URL);
-    expect(originalUrl).toBe(STORE_URL);
+    expect(url).toBe('/admin');
+    expect(originalUrl).toBe('/admin');
     expect(host).toBe('mystore.com');
     expect(path).toBe('/admin');
     expect(protocol).toBe('http');
@@ -71,13 +71,14 @@ describe('create-mock-context', () => {
   });
 
   it('defaults url segments when no origin is given', () => {
-    const context = createContext({url: '/foo'});
+    const context = createContext({url: '/foo?baz=qux'});
 
-    const {url, originalUrl, host, origin, path, protocol} = context;
-    expect(url).toBe('http://test.com/foo');
-    expect(originalUrl).toBe('http://test.com/foo');
+    const {url, originalUrl, host, origin, path, protocol, search} = context;
+    expect(url).toBe('/foo?baz=qux');
+    expect(originalUrl).toBe('/foo?baz=qux');
     expect(host).toBe('test.com');
     expect(path).toBe('/foo');
+    expect(search).toBe('?baz=qux');
     expect(protocol).toBe('http');
     expect(origin).toBe('http://test.com');
   });
@@ -108,13 +109,14 @@ describe('create-mock-context', () => {
   it('prefers fully qualified url over explicit segments', () => {
     const expectedUrl = 'https://www.foobarbaz.com/foo/bar';
 
-    const {originalUrl} = createContext({
+    const {originalUrl, host} = createContext({
       url: 'https://www.foobarbaz.com/foo/bar',
       host: 'someotherplace.com',
       encrypted: false,
     });
 
-    expect(originalUrl).toBe(expectedUrl);
+    expect(originalUrl).toBe('/foo/bar');
+    expect(host).toBe('www.foobarbaz.com');
   });
 
   it('includes custom cookies', () => {


### PR DESCRIPTION
## Description

Fix Koa mock-context so that `ctx.url` (and `ctx.originalUrl`) works the same way as it does in Koa and as it's [defined by Node.js](https://nodejs.org/api/http.html#http_message_url).

> Request URL string. This contains only the URL that is present in the actual HTTP request. Take the following request:
>
> ``` 
> GET /status?name=ryan HTTP/1.1
> Accept: text/plain 
> ```

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
