### PR TITLE
✨ always include the react-bugsnag plugin

### DIFF
--- a/packages/react-bugsnag/CHANGELOG.md
+++ b/packages/react-bugsnag/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-## Added
+### Added
 
 - Now also includes the react plugin in server environments to avoid warnings from bugsnag during React SSR and give better bugsnag support to SSR apps in general.
 

--- a/packages/react-bugsnag/CHANGELOG.md
+++ b/packages/react-bugsnag/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+## Added
+
+- Now also includes the react plugin in server environments to avoid warnings from bugsnag during React SSR and give better bugsnag support to SSR apps in general.
 
 ## 2.0.0 - 2021-05-21
 

--- a/packages/react-bugsnag/src/client.ts
+++ b/packages/react-bugsnag/src/client.ts
@@ -2,16 +2,13 @@ import bugsnag, {Config} from '@bugsnag/js';
 import BugsnagPluginReact from '@bugsnag/plugin-react';
 
 export function createBugsnagClient(options: Config) {
-  const defaultPlugins =
-    typeof window === 'undefined' ? [] : [new BugsnagPluginReact()];
-
   // We could alternatively use `start` here, the only difference between them is that `start` also sets a property on the Bugsnag global
   return bugsnag.createClient({
     // eslint-disable-next-line no-process-env
     releaseStage: process.env.NODE_ENV,
     autoTrackSessions: false,
     enabledReleaseStages: ['production', 'staging'],
-    plugins: defaultPlugins,
+    plugins: [new BugsnagPluginReact()],
     maxBreadcrumbs: 40,
     ...options,
   });


### PR DESCRIPTION
## Description
We were not including the bugsnag react plugin in server environments. This lead to incomplete bugnsag support for SSR and obnoxious warnings in dev. Now we include it.

**TLDR - no more this**
![image](https://user-images.githubusercontent.com/4889856/120029395-a43a3600-bfbb-11eb-84af-e36aa572bffe.png)

## Type of change
`@shopify/react-bugsnag` - imo somewhere between fix and addition, since we are doing what one would assume and preventing weird warnings and incomplete bugsnag features.

## Checklist
- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
