### PR TITLE
Prioritise using allowlist from ShopifySecurityBase

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Prioritize using `allowlist` over `whitelist` from ShopifySecurityBase ([#1923](https://github.com/Shopify/quilt/pull/1923))
+
 ## 3.4.2 - 2021-02-23
 
 ### Changed
 
-- Claerify quilt_rails error ([#1752](https://github.com/Shopify/quilt/pull/1752))
+- Clarify quilt_rails error ([#1752](https://github.com/Shopify/quilt/pull/1752))
 
 ## 3.4.1 - 2021-02-18
 

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -20,7 +20,8 @@ module Quilt
 
     def call_proxy(headers, data)
       if defined? ShopifySecurityBase
-        ShopifySecurityBase::HTTPHostRestriction.whitelist([Quilt.configuration.react_server_host]) do
+        allowlist = ShopifySecurityBase::HTTPHostRestriction.respond_to?(:allowlist) ? :allowlist : :whitelist
+        ShopifySecurityBase::HTTPHostRestriction.send(allowlist, [Quilt.configuration.react_server_host]) do
           proxy(headers, data)
         end
       else


### PR DESCRIPTION

## Description

Fixes warnings in applications that use quilt rails in combination with Shopify Security Base

```
DEPRECATION WARNING: whitelist is deprecated and will be removed from Rails 6.2 (use allowlist instead) (called from call_proxy at /Users/dougedey/.gem/ruby/2.7.3/gems/quilt_rails-3.4.2/lib/quilt_rails/react_renderable.rb:23)
```

The whitelist method is deprecated and we should be using allowlist when it is available, this was we're compatible with apps using an old version of ShopifySecurityBase where the allowlist method was added.

This is not a breaking change

## Type of change

- [x] Quilt_rails Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
