### PR TITLE
`.gitignore` generated `*.d.ts` files not in `./build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ packages/*/bin
 packages/*/*.esnext
 packages/*/*.mjs
 packages/*/*.js
+packages/*/*.d.ts
 !packages/*/.eslintrc.js
 
 .package-build-cache


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Add `packages/*/*.d.ts` to git ignore.





