### PR TITLE
[react-i18n] - Update `currencyDecimalSymbol` to handle mismatched locale/currency case and simplify

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- Unreleased -->
 
+- Updated `currencyDecimalSymbol` to handle mismatched locale/currency []()
+
+## 5.4.0 - 2021-05-20
+
+### Changed
+
 - Added a `none` option to the `CurrencyFormatOptions` that returns a currency-formatted string without a currency symbol [#1907](https://github.com/Shopify/quilt/pull/1907)
 
 ### Fixed

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- Unreleased -->
 
-- Updated `currencyDecimalSymbol` to handle mismatched locale/currency []()
+- Updated `currencyDecimalSymbol` to handle mismatched locale/currency [#1912](https://github.com/Shopify/quilt/pull/1912)
 
 ## 5.4.0 - 2021-05-20
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -587,15 +587,11 @@ export class I18n {
 
   private currencyDecimalSymbol(currencyCode: string) {
     const digitOrSpace = /\s|\d/g;
-    const {symbol} = this.getCurrencySymbolLocalized(this.locale, currencyCode);
-
     const templatedInput = 1;
-    const decimal = this.formatCurrency(templatedInput, {
+
+    const decimal = this.formatCurrencyNone(templatedInput, {
       currency: currencyCode,
-      form: 'short',
-    })
-      .replace(symbol, '')
-      .replace(digitOrSpace, '');
+    }).replace(digitOrSpace, '');
 
     return decimal.length === 0 ? DECIMAL_NOT_SUPPORTED : decimal;
   }

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -921,7 +921,11 @@ describe('I18n', () => {
       });
 
       const formatted = '12,34';
-      const mismatchI18n = new I18n(defaultTranslations, {...defaultDetails, locale: 'fr', currency: 'cad'});
+      const mismatchI18n = new I18n(defaultTranslations, {
+        ...defaultDetails,
+        locale: 'fr',
+        currency: 'cad',
+      });
 
       expect(mismatchI18n.unformatCurrency(formatted, 'CAD')).toBe('12.34');
     });

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -914,6 +914,18 @@ describe('I18n', () => {
       prefixed: true,
     };
 
+    it('handles locale/currency mismatch', () => {
+      getCurrencySymbol.mockReturnValue({
+        symbol: '$CA',
+        prefixed: 'false',
+      });
+
+      const formatted = '12,34';
+      const mismatchI18n = new I18n(defaultTranslations, {...defaultDetails, locale: 'fr', currency: 'cad'});
+
+      expect(mismatchI18n.unformatCurrency(formatted, 'CAD')).toBe('12.34');
+    });
+
     it('handles formatted USD input', () => {
       getCurrencySymbol.mockReturnValue(mockSymbolResult);
 


### PR DESCRIPTION
## Description
During the course of testing `react-i18n@5.4.0` changes, found that `currencyDecimalSymbol` doesn't currently handle the case where your locale and currency don't match (e.g. `{locale: 'fr', currency: 'cad'}`). Updated the function and added that test case + reduced some string manipulation by utilizing the new `formatCurrencyNone` util.

## Type of change

- [x] **react-i18n** Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
