### PR TITLE
Updated the enum Api version

### DIFF
--- a/packages/koa-shopify-graphql-proxy/CHANGELOG.md
+++ b/packages/koa-shopify-graphql-proxy/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated build tooling, types are now compiled with TypeScript 4.3. [[#1997](https://github.com/Shopify/quilt/pull/1997)]
+- The `ApiVersion` enum now have been updated to remove obsolete versions and add supported ones. [#2000](https://github.com/Shopify/quilt/pull/2000)
 
 ## 5.0.2 - 2021-08-04
 

--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -5,12 +5,10 @@ export const PROXY_BASE_PATH = '/graphql';
 export const GRAPHQL_PATH_PREFIX = '/admin/api';
 
 export enum ApiVersion {
-  July19 = '2019-07',
-  October19 = '2019-10',
-  January20 = '2020-01',
-  April20 = '2020-04',
-  July20 = '2020-07',
   October20 = '2020-10',
+  January21 = '2021-01',
+  April21 = '2021-04',
+  July21 = '2021-07',
   Unstable = 'unstable',
   Unversioned = 'unversioned',
 }

--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated build tooling, types are now compiled with TypeScript 4.3. [[#1997](https://github.com/Shopify/quilt/pull/1997)]
+- The `ApiVersion` enum now have been updated to remove obsolete versions and add supported ones. [#2000](https://github.com/Shopify/quilt/pull/2000)
 
 ## 3.0.2 - 2021-08-04
 

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -3,13 +3,10 @@ import {Method, Header} from '@shopify/network';
 import {WebhookHeader, Topic} from './types';
 
 export enum ApiVersion {
-  April19 = '2019-04',
-  July19 = '2019-07',
-  October19 = '2019-10',
-  January20 = '2020-01',
-  April20 = '2020-04',
-  July20 = '2020-07',
   October20 = '2020-10',
+  January21 = '2021-01',
+  April21 = '2021-04',
+  July21 = '2021-07',
   Unstable = 'unstable',
   Unversioned = 'unversioned',
 }

--- a/packages/koa-shopify-webhooks/src/test/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/register.test.ts
@@ -1,18 +1,18 @@
-import {Header} from '@shopify/network';
-import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
+import { Header } from '@shopify/network';
+import { fetch as fetchMock } from '@shopify/jest-dom-mocks';
 
-import {ApiVersion, DeliveryMethod} from '../register';
-import {registerWebhook, Options, WebhookHeader} from '..';
+import { ApiVersion, DeliveryMethod } from '../register';
+import { registerWebhook, Options, WebhookHeader } from '..';
 
 const successResponse = {
   data: {
     webhookSubscriptionCreate: {
       userErrors: [],
-      webhookSubscription: {id: 'gid://shopify/WebhookSubscription/12345'},
+      webhookSubscription: { id: 'gid://shopify/WebhookSubscription/12345' },
     },
   },
 };
-const failResponse = {data: {}};
+const failResponse = { data: {} };
 
 describe('registerWebhook', () => {
   afterEach(async () => {
@@ -103,7 +103,7 @@ describe('registerWebhook', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.April20,
+      apiVersion: ApiVersion.April21,
       deliveryMethod: DeliveryMethod.EventBridge,
     };
 
@@ -125,7 +125,7 @@ describe('registerWebhook', () => {
 
     const [address, request] = fetchMock.lastCall();
     expect(address).toBe(
-      `https://${webhook.shop}/admin/api/${ApiVersion.April20}/graphql.json`,
+      `https://${webhook.shop}/admin/api/${ApiVersion.April21}/graphql.json`,
     );
     expect(request.body).toBe(webhookQuery);
     expect(request.headers).toMatchObject({


### PR DESCRIPTION
## Description

Fixes (issue #1895)

Removal of old unsupported version from both GraphQL proxy and Webhook packages.
Add of supported version that were missing in packages.

## Type of change

- [X] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
