### PR TITLE
⬆️ support graphql 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "full-icu": "^1.3.0",
     "get-port": "^5.0.0",
     "glob": "^7.1.6",
-    "graphql": "^14.0.0",
+    "graphql": "^15.4.0",
     "graphql-tag": "^2.10.3",
     "intl-pluralrules": "^0.2.1",
     "jest-extended": "^0.11.5",

--- a/packages/graphql-fixtures/package.json
+++ b/packages/graphql-fixtures/package.json
@@ -27,7 +27,7 @@
     "@shopify/useful-types": "^3.0.4",
     "@types/faker": "^4.1.2",
     "faker": "^4.1.0",
-    "graphql": ">=14.5.0 <15.0.0",
+    "graphql": ">=14.5.0 <16.0.0",
     "graphql-tool-utilities": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -41,7 +41,7 @@
     "@types/fs-extra": "^9.0.11",
     "@types/webpack": "^4.41.11",
     "fs-extra": "^9.1.0",
-    "graphql": ">=14.5.0 <15.0.0",
+    "graphql": "^15.4.0",
     "graphql-typed": "^1.0.3",
     "loader-utils": "^2.0.0"
   },

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -41,7 +41,7 @@
     "@types/fs-extra": "^9.0.11",
     "@types/webpack": "^4.41.11",
     "fs-extra": "^9.1.0",
-    "graphql": "^15.4.0",
+    "graphql": ">=14.5.0 <16.0.0",
     "graphql-typed": "^1.0.3",
     "loader-utils": "^2.0.0"
   },

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -34,7 +34,7 @@
     "apollo-cache-inmemory": ">=1.0.0 <2.0.0",
     "apollo-client": ">=2.0.0 <3.0.0",
     "apollo-link": ">=1.0.0 <2.0.0",
-    "graphql": "^14.0.0",
+    "graphql": ">=14.5.0 <16.0.0",
     "jest-matcher-utils": "^26.6.2"
   },
   "devDependencies": {

--- a/packages/graphql-tool-utilities/package.json
+++ b/packages/graphql-tool-utilities/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "apollo-codegen-core": "0.36.5",
-    "graphql": ">=14.5.0 <15.0.0"
+    "graphql": ">=14.5.0 <16.0.0"
   },
   "files": [
     "build/",

--- a/packages/graphql-typed/package.json
+++ b/packages/graphql-typed/package.json
@@ -24,7 +24,7 @@
     "node": ">=12.14.0"
   },
   "peerDependencies": {
-    "graphql": ">=14.5.0 <15.0.0"
+    "graphql": ">=14.5.0 <16.0.0"
   },
   "files": [
     "build/",

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -34,7 +34,7 @@
     "change-case": "^4.1.1",
     "chokidar": "^3.3.1",
     "fs-extra": "^9.1.0",
-    "graphql": ">=14.5.0 <15.0.0",
+    "graphql": ">=14.5.0 <16.0.0",
     "graphql-config": "^3.2.0",
     "graphql-config-utilities": "^3.0.4",
     "graphql-tool-utilities": "^2.0.3",

--- a/packages/graphql-validate-fixtures/CHANGELOG.md
+++ b/packages/graphql-validate-fixtures/CHANGELOG.md
@@ -15,6 +15,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Added file exclusion for tests to package.json and enable type checking for tests. [[#2005](https://github.com/Shopify/quilt/pull/2005)]
 - Rename test/ to tests/ [[#2005](https://github.com/Shopify/quilt/pull/2005)]
 
+### Added
+
+- Support for `graphql`@`15.x` [[#1978](https://github.com/Shopify/quilt/pull/1978/files)]
+
 ## 2.0.5 - 2021-08-04
 
 ### Changed

--- a/packages/graphql-validate-fixtures/package.json
+++ b/packages/graphql-validate-fixtures/package.json
@@ -28,7 +28,7 @@
     "chalk": "^4.0.0",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.2",
-    "graphql": ">=14.5.0 <15.0.0",
+    "graphql": ">=14.5.0 <16.0.0",
     "graphql-config": "^3.2.0",
     "graphql-config-utilities": "^3.0.4",
     "graphql-tool-utilities": "^2.0.3",

--- a/packages/graphql-validate-fixtures/src/validate.ts
+++ b/packages/graphql-validate-fixtures/src/validate.ts
@@ -480,19 +480,23 @@ function validateValueAgainstType(
   }
 
   if (isEnumType(type)) {
-    return type.parseValue(value) == null
-      ? [
-          error(
-            keyPath,
-            `value does not match enum ${nameForType(
-              type,
-            )} (available values: ${type
-              .getValues()
-              .map((enumValue) => enumValue.value)
-              .join(', ')})`,
-          ),
-        ]
-      : [];
+    try {
+      return type.parseValue(value) == null
+        ? [
+            error(
+              keyPath,
+              `value does not match enum ${nameForType(
+                type,
+              )} (available values: ${type
+                .getValues()
+                .map((enumValue) => enumValue.value)
+                .join(', ')})`,
+            ),
+          ]
+        : [];
+    } catch (err) {
+      return [error(keyPath, err.message)];
+    }
   }
 
   return [];

--- a/packages/graphql-validate-fixtures/tests/__snapshots__/index.test.ts.snap
+++ b/packages/graphql-validate-fixtures/tests/__snapshots__/index.test.ts.snap
@@ -138,5 +138,5 @@ exports[`evaluateFixtures() throws an error when the schema is not found 1`] = `
 exports[`evaluateFixtures() throws an error when there are malformed GraphQL documents 1`] = `
 [Error: Error parsing 'packages/graphql-validate-fixtures/tests/fixtures/malformed-query/queries/Another.graphql':
 
-Syntax Error: Expected {, found Name "name"]
+Syntax Error: Expected "{", found Name "name".]
 `;

--- a/packages/graphql-validate-fixtures/tests/__snapshots__/validate.test.ts.snap
+++ b/packages/graphql-validate-fixtures/tests/__snapshots__/validate.test.ts.snap
@@ -1179,7 +1179,7 @@ Object {
   "validationErrors": Array [
     Object {
       "keyPath": "generation",
-      "message": "value does not match enum Generation (available values: FIRST, SECOND, THIRD)",
+      "message": "Value \\"SEVENTH\\" does not exist in \\"Generation\\" enum.",
     },
   ],
 }
@@ -1194,7 +1194,7 @@ Object {
   "validationErrors": Array [
     Object {
       "keyPath": "generation",
-      "message": "value does not match enum Generation (available values: FIRST, SECOND, THIRD)",
+      "message": "Enum \\"Generation\\" cannot represent non-string value: true.",
     },
   ],
 }
@@ -1244,7 +1244,7 @@ Object {
   "validationErrors": Array [
     Object {
       "keyPath": "generation",
-      "message": "value does not match enum Generation (available values: FIRST, SECOND, THIRD)",
+      "message": "Value \\"SEVENTH\\" does not exist in \\"Generation\\" enum.",
     },
   ],
 }
@@ -1259,7 +1259,7 @@ Object {
   "validationErrors": Array [
     Object {
       "keyPath": "generation",
-      "message": "value does not match enum Generation (available values: FIRST, SECOND, THIRD)",
+      "message": "Enum \\"Generation\\" cannot represent non-string value: true.",
     },
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7076,12 +7076,17 @@ graphql-ws@^4.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-4.5.0.tgz#c71c6eed34850c375156c29b1ed45cea2f9aee6b"
   integrity sha512-J3PuSfOKX2y9ryOtWxOcKlizkFWyhCvPAc3hhMKMVSTcPxtWiv9oNzvAZp1HKfuQng32YQduHeX+lRDy2+F6VQ==
 
-"graphql@14.0.2 - 14.2.0 || ^14.3.1", "graphql@>=14.5.0 <15.0.0", graphql@^14.0.0:
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
-  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
+"graphql@14.0.2 - 14.2.0 || ^14.3.1":
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
+  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
   dependencies:
     iterall "^1.2.2"
+
+"graphql@>=14.5.0 <16.0.0", graphql@^15.4.0:
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
+  integrity sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==
 
 handlebars@*, handlebars@^4.4.3, handlebars@^4.7.6:
   version "4.7.7"


### PR DESCRIPTION
## Description

Our version ranges meant that projects with dependencies that want `graphql@15.x` would have (possibly worrisome) duplicate graphql dependencies.

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
