### PR TITLE
⬆️ widen the react peer deps to show support for 17

### DIFF
--- a/packages/react-app-bridge-universal-provider/CHANGELOG.md
+++ b/packages/react-app-bridge-universal-provider/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.2 - 2021-06-29
 

--- a/packages/react-app-bridge-universal-provider/package.json
+++ b/packages/react-app-bridge-universal-provider/package.json
@@ -28,7 +28,7 @@
     "@shopify/react-html": "^11.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "faker": "^4.1.0"

--- a/packages/react-async/CHANGELOG.md
+++ b/packages/react-async/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 4.0.0 - 2021-05-21
 

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -33,7 +33,7 @@
     "@shopify/useful-types": "^3.0.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-bugsnag/CHANGELOG.md
+++ b/packages/react-bugsnag/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.1.0 - 2021-06-01
 

--- a/packages/react-bugsnag/package.json
+++ b/packages/react-bugsnag/package.json
@@ -28,7 +28,7 @@
     "@bugsnag/plugin-react": "^7.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.1"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-compose/CHANGELOG.md
+++ b/packages/react-compose/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.0 - 2021-05-21
 

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -27,7 +27,7 @@
     "hoist-non-react-statics": "^3.0.1"
   },
   "peerDependencies": {
-    "react": "^16.3.2"
+    "react": ">=16.8.0 <18.0.0"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react-cookie/CHANGELOG.md
+++ b/packages/react-cookie/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 1.0.2 - 2021-06-29
 

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -29,8 +29,8 @@
     "cookie": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-csrf-universal-provider/CHANGELOG.md
+++ b/packages/react-csrf-universal-provider/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.2 - 2021-06-29
 

--- a/packages/react-csrf-universal-provider/package.json
+++ b/packages/react-csrf-universal-provider/package.json
@@ -29,7 +29,7 @@
     "@shopify/react-universal-provider": "^2.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@shopify/react-effect": "^4.0.1",

--- a/packages/react-csrf/CHANGELOG.md
+++ b/packages/react-csrf/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.0 - 2021-05-21
 

--- a/packages/react-csrf/package.json
+++ b/packages/react-csrf/package.json
@@ -24,7 +24,7 @@
     "node": ">=12.14.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-effect/CHANGELOG.md
+++ b/packages/react-effect/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 4.0.0 - 2021-05-21
 

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -39,8 +39,8 @@
     "server.d.ts"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-form-state/CHANGELOG.md
+++ b/packages/react-form-state/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 1.0.2 - 2021-06-22
 

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -27,7 +27,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
-    "react": "^16.4.1"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@shopify/useful-types": "^3.0.1",

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 1.0.0 - 2021-05-21
 

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -24,7 +24,7 @@
     "node": ">=12.14.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@types/faker": "^4.1.5",

--- a/packages/react-google-analytics/CHANGELOG.md
+++ b/packages/react-google-analytics/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 4.0.3 - 2021-06-29
 

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -27,7 +27,7 @@
     "@shopify/react-import-remote": "^2.0.2"
   },
   "peerDependencies": {
-    "react": "^16.4.1"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 4.0.2 - 2021-06-29
 

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -34,7 +34,7 @@
     "apollo-link-context": ">=1.0.0 <2.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@shopify/react-effect": "^4.0.1"

--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
+
 ### Fixed
 
 - Changes to tests for React-17 compatibility in dev. [#1957](https://github.com/Shopify/quilt/issues/1957)

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -49,7 +49,7 @@
     "index.d.ts"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
+
 ### Fixed
 
 - `useMountedRef` now works with React 17 [#1964](https://github.com/Shopify/quilt/pull/1964).

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Shopify/quilt/issues"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "homepage": "https://github.com/Shopify/quilt/blob/main/packages/react-hooks/README.md",
   "engines": {

--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 11.0.2 - 2021-06-29
 

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -31,8 +31,8 @@
     "serialize-javascript": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@shopify/react-testing": "^3.1.0",

--- a/packages/react-hydrate/CHANGELOG.md
+++ b/packages/react-hydrate/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.0 - 2021-05-21
 

--- a/packages/react-hydrate/package.json
+++ b/packages/react-hydrate/package.json
@@ -31,7 +31,7 @@
     "faker": "^4.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-i18n-universal-provider/CHANGELOG.md
+++ b/packages/react-i18n-universal-provider/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.4 - 2021-06-29
 

--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -29,7 +29,7 @@
     "@shopify/react-i18n": "^6.0.4"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@shopify/react-effect": "^4.0.1",

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 6.0.4 - 2021-06-29
 

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -50,7 +50,7 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "optionalDependencies": {
     "@babel/template": "^7.0.0",

--- a/packages/react-idle/CHANGELOG.md
+++ b/packages/react-idle/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.0 - 2021-05-21
 

--- a/packages/react-idle/package.json
+++ b/packages/react-idle/package.json
@@ -28,7 +28,7 @@
     "@shopify/useful-types": "^3.0.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-import-remote/CHANGELOG.md
+++ b/packages/react-import-remote/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.2 - 2021-06-29
 

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -30,7 +30,7 @@
     "@shopify/useful-types": "^3.0.1"
   },
   "peerDependencies": {
-    "react": "^16.4.1"
+    "react": ">=16.8.0 <18.0.0"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react-intersection-observer/CHANGELOG.md
+++ b/packages/react-intersection-observer/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 3.0.0 - 2021-05-21
 

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -32,7 +32,7 @@
     "index.d.ts"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-network/CHANGELOG.md
+++ b/packages/react-network/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 4.0.2 - 2021-06-29
 

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "koa": "^2.5.0",
-    "react": "^16.9.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-performance/CHANGELOG.md
+++ b/packages/react-performance/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.0 - 2021-05-21
 

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -27,7 +27,7 @@
     "@shopify/performance": "^2.0.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@shopify/network": "^2.0.0"

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 1.0.2 - 2021-06-29
 

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -29,8 +29,8 @@
     "react-router-dom": ">=5.1.0 <6.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 1.1.3 - 2021-06-29
 

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -46,16 +46,16 @@
     "@types/webpack-virtual-modules": "^0.1.0",
     "get-port": "^5.0.0",
     "node-loader": "^1.0.0",
-    "react": "^16.8.1",
-    "react-dom": "^16.8.1",
+    "react": "^17.0.2",
+    "react-dom": "17.0.2",
     "saddle-up": "^0.5.1",
     "setimmediate": "^1.0.5",
     "webpack": "^4.25.1"
   },
   "peerDependencies": {
     "cross-fetch": ">=3.0.0",
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "optionalDependencies": {
     "@babel/types": ">=7.0.0",

--- a/packages/react-shortcuts/CHANGELOG.md
+++ b/packages/react-shortcuts/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 4.0.0 - 2021-05-21
 

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -23,7 +23,7 @@
     "node": ">=12.14.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
+
 ### Fixed
 
 - Changes to tests for compatibility in dev. [#1957](https://github.com/Shopify/quilt/issues/1957)

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -44,8 +44,8 @@
     "matchers.d.ts"
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-tracking-pixel/CHANGELOG.md
+++ b/packages/react-tracking-pixel/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 4.0.2 - 2021-06-29
 

--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -26,7 +26,7 @@
     "@shopify/react-html": "^11.0.2"
   },
   "peerDependencies": {
-    "react": "^16.4.1"
+    "react": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/packages/react-universal-provider/CHANGELOG.md
+++ b/packages/react-universal-provider/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.2 - 2021-06-29
 

--- a/packages/react-universal-provider/package.json
+++ b/packages/react-universal-provider/package.json
@@ -28,7 +28,7 @@
     "@shopify/react-html": "^11.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "faker": "^4.1.0"

--- a/packages/react-web-worker/CHANGELOG.md
+++ b/packages/react-web-worker/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Officially supports React `17.x` [1969](https://github.com/Shopify/quilt/pull/1969/files)
 
 ## 2.0.2 - 2021-06-08
 

--- a/packages/react-web-worker/package.json
+++ b/packages/react-web-worker/package.json
@@ -29,8 +29,8 @@
     "@shopify/web-worker": "^2.1.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "files": [
     "build/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6743,6 +6743,13 @@ errno@^0.1.3:
   dependencies:
     prr "~1.0.1"
 
+errno@~0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz#8bb3e9c7d463be4976ff888f76b4809ebc2e811f"
+  integrity sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==
+  dependencies:
+    prr "~1.0.1"
+
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -13183,16 +13190,6 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-dom@^16.8.1:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
-  integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.18.0"
-
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -13246,22 +13243,13 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react@17.0.2:
+react@17.0.2, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-react@^16.8.1:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
-  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -13852,14 +13840,6 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
-  integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
## Description
Closes #1956 

It does what it says on the tin.

Since we were able to upgrade the packages with minimal changes and while retaining support for 16 we are able to simply just open up our version range support. This should stop folks from getting annoying warnings when installing our packages whether they use 16.x or 17.x.