### PR TITLE
Fix references in the polyfills migration guide

### DIFF
--- a/packages/polyfills/migration-guide.md
+++ b/packages/polyfills/migration-guide.md
@@ -8,8 +8,8 @@ This is a concise summary of changes and recommendations around updating `@shopi
 
 Base polyfills now use `core-js@3`. The following polyfills have been removed because they are provided by `core-js@3`. Please remove imports containing:
 
-- `@shopify/polyfill/url`
-- `@shopify/polyfill/unhandled-rejection`
+- `@shopify/polyfills/url`
+- `@shopify/polyfills/unhandled-rejection`
 
 ## [2.0.0] - 2021-05-21
 


### PR DESCRIPTION
## Description

The migration guide for the `@shopify/polyfills` package contain references that are missing the "s" from "polyfills". This change fixes those references.

## Type of change

This is a simple documentation fix that does not require a new release.

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
