### PR TITLE
Fix typesVersions fields

### DIFF
--- a/packages/graphql-testing/CHANGELOG.md
+++ b/packages/graphql-testing/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Add matchers entrypoint to `typesVersions` fields. This should have happened in 5.0.2 but was missed.
 
 ## 5.0.3 - 2021-08-04
 

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -5,6 +5,13 @@
   "description": "Utilities to create mock GraphQL factories",
   "main": "index.js",
   "types": "./build/ts/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "matchers": [
+        "./build/ts/matchers/index.d.ts"
+      ]
+    }
+  },
   "sideEffects": false,
   "publishConfig": {
     "access": "public",

--- a/packages/polyfills/CHANGELOG.md
+++ b/packages/polyfills/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Fix `idle-callback.browser` entrypoint path in `typesVersions` field.
 
 ## 3.1.2 - 2021-08-04
 

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -33,7 +33,7 @@
         "./build/ts/formdata.node.d.ts"
       ],
       "idle-callback.browser": [
-        "./build/ts/idle-callback.browser'.d.ts"
+        "./build/ts/idle-callback.browser.d.ts"
       ],
       "idle-callback.jest": [
         "./build/ts/idle-callback.jest.d.ts"

--- a/packages/semaphore/CHANGELOG.md
+++ b/packages/semaphore/CHANGELOG.md
@@ -18,6 +18,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Remove use of `setImmediate` in tests. [#1948](https://github.com/Shopify/quilt/pull/1948)
+- Update to latest sewiing-kit-next for build. Update `types`/`typeVersions` fields to point directly into the build folder [[#1980](https://github.com/Shopify/quilt/pull/1980)]
 
 ## 2.0.0 - 2021-05-21
 


### PR DESCRIPTION
## Description

Fixing two little bugs that snuck into https://github.com/Shopify/quilt/pull/1980

- Fix typo in polyfills typesVersions
- Add typesVersions to graphql-testing


## Type of change

- polyfills: patch
- graphql-testing: patch
