### PR TITLE
Add .markdownlint.jsonc to make Markdownlint happy with our CHANGELOGs

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,5 @@
+{
+  "no-duplicate-heading": {
+    "siblings_only": true
+  }
+}


### PR DESCRIPTION
## Description

[MD024](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md024---multiple-headings-with-the-same-content)  forbids the repeated subheadings we have in our CHANGELOG files. Allow non-sibling repeat headers.
