### PR TITLE
Revert "`.gitignore` generated `*.d.ts` files not in `./build`"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ packages/*/bin
 packages/*/*.esnext
 packages/*/*.mjs
 packages/*/*.js
-packages/*/*.d.ts
 !packages/*/.eslintrc.js
 
 .package-build-cache


### PR DESCRIPTION
Reverts Shopify/quilt#2007

This change is no longer needed and connected to an old version locally.