### PR TITLE
Prettier fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,7 +1,7 @@
 ---
 name: '🐛 Bug Report'
 about: Something isn't working
-labels: "Type: Bug 🐛"
+labels: 'Type: Bug 🐛'
 ---
 
 ## Overview

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
@@ -1,7 +1,7 @@
 ---
 name: '📈 Enhancement'
 about: Enhancement to our codebase that isn't a adding or changing a feature
-labels: "Type: Enhancement 📈" 
+labels: 'Type: Enhancement 📈'
 ---
 
 ## Overview

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,7 +1,7 @@
 ---
 name: '🙌 Feature Request'
 about: Suggest a new feature, or changes to an existing one
-labels: "Type: Feature Request :raised_hands:" 
+labels: 'Type: Feature Request :raised_hands:'
 ---
 
 ## Overview

--- a/gems/quilt_rails/test/dummy/config/storage.yml
+++ b/gems/quilt_rails/test/dummy/config/storage.yml
@@ -5,7 +5,6 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
-
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/packages/graphql-fixtures/migration-guide.md
+++ b/packages/graphql-fixtures/migration-guide.md
@@ -9,7 +9,7 @@ However, if you were using `fillGraphQL` and expected to receive the data, this 
 ```ts
 const fillGraphQL = createFiller(/* options */);
 const data = fillGraphQL(myQuery);
-const graphQL = createGraphQL({ MyQuery: data });
+const graphQL = createGraphQL({MyQuery: data});
 
 /* ... */
 
@@ -22,9 +22,9 @@ You have two options to update code like what is shown above:
 
 ```ts
 const fillGraphQL = createFiller(/* options */);
-const someDataOnTheQuery = "foo";
-const fillMyQuery = fillGraphQL(myQuery, { someDataOnTheQuery });
-const graphQL = createGraphQL({ MyQuery: fillMyQuery });
+const someDataOnTheQuery = 'foo';
+const fillMyQuery = fillGraphQL(myQuery, {someDataOnTheQuery});
+const graphQL = createGraphQL({MyQuery: fillMyQuery});
 
 /* ... */
 
@@ -36,8 +36,8 @@ expect(something).toBe(someDataOnTheQuery);
 ```ts
 const fillGraphQL = createFiller(/* options */);
 const fillMyQuery = fillGraphQL(myQuery);
-const data = fillMyQuery({ query: myQuery });
-const graphQL = createGraphQL({ MyQuery: data });
+const data = fillMyQuery({query: myQuery});
+const graphQL = createGraphQL({MyQuery: data});
 
 /* ... */
 

--- a/packages/graphql-testing/README.md
+++ b/packages/graphql-testing/README.md
@@ -64,7 +64,7 @@ The `wrap()` method allows you to wrap all GraphQL resolutions in a function cal
 const myComponent = mount(<MyComponent />);
 const graphQL = createGraphQL(mocks);
 
-graphQL.wrap(resolve => myComponent.act(resolve));
+graphQL.wrap((resolve) => myComponent.act(resolve));
 
 // Before, calling this could cause warnings about state updates happening outside
 // of act(). Now, all GraphQL resolutions are safely wrapped in myComponent.act().
@@ -87,7 +87,7 @@ const graphQL = createGraphQL({
   },
 });
 
-graphQL.wrap(resolve => myComponent.act(resolve));
+graphQL.wrap((resolve) => myComponent.act(resolve));
 await graphQL.resolveAll();
 
 graphQL.update({

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -266,12 +266,12 @@ const builder = new Builder({
   schemaTypesPath: 'app/graphql/types',
 });
 
-builder.on('build', build => {
+builder.on('build', (build) => {
   // See the source file for details on the shape of the object returned here
   console.log(build);
 });
 
-builder.on('error', error => {
+builder.on('error', (error) => {
   console.error(error);
 });
 

--- a/packages/graphql-validate-fixtures/README.md
+++ b/packages/graphql-validate-fixtures/README.md
@@ -49,9 +49,9 @@ yarn run graphql-validate-fixtures 'src/**/fixtures/**/*.graphql.json'
 const {evaluateFixtures} = require('graphql-validate-fixtures');
 evaluateFixtures({
   fixturePaths: ['test/fixtures/one.json', 'test/fixtures/two.json'],
-}).then(results => {
+}).then((results) => {
   // See the TypeScript definition file for more details on the
   // structure of the `results`
-  results.forEach(result => console.log(result));
+  results.forEach((result) => console.log(result));
 });
 ```

--- a/packages/koa-shopify-webhooks/README.md
+++ b/packages/koa-shopify-webhooks/README.md
@@ -78,7 +78,7 @@ app.use(
         topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
-        apiVersion: ApiVersion.Unstable
+        apiVersion: ApiVersion.Unstable,
       });
 
       if (registration.success) {
@@ -106,7 +106,7 @@ app.use(
 
 app.use(verifyRequest());
 
-app.use(ctx => {
+app.use((ctx) => {
   /* app code */
 });
 ```
@@ -144,7 +144,7 @@ app.use(
         topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
-        apiVersion: ApiVersion.Unstable
+        apiVersion: ApiVersion.Unstable,
       });
 
       await registerWebhook({
@@ -152,7 +152,7 @@ app.use(
         topic: 'ORDERS_CREATE',
         accessToken,
         shop,
-        apiVersion: ApiVersion.Unstable
+        apiVersion: ApiVersion.Unstable,
       });
 
       ctx.redirect('/');

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -31,7 +31,7 @@ If you want to listen for events, you can use the `on` method. There are three e
 ```ts
 // Listen for completed navigations. If you call this after the initial load
 // "navigation", your handler will immediately be invoked with that object.
-performance.on('navigation', navigation => {});
+performance.on('navigation', (navigation) => {});
 
 // Listen for the start of new navigations.
 performance.on('inflightNavigation', () => {});
@@ -42,7 +42,7 @@ performance.on('inflightNavigation', () => {});
 // the full set of possible events. If you add your listener after some of these
 // events have been triggered, it will immediately be invoked once for each
 // previously-triggered event.
-performance.on('lifecycleEvent', event => {});
+performance.on('lifecycleEvent', (event) => {});
 ```
 
 The `on` method returns a clean-up function that you can invoke when you're done listening on the event:
@@ -50,7 +50,7 @@ The `on` method returns a clean-up function that you can invoke when you're done
 ```ts
 const cleanupNavigationListener = performance.on(
   'navigation',
-  navigation => {},
+  (navigation) => {},
 );
 
 cleanupNavigationListener();

--- a/packages/react-async/README.md
+++ b/packages/react-async/README.md
@@ -305,7 +305,7 @@ This component might be rendered when the URL matches `/products/:id`. If we wan
 ```tsx
 <PrefetchRoute
   path={/^\/products\/(\d+)$/}
-  render={url => {
+  render={(url) => {
     const id = url.pathname.split('/').pop();
     return <ProductDetails.Prefetch id={id} />;
   }}
@@ -379,7 +379,7 @@ const ExpensiveFileContext = createAsyncContext({
 // and use the consumer to access the value:
 
 <ExpensiveFileContext.Consumer>
-  {file => (file ? <CsvViewer file={file} /> : null)}
+  {(file) => (file ? <CsvViewer file={file} /> : null)}
 </ExpensiveFileContext.Consumer>;
 ```
 

--- a/packages/react-cookie/README.md
+++ b/packages/react-cookie/README.md
@@ -42,7 +42,7 @@ export default function renderApp(ctx: Context) {
   const app = <App />;
 
   await extract(app, {
-    decorate: element => (
+    decorate: (element) => (
       <NetworkContext.Provider value={networkManager}>
         {element}
       </NetworkContext.Provider>
@@ -95,7 +95,7 @@ import {useCookie} from '@shopify/react-cookie';
 
 function SomeComponent() {
   const [cookie, setCookie] = useCookie('fooCookie');
-  const handleChange = event => setCookie(event.target.value);
+  const handleChange = (event) => setCookie(event.target.value);
   const removeCookie = () => setCookie();
 
   return (

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -120,7 +120,7 @@ export default function App() {
   return (
     <Provider value={new StatefulManager()}>
       <Consumer>
-        {manager => <Effect perform={() => (manager.value = true)} />}
+        {(manager) => <Effect perform={() => (manager.value = true)} />}
       </Consumer>
     </Provider>
   );
@@ -137,7 +137,7 @@ export default function App({manager}) {
   return (
     <Provider value={manager}>
       <Consumer>
-        {manager => <Effect perform={() => (manager.value = true)} />}
+        {(manager) => <Effect perform={() => (manager.value = true)} />}
       </Consumer>
     </Provider>
   );

--- a/packages/react-effect/documentation/migrating-version-1-to-2.md
+++ b/packages/react-effect/documentation/migrating-version-1-to-2.md
@@ -31,7 +31,7 @@ class Manager {
 
 <Context.Provider value={new Manager()}>
   <Context.Consumer>
-    {manager => (
+    {(manager) => (
       <Effect kind={manager.effect} perform={doSomethingWithManager(manager)} />
     )}
   </Context.Consumer>

--- a/packages/react-form-state/docs/building-forms.md
+++ b/packages/react-form-state/docs/building-forms.md
@@ -42,7 +42,7 @@ function MyComponent() {
         description: 'Cool product',
       }}
     >
-      {formDetails => {
+      {(formDetails) => {
         const {fields} = formDetails;
         const {title, description} = fields;
 
@@ -92,7 +92,7 @@ function MyComponent() {
         description: 'Cool product',
       }}
     >
-      {formDetails => {
+      {(formDetails) => {
         const {fields} = formDetails;
 
         return (
@@ -132,7 +132,7 @@ const fakeErrorResult = {error: [{message: 'api is not real'}]};
 
 // simple async function that fakes a failing api call
 export function fakeApiCall(data: any) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(fakeErrorResult);
     }, 2000);
@@ -165,7 +165,7 @@ export function MyPage() {
             {!valid && (
               <Banner status="critical">
                 <ul>
-                  {errors.map(error => (
+                  {errors.map((error) => (
                     <li key={`${error.message}${error.field}`}>
                       {error.message}
                     </li>
@@ -274,7 +274,7 @@ export function MyPage() {
 export type ValidatorDictionary<Fields> = {
   [FieldPath in keyof Fields]: MaybeArray<
     ValidationFunction<Fields[FieldPath], Fields>
-  >
+  >;
 };
 
 interface ValidationFunction<Value, Fields> {
@@ -359,7 +359,7 @@ function MyComponent() {
         },
       }}
     >
-      {formDetails => {
+      {(formDetails) => {
         const {fields} = formDetails;
 
         return (
@@ -401,7 +401,7 @@ function MyComponent() {
         console.log('I will not be run if title is too long');
       }}
     >
-      {formDetails => {
+      {(formDetails) => {
         const {errors, fields, submit} = formDetails;
 
         const errorBanner = Boolean(errors.length) && (
@@ -706,7 +706,7 @@ function CreateProductPage({initialValues}: Props) {
         return [{message: 'server error'}];
       }}
     >
-      {formDetails => {
+      {(formDetails) => {
         const {fields, dirty, reset, submit, submitting, errors} = formDetails;
         const {
           title,
@@ -733,7 +733,7 @@ function CreateProductPage({initialValues}: Props) {
         const errorBanner = errors.length > 0 && (
           <Banner status="critical">
             <ul>
-              {errors.map(error => (
+              {errors.map((error) => (
                 <li key={`${error.message}${error.field}`}>{error.message}</li>
               ))}
             </ul>

--- a/packages/react-form-state/docs/validators.md
+++ b/packages/react-form-state/docs/validators.md
@@ -46,7 +46,7 @@ function MyComponent() {
         ],
       }}
     >
-      {formDetails => {
+      {(formDetails) => {
         const {fields} = formDetails;
 
         return (
@@ -118,7 +118,7 @@ import {validate, ErrorContent} from '@shopify/react-form-state';
 
 export function validEmail(input: string, errorContent: ErrorContent) {
   // example only
-  return validate(input => /+\@.+\..+/.test(input), errorContent);
+  return validate((input) => /+\@.+\..+/.test(input), errorContent);
 }
 ```
 

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -70,7 +70,7 @@ function MyComponent() {
     fields: {
       title: useField('some default title'),
     },
-    onSubmit: async fieldValues => {
+    onSubmit: async (fieldValues) => {
       return {status: 'fail', errors: [{message: 'bad form data'}]};
     },
   });
@@ -258,7 +258,7 @@ export default function MyComponent() {
 
   // handle submission state
   const {submit, submitting, errors, setErrors} = useSubmit(
-    async fieldValues => {
+    async (fieldValues) => {
       const remoteErrors = []; // your API call goes here
       if (remoteErrors.length > 0) {
         return {status: 'fail', errors: remoteErrors};
@@ -361,7 +361,7 @@ You can also pass a more complex configuration object specifying a validation fu
 ```tsx
 const field = useField({
   value: someRemoteData.title,
-  validates: title => {
+  validates: (title) => {
     if (title.length > 3) {
       return 'Title must be longer than three characters';
     }
@@ -375,12 +375,12 @@ You may also pass multiple validators.
 const field = useField({
   value: someRemoteData.title,
   validates: [
-    title => {
+    (title) => {
       if (title.length > 3) {
         return 'Title must be longer than three characters';
       }
     },
-    title => {
+    (title) => {
       if (!title.includes('radical')) {
         return 'Only radical items are allowed';
       }
@@ -548,12 +548,12 @@ const field = useList({
     {title: '', description: ''},
   ],
   validates: {
-    title: title => {
+    title: (title) => {
       if (title.length > 3) {
         return 'Title must be longer than three characters';
       }
     },
-    description: description => {
+    description: (description) => {
       if (description === '') {
         return 'Description is required!';
       }
@@ -777,14 +777,14 @@ newDefaultValue(newValue);
 You can iterate through the values and defaultValues of the dynamicList
 
 ```tsx
-value.map(card => (
+value.map((card) => (
   <div>
     <p>Card number: {card.cardNumber}</p>
     <p>CVV : {card.cvv}</p>
   </div>
 ));
 
-defaultValue.map(card => (
+defaultValue.map((card) => (
   <div>
     <p>Card number: {card.cardNumber}</p>
     <p>CVV : {card.cvv}</p>
@@ -805,7 +805,7 @@ const form = useForm({
   fields: {
     customerCards: fields,
   },
-  onSubmit: async fieldValues => {
+  onSubmit: async (fieldValues) => {
     console.log(fieldValues);
     return submitSuccess();
   },
@@ -826,7 +826,7 @@ const form = useForm<typeof fields, typeof customerCards>({
   dynamicLists: {
     customerCards,
   },
-  onSubmit: async fieldValues => {
+  onSubmit: async (fieldValues) => {
     console.log(fieldValues);
     return submitSuccess();
   },
@@ -877,7 +877,7 @@ function MyComponent() {
     fields: {
       title: useField('some default title'),
     },
-    onSubmit: async fieldValues => {
+    onSubmit: async (fieldValues) => {
       return {status: 'fail', errors: [{message: 'bad form data'}]};
     },
   });
@@ -950,7 +950,7 @@ function MyComponent() {
       title: useField('some default title'),
       description: useField('some default description'),
     },
-    onSubmit: async fieldValues => {
+    onSubmit: async (fieldValues) => {
       return {status: 'fail', errors: [{message: 'bad form data'}]};
     },
   });
@@ -1034,7 +1034,7 @@ function MyComponent() {
   const price = useField(
     {
       value: '0.00',
-      validates: value => {
+      validates: (value) => {
         if (title.value.includes('expensive') && parseFloat(value) < 1000) {
           return 'Expensive items must cost more than 1000 dollars';
         }
@@ -1045,7 +1045,7 @@ function MyComponent() {
 
   const {submit, submitting, dirty, reset, submitErrors, makeClean} = useForm({
     fields: {title, description},
-    onSubmit: async fieldValues => {
+    onSubmit: async (fieldValues) => {
       return {status: 'fail', errors: [{message: 'bad form data'}]};
     },
   });
@@ -1270,7 +1270,7 @@ const {
   submit,
 } = useForm({
   fields,
-  onSubmit: async values => {
+  onSubmit: async (values) => {
     console.log('You submitted the form!', values);
     if (someCondition) {
       makeCleanFields(fields); // set form state to 'clean'
@@ -1305,7 +1305,7 @@ function MyForm() {
   const price = useField(
     {
       value: '2.00',
-      validates: value => {
+      validates: (value) => {
         if (title.value.includes('expensive') && parseFloat(value) < 1000) {
           return 'Expensive items must be at least 1000 dollars.';
         }

--- a/packages/react-google-analytics/README.md
+++ b/packages/react-google-analytics/README.md
@@ -61,7 +61,7 @@ const UNIVERSAL_GA_ACCOUNT_ID = 'UA-xxxx-xx';
 <Universal
   account={UNIVERSAL_GA_ACCOUNT_ID}
   domain={shopDomain}
-  onLoad={ga => {
+  onLoad={(ga) => {
     this.ga = ga;
   }}
 />;
@@ -87,7 +87,7 @@ const UNIVERSAL_GA_ACCOUNT_ID = 'UA-xxxx-xx';
 <Universal
   account={UNIVERSAL_GA_ACCOUNT_ID}
   domain={shopDomain}
-  onError={error => {
+  onError={(error) => {
     // do something with error
   }}
 />;
@@ -141,7 +141,7 @@ const GA_JS_ACCOUNT_ID = 'UA-xxxx-xx';
 <GaJS
   account={GA_JS_ACCOUNT_ID}
   domain={shopDomain}
-  onLoad={_gaq => {
+  onLoad={(_gaq) => {
     this._gaq = _gaq;
   }}
 />;

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -56,7 +56,7 @@ export default async function middleware(ctx) {
   const app = <App />;
 
   await extract(app, {
-    decorate: element => (
+    decorate: (element) => (
       <HtmlContext.Provider value={manager}>{element}</HtmlContext.Provider>
     ),
   });

--- a/packages/react-html/documentation/migration-version-7-to-8.md
+++ b/packages/react-html/documentation/migration-version-7-to-8.md
@@ -48,7 +48,7 @@ export default async function middleware(ctx) {
 
   await extract(app, {
     // Or, sometimes, `htmlManager` was provided as a prop to `<App />`
-    decorate: app => <Provider manager={manager}>{app}</Provider>,
+    decorate: (app) => <Provider manager={manager}>{app}</Provider>,
   });
 
   ctx.body = render(<Html manager={manager}>{app}</Html>);
@@ -71,7 +71,7 @@ export default async function middleware(ctx) {
   const htmlManager = new HtmlManager();
 
   await extract(app, {
-    decorate: app => (
+    decorate: (app) => (
       <HtmlContext.Provider manager={htmlManager}>{app}</HtmlContext.Provider>
     ),
   });

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -129,7 +129,7 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 - `unformatNumber()`: converts a localized number string to a number string parseable by JavaScript. Example: `123.456,45 => 123456.45`
 - `formatCurrency()`: formats a number as a currency according to the locale. Its behaviour depends on the `form:` option.
   - if `form: 'short'` is given, then a possibly-ambiguous short form is used, consisting of the bare symbol if the currency has a symbol, or the ISO 4217 code if there is no symbol for that currency. Examples: `CHF 1.25`, `€1.25`, `OMR 1.250`, `$1.25`
-  - if `form: 'none'` is given, the number will be formatted with currency rules but will not include a currency symbol or ISO code in the string. Examples: `1,234.56`, `1 234,56`
+  - if `form: 'none'` is given, the number will be formatted with currency rules but will not include a currency symbol or ISO code in the string. Examples: `1,234.56`, `1 234,56`
   - if `form: 'explicit'` is given, then the result will be the same as for `short`, but will append the ISO 4217 code if it is not already present
   - if `form: 'auto'` is given, then `explicit` will be selected if the `currency` option does not match the `defaultCurrency`, otherwise `short` is selected. If either `currency` or `defaultCurrency` is not defined then `short` is selected.
   - if `form:` is not given, then behaviour reverts to the legacy (deprecated) `formatCurrency()`, which is a convenience function that simply _auto-assigns_ the `as` option to `currency` and calls `formatNumber()`. Note that this will resemble `form: 'short'`, but will sometimes extend the symbol with extra information depending on the browser's implementation of `Intl.NumberFormat` and the locale in use. For example, `formatCurrency(1.25, {currency: 'CAD'})` may return `$ 1.25`, or it might return `CA$ 1.25`.
@@ -351,7 +351,6 @@ import {
 import {I18nManager} from '@shopify/react-i18n';
 import {extract} from '@shopify/react-effect/server';
 
-
 function App({locale}: {locale?: string}) {
   return (
     <I18nUniversalProvider locale={locale}>
@@ -359,7 +358,7 @@ function App({locale}: {locale?: string}) {
     </I18nUniversalProvider>
   );
 }
-const app = <App locale='en' />;
+const app = <App locale="en" />;
 
 const htmlManager = new HtmlManager();
 await extract(element, {
@@ -370,11 +369,7 @@ await extract(element, {
   },
 });
 
-const html = render(
-  <Html manager={htmlManager}>
-    {app}
-  </Html>,
-);
+const html = render(<Html manager={htmlManager}>{app}</Html>);
 ```
 
 ### Babel

--- a/packages/react-i18n/docs/react_i18n_schema.md
+++ b/packages/react-i18n/docs/react_i18n_schema.md
@@ -3,6 +3,7 @@
 React I18n is a schema comprised of a structure of nested key-value pairs (KVPs). This document captures the nuances of the constraints placed on the schema by the different levels of concern.
 
 <!-- Created using "Markdown All in One" extension for VS Code -->
+
 - [History](#history)
   - [Version 2.0](#version-20)
   - [Version 1.0](#version-10)
@@ -21,19 +22,19 @@ React I18n is a schema comprised of a structure of nested key-value pairs (KVPs)
     - [Comments](#comments)
   - [Serialization to JSON+Comments](#serialization-to-jsoncomments)
 - [Appendix A: Comparison with Rails I18n](#appendix-a-comparison-with-rails-i18n)
-    - [Root locale key](#root-locale-key)
-    - [Pluralization](#pluralization-1)
-    - [Interpolation](#interpolation)
+  - [Root locale key](#root-locale-key)
+  - [Pluralization](#pluralization-1)
+  - [Interpolation](#interpolation)
 
 # History
 
 ## Version 2.0
 
-* Use the more precise language: `"Pluralization" -> "Cardinal Pluralization"`
-* Clarify that a cardinal pluralization context only includes immediate children
-* Add a description of how ordinal pluralization works.
-    * This was an omission in the version `1.0` specification.
-* Adjust the rules for reserved cardinal pluralization keys to account for their usage in ordinal pluralization contexts
+- Use the more precise language: `"Pluralization" -> "Cardinal Pluralization"`
+- Clarify that a cardinal pluralization context only includes immediate children
+- Add a description of how ordinal pluralization works.
+  - This was an omission in the version `1.0` specification.
+- Adjust the rules for reserved cardinal pluralization keys to account for their usage in ordinal pluralization contexts
 
 ## Version 1.0
 
@@ -87,7 +88,8 @@ Pluralization of cardinal numbers is handled by providing the cardinal pluraliza
 
 ```jsonc
 {
-  "cars": {  // All the children of `cars` are in a "cardinal pluralization context"
+  "cars": {
+    // All the children of `cars` are in a "cardinal pluralization context"
     "one": "I have {count} car",
     "other": "I have {count} cars"
   }
@@ -113,12 +115,12 @@ Different languages require different sets of cardinal pluralization keys. For e
 
 In order to avoid key collisions, the following keys are reserved for use as cardinal pluralization keys and must not be used as keys of leaf KVPs outside of a cardinal pluralization context:
 
-* `few`
-* `many`
-* `one`
-* `other`
-* `two`
-* `zero`
+- `few`
+- `many`
+- `one`
+- `other`
+- `two`
+- `zero`
 
 **Note:** There is an exception. These keys are also allowed to be present within an **ordinal pluralization context**.
 
@@ -127,6 +129,7 @@ These keys are derived from the names given to the cardinal pluralization rules 
 This list is current as of version `37` of the CLDR. In the unlikely event that new cardinal pluralization rule names are added, they will be added to this reserved list in a future version of this specification.
 
 **Example INVALID English file:**
+
 ```jsonc
 {
   "foo": "bar",
@@ -151,6 +154,7 @@ Furthermore, cardinal pluralization keys that are not required by the language m
 For example, even though `zero` is a required cardinal pluralization key for some languages (eg. Arabic), it is not a required cardinal pluralization key in English. Therefore, the `zero` key must not be present in an English file alongside the cardinal pluralization KVPs required by English.
 
 **Example INVALID English file:**
+
 ```jsonc
 {
   "cars": {
@@ -165,7 +169,7 @@ For example, even though `zero` is a required cardinal pluralization key for som
 
 These constraints allow for a simple algorithm for identifying cardinal pluralization contexts:
 
-* If a node has child leaf KVPs for **any** of the cardinal pluralization keys required by the language, and the node is not `ordinal` (which would make it an [ordinal pluralization context](#ordinal-pluralization), then its **immediate** children are within a cardinal pluralization context.
+- If a node has child leaf KVPs for **any** of the cardinal pluralization keys required by the language, and the node is not `ordinal` (which would make it an [ordinal pluralization context](#ordinal-pluralization), then its **immediate** children are within a cardinal pluralization context.
 
 **Note**: in order to be a valid cardinal pluralization context, any other required cardinal pluralization keys must also be present within the cardinal pluralization context.
 
@@ -178,7 +182,8 @@ Pluralization of ordinal numbers is handled by providing the ordinal pluralizati
 ```jsonc
 {
   "cars": {
-    "ordinal": { // The special key "ordinal" creates an ordinal pluralization context
+    "ordinal": {
+      // The special key "ordinal" creates an ordinal pluralization context
       "one": "This is my {amount}st car", // Used for 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …
       "two": "This is my {amount}nd car", // Used for 2, 22, 32, 42, 52, 62, 72, 82, 102, 1002, …
       "few": "This is my {amount}rd car", // Used for 3, 23, 33, 43, 53, 63, 73, 83, 103, 1003, …
@@ -209,6 +214,7 @@ Ordinal pluralization keys that are not required by the language must not be use
 For example, even though `many` is a required cardinal pluralization key for some languages (eg. Italian), it is not a required ordinal pluralization key in English. Therefore, the `many` key must not be present in an English file alongside the ordinal pluralization KVPs required by English.
 
 **Example INVALID English file:**
+
 ```jsonc
 {
   "cars": {
@@ -227,7 +233,7 @@ For example, even though `many` is a required cardinal pluralization key for som
 
 These constraints allow for a simple algorithm for identifying ordinal pluralization contexts:
 
-* If a node has the special key name `ordinal`, then its **immediate** children are within a ordinal pluralization context.
+- If a node has the special key name `ordinal`, then its **immediate** children are within a ordinal pluralization context.
 
 **Note**: in order to be a valid ordinal pluralization context, any other required ordinal pluralization keys must also be present within the ordinal pluralization context.
 
@@ -235,8 +241,8 @@ These constraints allow for a simple algorithm for identifying ordinal pluraliza
 
 React I18n can be serialized to different formats. Two serializations are officially defined:
 
-* JSON+Comments
-* JSON
+- JSON+Comments
+- JSON
 
 Consumers of React I18n `2.0` schema files are expected to be able to parse files serialized into each of these serialization formats.
 
@@ -307,6 +313,7 @@ This section compares the two schemas, in order to point out the ways in which t
 Rails I18n has a locale root key, while React I18n doesn't:
 
 **Rails I18n:**
+
 ```yaml
 en:
   foo: bar
@@ -335,12 +342,13 @@ React I18n avoids this by disallowing the use of the `zero` key unless the sourc
 When manually converting Rails I18n files to React I18n, use a different key (eg. `none` or `blank`) for storing strings that should be used for placeholder or empty values.
 
 **Rails I18n:**
+
 ```yaml
 en:
   cars:
     zero: "I don't have any cars" # Problematic when translating into languages that use the `zero` pluralization key
-    one: "I have %{count} car"
-    other: "I have %{count} car"
+    one: 'I have %{count} car'
+    other: 'I have %{count} car'
 ```
 
 **React I18n**
@@ -360,6 +368,7 @@ en:
 While neither schema defines an interpolation syntax, the most common syntax used in Rails I18n is `%{}`, while in React I18n, the most common syntax is `{}`.
 
 **Rails I18n:**
+
 ```yaml
 en:
   hello: My name is %{name}

--- a/packages/react-intersection-observer/README.md
+++ b/packages/react-intersection-observer/README.md
@@ -52,8 +52,8 @@ Unlike the `useIntersection` hook, this component will create its own DOM node t
     root={this.parentElement.current}
     rootMargin="10px 10%"
     threshold={1}
-    onIntersecting={entry => console.log('intersectionRatio > 0', entry)}
-    onNotIntersecting={entry => console.log('intersectionRatio = 0', entry)}
+    onIntersecting={(entry) => console.log('intersectionRatio > 0', entry)}
+    onNotIntersecting={(entry) => console.log('intersectionRatio = 0', entry)}
   />
 </div>
 ```

--- a/packages/react-network/README.md
+++ b/packages/react-network/README.md
@@ -206,7 +206,7 @@ export default function renderApp(ctx: Context) {
   const app = <App />;
 
   await extract(app, {
-    decorate: element => (
+    decorate: (element) => (
       <NetworkContext.Provider value={networkManager}>
         {element}
       </NetworkContext.Provider>

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -72,7 +72,7 @@ export function LastNavigationDetails() {
   const [lastNavigation, setLastNavigation] = useState<Navigation | null>(null);
 
   // listen for subsequent client-side navigations and update our state
-  useNavigationListener(navigation => {
+  useNavigationListener((navigation) => {
     setLastNavigation(navigation);
   });
 
@@ -170,7 +170,7 @@ A custom hook which takes in callback to invoke whenever the `Performance` conte
 import {useLifecycleEventListener} from '@shopify/react-performance';
 
 function SomeComponent() {
-  useLifecycleEventListener(event => {
+  useLifecycleEventListener((event) => {
     console.log(event);
   });
 
@@ -186,7 +186,7 @@ A custom hook which takes in a callback to invoke whenever a navigation takes pl
 import {useNavigationListener} from '@shopify/react-performance';
 
 function SomeComponent() {
-  useNavigationListener(navigation => {
+  useNavigationListener((navigation) => {
     console.log(navigation);
   });
 

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -75,7 +75,7 @@ The `endpoint.call` object allows you to call methods that were exposed on the s
 const endpoint = createEndpoint(messenger);
 
 // Logs "Hello, Michelle!"
-endpoint.call.greet('Michelle').then(result => console.log(result));
+endpoint.call.greet('Michelle').then((result) => console.log(result));
 ```
 
 This example also demonstrates that, because this function call is implemented using messages, it will always return a promise for the result, even if the source function returned synchronously.

--- a/packages/sewing-kit-koa/README.md
+++ b/packages/sewing-kit-koa/README.md
@@ -29,7 +29,7 @@ In subsequent middleware, you can now use `getAssets()`, which return an object 
 ```ts
 import {getAssets} from '@shopify/sewing-kit-koa';
 
-app.use(async ctx => {
+app.use(async (ctx) => {
   const assets = getAssets(ctx);
   // Both `styles` and `scripts` return a Promise for an array of objects.
   // Each object has a `path` for its resolved URL, and an optional `integrity`
@@ -66,7 +66,7 @@ export default function sewingKitConfig(plugins: Plugins) {
 // In your server...
 import {getAssets} from '@shopify/sewing-kit-koa';
 
-app.use(async ctx => {
+app.use(async (ctx) => {
   const assets = getAssets(ctx);
 
   const styles = (await assets.styles({name: 'error'})).map(({path}) => path);
@@ -85,7 +85,7 @@ You can also pass an optional `asyncAssets` to either the `scripts()` or `styles
 import {AsyncAssetManager} from '@shopify/react-async';
 import {getAssets} from '@shopify/sewing-kit-koa';
 
-app.use(async ctx => {
+app.use(async (ctx) => {
   const assets = getAssets(ctx);
   const asyncAssetManager = new AsyncAssetManager();
 

--- a/packages/statsd/documentation/decisions/01 - We use hot-shots as our dogstatsd client.md
+++ b/packages/statsd/documentation/decisions/01 - We use hot-shots as our dogstatsd client.md
@@ -6,7 +6,7 @@ May 18, 2018
 
 ## Contributors
 
-* tzvipm
+- tzvipm
 
 ## Summary
 
@@ -26,8 +26,8 @@ This same documentation provides a [list of libraries in various programming lan
 
 Among those, there are 2 libraries listed under `Node.js` with support for `DogStatsD`:
 
-* `hot-shots`
-* `node-dogstatsd`
+- `hot-shots`
+- `node-dogstatsd`
 
 `hot-shots` appears to be the clear choice between these 2 for the following reasons:
 

--- a/packages/useful-types/README.md
+++ b/packages/useful-types/README.md
@@ -109,19 +109,18 @@ The following type aliases are provided by this library:
 
 - `DeepOmit<T, K>` Recursively maps over all properties in a type and omits those matching `K`.
 
- ```ts
-  interface Obj {
+```ts
+interface Obj {
+  __typename: string;
+  foo: string;
+  bar: {
     __typename: string;
-    foo: string;
-    bar: {
-      __typename: string,
-      baz: string
-    };
-    
-  }
-  
-  type SelectiveObj = DeepOmit<Obj, '__typename'>; // {foo: string; bar: {baz: string}}
-  ```
+    baz: string;
+  };
+}
+
+type SelectiveObj = DeepOmit<Obj, '__typename'>; // {foo: string; bar: {baz: string}}
+```
 
 - `DeepOmitArray<T extends any[], K>` Iterate over all properties in an array of types and omits those matching `K`.
 


### PR DESCRIPTION
## Description

A while back we adjusted our prettier config (adding `"arrowParens": "always",`), but forgot to run it over
non-js/ts files. So whenever we make readme changes these pprettier adjustments get thrown in too and it's kinda noisy

This PR is the result of running `"node_modules/.bin/prettier" "**/*.{json,md,yaml,yml}" --write`


---

I recently created a `@sewing-kit/plugin-prettier` to make this part of the skn lint command, but I need to update the rest of our skn config at the same time thanks to a bunch of reworking. I'll do that later.

