### PR TITLE
update webpack-virtual-modules to the version that support webpack 5

### DIFF
--- a/packages/magic-entries-webpack-plugin/CHANGELOG.md
+++ b/packages/magic-entries-webpack-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Update `webpack-virtual-modules` to 0.4.3 which support webpack 5
+
 ## 1.0.0 - 2021-05-21
 
 ### Breaking Change

--- a/packages/magic-entries-webpack-plugin/package.json
+++ b/packages/magic-entries-webpack-plugin/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "@types/webpack-virtual-modules": "^0.1.0",
-    "webpack-virtual-modules": "^0.2.2"
+    "webpack-virtual-modules": "^0.4.3"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Update `webpack-virtual-modules` to 0.4.3 which support webpack 5
+
 ## 1.0.0 - 2021-05-21
 
 ### Breaking Change

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -58,7 +58,7 @@
   },
   "optionalDependencies": {
     "@babel/types": ">=7.0.0",
-    "webpack-virtual-modules": "^0.2.2"
+    "webpack-virtual-modules": "^0.4.3"
   },
   "files": [
     "build/*",

--- a/packages/sewing-kit-plugin-quilt/CHANGELOG.md
+++ b/packages/sewing-kit-plugin-quilt/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Update `webpack-virtual-modules` to 0.4.3 which support webpack 5
+
 ## 0.1.0 - 2021-05-21
 
 ### Breaking Change

--- a/packages/sewing-kit-plugin-quilt/package.json
+++ b/packages/sewing-kit-plugin-quilt/package.json
@@ -61,6 +61,6 @@
     "@types/execa": "^0.9.0",
     "browserslist": "^4.16.0",
     "fs-extra": "^9.0.0",
-    "webpack-virtual-modules": "^0.4.0"
+    "webpack-virtual-modules": "^0.4.3"
   }
 }

--- a/packages/web-worker/CHANGELOG.md
+++ b/packages/web-worker/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Update `webpack-virtual-modules` to 0.4.3 which support webpack 5
+
 ## 2.0.0 - 2021-05-21
 
 ### Breaking Change

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@shopify/rpc": "^2.0.1",
     "loader-utils": "^1.0.0",
-    "webpack-virtual-modules": "^0.2.2"
+    "webpack-virtual-modules": "^0.4.3"
   },
   "devDependencies": {
     "@babel/types": ">=7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6589,7 +6589,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.1, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@^3.0.0, debug@^3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@^3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -16846,17 +16846,10 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-virtual-modules@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz#20863dc3cb6bb2104729fff951fbe14b18bd0299"
-  integrity sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
-  dependencies:
-    debug "^3.0.0"
-
-webpack-virtual-modules@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.2.tgz#68ce4479df7334a491b7a3f3bead47fe382947d9"
-  integrity sha512-OUsT1VZhArN8nY7g6mMlw91HWnXcNXsIQjsQ83WteF4ViZ6YXqF2sWKOTDIZ0H+PPiApQdszLdZIrD7NNlU0Yw==
+webpack-virtual-modules@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.3.tgz#cd597c6d51d5a5ecb473eea1983a58fa8a17ded9"
+  integrity sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==
 
 webpack@^4.25.1, webpack@^4.42.1:
   version "4.46.0"


### PR DESCRIPTION
Part of https://github.com/Shopify/sewing-kit/issues/2692

Update `webpack-virtual-modules` to v0.4.3 which is webpack 5 compatible 