### PR TITLE
Replace ApiVersion enum with a looser string union type

### DIFF
--- a/packages/koa-shopify-graphql-proxy/CHANGELOG.md
+++ b/packages/koa-shopify-graphql-proxy/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated build tooling, types are now compiled with TypeScript 4.3. [[#1997](https://github.com/Shopify/quilt/pull/1997)]
+- Replace ApiVersion enum with a looser string union type [[#2001](https://github.com/Shopify/quilt/pull/2001)]
 
 ## 5.0.2 - 2021-08-04
 

--- a/packages/koa-shopify-graphql-proxy/CHANGELOG.md
+++ b/packages/koa-shopify-graphql-proxy/CHANGELOG.md
@@ -10,7 +10,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated build tooling, types are now compiled with TypeScript 4.3. [[#1997](https://github.com/Shopify/quilt/pull/1997)]
-- Replace ApiVersion enum with a looser string union type [[#2001](https://github.com/Shopify/quilt/pull/2001)]
+
+### Breaking Change
+
+- Replace ApiVersion enum with a looser string union type and update supported versions [[#2001](https://github.com/Shopify/quilt/pull/2001)]
 
 ## 5.0.2 - 2021-08-04
 

--- a/packages/koa-shopify-graphql-proxy/README.md
+++ b/packages/koa-shopify-graphql-proxy/README.md
@@ -25,7 +25,7 @@ Attaching the middleware will proxy any requests sent to `/graphql` on your app 
 import koa from 'koa';
 import session from 'koa-session';
 import createShopifyAuth from '@shopify/koa-shopify-auth';
-import proxy, {ApiVersion} from '@shopify/koa-shopify-graphql-proxy';
+import proxy from '@shopify/koa-shopify-graphql-proxy';
 
 const app = koa();
 
@@ -37,7 +37,7 @@ app.use(
   }),
 );
 
-app.use(proxy({version: ApiVersion.Unstable}));
+app.use(proxy({version: 'unstable'}));
 ```
 
 This allows client-side scripts to query a logged-in merchant's shop without needing to know the user's access token.
@@ -56,7 +56,7 @@ import mount from 'koa-mount';
 
 //....
 
-app.use(mount('/shopify', proxy({version: ApiVersion.Unstable}));
+app.use(mount('/shopify', proxy({version: 'unstable'}));
 ```
 
 ```javascript
@@ -72,7 +72,7 @@ If you have a [private shopify app](https://help.shopify.com/en/manual/apps/priv
 // server/index.js
 import koa from 'koa';
 import session from 'koa-session';
-import proxy, {ApiVersion} from '@shopify/koa-shopify-graphql-proxy';
+import proxy from '@shopify/koa-shopify-graphql-proxy';
 
 const app = koa();
 
@@ -80,7 +80,7 @@ app.use(session());
 
 app.use(
   proxy({
-    version: ApiVersion.Unstable,
+    version: 'unstable',
     shop: '<my-shop-name>.myshopify.com',
     password: '<your-app-password>',
   }),

--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -4,16 +4,14 @@ import {Context} from 'koa';
 export const PROXY_BASE_PATH = '/graphql';
 export const GRAPHQL_PATH_PREFIX = '/admin/api';
 
-export enum ApiVersion {
-  July19 = '2019-07',
-  October19 = '2019-10',
-  January20 = '2020-01',
-  April20 = '2020-04',
-  July20 = '2020-07',
-  October20 = '2020-10',
-  Unstable = 'unstable',
-  Unversioned = 'unversioned',
-}
+export type ApiVersion =
+  | '2020-10'
+  | '2021-01'
+  | '2021-04'
+  | '2021-07'
+  | 'unstable'
+  | 'unversioned'
+  | string;
 
 interface DefaultProxyOptions {
   version: ApiVersion;

--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -11,7 +11,7 @@ export type ApiVersion =
   | '2021-07'
   | 'unstable'
   | 'unversioned'
-  | string;
+  | (string & {});
 
 interface DefaultProxyOptions {
   version: ApiVersion;

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -1,7 +1,6 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
 
 import koaShopifyGraphQLProxy, {
-  ApiVersion,
   PROXY_BASE_PATH,
   GRAPHQL_PATH_PREFIX,
 } from '../shopify-graphql-proxy';

--- a/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/test/proxy.test.ts
@@ -19,7 +19,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('throws when no session is provided', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
@@ -34,7 +34,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('throws when no accessToken is on session', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
 
     const ctx = createMockContext({
@@ -51,7 +51,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('throws when no shop is on session', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
@@ -67,7 +67,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('bails and calls next if method is not POST', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const ctx = createMockContext({
       url: '/graphql',
@@ -85,7 +85,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('bails and calls next if path does not start with the base url', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const ctx = createMockContext({
       url: '/not/graphql',
@@ -102,7 +102,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('bails and calls next if path does not start with the base url and no session', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const ctx = createMockContext({
       url: '/not/graphql',
@@ -118,7 +118,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('does not bail or throw when request is for the graphql api', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const ctx = createMockContext({
       url: PROXY_BASE_PATH,
@@ -136,7 +136,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('configures a custom koa-better-http-proxy', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const accessToken = 'asdfasdf';
     const shop = 'i-sell-things.myshopify.com';
@@ -167,7 +167,7 @@ describe('koa-shopify-graphql-proxy', () => {
     const password = 'sdfghsdghsh';
     const shop = 'i-sell-things.myshopify.com';
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
       password,
       shop,
     });
@@ -194,7 +194,7 @@ describe('koa-shopify-graphql-proxy', () => {
   });
 
   it('passes a proxyReqPathResolver that returns full shop url with the API version', async () => {
-    const version = ApiVersion.Unstable;
+    const version = 'unstable';
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
       version,
     });
@@ -217,7 +217,7 @@ describe('koa-shopify-graphql-proxy', () => {
 
   it('terminates middleware chain when proxying (does not call next)', async () => {
     const koaShopifyGraphQLProxyMiddleware = koaShopifyGraphQLProxy({
-      version: ApiVersion.Unstable,
+      version: 'unstable',
     });
     const shop = 'some-shop.myshopify.com';
 

--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated build tooling, types are now compiled with TypeScript 4.3. [[#1997](https://github.com/Shopify/quilt/pull/1997)]
+- Replace ApiVersion enum with a looser string union type [[#2001](https://github.com/Shopify/quilt/pull/2001)]
 
 ## 3.0.2 - 2021-08-04
 

--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -10,7 +10,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated build tooling, types are now compiled with TypeScript 4.3. [[#1997](https://github.com/Shopify/quilt/pull/1997)]
-- Replace ApiVersion enum with a looser string union type [[#2001](https://github.com/Shopify/quilt/pull/2001)]
+
+### Breaking Change
+
+- Replace ApiVersion enum with a looser string union type and update supported versions [[#2001](https://github.com/Shopify/quilt/pull/2001)]
 
 ## 3.0.2 - 2021-08-04
 

--- a/packages/koa-shopify-webhooks/README.md
+++ b/packages/koa-shopify-webhooks/README.md
@@ -78,7 +78,7 @@ app.use(
         topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
-        apiVersion: ApiVersion.Unstable,
+        apiVersion: 'unstable',
       });
 
       if (registration.success) {
@@ -144,7 +144,7 @@ app.use(
         topic: 'PRODUCTS_CREATE',
         accessToken,
         shop,
-        apiVersion: ApiVersion.Unstable,
+        apiVersion: 'unstable',
       });
 
       await registerWebhook({
@@ -152,7 +152,7 @@ app.use(
         topic: 'ORDERS_CREATE',
         accessToken,
         shop,
-        apiVersion: ApiVersion.Unstable,
+        apiVersion: 'unstable',
       });
 
       ctx.redirect('/');

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -2,17 +2,14 @@ import {Method, Header} from '@shopify/network';
 
 import {WebhookHeader, Topic} from './types';
 
-export enum ApiVersion {
-  April19 = '2019-04',
-  July19 = '2019-07',
-  October19 = '2019-10',
-  January20 = '2020-01',
-  April20 = '2020-04',
-  July20 = '2020-07',
-  October20 = '2020-10',
-  Unstable = 'unstable',
-  Unversioned = 'unversioned',
-}
+export type ApiVersion =
+  | '2020-10'
+  | '2021-01'
+  | '2021-04'
+  | '2021-07'
+  | 'unstable'
+  | 'unversioned'
+  | string;
 
 export enum DeliveryMethod {
   Http = 'http',

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -9,7 +9,7 @@ export type ApiVersion =
   | '2021-07'
   | 'unstable'
   | 'unversioned'
-  | string;
+  | (string & {});
 
 export enum DeliveryMethod {
   Http = 'http',

--- a/packages/koa-shopify-webhooks/src/test/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/test/register.test.ts
@@ -1,7 +1,7 @@
 import {Header} from '@shopify/network';
 import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
 
-import {ApiVersion, DeliveryMethod} from '../register';
+import {DeliveryMethod} from '../register';
 import {registerWebhook, Options, WebhookHeader} from '..';
 
 const successResponse = {
@@ -27,7 +27,7 @@ describe('registerWebhook', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
+      apiVersion: 'unstable',
     };
 
     const webhookQuery = `
@@ -103,7 +103,7 @@ describe('registerWebhook', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.April20,
+      apiVersion: '2020-04',
       deliveryMethod: DeliveryMethod.EventBridge,
     };
 
@@ -125,7 +125,7 @@ describe('registerWebhook', () => {
 
     const [address, request] = fetchMock.lastCall();
     expect(address).toBe(
-      `https://${webhook.shop}/admin/api/${ApiVersion.April20}/graphql.json`,
+      `https://${webhook.shop}/admin/api/2020-04/graphql.json`,
     );
     expect(request.body).toBe(webhookQuery);
     expect(request.headers).toMatchObject({


### PR DESCRIPTION
## Description

Fixes (issue #1895)

This PR converts the ApiVersion (used in `koa-shopify-webhooks` and `koa-shopify-graphql-proxy`) from an `enum` to a union that allows for any string while still providing suggestions. This change allows developers to use new versions without waiting for the enum to be updated in the package.

Breaking: Any code that used the previous enum type values  will have to be changed to string values:

`ApiVersion.Unstable` ==> `'unstable'`, `ApiVersion.April20` ==> `'2020-04'`

## Type of change

- [x] `koa-shopify-webhooks` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] `koa-shopify-graphql-proxy` Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
