### PR TITLE
added to local lowercase back in

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- added back `toLocalLowerCase` to humanized times. [#1972](https://github.com/Shopify/quilt/pull/1972) removed it which caused `am` and `pm` to be capitalized in some cases [#1976](https://github.com/Shopify/quilt/pull/1976)
 
 ## 6.1.1 - 2021-07-26
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -573,7 +573,7 @@ export class I18n {
       timeZoneName: options?.timeZoneName,
       hour: 'numeric',
       minute: '2-digit',
-    });
+    }).toLocaleLowerCase();
   }
 
   private getWeekdayFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1326,7 +1326,7 @@ describe('I18n', () => {
           'date.humanize.lessThanOneYearAgo',
           {
             pseudotranslate: false,
-            replacements: {date: 'Nov. 20', time: '12:00 a.m. EST'},
+            replacements: {date: 'Nov. 20', time: '12:00 a.m. est'},
           },
           defaultTranslations,
           i18n.locale,
@@ -1353,7 +1353,7 @@ describe('I18n', () => {
           'date.humanize.lessThanOneWeekAgo',
           {
             pseudotranslate: false,
-            replacements: {weekday: 'Tuesday', time: '12:00 a.m. EST'},
+            replacements: {weekday: 'Tuesday', time: '12:00 a.m. est'},
           },
           defaultTranslations,
           i18n.locale,
@@ -1380,7 +1380,7 @@ describe('I18n', () => {
           'date.humanize.yesterday',
           {
             pseudotranslate: false,
-            replacements: {time: '12:00 a.m. EST'},
+            replacements: {time: '12:00 a.m. est'},
           },
           defaultTranslations,
           i18n.locale,
@@ -1407,7 +1407,7 @@ describe('I18n', () => {
           'date.humanize.today',
           {
             pseudotranslate: false,
-            replacements: {time: '1:00 a.m. EST'},
+            replacements: {time: '1:00 a.m. est'},
           },
           defaultTranslations,
           i18n.locale,


### PR DESCRIPTION
## Description

Fixes (issue #)

adding `toLocalLowercase` back in to ensure `am` and `pm` are lowercase in all contexts

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
