### PR TITLE
changed short timezone to uppercase in humanized dates

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -9,6 +9,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Makes humanized short timezones uppercase. [#1977](https://github.com/Shopify/quilt/pull/1977)
+
+### Changed
+
 - added back `toLocalLowerCase` to humanized times. [#1972](https://github.com/Shopify/quilt/pull/1972) removed it which caused `am` and `pm` to be capitalized in some cases [#1976](https://github.com/Shopify/quilt/pull/1976)
 
 ## 6.1.1 - 2021-07-26

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -563,17 +563,43 @@ export class I18n {
     });
   }
 
+  private getTimeZone(
+    date: Date,
+    options?: Intl.DateTimeFormatOptions,
+  ): string {
+    const {localeMatcher, formatMatcher, timeZone} = options || {};
+
+    const hourZone = this.formatDate(date, {
+      localeMatcher,
+      formatMatcher,
+      timeZone,
+      hour12: false,
+      timeZoneName: 'short',
+      hour: 'numeric',
+    });
+
+    const zoneMatchGroup = /\s(\w*$)/i.exec(hourZone);
+
+    return zoneMatchGroup ? zoneMatchGroup[1] : '';
+  }
+
   private getTimeFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {
-    const {localeMatcher, formatMatcher, hour12, timeZone} = options || {};
-    return this.formatDate(date, {
+    const {localeMatcher, formatMatcher, hour12, timeZone, timeZoneName} =
+      options || {};
+
+    const formattedTime = this.formatDate(date, {
       localeMatcher,
       formatMatcher,
       hour12,
       timeZone,
-      timeZoneName: options?.timeZoneName,
+      timeZoneName: timeZoneName === 'short' ? undefined : timeZoneName,
       hour: 'numeric',
       minute: '2-digit',
     }).toLocaleLowerCase();
+
+    return timeZoneName === 'short'
+      ? `${formattedTime} ${this.getTimeZone(date, options)}`
+      : formattedTime;
   }
 
   private getWeekdayFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {

--- a/packages/react-i18n/src/test/i18n.test.ts
+++ b/packages/react-i18n/src/test/i18n.test.ts
@@ -1326,7 +1326,7 @@ describe('I18n', () => {
           'date.humanize.lessThanOneYearAgo',
           {
             pseudotranslate: false,
-            replacements: {date: 'Nov. 20', time: '12:00 a.m. est'},
+            replacements: {date: 'Nov. 20', time: '12:00 a.m. EST'},
           },
           defaultTranslations,
           i18n.locale,
@@ -1353,7 +1353,7 @@ describe('I18n', () => {
           'date.humanize.lessThanOneWeekAgo',
           {
             pseudotranslate: false,
-            replacements: {weekday: 'Tuesday', time: '12:00 a.m. est'},
+            replacements: {weekday: 'Tuesday', time: '12:00 a.m. EST'},
           },
           defaultTranslations,
           i18n.locale,
@@ -1380,7 +1380,7 @@ describe('I18n', () => {
           'date.humanize.yesterday',
           {
             pseudotranslate: false,
-            replacements: {time: '12:00 a.m. est'},
+            replacements: {time: '12:00 a.m. EST'},
           },
           defaultTranslations,
           i18n.locale,
@@ -1407,7 +1407,34 @@ describe('I18n', () => {
           'date.humanize.today',
           {
             pseudotranslate: false,
-            replacements: {time: '1:00 a.m. est'},
+            replacements: {time: '1:00 a.m. EST'},
+          },
+          defaultTranslations,
+          i18n.locale,
+        );
+      });
+
+      it('formats a date with a full timezone name in lowercase', () => {
+        const today = new Date('2012-12-20T05:00:00-00:00');
+        clock.mock(today);
+
+        const date = new Date('2012-12-20T06:00:00-00:00');
+        const defaultTimezone = 'America/Toronto';
+        const i18n = new I18n(defaultTranslations, {
+          ...defaultDetails,
+          timezone: defaultTimezone,
+        });
+
+        i18n.formatDate(date, {
+          timeZoneName: 'long',
+          style: DateStyle.Humanize,
+        });
+
+        expect(translate).toHaveBeenCalledWith(
+          'date.humanize.today',
+          {
+            pseudotranslate: false,
+            replacements: {time: '1:00 a.m. eastern standard time'},
           },
           defaultTranslations,
           i18n.locale,


### PR DESCRIPTION
## Description

Fixes (issue #)

we need `toLocaleLowercase` on humanized times to ensure that `am` and `pm` are lowercase, but this also affects short timezones that should be uppercase. This separates out the timezone so that it remains uppercase

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
