### PR TITLE
[DO NOT MERGE] Update quilt to support webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,16 @@
   },
   "homepage": "https://github.com/shopify/quilt#readme",
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "nohoist": [
+      "**/webpack",
+      "**/@types/webpack",
+      "**/tapable"
+    ]
+  },
   "devDependencies": {
     "@apollo/react-common": "^3.1.3",
     "@apollo/react-hooks": "^3.1.3",

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -38,17 +38,18 @@
   },
   "dependencies": {
     "@jest/transform": "^27.0.2",
-    "@types/fs-extra": "^9.0.11",
-    "@types/webpack": "^4.41.11",
     "fs-extra": "^9.1.0",
     "graphql": ">=14.5.0 <16.0.0",
-    "graphql-typed": "^1.1.0",
-    "loader-utils": "^2.0.0"
+    "graphql-typed": "^1.1.0"
   },
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
     "@types/loader-utils": "^1.1.3",
-    "common-tags": "^1.8.0"
+    "common-tags": "^1.8.0",
+    "webpack": "^5.40.0"
+  },
+  "peerDependencies": {
+    "webpack": ">=5.38.0"
   },
   "files": [
     "build/",

--- a/packages/graphql-mini-transforms/src/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/src/tests/webpack.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import {createHash} from 'crypto';
 
-import {loader} from 'webpack';
+import type {LoaderContext} from 'webpack';
 import {stripIndent} from 'common-tags';
 
 import graphQLLoader from '../webpack-loader';
@@ -272,7 +272,7 @@ function createLoaderContext({
   context = __dirname,
   readFile = () => '',
   resolve = (context, imported) => path.resolve(context, imported),
-}: Options = {}): loader.LoaderContext {
+}: Options = {}): LoaderContext<Options> {
   return {
     context,
     query,
@@ -291,6 +291,9 @@ function createLoaderContext({
       },
     },
     cacheable() {},
+    getOptions() {
+      return this.query;
+    },
     async() {
       return () => {};
     },

--- a/packages/graphql-mini-transforms/src/webpack-loader.ts
+++ b/packages/graphql-mini-transforms/src/webpack-loader.ts
@@ -1,23 +1,22 @@
 import {dirname} from 'path';
 
-import type {loader} from 'webpack';
+import type {LoaderContext} from 'webpack';
 import {parse, DocumentNode} from 'graphql';
-import {getOptions} from 'loader-utils';
 
 import {cleanDocument, extractImports, toSimpleDocument} from './document';
 
 interface Options {
   simple?: boolean;
 }
-
+// release comment
 export default async function graphQLLoader(
-  this: loader.LoaderContext,
+  this: LoaderContext<Options>,
   source: string | Buffer,
 ) {
   this.cacheable();
 
   const done = this.async();
-  const {simple = false} = getOptions(this) as Options;
+  const {simple = false} = this.getOptions();
 
   if (done == null) {
     throw new Error(
@@ -43,7 +42,7 @@ export default async function graphQLLoader(
 async function loadDocument(
   rawSource: string | Buffer,
   resolveContext: string,
-  loader: loader.LoaderContext,
+  loader: LoaderContext<Options>,
 ): Promise<DocumentNode> {
   const normalizedSource =
     typeof rawSource === 'string' ? rawSource : rawSource.toString();
@@ -61,7 +60,7 @@ async function loadDocument(
         loader.resolve(resolveContext, imported, (error, result) => {
           if (error) {
             reject(error);
-          } else {
+          } else if (result) {
             loader.addDependency(result);
             resolve(result);
           }

--- a/packages/graphql-persisted/package.json
+++ b/packages/graphql-persisted/package.json
@@ -54,7 +54,7 @@
     "koa.esnext"
   ],
   "optionalDependencies": {
-    "@shopify/sewing-kit-koa": "^7.0.5"
+    "@shopify/sewing-kit-koa": "^7.0.2-webpack-5-betat.10"
   },
   "peerDependencies": {
     "koa": ">=2.0.0"

--- a/packages/magic-entries-webpack-plugin/package.json
+++ b/packages/magic-entries-webpack-plugin/package.json
@@ -39,8 +39,10 @@
     "index.esnext"
   ],
   "devDependencies": {
+    "@types/webpack": "^4.25.1",
     "@types/webpack-virtual-modules": "^0.1.0",
     "setimmediate": "^1.0.5",
+    "webpack": "^4.25.1",
     "webpack-virtual-modules": "^0.4.3"
   },
   "module": "index.mjs",

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -38,7 +38,7 @@
     "@shopify/react-html": "^11.1.4",
     "@shopify/react-hydrate": "^2.1.3",
     "@shopify/react-network": "^4.1.4",
-    "@shopify/sewing-kit-koa": "^7.0.5",
+    "@shopify/sewing-kit-koa": "^7.0.2-webpack-5-betat.10",
     "@shopify/useful-types": "^3.0.4",
     "chalk": "^2.4.2",
     "koa": "^2.5.0",
@@ -52,12 +52,13 @@
     "@types/koa": "^2.0.0",
     "@types/webpack-virtual-modules": "^0.1.0",
     "get-port": "^5.0.0",
+    "memfs": "^3.2.2",
     "node-loader": "^1.0.0",
     "react": "^17.0.2",
     "react-dom": "17.0.2",
     "saddle-up": "^0.5.4",
     "setimmediate": "^1.0.5",
-    "webpack": "^4.25.1"
+    "webpack": ">=5.40.0"
   },
   "peerDependencies": {
     "cross-fetch": ">=3.0.0",

--- a/packages/react-server/src/index.ts
+++ b/packages/react-server/src/index.ts
@@ -1,4 +1,4 @@
-// release comment
+// release comment 2
 export {createServer} from './server';
 export {createRender} from './render';
 export type {Context} from './render';

--- a/packages/react-server/src/webpack-plugin/tests/webpack-plugin.test.ts
+++ b/packages/react-server/src/webpack-plugin/tests/webpack-plugin.test.ts
@@ -2,13 +2,18 @@ import 'setimmediate';
 
 import path from 'path';
 
-import webpack, {Compiler} from 'webpack';
+import memfs from 'memfs';
+import webpack, {Compiler, Stats} from 'webpack';
 
-import {HEADER, Options} from '../shared';
+import {HEADER, Options, Entrypoint} from '../shared';
 
 import {withWorkspace} from './utilities/workspace';
 
 const BUILD_TIMEOUT = 10000;
+
+const DEFAULT_SERVER_FILE_EPATH = `${Entrypoint.Server}.js`;
+const DEFAULT_CLIENT_FILE_PATH = `${Entrypoint.Client}.js`;
+const DEFAULT_ERROR_FILE_PATH = `${Entrypoint.Error}.entry.client.js`;
 
 describe('webpack-plugin', () => {
   describe('node', () => {
@@ -21,11 +26,10 @@ describe('webpack-plugin', () => {
           await workspace.write('index.js', BASIC_JS_MODULE);
           await workspace.write('webpack.config.js', BASIC_WEBPACK_CONFIG);
 
-          const [serverResults, clientResults] = await runBuild(name);
-          const [client, server] = [
-            getModule(clientResults, 'client').source,
-            getModule(serverResults, 'server').source,
-          ];
+          const [client, server] = await runBuild(name, [
+            DEFAULT_CLIENT_FILE_PATH,
+            DEFAULT_SERVER_FILE_EPATH,
+          ]);
 
           expect(client).toBeDefined();
           expect(client).toMatch(HEADER);
@@ -49,12 +53,13 @@ describe('webpack-plugin', () => {
           await workspace.write('index.js', BASIC_JS_MODULE);
           await workspace.write('webpack.config.js', BASIC_WEBPACK_CONFIG);
 
-          const [serverResults, clientResults] = await runBuild(name);
-          const clientModule = getModule(clientResults, 'client');
-          const serverModule = getModule(serverResults, 'server');
+          const [client, server] = await runBuild(name, [
+            DEFAULT_CLIENT_FILE_PATH,
+            DEFAULT_SERVER_FILE_EPATH,
+          ]);
 
-          expect(serverModule.source).toMatch(HEADER);
-          expect(clientModule.source).toMatch(HEADER);
+          expect(server).toMatch(HEADER);
+          expect(client).toMatch(HEADER);
         });
       },
       BUILD_TIMEOUT,
@@ -70,13 +75,16 @@ describe('webpack-plugin', () => {
           await workspace.write('webpack.config.js', BASIC_WEBPACK_CONFIG);
           await workspace.write('client/index.js', BASIC_ENTRY);
 
-          const [serverResults, clientResults] = await runBuild(name);
-          const clientModule = getModule(clientResults, 'client');
-          const serverModule = getModule(serverResults, 'server');
+          const [client, clientIndex, server] = await runBuild(name, [
+            DEFAULT_CLIENT_FILE_PATH,
+            'client/index.js',
+            DEFAULT_SERVER_FILE_EPATH,
+          ]);
 
-          expect(serverModule.source).toMatch(HEADER);
-          expect(clientModule.source).toMatch('I am a bespoke entry');
-          expect(clientModule.source).not.toMatch(HEADER);
+          expect(server).toMatch(HEADER);
+          expect(client).toBeNull();
+          expect(clientIndex).toMatch('I am a bespoke entry');
+          expect(clientIndex).not.toMatch(HEADER);
         });
       },
       BUILD_TIMEOUT,
@@ -92,13 +100,14 @@ describe('webpack-plugin', () => {
           await workspace.write('webpack.config.js', BASIC_WEBPACK_CONFIG);
           await workspace.write('client.js', BASIC_ENTRY);
 
-          const [serverResults, clientResults] = await runBuild(name);
-          const clientModule = getModule(clientResults, 'client');
-          const serverModule = getModule(serverResults, 'server');
+          const [client, server] = await runBuild(name, [
+            DEFAULT_CLIENT_FILE_PATH,
+            DEFAULT_SERVER_FILE_EPATH,
+          ]);
 
-          expect(serverModule.source).toMatch(HEADER);
-          expect(clientModule.source).toMatch('I am a bespoke entry');
-          expect(clientModule.source).not.toMatch(HEADER);
+          expect(server).toMatch(HEADER);
+          expect(client).toMatch('I am a bespoke entry');
+          expect(client).not.toMatch(HEADER);
         });
       },
       BUILD_TIMEOUT,
@@ -114,13 +123,14 @@ describe('webpack-plugin', () => {
           await workspace.write('webpack.config.js', BASIC_WEBPACK_CONFIG);
           await workspace.write('server.js', BASIC_ENTRY);
 
-          const [serverResults, clientResults] = await runBuild(name);
-          const clientModule = getModule(clientResults, 'client');
-          const serverModule = getModule(serverResults, 'server');
+          const [client, server] = await runBuild(name, [
+            DEFAULT_CLIENT_FILE_PATH,
+            DEFAULT_SERVER_FILE_EPATH,
+          ]);
 
-          expect(serverModule.source).not.toMatch(HEADER);
-          expect(serverModule.source).toMatch('I am a bespoke entry');
-          expect(clientModule.source).toMatch(HEADER);
+          expect(server).not.toMatch(HEADER);
+          expect(server).toMatch('I am a bespoke entry');
+          expect(client).toMatch(HEADER);
         });
       },
       BUILD_TIMEOUT,
@@ -136,13 +146,16 @@ describe('webpack-plugin', () => {
           await workspace.write('webpack.config.js', BASIC_WEBPACK_CONFIG);
           await workspace.write('server/index.js', BASIC_ENTRY);
 
-          const [serverResults, clientResults] = await runBuild(name);
-          const clientModule = getModule(clientResults, 'client');
-          const serverModule = getModule(serverResults, 'server');
+          const [client, server, serverIndex] = await runBuild(name, [
+            DEFAULT_CLIENT_FILE_PATH,
+            DEFAULT_SERVER_FILE_EPATH,
+            'server/index.js',
+          ]);
 
-          expect(serverModule.source).not.toMatch(HEADER);
-          expect(serverModule.source).toMatch('I am a bespoke entry');
-          expect(clientModule.source).toMatch(HEADER);
+          expect(server).toBeNull();
+          expect(serverIndex).not.toMatch(HEADER);
+          expect(serverIndex).toMatch('I am a bespoke entry');
+          expect(client).toMatch(HEADER);
         });
       },
       BUILD_TIMEOUT,
@@ -162,12 +175,13 @@ describe('webpack-plugin', () => {
           );
           await workspace.write(`${basePath}/index.js`, BASIC_ENTRY);
 
-          const [serverResults, clientResults] = await runBuild(name);
-          const serverModule = getModule(serverResults, 'app/ui/server');
-          const clientModule = getModule(clientResults, 'app/ui/client');
+          const [client, server] = await runBuild(name, [
+            `${basePath}/${DEFAULT_CLIENT_FILE_PATH}`,
+            `${basePath}/${DEFAULT_SERVER_FILE_EPATH}`,
+          ]);
 
-          expect(serverModule.source).toMatch(HEADER);
-          expect(clientModule.source).toMatch(HEADER);
+          expect(server).toMatch(HEADER);
+          expect(client).toMatch(HEADER);
         });
       },
       BUILD_TIMEOUT,
@@ -191,9 +205,9 @@ describe('webpack-plugin', () => {
             createWebpackConfig(customConfig),
           );
 
-          const [serverResults] = await runBuild(name);
-          const serverModule = getModule(serverResults, 'server');
-          expect(serverModule.source).toMatch('proxy: false');
+          const [server] = await runBuild(name, [DEFAULT_SERVER_FILE_EPATH]);
+
+          expect(server).toMatch('proxy: false');
         });
       },
       BUILD_TIMEOUT,
@@ -218,15 +232,12 @@ describe('webpack-plugin', () => {
             createWebpackConfig(customConfig),
           );
 
-          const [serverResults] = await runBuild(name);
-          const serverModule = getModule(serverResults, 'server');
+          const [server] = await runBuild(name, [DEFAULT_SERVER_FILE_EPATH]);
 
-          expect(serverModule.source).toMatch(`port: ${customConfig.port}`);
-          expect(serverModule.source).toMatch(`ip: "${customConfig.host}"`);
-          expect(serverModule.source).toMatch(
-            `assetPrefix: "${customConfig.assetPrefix}"`,
-          );
-          expect(serverModule.source).toMatch(`proxy: ${customConfig.proxy}`);
+          expect(server).toMatch(`port: ${customConfig.port}`);
+          expect(server).toMatch(`ip: "${customConfig.host}"`);
+          expect(server).toMatch(`assetPrefix: "${customConfig.assetPrefix}"`);
+          expect(server).toMatch(`proxy: ${customConfig.proxy}`);
         });
       },
       BUILD_TIMEOUT,
@@ -252,10 +263,11 @@ describe('webpack-plugin', () => {
             createWebpackConfig({basePath}),
           );
 
-          const [serverResults] = await runBuild(name);
-          const serverModule = getModule(serverResults, 'app/ui/server');
+          const [server] = await runBuild(name, [
+            `${basePath}/${DEFAULT_SERVER_FILE_EPATH}`,
+          ]);
 
-          expect(serverModule.source).toMatch("import Error from 'error';");
+          expect(server).toMatch("import Error from 'error';");
         });
       },
       BUILD_TIMEOUT,
@@ -275,10 +287,11 @@ describe('webpack-plugin', () => {
             createWebpackConfig({basePath}),
           );
 
-          const [serverResults] = await runBuild(name);
-          const serverModule = getModule(serverResults, 'app/ui/server');
+          const [server] = await runBuild(name, [
+            `${basePath}/${DEFAULT_SERVER_FILE_EPATH}`,
+          ]);
 
-          expect(serverModule.source).not.toMatch("import Error from 'error';");
+          expect(server).not.toMatch("import Error from 'error';");
         });
       },
       BUILD_TIMEOUT,
@@ -302,10 +315,11 @@ describe('webpack-plugin', () => {
             createWebpackConfig({basePath}),
           );
 
-          const [serverResults] = await runBuild(name);
-          const serverModule = getModule(serverResults, 'app/ui/server');
+          const [server] = await runBuild(name, [
+            `${basePath}/${DEFAULT_SERVER_FILE_EPATH}`,
+          ]);
 
-          expect(serverModule.source).toMatch("import Error from 'error';");
+          expect(server).toMatch("import Error from 'error';");
         });
       },
       BUILD_TIMEOUT,
@@ -313,7 +327,10 @@ describe('webpack-plugin', () => {
   });
 });
 
-function runBuild(configPath: string): Promise<any[]> {
+function runBuild(
+  configPath: string,
+  basePaths: string[],
+): Promise<(string | null)[]> {
   return new Promise((resolve, reject) => {
     const pathFromRoot = path.resolve(
       './packages/react-server/src/webpack-plugin/tests/fixtures',
@@ -332,12 +349,10 @@ function runBuild(configPath: string): Promise<any[]> {
           context: pathFromRoot,
         };
 
-    // We use MemoryOutputFileSystem to prevent webpack from outputting to our actual FS
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const MemoryOutputFileSystem = require('webpack/lib/MemoryOutputFileSystem');
-
     const compiler: Compiler = webpack(contextConfig);
-    compiler.outputFileSystem = new MemoryOutputFileSystem({});
+    // We use memfs.fs to prevent webpack from outputting to our actual FS
+    // from https://github.com/webpack/webpack/blob/4837c3ddb9da8e676c73d97460e19689dd9d4691/test/configCases/types/filesystems/webpack.config.js#L8
+    compiler.outputFileSystem = memfs.fs;
 
     compiler.run((err, stats) => {
       if (err) {
@@ -350,24 +365,22 @@ function runBuild(configPath: string): Promise<any[]> {
         return;
       }
 
-      const statsObject = stats.toJson();
-      resolve(statsObject.children);
+      // the Stats type is incorrect from webpack v5.39.1
+      // https://github.com/webpack/webpack/blob/5d297327bc1f208de16c29f5c9b31d2b8a06bce4/types.d.ts#L1848
+      const fs = ((stats as any).stats[0] as Stats).compilation
+        .inputFileSystem as typeof memfs.fs;
+
+      const sources = basePaths.map((basePath) => {
+        try {
+          return fs.readFileSync(path.join(pathFromRoot, basePath)).toString();
+        } catch {
+          return null;
+        }
+      });
+
+      resolve(sources);
     });
   });
-}
-
-function getModule(results: any, basePath: string) {
-  const newResults = results.modules.find(
-    ({name}) =>
-      name.includes(`./${basePath}.js`) ||
-      name.includes(`./${basePath}/index.js`),
-  );
-
-  if (newResults.source) {
-    return newResults;
-  }
-
-  return getModule(newResults, basePath);
 }
 
 const BASIC_ENTRY = `console.log('I am a bespoke entry');`;
@@ -406,7 +419,9 @@ const universal = {
     rules: [
       {
         test: /\\.mjs$/,
-        type: "javascript/auto"
+        resolve: {
+          fullySpecified: false,
+        },
       },
       {
         test: /node\\/.*\\.js$/,
@@ -421,9 +436,9 @@ const server = {
   target: 'node',
   entry: './${basePath}/server',
   externals: [
-    (context, request, callback) => {
+    ({context, request}, callback) => {
       if (/node_modules/.test(context)) {
-        return callback(null, 'commonjs' + request);
+        return callback(null, 'commonjs ' + request);
       }
       callback();
     },

--- a/packages/react-server/src/webpack-plugin/webpack-plugin.ts
+++ b/packages/react-server/src/webpack-plugin/webpack-plugin.ts
@@ -1,6 +1,6 @@
 import {join} from 'path';
 
-import {Compiler} from 'webpack';
+import {Compiler, WatchIgnorePlugin} from 'webpack';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
 import {HEADER, Options, Entrypoint, noSourceExists} from './shared';
@@ -34,6 +34,12 @@ export class ReactServerPlugin {
     const modules = this.modules(compiler);
     const virtualModules = new VirtualModulesPlugin(modules);
     (virtualModules as any).apply(compiler);
+
+    const ignorePaths = (Object.keys(modules) as (string | RegExp)[]).concat(
+      compiler.options.watchOptions.ignored || [],
+    );
+    const watchIgnore = new WatchIgnorePlugin({paths: ignorePaths});
+    watchIgnore.apply(compiler);
   }
 
   private modules(compiler: Compiler) {

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -44,20 +44,10 @@ export default class Assets {
   }
 
   async scripts(options: AssetOptions = {}) {
-    const js = getAssetsFromManifest(
+    return getAssetsFromManifest(
       {...options, kind: AssetKind.Scripts},
       await this.getResolvedManifest(options.locale),
     );
-
-    const scripts =
-      // Sewing Kit does not currently include the vendor DLL in its asset
-      // manifest, so we manually add it here (it only exists in dev).
-      // eslint-disable-next-line no-process-env
-      process.env.NODE_ENV === 'development'
-        ? [{path: `${this.assetPrefix}dll/vendor.js`}, ...js]
-        : js;
-
-    return scripts;
   }
 
   async styles(options: AssetOptions = {}) {

--- a/packages/sewing-kit-koa/src/tests/assets.test.ts
+++ b/packages/sewing-kit-koa/src/tests/assets.test.ts
@@ -119,31 +119,6 @@ describe('Assets', () => {
         assets.scripts({name: 'non-existent'}),
       ).rejects.toBeInstanceOf(Error);
     });
-
-    it('prefixes the list with the vendor DLL in development', async () => {
-      const js = '/style.js';
-      const assetPrefix = '/sewing-kit-assets/';
-
-      setManifest(
-        mockManifest({
-          entrypoints: {
-            custom: mockEntrypoint({
-              scripts: [mockAsset(js)],
-            }),
-          },
-        }),
-      );
-
-      const assets = new Assets({...defaultOptions, assetPrefix});
-      const scripts = await withEnv('development', () =>
-        assets.scripts({name: 'custom'}),
-      );
-
-      expect(scripts).toStrictEqual([
-        {path: `${assetPrefix}dll/vendor.js`},
-        {path: js},
-      ]);
-    });
   });
 
   describe('styles', () => {

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@shopify/rpc": "^2.0.4",
-    "loader-utils": "^1.0.0",
     "webpack-virtual-modules": "^0.4.3"
   },
   "devDependencies": {
@@ -49,10 +48,8 @@
     "@types/babel__core": ">=7.0.0",
     "@types/babel__traverse": ">=7.0.0",
     "@types/koa-mount": "^3.0.1",
-    "@types/loader-utils": "^1.0.0",
-    "@types/webpack": "^4.0.0",
-    "@types/webpack-virtual-modules": "^0.1.0",
-    "koa-mount": "^3.0.0"
+    "koa-mount": "^3.0.0",
+    "webpack": ">=5.38.0"
   },
   "files": [
     "build/",
@@ -72,8 +69,7 @@
     "worker.esnext"
   ],
   "optionalDependencies": {
-    "@babel/core": "^7.0.0",
-    "webpack": "^4.25.1"
+    "@babel/core": "^7.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/web-worker/src/tests/e2e.test.ts
+++ b/packages/web-worker/src/tests/e2e.test.ts
@@ -18,9 +18,7 @@ const secondWorkerFile = 'src/worker2.js';
 
 jest.setTimeout(30_000);
 
-// @TODO: Disabled for now because these tests are flaky and take a long time to run
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('web-worker', () => {
+describe('web-worker', () => {
   it('creates a worker factory that can produce workers that act like the original module', async () => {
     const greetingPrefix = 'Hello ';
     const greetingTarget = 'world';
@@ -1222,7 +1220,7 @@ function runWebpack(
       rules: [
         {
           include: context.workspace.resolvePath(mainFile),
-          loaders: [
+          use: [
             {
               loader: 'babel-loader',
               options: {

--- a/packages/web-worker/src/tests/utilities/webpack.ts
+++ b/packages/web-worker/src/tests/utilities/webpack.ts
@@ -37,13 +37,21 @@ export function runWebpack(
             {
               test: /\.ts$/,
               include: {or: [srcRoot, rpcSrcRoot]},
-              loaders: [
+              use: [
                 {
                   loader: 'babel-loader',
                   options: {
                     babelrc: false,
-                    browsers: 'last 1 chrome version',
-                    presets: [['@shopify/babel-preset', {typescript: true}]],
+                    presets: [
+                      [
+                        '@shopify/babel-preset',
+                        {
+                          typescript: true,
+                          browsers: 'last 1 chrome version',
+                          useBuiltIns: 'usage',
+                        },
+                      ],
+                    ],
                   },
                 },
               ],

--- a/packages/web-worker/src/webpack-parts/plugin.ts
+++ b/packages/web-worker/src/webpack-parts/plugin.ts
@@ -1,26 +1,25 @@
 import VirtualModulesPlugin from 'webpack-virtual-modules';
+import type {WebpackPluginInstance, Compiler} from 'webpack';
 
 import {PLUGIN} from '../common';
 
-type Plugin = import('webpack').Plugin;
-
 interface Options {
   globalObject?: string;
-  plugins?: Plugin[];
+  plugins?: WebpackPluginInstance[];
 }
 
-export class WebWorkerPlugin implements Plugin {
+export class WebWorkerPlugin implements WebpackPluginInstance {
   static isInstance(value: unknown): value is WebWorkerPlugin {
     return value != null && (value as WebWorkerPlugin)[PLUGIN];
   }
 
-  public readonly virtualModules = new VirtualModulesPlugin({});
+  public readonly virtualModules = new VirtualModulesPlugin();
   public workerId = 0;
   private readonly [PLUGIN] = true;
 
   constructor(public readonly options: Options = {}) {}
 
-  apply(compiler: import('webpack').Compiler) {
+  apply(compiler: Compiler) {
     this.virtualModules.apply(compiler);
   }
 }

--- a/packages/web-worker/tsconfig.json
+++ b/packages/web-worker/tsconfig.json
@@ -4,10 +4,7 @@
   "compilerOptions": {
     "outDir": "build/ts",
     "baseUrl": "src",
-    "rootDir": "src",
-    "paths": {
-      "webpack": ["node_modules/webpack"]
-    }
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/web-worker/types/webpack-virtual-modules/index.d.ts
+++ b/packages/web-worker/types/webpack-virtual-modules/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for webpack-virtual-modules 0.1
+// Project: https://github.com/sysgears/webpack-virtual-modules
+// Definitions by: Avi Vahl <https://github.com/AviVahl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+// @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack-virtual-modules/index.d.ts
+
+import webpack = require('webpack');
+
+/**
+ * Plugin that allows dynamic generation of in-memory virtual modules for JavaScript builds
+ * created with webpack.
+ */
+declare class VirtualModulesPlugin {
+  constructor(modules?: {[key: string]: string});
+
+  /**
+   * Attaches necessary hooks, in particular, `afterEnvironment`, `afterResolvers`, and `watchRun` hooks,
+   * to ensure that the virtual files are added dynamically.
+   */
+  apply(compiler: webpack.Compiler): void;
+
+  /**
+   * Writes a static or dynamic virtual module to a path.
+   */
+  writeModule(filePath: string, fileContents: string): void;
+}
+
+export = VirtualModulesPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,10 +2755,36 @@
     "@types/keygrip" "*"
     "@types/node" "*"
 
-"@types/estree@*", "@types/estree@0.0.39":
+"@types/eslint-scope@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
+  integrity sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
+"@types/eslint@*":
+  version "7.2.13"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.13.tgz#e0ca7219ba5ded402062ad6f926d491ebb29dd53"
+  integrity sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*", "@types/estree@^0.0.47":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
+  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+
+"@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@^0.0.50":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
 "@types/events@*":
   version "3.0.0"
@@ -2895,7 +2921,7 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
+"@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
@@ -2967,13 +2993,13 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
-"@types/loader-utils@^1.0.0", "@types/loader-utils@^1.1.3":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@types/loader-utils/-/loader-utils-1.1.4.tgz#e8b44fda9e965e8c4eba864c7918e7f7528eaa25"
-  integrity sha512-puqX4dZW2ZRAz0orsBvQx6SmuE0pf/iGFqkA7rH0nC/lfCS6H1pdkLIagb/Ud8QMQMG0UlyOE3Hpb+SgQIpTmA==
+"@types/loader-utils@^1.1.3":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@types/loader-utils/-/loader-utils-1.1.6.tgz#41a6e6750ad1938e0498394d23459f9a62c5c73a"
+  integrity sha512-0U4S5kLpm3Cu9YkO46JrmujS2abL2tWsxA1SR8km6X0a1E96tfPu34zRdQSZsJ6dfRYwQpmuKmy9Mx2Od7AXag==
   dependencies:
     "@types/node" "*"
-    "@types/webpack" "*"
+    "@types/webpack" "^4"
 
 "@types/lolex@^2.1.3":
   version "2.1.3"
@@ -3174,7 +3200,28 @@
   dependencies:
     "@types/webpack" "*"
 
-"@types/webpack@*", "@types/webpack@^4.0.0", "@types/webpack@^4.41.11":
+"@types/webpack@*":
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
+  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
+  dependencies:
+    "@types/node" "*"
+    tapable "^2.2.0"
+    webpack "^5"
+
+"@types/webpack@^4":
+  version "4.41.30"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.30.tgz#fd3db6d0d41e145a8eeeafcd3c4a7ccde9068ddc"
+  integrity sha512-GUHyY+pfuQ6haAfzu4S14F+R5iGRwN6b2FRNJY7U0NilmFAqbsOfK6j1HwuLBAqwRIT+pVdNDJGJ6e8rpp0KHA==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^1"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
+    source-map "^0.6.0"
+
+"@types/webpack@^4.0.0":
   version "4.41.27"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.27.tgz#f47da488c8037e7f1b2dbf2714fbbacb61ec0ffc"
   integrity sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==
@@ -3184,6 +3231,18 @@
     "@types/tapable" "^1"
     "@types/uglify-js" "*"
     "@types/webpack-sources" "*"
+    source-map "^0.6.0"
+
+"@types/webpack@^4.25.1":
+  version "4.41.29"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.29.tgz#2e66c1de8223c440366469415c50a47d97625773"
+  integrity sha512-6pLaORaVNZxiB3FSHbyBiWM7QdazAWda1zvAq4SbZObZqHSDbWLi62iFdblVea6SK9eyBIVp5yHhKt/yNQdR7Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^1"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
     source-map "^0.6.0"
 
 "@types/websocket@1.0.2":
@@ -3301,6 +3360,22 @@
     "@typescript-eslint/types" "4.26.0"
     eslint-visitor-keys "^2.0.0"
 
+"@webassemblyjs/ast@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
+  integrity sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+
+"@webassemblyjs/ast@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
+  integrity sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3310,15 +3385,45 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz#34d62052f453cd43101d72eab4966a022587947c"
+  integrity sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==
+
+"@webassemblyjs/floating-point-hex-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
+  integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
+
 "@webassemblyjs/floating-point-hex-parser@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
   integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
+"@webassemblyjs/helper-api-error@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz#aaea8fb3b923f4aaa9b512ff541b013ffb68d2d4"
+  integrity sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==
+
+"@webassemblyjs/helper-api-error@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
+  integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
+
 "@webassemblyjs/helper-api-error@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
   integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
+
+"@webassemblyjs/helper-buffer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz#d026c25d175e388a7dbda9694e91e743cbe9b642"
+  integrity sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==
+
+"@webassemblyjs/helper-buffer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
+  integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
 
 "@webassemblyjs/helper-buffer@1.9.0":
   version "1.9.0"
@@ -3344,10 +3449,58 @@
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
 
+"@webassemblyjs/helper-numbers@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz#7ab04172d54e312cc6ea4286d7d9fa27c88cd4f9"
+  integrity sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-numbers@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
+  integrity sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz#85fdcda4129902fe86f81abf7e7236953ec5a4e1"
+  integrity sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
+  integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
+
 "@webassemblyjs/helper-wasm-bytecode@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
   integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
+
+"@webassemblyjs/helper-wasm-section@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz#9ce2cc89300262509c801b4af113d1ca25c1a75b"
+  integrity sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+
+"@webassemblyjs/helper-wasm-section@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a"
+  integrity sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
 
 "@webassemblyjs/helper-wasm-section@1.9.0":
   version "1.9.0"
@@ -3359,12 +3512,40 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
 
+"@webassemblyjs/ieee754@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz#46975d583f9828f5d094ac210e219441c4e6f5cf"
+  integrity sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/ieee754@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
+  integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
   integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.0.tgz#f7353de1df38aa201cba9fb88b43f41f75ff403b"
+  integrity sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==
+  dependencies:
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/leb128@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
+  integrity sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.9.0":
   version "1.9.0"
@@ -3373,10 +3554,48 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/utf8@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.0.tgz#86e48f959cf49e0e5091f069a709b862f5a2cadf"
+  integrity sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==
+
+"@webassemblyjs/utf8@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
+  integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
+
 "@webassemblyjs/utf8@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
   integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
+
+"@webassemblyjs/wasm-edit@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz#ee4a5c9f677046a210542ae63897094c2027cb78"
+  integrity sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/helper-wasm-section" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-opt" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    "@webassemblyjs/wast-printer" "1.11.0"
+
+"@webassemblyjs/wasm-edit@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
+  integrity sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/helper-wasm-section" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-opt" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    "@webassemblyjs/wast-printer" "1.11.1"
 
 "@webassemblyjs/wasm-edit@1.9.0":
   version "1.9.0"
@@ -3392,6 +3611,28 @@
     "@webassemblyjs/wasm-parser" "1.9.0"
     "@webassemblyjs/wast-printer" "1.9.0"
 
+"@webassemblyjs/wasm-gen@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz#3cdb35e70082d42a35166988dda64f24ceb97abe"
+  integrity sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
+
+"@webassemblyjs/wasm-gen@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
+  integrity sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
+
 "@webassemblyjs/wasm-gen@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
@@ -3403,6 +3644,26 @@
     "@webassemblyjs/leb128" "1.9.0"
     "@webassemblyjs/utf8" "1.9.0"
 
+"@webassemblyjs/wasm-opt@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz#1638ae188137f4bb031f568a413cd24d32f92978"
+  integrity sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+
+"@webassemblyjs/wasm-opt@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
+  integrity sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+
 "@webassemblyjs/wasm-opt@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
@@ -3412,6 +3673,30 @@
     "@webassemblyjs/helper-buffer" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
+
+"@webassemblyjs/wasm-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz#3e680b8830d5b13d1ec86cc42f38f3d4a7700754"
+  integrity sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
+
+"@webassemblyjs/wasm-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199"
+  integrity sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
 
 "@webassemblyjs/wasm-parser@1.9.0":
   version "1.9.0"
@@ -3435,6 +3720,22 @@
     "@webassemblyjs/helper-api-error" "1.9.0"
     "@webassemblyjs/helper-code-frame" "1.9.0"
     "@webassemblyjs/helper-fsm" "1.9.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/wast-printer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz#680d1f6a5365d6d401974a8e949e05474e1fab7e"
+  integrity sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/wast-printer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
+  integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/wast-printer@1.9.0":
@@ -3530,10 +3831,20 @@ acorn@^7.1.1, acorn@^7.2.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
+acorn@^8.2.1:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.3.0.tgz#1193f9b96c4e8232f00b11a9edff81b2c8b98b88"
+  integrity sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==
+
 acorn@^8.2.4:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.0.tgz#af53266e698d7cffa416714b503066a82221be60"
   integrity sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==
+
+acorn@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
+  integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -3653,6 +3964,14 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+anymatch@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
 
 anymatch@^3.0.3, anymatch@~3.1.1:
   version "3.1.1"
@@ -4391,7 +4710,18 @@ browserslist-useragent@^2.0.1:
     semver "^5.4.1"
     useragent "^2.2.1"
 
-browserslist@^4.0.0, browserslist@^4.0.1, browserslist@^4.16.6:
+browserslist@^4.0.0, browserslist@^4.0.1:
+  version "4.16.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.5.tgz#952825440bca8913c62d0021334cbe928ef062ae"
+  integrity sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==
+  dependencies:
+    caniuse-lite "^1.0.30001214"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.719"
+    escalade "^3.1.1"
+    node-releases "^1.1.71"
+
+browserslist@^4.14.5, browserslist@^4.16.6:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
   integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
@@ -4652,6 +4982,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219:
   version "1.0.30001239"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
   integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
+
+caniuse-lite@^1.0.30001214:
+  version "1.0.30001251"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
+  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -5798,6 +6133,11 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+electron-to-chromium@^1.3.719:
+  version "1.3.817"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.817.tgz#911b4775b5d9fa0c4729d4694adc81de85d8d8f6"
+  integrity sha512-Vw0Faepf2Id9Kf2e97M/c99qf168xg86JLKDxivvlpBQ9KDtjSeX0v+TiuSE25PqeQfTz+NJs375b64ca3XOIQ==
+
 electron-to-chromium@^1.3.723:
   version "1.3.752"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz#0728587f1b9b970ec9ffad932496429aef750d09"
@@ -5874,6 +6214,14 @@ enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^5.8.0:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
+  integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -5938,6 +6286,16 @@ es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.0"
+
+es-module-lexer@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.6.0.tgz#e72ab05b7412e62b9be37c37a09bdb6000d706f0"
+  integrity sha512-f8kcHX1ArhllUtb/wVSyvygoKCznIjnxhLxy7TCvIiMdT7fL4ZDTIKaadMe6eLvOXg6Wk02UeoFgUoZ2EKZZUA==
+
+es-module-lexer@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.7.1.tgz#c2c8e0f46f2df06274cdaf0dd3f3b33e0a0b267d"
+  integrity sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -6143,20 +6501,20 @@ eslint-rule-composer@^0.3.0:
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
   integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
+eslint-scope@5.1.1, eslint-scope@^5.1.0, eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-scope@^5.1.0, eslint-scope@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-utils@^2.0.0:
@@ -6283,10 +6641,10 @@ eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
-  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
+events@^3.0.0, events@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 eventsource@1.1.0:
   version "1.1.0"
@@ -6770,6 +7128,11 @@ fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   dependencies:
     minipass "^3.0.0"
+
+fs-monkey@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
+  integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -8991,7 +9354,12 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.0.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-runner@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
+  integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
+
+loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -9342,6 +9710,13 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+memfs@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.2.tgz#5de461389d596e3f23d48bb7c2afb6161f4df40e"
+  integrity sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==
+  dependencies:
+    fs-monkey "1.0.3"
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -9460,17 +9835,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.43.0:
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
-  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
+mime-db@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.26"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
-  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.27, mime-types@~2.1.19, mime-types@~2.1.24:
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
-    mime-db "1.43.0"
+    mime-db "1.48.0"
 
 mime@^1.3.4:
   version "1.6.0"
@@ -9769,7 +10144,7 @@ negotiator@0.6.2, negotiator@^0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -10341,7 +10716,7 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
-p-limit@3.1.0:
+p-limit@3.1.0, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -11811,6 +12186,13 @@ serialize-javascript@^3.0.0, serialize-javascript@^3.1.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -11992,7 +12374,7 @@ sort-keys@^4.0.0:
   dependencies:
     is-plain-obj "^2.0.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -12008,7 +12390,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -12031,7 +12413,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -12450,6 +12832,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
+
 tar-fs@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
@@ -12535,6 +12922,18 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
+terser-webpack-plugin@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.3.tgz#30033e955ca28b55664f1e4b30a1347e61aa23af"
+  integrity sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==
+  dependencies:
+    jest-worker "^27.0.2"
+    p-limit "^3.1.0"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    source-map "^0.6.1"
+    terser "^5.7.0"
+
 terser@^4.1.2:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -12543,6 +12942,15 @@ terser@^4.1.2:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
+
+terser@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.0.tgz#a761eeec206bc87b605ab13029876ead938ae693"
+  integrity sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -13362,6 +13770,14 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
 
+watchpack@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.2.0.tgz#47d78f5415fe550ecd740f99fe2882323a58b1ce"
+  integrity sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
@@ -13392,10 +13808,76 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-sources@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
+  integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
+
 webpack-virtual-modules@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.3.tgz#cd597c6d51d5a5ecb473eea1983a58fa8a17ded9"
   integrity sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==
+
+webpack@>=5.38.0:
+  version "5.44.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.44.0.tgz#97b13a02bd79fb71ac6301ce697920660fa214a1"
+  integrity sha512-I1S1w4QLoKmH19pX6YhYN0NiSXaWY8Ou00oA+aMcr9IUGeF5azns+IKBkfoAAG9Bu5zOIzZt/mN35OffBya8AQ==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.50"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.0"
+    es-module-lexer "^0.7.1"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.2.0"
+    webpack-sources "^2.3.0"
+
+webpack@>=5.40.0, webpack@^5, webpack@^5.40.0:
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.40.0.tgz#3182cfd324759d715252cf541901a226e57b5061"
+  integrity sha512-c7f5e/WWrxXWUzQqTBg54vBs5RgcAgpvKE4F4VegVgfo4x660ZxYUF2/hpMkZUnLjgytVTitjeXaN4IPlXCGIw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.47"
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/wasm-edit" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    acorn "^8.2.1"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.0"
+    es-module-lexer "^0.6.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.2.0"
+    webpack-sources "^2.3.0"
 
 webpack@^4.25.1:
   version "4.46.0"


### PR DESCRIPTION
## Description
This PR updates `graphql-mini-transforms` to support webpack 5.

Closes https://github.com/Shopify/sewing-kit/issues/2689
Closes https://github.com/Shopify/sewing-kit/issues/2693

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change
- [X] `graphql-mini-transforms` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] `web-worker` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] `sewing-kit-koa` Major: Breaking change to support webpack 5 + remove `vendor.js`
- [X] `react-server` Major: Breaking change to support webpack 5
- [X] `magic-entries-webpack-plugin` Major: Breaking change to support webpack 5

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
