### PR TITLE
📝 Fix typo in mime-types readme

### DIFF
--- a/packages/mime-types/README.md
+++ b/packages/mime-types/README.md
@@ -36,7 +36,7 @@ This helps keeping MIME types and file extensions consistent.
 Takes in a file name string and returns a `MimeType`.
 
 ```ts
-import {getMimeTypeFromFilename} from '@shopify/files';
+import {getMimeTypeFromFilename} from '@shopify/mime-types';
 
 getMimeTypeFromFilename('image.jpg'); // image/jpeg
 ```
@@ -46,7 +46,7 @@ getMimeTypeFromFilename('image.jpg'); // image/jpeg
 Takes in a `MimeType` and returns a string filename extension that matches the inputted `MimeType`.
 
 ```ts
-import {getExtensionFromMimeType, MimeType} from '@shopify/files';
+import {getExtensionFromMimeType, MimeType} from '@shopify/mime-types';
 
 getExtensionFromMimeType(MimeType.Pdf); // .pdf
 ```


### PR DESCRIPTION
## Description

Fixes typo in an `import` statement in README of `@shopify/mime-types`


## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] mime-types Patch: Bug (non-breaking change which fixes an issue)
expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
