### PR TITLE
Remove reference to deprecated resolveProjectName

### DIFF
--- a/packages/graphql-validate-fixtures/CHANGELOG.md
+++ b/packages/graphql-validate-fixtures/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Remove reference to depracated `resolveProjectName` [[#2010](https://github.com/Shopify/quilt/pull/2010)]
 
 ## 2.0.6 - 2021-08-24
 

--- a/packages/graphql-validate-fixtures/CHANGELOG.md
+++ b/packages/graphql-validate-fixtures/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Remove reference to depracated `resolveProjectName` [[#2010](https://github.com/Shopify/quilt/pull/2010)]
+- Remove reference to deprecated `resolveProjectName` [[#2010](https://github.com/Shopify/quilt/pull/2010)]
 
 ## 2.0.6 - 2021-08-24
 

--- a/packages/graphql-validate-fixtures/src/validate.ts
+++ b/packages/graphql-validate-fixtures/src/validate.ts
@@ -16,7 +16,6 @@ import {
   isScalarType,
 } from 'graphql';
 import {GraphQLProjectConfig} from 'graphql-config';
-import {resolveProjectName} from 'graphql-config-utilities';
 import {AST, Field, Operation} from 'graphql-tool-utilities';
 
 export type KeyPath = string;
@@ -76,7 +75,7 @@ export class AmbiguousOperationNameError extends Error {
         ).join(', ')})`,
         `in projects:`,
         `${foundOperations
-          .map(({projectAST: {config}}) => resolveProjectName(config))
+          .map(({projectAST: {config}}) => config.name)
           .join(', ')}.`,
         `Try renaming the operation in one of the projects listed and updating`,
         `the fixture folder name or use an '${OPERATION_MARKER}' key indicating`,


### PR DESCRIPTION
## Description
This PR removes a reference to `resolveProjectName` from `graphql-validate-fixtures` which has been deprecated.
Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [X] `graphql-validate-fixtures` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
