### PR TITLE
add more info to the react-i18n babel plugin README

### DIFF
--- a/packages/react-i18n/babel-plugin.md
+++ b/packages/react-i18n/babel-plugin.md
@@ -1,0 +1,292 @@
+# `@shopify/react-i18n/babel`
+
+This package includes a plugin for Babel that auto-fills `useI18n`'s or `withI18n`'s arguments from an adjacent translations folder.
+
+## Installation
+
+```bash
+$ yarn add @shopify/react-i18n
+```
+
+## Usage
+
+The Babel plugin is exported from the `@shopify/react-i18n/babel` entrypoint:
+
+```js
+// webpack.config.js
+module.exports = {
+  resolve: {
+    extensions: ['.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js)$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: ['@shopify/react-i18n/babel'],
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+This plugin will look for an adjacent _`translations`_ folder containing, at minimum, an `en.json` file (the default locale). It will then iterate over each reference to the `useI18n` hook or `withI18n` decorator and, if the reference is a call expression with no arguments, and inject the appropriate arguments.
+
+### Default Transform
+
+Given folder structure
+
+```
+├── MyComponent.tsx
+└── translations
+   └── en.json
+   └── fr.json
+   └── jp.json
+
+```
+
+File content
+
+```js
+// Within translations/en.js
+
+{
+  "heading": "All Films"
+}
+
+// Within translations/fr.js
+
+{
+  "heading": "fr_All Films"
+}
+
+// Within translations/jp.js
+
+{
+  "heading": "jp_All Films"
+}
+```
+
+```js
+// Within MyComponent.tsx:
+
+useI18n();
+
+// Becomes:
+
+import _en from './translations/en.json';
+
+useI18n({
+  id: 'MyComponent_<hash>',
+  fallback: _en,
+  async translations(locale) {
+    if (['fr', 'jp'].indexOf(locale) < 0) {
+      return;
+    }
+
+    return (async () => {
+      const dictionary = await import(
+        /* webpackChunkName: "MyComponent_<hash>-i18n", webpackMode: "lazy-once" */ `./translations/${locale}.json`
+      );
+      return dictionary && dictionary.default;
+    })();
+  },
+});
+```
+
+## Options
+
+### `mode`
+
+Type: `undefined`, `from-generated-index`, `from-dictionary-index`
+
+Default: `undefined`
+
+#### `from-generated-index`
+
+_*Use this mode to avoid caching issues when integrating with babel-loader.*_
+
+Because `babel-loader`'s cache is based on a component's source content hash, newly added translation files will not invalidate the component's Babel cache. To combat this, run the `generateTranslationIndexes` function before building, and configure the plugin to use its `from-generated-index` mode.
+
+The generator will look for any `translations` folders and generate an array of local ids in `translations/index.js` based on the `{locale}.json` files found. We recommend that you add `**/translations/index.js` to `.gitignore` to make sure the generated files are not checked-in.
+
+##### Usage
+
+```js
+// webpack.config.js
+module.exports = {
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              plugins: [
+                '@babel/plugin-syntax-dynamic-import',
+                ['@shopify/react-i18n/babel', {mode: 'from-generated-index'}],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+```js
+// generate-translations.js
+const {
+  generateTranslationIndexes,
+} = require('@shopify/react-i18n/generate-index');
+
+generateTranslationIndexes();
+webpack(require(./webpack.config.js));
+```
+
+##### Transform
+
+```js
+// Generated translations/index.js from generateTranslationIndexes()
+export default ['fr', 'jp'];
+```
+
+```js
+// Within MyComponent.tsx:
+
+useI18n();
+
+// Becomes:
+
+import _en from './translations/en.json';
+import __shopify__i18n_translations from './translations';
+
+useI18n({
+  id: 'MyComponent_<hash>',
+  fallback: _en,
+  async translations(locale) {
+    if (__shopify__i18n_translations.indexOf(locale) < 0) {
+      return;
+    }
+
+    return (async () => {
+      const dictionary = await import(
+        /* webpackChunkName: "MyComponent_<hash>-i18n", webpackMode: "lazy-once" */ `./translations/${locale}.json`
+      );
+      return dictionary && dictionary.default;
+    })();
+  },
+});
+```
+
+#### `from-dictionary-index`
+
+_*Use this mode to statically embed locale-specific translations.*_
+
+For large applications, even asynchronously loaded translations can significantly degrade the user experience:
+
+- Bundlers like webpack have to embed kilobytes of data to track each translation import
+- Users not using the "default" language have to download kilobytes of translations for every language
+
+To avoid this, it is possible to build versions of app with specific locale translations embedded directly in JavaScript.
+
+##### Usage
+
+```js
+// webpack.config.js
+{
+  plugins: [
+    ['@shopify/react-i18n/babel', {mode: 'from-dictionary-index'}],
+  ],
+}
+```
+
+Then generate `translations/index.js` files containing specific locale data using the `@shopify/react-i18n/generate-dictionaries` helper. e.g., the following code generates three versions of an application with English, French, and German content using webpack.
+
+```js
+// generate-translations.js
+const {
+  generateTranslationDictionaries,
+} = require('@shopify/react-i18n/generate-dictionaries');
+
+// Build English app.
+await generateTranslationDictionaries(['en']);
+webpack(require(./webpack.config.js));
+
+// Build French app.
+await generateTranslationDictionaries(['fr'], {fallbackLocale: 'en'});
+webpack(require(./webpack.config.js));
+
+// Build German app.
+await generateTranslationDictionaries(['de'], {fallbackLocale: 'en'});
+webpack(require(./webpack.config.js));
+
+```
+
+##### Transform
+
+```js
+// Generated translations/index.js using generateTranslationDictionaries(['fr'], {fallbackLocale: 'en'});
+
+export default JSON.parse(
+  '{"en":{"heading":"All Films"},"fr":{"heading":"fr_All Films"}}',
+);
+```
+
+```js
+// Within MyComponent.tsx:
+
+useI18n();
+
+// Becomes:
+import __shopify__i18n_translations from './translations';
+
+useI18n({
+  id: 'MyComponent_<hash>',
+  fallback: Object.values(__shopify__i18n_translations)[0],
+  translations(locale) {
+    return Promise.resolve(__shopify__i18n_translations[locale]);
+  },
+});
+```
+
+### `defaultLocale`
+
+Type: `string`
+
+Default: `en`
+
+#### Setting the default locale to something other than `en`
+
+If you want your default locale to be something else than English because it's not your primary locale, you can pass the `defaultLocale` option to the babel plugin:
+
+```js
+// webpack.config.js
+module.exports = {
+  resolve: {
+    extensions: ['.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js)$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: [['@shopify/react-i18n/babel', {defaultLocale: 'fr'}]],
+          },
+        },
+      },
+    ],
+  },
+};
+```


### PR DESCRIPTION
Add some more information on react-i18n babel plugin.

- Separate it from the main package README to babel-plugin/README
- Make it clear that there are 3 different mode in this plugin
- Modify the examples to make it clear what the transform will generate