### PR TITLE
Add generics to findWhere and findWhereAll in react-testing

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added ability to specify a generic when calling `findWhere` and `findWhereAll` [[#1999](https://github.com/Shopify/quilt/pull/1999)]
 - Updated build tooling, types are now compiled with TypeScript 4.3. [[#1997](https://github.com/Shopify/quilt/pull/1997)]
 
 ## 3.2.2 - 2021-08-04

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -482,23 +482,23 @@ function MyComponent({name}: {name: string}) {
 function Wrapper() {
   return (
     <>
-      <MyComponent name="Michelle" />
+      <div id="Michelle" />
       <MyComponent name="Gord" />
     </>
   );
 }
 
 const wrapper = mount(<Wrapper />);
-const startsWithM = wrapper.findWhere<typeof MyComponent>(
-  (node) => node.is(MyComponent) && node.prop('name').startsWith('M'),
+const divElement = wrapper.findWhere<'div'>(
+  (node) => node.is('div') && node.prop('id').startsWith('M'),
 );
 
-const startsWithG = wrapper.findWhere<typeof MyComponent>(
+const componentElement = wrapper.findWhere<typeof MyComponent>(
   (node) => node.is(MyComponent) && node.prop('name').startsWith('G'),
 );
 
-expect(startsWithM.prop('name')).toBe('Michelle');
-expect(startsWithG.prop('name')).toBe('Gord');
+expect(divElement.prop('id')).toBe('Michelle');
+expect(componentElement.prop('name')).toBe('Gord');
 ```
 
 ````

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -489,11 +489,11 @@ function Wrapper() {
 }
 
 const wrapper = mount(<Wrapper />);
-const startsWithM = wrapper.findWhere<MyComponent>(
+const startsWithM = wrapper.findWhere<typeof MyComponent>(
   (node) => node.is(MyComponent) && node.prop('name').startsWith('M'),
 );
 
-const startsWithG = wrapper.findWhere<MyComponent>(
+const startsWithG = wrapper.findWhere<typeof MyComponent>(
   (node) => node.is(MyComponent) && node.prop('name').startsWith('G'),
 );
 

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -468,11 +468,42 @@ expect(wrapper.find(MyComponent, {name: 'Gord'})!.props).toMatchObject({
 
 Like `find()`, but returns all matches as an array.
 
-##### <a name="findWhere"></a> `findWhere(predicate: (element: Element<unknown>) => boolean): Element<unknown> | null`
+##### <a name="findWhere"></a> `findWhere<Type = unknown>(predicate: (element: Element<unknown>) => boolean): Element<PropsForComponent<Type>> | null`
 
 Finds the first descendant component matching the passed function. The function is called with each `Element` from [`descendants`](#descendants) until a match is found. If no match is found, `null` is returned.
 
-##### <a name="findAllWhere"></a> `findAllWhere(predicate: (element: Element<unknown>) => boolean): Element<unknown>[]`
+`findWhere` accepts an optional generic argument that can be used to specify the type of the returned element. This argument is either a string or a React component, the same as the first argument on `.find`. If the generic argument is omited then the returned element will have unknown props and thus calling `.props` and `.trigger` on it will cause type errors as those functions won't know what props are valid on your element:
+
+```tsx
+function MyComponent({name}: {name: string}) {
+  return <div>Hello, {name}!</div>;
+}
+
+function Wrapper() {
+  return (
+    <>
+      <MyComponent name="Michelle" />
+      <MyComponent name="Gord" />
+    </>
+  );
+}
+
+const wrapper = mount(<Wrapper />);
+const startsWithM = wrapper.findWhere<MyComponent>(
+  (node) => node.is(MyComponent) && node.prop('name').startsWith('M'),
+);
+
+const startsWithG = wrapper.findWhere<MyComponent>(
+  (node) => node.is(MyComponent) && node.prop('name').startsWith('G'),
+);
+
+expect(startsWithM.prop('name')).toBe('Michelle');
+expect(startsWithG.prop('name')).toBe('Gord');
+```
+
+````
+
+##### <a name="findAllWhere"></a> `findAllWhere<Type = unknown>(predicate: (element: Element<unknown>) => boolean): Element<PropsForComponent<Type>>[]`
 
 Like `findWhere`, but returns all matches as an array.
 
@@ -505,7 +536,7 @@ function Wrapper() {
 const wrapper = mount(<Wrapper />);
 wrapper.find(MyComponent)!.trigger('onClick', 'some-id');
 expect(wrapper.find('div')!.text()).toContain('some-id');
-```
+````
 
 ##### <a name="triggerKeypath"></a> `triggerKeypath<T>(keypath: string, ...args: any[]): T`
 

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -12,6 +12,7 @@ import {
   FunctionKeys,
   DeepPartialArguments,
   PropsFor,
+  UnknowablePropsFor,
   DebugOptions,
 } from './types';
 
@@ -178,14 +179,19 @@ export class Element<Props> implements Node<Props> {
     ) as Element<PropsFor<Type>>[];
   }
 
-  findWhere(predicate: Predicate): Element<unknown> | null {
-    return (
-      this.elementDescendants.find((element) => predicate(element)) || null
-    );
+  findWhere<Type extends React.ComponentType<any> | string | unknown = unknown>(
+    predicate: Predicate,
+  ): Element<UnknowablePropsFor<Type>> | null {
+    return (this.elementDescendants.find((element) => predicate(element)) ||
+      null) as Element<UnknowablePropsFor<Type>> | null;
   }
 
-  findAllWhere(predicate: Predicate): Element<unknown>[] {
-    return this.elementDescendants.filter((element) => predicate(element));
+  findAllWhere<
+    Type extends React.ComponentType<any> | string | unknown = unknown
+  >(predicate: Predicate): Element<UnknowablePropsFor<Type>>[] {
+    return this.elementDescendants.filter((element) =>
+      predicate(element),
+    ) as Element<UnknowablePropsFor<Type>>[];
   }
 
   trigger<K extends FunctionKeys<Props>>(

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -164,12 +164,16 @@ export class Root<Props> implements Node<Props> {
     return this.withRoot((root) => root.findAll(type, props));
   }
 
-  findWhere(predicate: Predicate) {
-    return this.withRoot((root) => root.findWhere(predicate));
+  findWhere<Type extends React.ComponentType<any> | string | unknown = unknown>(
+    predicate: Predicate,
+  ) {
+    return this.withRoot((root) => root.findWhere<Type>(predicate));
   }
 
-  findAllWhere(predicate: Predicate) {
-    return this.withRoot((root) => root.findAllWhere(predicate));
+  findAllWhere<
+    Type extends React.ComponentType<any> | string | unknown = unknown
+  >(predicate: Predicate) {
+    return this.withRoot((root) => root.findAllWhere<Type>(predicate));
   }
 
   trigger<K extends FunctionKeys<Props>>(

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -11,6 +11,10 @@ export type PropsFor<
   ? React.ComponentPropsWithoutRef<T>
   : never;
 
+export type UnknowablePropsFor<
+  T extends string | React.ComponentType<any> | unknown
+> = T extends string | React.ComponentType<any> ? PropsFor<T> : unknown;
+
 export type FunctionKeys<T> = {
   [K in keyof T]-?: NonNullable<T[K]> extends (...args: any[]) => any
     ? K


### PR DESCRIPTION
## Description

`findWhere` and `findAllWhere` previously always returned `Element<unknown>` which meant that code didn't know the type of the element returned And thus you got TS errors (forgive this trivial example, where using `find` would be preferred):

```ts
const wrapper = mount(<div><form method="GET">Hello</form></div>);

const form = wrapper.findWhere((node) => node.is('form'))!;
// This line is a type error because form is typed as `Element<unknown>` 
// which means that the prop (and trigger etc) methods do not know the
// props present on the element so it claims the `method` prop does not exist
const method = form.prop('method');
```

This PR adds a generic type to `findWhere` and findAllWhere` so that you can specify the type of element that you shall be returning.

```ts
const wrapper = mount(<div><form method="GET">Hello</form></div>);

const form = wrapper.findWhere<'form'>((node) => node.is('form'))!;
// form is now typed an Element with the props of a form element, which
// means that this line now passes
const method = form.prop('method');
```

This generic type is either a string referring to a html element (`'div'`, `'form'` etc), or a React component (`Card` etc). This is the same type as what you can pass into `find` as it's first argument.

## Type of change

- react-testing: minor