### PR TITLE
Stabilise width/height mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "skn build",
     "lint": "skn lint",
+    "type-check": "skn type-check",
     "ci:lint-docs": "yarn generate docs && ./scripts/check-docs.sh",
     "test": "NODE_ICU_DATA=node_modules/full-icu skn test",
     "check": "lerna run check",

--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-## Fixed
+### Fixed
 
 - Dimension mocks no longer leak invalid values into other tests after being restored. [[#1961](https://github.com/Shopify/quilt/pull/1961)]
 

--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+## Fixed
+
+- Dimension mocks no longer leak invalid values into other tests after being restored. [[#1961](https://github.com/Shopify/quilt/pull/1961)]
 
 ## 3.0.0 - 2021-05-21
 

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@shopify/async": "^3.0.1",
-    "@shopify/decorators": "^2.0.0",
     "@types/fetch-mock": "^7.3.3",
     "@types/lolex": "^2.1.3",
     "fetch-mock": "^9.11.0",

--- a/packages/jest-dom-mocks/src/dimension.ts
+++ b/packages/jest-dom-mocks/src/dimension.ts
@@ -1,5 +1,3 @@
-import {memoize} from '@shopify/decorators';
-
 enum SupportedDimension {
   InnerWidth = 'innerWidth',
   OffsetWidth = 'offsetWidth',
@@ -8,97 +6,59 @@ enum SupportedDimension {
   ScrollHeight = 'scrollHeight',
 }
 
-type MockedGetter = (element: HTMLElement) => number;
-type Mock = MockedGetter | number;
-type Mocks = Partial<{[key: string]: Mock}>;
-
-type AugmentedElement = Element & {[key: string]: Mock};
-
-interface NativeImplentationMap {
-  [key: string]: Element;
-}
-
-function isGetterFunction(mock?: Mock): mock is MockedGetter {
-  return mock != null && typeof mock === 'function';
-}
+type DimensionMap = {[T in SupportedDimension]: HTMLElement | Element};
+type MockedDimensions = {[T in SupportedDimension]: number};
 
 export default class Dimension {
-  private isUsingMock = false;
-  private overwrittenImplementations: string[] = [];
+  private dimensionMap!: DimensionMap;
+  private undoMocks: Function[] = [];
 
-  mock(mocks: Mocks) {
-    if (this.isUsingMock) {
+  mock(mocks: Partial<MockedDimensions>) {
+    if (this.isMocked()) {
       throw new Error(
         'Dimensions are already mocked, but you tried to mock them again.',
       );
-    } else if (Object.keys(mocks).length === 0) {
-      throw new Error('No dimensions provided for mocking');
     }
 
-    this.mockDOMMethods(mocks);
-    this.isUsingMock = true;
-  }
-
-  restore() {
-    if (!this.isUsingMock) {
-      throw new Error(
-        "Dimensions haven't been mocked, but you are trying to restore them.",
-      );
-    }
-
-    this.restoreDOMMethods();
-    this.isUsingMock = false;
-  }
-
-  isMocked() {
-    return this.isUsingMock;
-  }
-
-  @memoize()
-  private get nativeImplementations(): NativeImplentationMap {
-    return {
+    // We initialize this lazily so that we don’t try to reference
+    // HTMLElement in test environments where it does not exist.
+    this.dimensionMap = this.dimensionMap || {
       [SupportedDimension.InnerWidth]: HTMLElement.prototype,
       [SupportedDimension.OffsetWidth]: HTMLElement.prototype,
       [SupportedDimension.OffsetHeight]: HTMLElement.prototype,
       [SupportedDimension.ScrollWidth]: Element.prototype,
       [SupportedDimension.ScrollHeight]: Element.prototype,
     };
+
+    this.undoMocks.push(...this.applyMocks(mocks));
   }
 
-  private mockDOMMethods(mocks: Mocks) {
-    Object.keys(mocks).forEach((method) => {
-      const nativeSource = this.nativeImplementations[method];
-      const mock: Mock | undefined = mocks[method];
+  restore() {
+    if (!this.isMocked()) {
+      throw new Error(
+        "Dimensions haven't been mocked, but you are trying to restore them.",
+      );
+    }
 
-      this.overwrittenImplementations.push(method);
-
-      if (isGetterFunction(mock)) {
-        Object.defineProperty(nativeSource, method, {
-          get() {
-            return mock.call(this, this);
-          },
-          configurable: true,
-        });
-      } else {
-        Object.defineProperty(nativeSource, method, {
-          value: mocks[method],
-          configurable: true,
-        });
-      }
-    });
+    [...this.undoMocks].reverse().forEach((undo) => undo());
+    this.undoMocks = [];
   }
 
-  private restoreDOMMethods() {
-    this.overwrittenImplementations.forEach((method) => {
-      const nativeSource = this.nativeImplementations[method];
+  isMocked() {
+    return this.undoMocks.length > 0;
+  }
 
-      if (nativeSource == null) {
-        return;
-      }
+  private applyMocks(properties: Partial<MockedDimensions>) {
+    const keys = Object.getOwnPropertyNames(properties) as SupportedDimension[];
+    return keys.map((key) => {
+      const base = this.dimensionMap[key];
+      const orignalDescriptor = Object.getOwnPropertyDescriptor(base, key);
 
-      delete (nativeSource as AugmentedElement)[method];
+      Object.defineProperty(base, key, {value: properties[key]});
+
+      return () => {
+        Object.defineProperty(base, key, {...orignalDescriptor});
+      };
     });
-
-    this.overwrittenImplementations = [];
   }
 }

--- a/packages/jest-dom-mocks/src/test/dimension.test.ts
+++ b/packages/jest-dom-mocks/src/test/dimension.test.ts
@@ -70,7 +70,7 @@ describe('Dimension mocks', () => {
       targetEl.id = 'testId';
 
       dimension.mock({
-        scrollWidth(element: HTMLElement) {
+        scrollWidth(element) {
           return element.id === 'testId' ? 200 : 0;
         },
       });
@@ -105,13 +105,16 @@ describe('Dimension mocks', () => {
       const dimension = new Dimension();
       const testEl = document.createElement('div');
 
+      const originalScrollWidth = testEl.scrollWidth;
+      expect(originalScrollWidth).not.toBeUndefined();
+
       dimension.mock({
         scrollWidth: 200,
       });
       dimension.restore();
 
       expect(testEl.scrollWidth).not.toBe(200);
-      expect(testEl.scrollWidth).toBeUndefined();
+      expect(testEl.scrollWidth).toBe(originalScrollWidth);
     });
   });
 });

--- a/packages/jest-dom-mocks/tsconfig.json
+++ b/packages/jest-dom-mocks/tsconfig.json
@@ -11,5 +11,5 @@
     "./src/**/*.tsx"
   ],
   "exclude": ["**/test/**/*", "**/tests/**/*"],
-  "references": [{"path": "../async"}, {"path": "../decorators"}]
+  "references": [{"path": "../async"}]
 }


### PR DESCRIPTION
## Description

Stops dimensions mocks leaking invalid properties into subsequent tests.

This PR ports @GoodForOneFare's fixes in https://github.com/Shopify/web/pull/42034 into jest-dom-mocks.

## Type of change

- jest-dom-mocks: patch 
