### PR TITLE
Change all require statement to import (exclude any require statement…

### DIFF
--- a/packages/polyfills/CHANGELOG.md
+++ b/packages/polyfills/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Fixed
+
+- Replace `require` statements with `import` statements (except for the conditional Jest polyfills) so we get a proper strict ESM module.
+
 ## 3.0.1 - 2021-05-31
 
 ### Fixed

--- a/packages/polyfills/src/fetch.browser.ts
+++ b/packages/polyfills/src/fetch.browser.ts
@@ -1,1 +1,1 @@
-require('whatwg-fetch');
+import 'whatwg-fetch';

--- a/packages/polyfills/src/fetch.jest.ts
+++ b/packages/polyfills/src/fetch.jest.ts
@@ -1,1 +1,1 @@
-require('whatwg-fetch');
+import 'whatwg-fetch';

--- a/packages/polyfills/src/fetch.node.ts
+++ b/packages/polyfills/src/fetch.node.ts
@@ -1,8 +1,7 @@
 // general logic and approach taken from
 // https://github.com/matthew-andrews/isomorphic-fetch/blob/master/fetch-npm-node.js
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const nodeFetch = require('node-fetch');
+import nodeFetch, {Response, Headers, Request} from 'node-fetch';
 
 function wrappedFetch(this: unknown, url: string | Request, options) {
   if (typeof url !== 'string') {
@@ -15,9 +14,7 @@ function wrappedFetch(this: unknown, url: string | Request, options) {
 
 if (!(global as any).fetch) {
   (global as any).fetch = wrappedFetch;
-  (global as any).Response = nodeFetch.Response;
-  (global as any).Headers = nodeFetch.Headers;
-  (global as any).Request = nodeFetch.Request;
+  (global as any).Response = Response;
+  (global as any).Headers = Headers;
+  (global as any).Request = Request;
 }
-
-export {};

--- a/packages/polyfills/src/idle-callback.browser.ts
+++ b/packages/polyfills/src/idle-callback.browser.ts
@@ -36,5 +36,3 @@ extendedWindow.requestIdleCallback =
 
 extendedWindow.cancelIdleCallback =
   extendedWindow.cancelIdleCallback || (window as any).clearImmediate;
-
-export {};

--- a/packages/polyfills/src/idle-callback.jest.ts
+++ b/packages/polyfills/src/idle-callback.jest.ts
@@ -39,5 +39,3 @@ if (typeof window !== 'undefined') {
   extendedWindow.cancelIdleCallback =
     extendedWindow.cancelIdleCallback || (window as any).clearImmediate;
 }
-
-export {};

--- a/packages/polyfills/src/intersection-observer.browser.ts
+++ b/packages/polyfills/src/intersection-observer.browser.ts
@@ -1,1 +1,1 @@
-require('intersection-observer');
+import 'intersection-observer';

--- a/packages/polyfills/src/intl.browser.ts
+++ b/packages/polyfills/src/intl.browser.ts
@@ -1,1 +1,1 @@
-require('intl-pluralrules');
+import 'intl-pluralrules';


### PR DESCRIPTION
… wrap in if statement)

As part of the Vite experiment, it was discovered that our `@shopify/polyfills` packages are actually shipping `mjs` files that uses `require` statement. Which make this package NOT a true ESM module. 

## Description

This PR changes
- most require statement to import statement
- remove empty `export {}` (because we no longer need the signal that those file are ESM)

What was NOT done but maybe should be consider:
these 3 require statements are only use in jest mode, and also wrap in a if statement. Questionable on how it should be updated to use import statement.
https://github.com/Shopify/quilt/blob/polyfill-proper-esm/packages/polyfills/src/formdata.jest.ts#L3-L5
https://github.com/Shopify/quilt/blob/polyfill-proper-esm/packages/polyfills/src/intersection-observer.jest.ts#L3-L5
https://github.com/Shopify/quilt/blob/polyfill-proper-esm/packages/polyfills/src/mutation-observer.jest.ts#L3-L6

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
