### PR TITLE
[storybook-a11y] Adds option to disable animation

### DIFF
--- a/packages/storybook-a11y-test/CHANGELOG.md
+++ b/packages/storybook-a11y-test/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added the ability to disable transitions and animations [#1910](https://github.com/Shopify/quilt/pull/1910)
 
 ## 0.1.0 - 2021-05-21
 

--- a/packages/storybook-a11y-test/src/index.ts
+++ b/packages/storybook-a11y-test/src/index.ts
@@ -105,8 +105,14 @@ const testPage = (iframePath, browser, timeout, disableAnimation) => {
       await page.goto(`${iframePath}?id=${id}`, {waitUntil: 'load', timeout});
       if (disableAnimation) {
         await page.addStyleTag({
-          content:
-            '* {transition: none !important; animation: none !important; }',
+          content: `*,
+            *::after,
+            *::before {
+              transition-delay: 0.0001s !important;
+              transition-duration: 0.0001s !important;
+              animation-delay: -0.0001s !important;
+              animation-duration: 0.0001s !important;
+            }`,
         });
       }
       const result = await page.evaluate(() =>


### PR DESCRIPTION
## Description

This adds the ability to disable animations when running the a11y tests to allow us to fix issues like https://github.com/Shopify/web/issues/42730.

## Type of change

- [x] storybook-a11y-test - Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
