### PR TITLE
Switch hook on useMountedRef from useEffect to useLayoutEffect to support React 17

### DIFF
--- a/packages/react-hooks/src/hooks/mounted-ref.ts
+++ b/packages/react-hooks/src/hooks/mounted-ref.ts
@@ -2,7 +2,6 @@ import {useRef} from 'react';
 
 import {useIsomorphicLayoutEffect} from './isomorphic-layout-effect';
 
-
 export function useMountedRef() {
   const mounted = useRef(true);
 

--- a/packages/react-hooks/src/hooks/mounted-ref.ts
+++ b/packages/react-hooks/src/hooks/mounted-ref.ts
@@ -1,9 +1,12 @@
-import {useRef, useLayoutEffect} from 'react';
+import {useRef} from 'react';
+
+import {useIsomorphicLayoutEffect} from './isomorphic-layout-effect';
+
 
 export function useMountedRef() {
   const mounted = useRef(true);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     return () => {
       mounted.current = false;
     };

--- a/packages/react-hooks/src/hooks/mounted-ref.ts
+++ b/packages/react-hooks/src/hooks/mounted-ref.ts
@@ -1,9 +1,9 @@
-import {useRef, useEffect} from 'react';
+import {useRef, useLayoutEffect} from 'react';
 
 export function useMountedRef() {
   const mounted = useRef(true);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     return () => {
       mounted.current = false;
     };

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- `useMountedRef` now works with React 17 [#1964](https://github.com/Shopify/quilt/pull/1964).
 
 ## 3.1.0 - 2021-06-29
 


### PR DESCRIPTION
## Description

`useEffect`'s cleanup function is no longer synchronous, so we switched to `useLayoutEffect` to preserve the behaviour of `useMountedRef` in React 17+.

Source: https://reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing

Fixes #1959

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)

## Tophat Instructions

On package.json, upgrade React and ReactDOM to the following:
```
    "react": "17.0.2",
    "react-dom": "17.0.2",
```
And the resolutions to:
```    
    "@types/react": "17.0.11",
    "@types/react-dom": "17.0.8"
```
Then run `yarn && yarn test react-hooks`. The tests should pass!