### PR TITLE
Fix the formatCurrencyShort that results in double negative nordic regions

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Fix format currency double negative bug in nordic regions [[#2004](https://github.com/Shopify/quilt/pull/2004)]
+
 ### Changed
 
 - Added file exclusion for tests to package.json. [[#2005](https://github.com/Shopify/quilt/pull/2005)]

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -431,7 +431,7 @@ export class I18n {
       : `${formattedAmount}${shortSymbol.symbol}`;
 
     return amount < 0
-      ? `-${formattedWithSymbol.replace('-', '')}`
+      ? `-${formattedWithSymbol.replace(/[-−]/, '')}`
       : formattedWithSymbol;
   }
 

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -865,6 +865,7 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${' JPY'} | ${false} | ${'1 235 JPY'}
       ${'fr-FR'} | ${'OMR'} | ${' OMR'} | ${false} | ${'1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${' $US'} | ${false} | ${'1 234,56 $'}
+      ${'sv-SE'} | ${'USD'} | ${' $'}   | ${false} | ${'1 234,56 $'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, symbol, prefixed, expected}) => {
@@ -895,6 +896,7 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${' JPY'} | ${false} | ${'-1 235 JPY'}
       ${'fr-FR'} | ${'OMR'} | ${' OMR'} | ${false} | ${'-1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${' $US'} | ${false} | ${'-1 234,56 $'}
+      ${'sv-SE'} | ${'USD'} | ${' $'}   | ${false} | ${'-1 234,56 $'}
     `(
       'formats -1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, symbol, prefixed, expected}) => {


### PR DESCRIPTION
## Description

This PR fixes an issue that results in a double negative symbol in the 3 nordic regions (Norway, Sweden, and Finland) that when run through the Intl formatter result in a different negative symbol than the standard one which does not get stripped in our replace. I have updated the replace matcher with a regex that can capture both the standard minus symbol and the nordic one. See screenshot below outlining the problem where I have highlighted the nordic negative symbol in yellow.

### Screenshot showing the issue in the Payouts List page (currently being webified)
<img width="1280" alt="Screen Shot 2021-08-19 at 4 21 33 PM" src="https://user-images.githubusercontent.com/1389310/130138497-90e472be-0cb1-45e1-8d2e-99dbea24a987.png">

### Screenshot showing the results of the Intl.NumberFormat being run through different locales
<img width="526" alt="Screen Shot 2021-08-19 at 4 18 42 PM" src="https://user-images.githubusercontent.com/1389310/130138210-c9bbd21b-f150-4461-b83f-e850b9ea99ef.png">

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
