### PR TITLE
Replace country-service with atlas

### DIFF
--- a/packages/address-consts/CHANGELOG.md
+++ b/packages/address-consts/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Replace [country-service](https://github.com/Shopify/country-service) with [atlas](https://github.com/Shopify/atlas) address service's GraphQL endpoint [#1965](https://github.com/Shopify/quilt/pull/1965)
 
 ## 3.0.0 - 2021-05-21
 

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -93,8 +93,7 @@ export interface GraphQlError {
   extensions?: object;
 }
 
-export const GRAPHQL_ENDPOINT =
-  'https://country-service.shopifycloud.com/graphql';
+export const GRAPHQL_ENDPOINT = 'https://atlas.shopifycloud.com/graphql';
 export enum GraphqlOperationName {
   Countries = 'countries',
   Country = 'country',


### PR DESCRIPTION
## Description

`country-service` will be deprecated in favour of `atlas` (with no changes in functionality)

Link to issue: https://github.com/Shopify/atlas/issues/175

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
