### PR TITLE
fix types for tests for non-react packages

### DIFF
--- a/packages/dates/src/tests/utilities.test.ts
+++ b/packages/dates/src/tests/utilities.test.ts
@@ -22,7 +22,7 @@ describe('formatDate()', () => {
     const date = new Date('2018-01-01T12:34:56-12:00');
     const locale = 'en';
     const timeZone = 'Etc/GMT+12';
-    const options = {
+    const options: Intl.DateTimeFormatOptions = {
       timeZone,
       year: 'numeric',
       month: 'numeric',

--- a/packages/dates/src/utilities/tests/timezone.test.ts
+++ b/packages/dates/src/utilities/tests/timezone.test.ts
@@ -28,7 +28,7 @@ describe('getIanaTimeZone()', () => {
 
   it('uses memoizedGetDateTimeFormat to get a memoized formatter', () => {
     const locale = 'en';
-    const options = {
+    const options: Intl.DateTimeFormatOptions = {
       timeZoneName: 'short',
     };
 

--- a/packages/dates/tsconfig.json
+++ b/packages/dates/tsconfig.json
@@ -10,6 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [{"path": "../decorators"}, {"path": "../jest-dom-mocks"}]
 }

--- a/packages/koa-metrics/src/tests/timer.test.ts
+++ b/packages/koa-metrics/src/tests/timer.test.ts
@@ -1,7 +1,5 @@
 import {initTimer} from '../timer';
 
-const NODE_VERSION = process.version;
-
 describe('timer', () => {
   it('measures the time between when initTimer and the returned timer objects stop method is called', async () => {
     const timer = initTimer();

--- a/packages/koa-metrics/tsconfig.json
+++ b/packages/koa-metrics/tsconfig.json
@@ -10,7 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../jest-koa-mocks"},
     {"path": "../with-env"},

--- a/packages/koa-performance/src/tests/middleware.test.ts
+++ b/packages/koa-performance/src/tests/middleware.test.ts
@@ -47,7 +47,7 @@ describe('client metrics middleware', () => {
     });
 
     await withEnv('production', async () => {
-      await clientPerformanceMetrics(config)(context);
+      await clientPerformanceMetrics(config)(context, () => Promise.resolve());
     });
 
     expect(context.status).toBe(StatusCode.Ok);
@@ -60,7 +60,7 @@ describe('client metrics middleware', () => {
     });
 
     await withEnv('production', async () => {
-      await clientPerformanceMetrics(config)(context);
+      await clientPerformanceMetrics(config)(context, () => Promise.resolve());
     });
 
     expect(context.status).toBe(StatusCode.UnprocessableEntity);
@@ -78,7 +78,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       StatsDClient.distributionSpy.mock.calls.forEach(
@@ -99,7 +101,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       StatsDClient.distributionSpy.mock.calls.forEach(
@@ -120,7 +124,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       StatsDClient.distributionSpy.mock.calls.forEach(
@@ -145,7 +151,7 @@ describe('client metrics middleware', () => {
         await clientPerformanceMetrics({
           ...config,
           additionalTags: additionalTagsSpy,
-        })(context);
+        })(context, () => Promise.resolve());
       });
 
       expect(additionalTagsSpy).toHaveBeenCalledWith(
@@ -167,7 +173,7 @@ describe('client metrics middleware', () => {
         await clientPerformanceMetrics({
           ...config,
           additionalTags: () => additionalTags,
-        })(context);
+        })(context, () => Promise.resolve());
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -190,7 +196,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -215,7 +223,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).not.toHaveBeenCalledWith(
@@ -242,7 +252,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -273,7 +285,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -307,7 +321,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -332,7 +348,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).not.toHaveBeenCalledWith(
@@ -372,7 +390,9 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('production', async () => {
-        await clientPerformanceMetrics(config)(context);
+        await clientPerformanceMetrics(config)(context, () =>
+          Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -404,7 +424,7 @@ describe('client metrics middleware', () => {
         await clientPerformanceMetrics({
           ...config,
           additionalNavigationTags: spy,
-        })(context);
+        })(context, () => Promise.resolve());
       });
 
       expect(spy).toHaveBeenCalledWith(expect.any(Navigation));
@@ -431,7 +451,7 @@ describe('client metrics middleware', () => {
         await clientPerformanceMetrics({
           ...config,
           additionalNavigationMetrics: spy,
-        })(context);
+        })(context, () => Promise.resolve());
       });
 
       expect(spy).toHaveBeenCalledWith(expect.any(Navigation));
@@ -461,7 +481,7 @@ describe('client metrics middleware', () => {
         await clientPerformanceMetrics({
           ...config,
           additionalNavigationMetrics: () => [additionalMetric],
-        })(context);
+        })(context, () => Promise.resolve());
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -488,7 +508,7 @@ describe('client metrics middleware', () => {
         await clientPerformanceMetrics({
           ...config,
           anomalousNavigationDurationThreshold,
-        })(context);
+        })(context, () => Promise.resolve());
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -515,7 +535,7 @@ describe('client metrics middleware', () => {
         await clientPerformanceMetrics({
           ...config,
           anomalousNavigationDurationThreshold,
-        })(context);
+        })(context, () => Promise.resolve());
       });
 
       expect(StatsDClient.distributionSpy).toHaveBeenCalledWith(
@@ -536,7 +556,10 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('development', async () => {
-        await clientPerformanceMetrics({...config, development: true})(context);
+        await clientPerformanceMetrics({...config, development: true})(
+          context,
+          () => Promise.resolve(),
+        );
       });
 
       expect(StatsDClient.distributionSpy).not.toHaveBeenCalled();
@@ -551,7 +574,10 @@ describe('client metrics middleware', () => {
       });
 
       await withEnv('development', async () => {
-        await clientPerformanceMetrics({...config, development: true})(context);
+        await clientPerformanceMetrics({...config, development: true})(
+          context,
+          () => Promise.resolve(),
+        );
       });
 
       expect(config.logger.log).toHaveBeenCalled();

--- a/packages/koa-performance/tsconfig.json
+++ b/packages/koa-performance/tsconfig.json
@@ -11,7 +11,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../network"},
     {"path": "../performance"},

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -22,7 +22,7 @@ export interface Options {
   shop: string;
   accessToken: string;
   apiVersion: ApiVersion;
-  deliveryMethod: DeliveryMethod;
+  deliveryMethod?: DeliveryMethod;
 }
 
 export async function registerWebhook({

--- a/packages/koa-shopify-webhooks/src/tests/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/tests/register.test.ts
@@ -46,12 +46,12 @@ describe('registerWebhook', () => {
 
     await registerWebhook(webhook);
 
-    const [address, request] = fetchMock.lastCall();
+    const [address, request] = fetchMock.lastCall()!;
     expect(address).toBe(
       `https://${webhook.shop}/admin/api/unstable/graphql.json`,
     );
-    expect(request.body).toBe(webhookQuery);
-    expect(request.headers).toMatchObject({
+    expect(request!.body).toBe(webhookQuery);
+    expect(request!.headers).toMatchObject({
       [WebhookHeader.AccessToken]: webhook.accessToken,
       [Header.ContentType]: 'application/graphql',
     });
@@ -64,6 +64,7 @@ describe('registerWebhook', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
+      apiVersion: 'unstable',
     };
 
     const result = await registerWebhook(webhook);
@@ -77,6 +78,7 @@ describe('registerWebhook', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
+      apiVersion: 'unstable',
     };
 
     const registerResponse = await registerWebhook(webhook);
@@ -90,6 +92,7 @@ describe('registerWebhook', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
+      apiVersion: 'unstable',
     };
 
     const result = await registerWebhook(webhook);
@@ -123,12 +126,12 @@ describe('registerWebhook', () => {
 
     await registerWebhook(webhook);
 
-    const [address, request] = fetchMock.lastCall();
+    const [address, request] = fetchMock.lastCall()!;
     expect(address).toBe(
       `https://${webhook.shop}/admin/api/2020-04/graphql.json`,
     );
-    expect(request.body).toBe(webhookQuery);
-    expect(request.headers).toMatchObject({
+    expect(request!.body).toBe(webhookQuery);
+    expect(request!.headers).toMatchObject({
       [WebhookHeader.AccessToken]: webhook.accessToken,
       [Header.ContentType]: 'application/graphql',
     });

--- a/packages/koa-shopify-webhooks/tsconfig.json
+++ b/packages/koa-shopify-webhooks/tsconfig.json
@@ -10,6 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [{"path": "../network"}]
 }

--- a/packages/magic-entries-webpack-plugin/src/tests/magic-entries-webpack-plugin.test.ts
+++ b/packages/magic-entries-webpack-plugin/src/tests/magic-entries-webpack-plugin.test.ts
@@ -44,7 +44,7 @@ describe('magic-entries-webpack-plugin', () => {
           await workspace.write('cats.js', CATS_MODULE);
 
           const result = await runBuild(workspace, BASIC_WEBPACK_CONFIG);
-          const main = getModule(result.modules, 'index').source;
+          const main = getModule(result.modules!, 'index').source;
 
           expect(main).toBeDefined();
           expect(main).toMatch(ENTRY_A);
@@ -67,20 +67,20 @@ describe('magic-entries-webpack-plugin', () => {
           await workspace.write('basic-tsx.entry.tsx', ENTRY_B);
           const result = await runBuild(workspace, BASIC_WEBPACK_CONFIG);
 
-          const main = getModule(result.modules, 'index').source;
+          const main = getModule(result.modules!, 'index').source;
           expect(main).toBeDefined();
           expect(main).toMatch(ENTRY_A);
 
-          const js = getModule(result.modules, 'basic-js').source;
+          const js = getModule(result.modules!, 'basic-js').source;
           expect(js).toBeDefined();
           expect(js).toMatch(ENTRY_B);
-          const jsx = getModule(result.modules, 'basic-jsx').source;
+          const jsx = getModule(result.modules!, 'basic-jsx').source;
           expect(jsx).toBeDefined();
           expect(jsx).toMatch(ENTRY_B);
-          const ts = getModule(result.modules, 'basic-ts').source;
+          const ts = getModule(result.modules!, 'basic-ts').source;
           expect(ts).toBeDefined();
           expect(ts).toMatch(ENTRY_B);
-          const tsx = getModule(result.modules, 'basic-tsx').source;
+          const tsx = getModule(result.modules!, 'basic-tsx').source;
           expect(tsx).toBeDefined();
           expect(tsx).toMatch(ENTRY_B);
         });
@@ -101,7 +101,7 @@ describe('magic-entries-webpack-plugin', () => {
             ...BASIC_WEBPACK_CONFIG,
             entry: undefined,
           });
-          const main = getModule(result.modules, 'main').source;
+          const main = getModule(result.modules!, 'main').source;
 
           expect(main).toBeDefined();
           expect(main).toMatch(ENTRY_A);
@@ -131,20 +131,20 @@ describe('magic-entries-webpack-plugin', () => {
           await workspace.write('basic-tsx.entry.client.tsx', ENTRY_B);
           const result = await runBuild(workspace, clientWebpackConfig);
 
-          const main = getModule(result.modules, 'index').source;
+          const main = getModule(result.modules!, 'index').source;
           expect(main).toBeDefined();
           expect(main).toMatch(ENTRY_A);
 
-          const js = getModule(result.modules, 'basic-js').source;
+          const js = getModule(result.modules!, 'basic-js').source;
           expect(js).toBeDefined();
           expect(js).toMatch(ENTRY_B);
-          const jsx = getModule(result.modules, 'basic-jsx').source;
+          const jsx = getModule(result.modules!, 'basic-jsx').source;
           expect(jsx).toBeDefined();
           expect(jsx).toMatch(ENTRY_B);
-          const ts = getModule(result.modules, 'basic-ts').source;
+          const ts = getModule(result.modules!, 'basic-ts').source;
           expect(ts).toBeDefined();
           expect(ts).toMatch(ENTRY_B);
-          const tsx = getModule(result.modules, 'basic-tsx').source;
+          const tsx = getModule(result.modules!, 'basic-tsx').source;
           expect(tsx).toBeDefined();
           expect(tsx).toMatch(ENTRY_B);
         });
@@ -173,20 +173,20 @@ describe('magic-entries-webpack-plugin', () => {
           await workspace.write('basic-tsx.entry.server.tsx', ENTRY_B);
           const result = await runBuild(workspace, serverWebpackConfig);
 
-          const main = getModule(result.modules, 'index').source;
+          const main = getModule(result.modules!, 'index').source;
           expect(main).toBeDefined();
           expect(main).toMatch(ENTRY_A);
 
-          const js = getModule(result.modules, 'basic-js').source;
+          const js = getModule(result.modules!, 'basic-js').source;
           expect(js).toBeDefined();
           expect(js).toMatch(ENTRY_B);
-          const jsx = getModule(result.modules, 'basic-jsx').source;
+          const jsx = getModule(result.modules!, 'basic-jsx').source;
           expect(jsx).toBeDefined();
           expect(jsx).toMatch(ENTRY_B);
-          const ts = getModule(result.modules, 'basic-ts').source;
+          const ts = getModule(result.modules!, 'basic-ts').source;
           expect(ts).toBeDefined();
           expect(ts).toMatch(ENTRY_B);
-          const tsx = getModule(result.modules, 'basic-tsx').source;
+          const tsx = getModule(result.modules!, 'basic-tsx').source;
           expect(tsx).toBeDefined();
           expect(tsx).toMatch(ENTRY_B);
         });
@@ -209,10 +209,10 @@ describe('magic-entries-webpack-plugin', () => {
             plugins: [new MagicEntriesPlugin({pattern: '*.js'})],
           });
 
-          const mainJs = getModule(result.modules, 'main').source;
+          const mainJs = getModule(result.modules!, 'main').source;
           expect(mainJs).toBeDefined();
           expect(mainJs).toMatch(content);
-          const floopJs = getModule(result.modules, 'floop').source;
+          const floopJs = getModule(result.modules!, 'floop').source;
           expect(floopJs).toBeDefined();
           expect(floopJs).toMatch(content);
         });
@@ -233,10 +233,11 @@ describe('magic-entries-webpack-plugin', () => {
             plugins: [new MagicEntriesPlugin({folder: 'entrypoints'})],
           });
 
-          const mainJs = getModule(result.modules, 'entrypoints/main').source;
+          const mainJs = getModule(result.modules!, 'entrypoints/main').source;
           expect(mainJs).toBeDefined();
           expect(mainJs).toMatch(content);
-          const floopJs = getModule(result.modules, 'entrypoints/floop').source;
+          const floopJs = getModule(result.modules!, 'entrypoints/floop')
+            .source;
           expect(floopJs).toBeDefined();
           expect(floopJs).toMatch(content);
         });
@@ -331,16 +332,16 @@ describe('magic-entries-webpack-plugin', () => {
           await workspace.write('cats.js', CATS_MODULE);
           const result = await runBuild(workspace, clientWebpackConfig);
 
-          const js = getModule(result.modules, 'basic-js').source;
+          const js = getModule(result.modules!, 'basic-js').source;
           expect(js).toBeDefined();
           expect(js).toMatch(ENTRY_B);
-          const jsx = getModule(result.modules, 'basic-jsx').source;
+          const jsx = getModule(result.modules!, 'basic-jsx').source;
           expect(jsx).toBeDefined();
           expect(jsx).toMatch(ENTRY_B);
-          const ts = getModule(result.modules, 'basic-ts').source;
+          const ts = getModule(result.modules!, 'basic-ts').source;
           expect(ts).toBeDefined();
           expect(ts).toMatch(ENTRY_B);
-          const tsx = getModule(result.modules, 'basic-tsx').source;
+          const tsx = getModule(result.modules!, 'basic-tsx').source;
           expect(tsx).toBeDefined();
           expect(tsx).toMatch(ENTRY_B);
         });

--- a/packages/magic-entries-webpack-plugin/tsconfig.json
+++ b/packages/magic-entries-webpack-plugin/tsconfig.json
@@ -9,6 +9,5 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"]
+  ]
 }

--- a/packages/performance/src/tests/navigation.test.ts
+++ b/packages/performance/src/tests/navigation.test.ts
@@ -342,14 +342,12 @@ function createStyleDownloadEvent(
   };
 }
 
-function createLifecycleEventEvent<T extends LifecycleEvent['type']>(
-  type: T,
-): EventMap[T] {
+function createLifecycleEventEvent<T extends LifecycleEvent['type']>(type: T) {
   return {
     type,
     duration: 0,
     start: 0,
-  } as LifecycleEvent;
+  } as EventMap[T];
 }
 
 function createNavigation(

--- a/packages/performance/tsconfig.json
+++ b/packages/performance/tsconfig.json
@@ -9,6 +9,5 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"]
+  ]
 }

--- a/packages/statsd/src/tests/client.test.ts
+++ b/packages/statsd/src/tests/client.test.ts
@@ -101,7 +101,7 @@ describe('StatsDClient', () => {
         },
       );
 
-      statsDClient.distribution(name, value, tags);
+      statsDClient.distribution(stat, value, tags);
       expect(logSpy).toHaveBeenCalled();
     });
   });
@@ -167,7 +167,7 @@ describe('StatsDClient', () => {
         callback(error);
       });
 
-      statsDClient.timing(name, value, tags);
+      statsDClient.timing(stat, value, tags);
       expect(logSpy).toHaveBeenCalled();
     });
   });
@@ -233,7 +233,7 @@ describe('StatsDClient', () => {
         callback(error);
       });
 
-      statsDClient.gauge(name, value, tags);
+      statsDClient.gauge(stat, value, tags);
       expect(logSpy).toHaveBeenCalled();
     });
   });
@@ -303,7 +303,7 @@ describe('StatsDClient', () => {
         },
       );
 
-      statsDClient.increment(name, tags);
+      statsDClient.increment(stat, tags);
       expect(logSpy).toHaveBeenCalled();
     });
   });
@@ -366,7 +366,7 @@ describe('StatsDClient', () => {
         globalTags: supplementaryTags,
       });
 
-      statsDClient.distribution(name, value);
+      statsDClient.distribution(stat, value);
 
       expect(StatsDMock.mock.instances[0].distribution).not.toHaveBeenCalled();
       expect(StatsDMock.mock.instances[1].distribution).toHaveBeenCalled();

--- a/packages/statsd/tsconfig.json
+++ b/packages/statsd/tsconfig.json
@@ -10,6 +10,5 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"]
+  ]
 }

--- a/packages/web-worker/src/tests/utilities/server.ts
+++ b/packages/web-worker/src/tests/utilities/server.ts
@@ -30,7 +30,7 @@ export class AppServer {
   }
 
   terminate() {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       this.server.close((error) => {
         if (error) {
           reject(error);

--- a/packages/web-worker/tsconfig.json
+++ b/packages/web-worker/tsconfig.json
@@ -14,6 +14,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [{"path": "../rpc"}]
 }


### PR DESCRIPTION
## Description

Enabled type checking for tests in a number of quilt packages.

### Changes
 
- date
  - specify `Intl.DateTimeFormatOptions` type for options.
- koa-performance
  - koa middleware was missing a next argument. Passed `() => Promise.resolve`
- koa-shopify-webhooks
  - Made `Options.deliveryMethod` an optional parameter because it has a default value in `registerWebhook()`. Tests were using the default value.
  - Used `'unstable'` for cases where `apiVersion` was missing in tests.
  - fetchMock.lastCall() returns `| undefined` causing assignment errors. Fixed with non-null assertion operators.
- magic-entries-webpack-plugin
  - Used non-null assertion operator for optional `webpack.Stats.ToJsonOutput.modules` param.
- performance
  - Adjusted some casting logic.
- statsd
  - `name` variable was being passed to several mock functions, but wasn't defined. Used `stats` variable to align with the other tests.
- web-worker - **Note**: these tests are currently skipped.
  - `Worker` import changed to `WebWorker`
  - Add non-null assertion to workerElement retrieved from `page.waitForSelector`
  - in `getTestClassInstanceCount` typescript complains that the function signatures between `Page` and `ExecutionContext` aren't compatible. Solved by adding typeguards and duplicating the function calls. Couldn't find a cleaner solution.

## Type of change

- [X] date Patch: Bug (non-breaking change which fixes an issue)
- [X] koa-performance Patch: Bug (non-breaking change which fixes an issue)
- [X] koa-shopify-webhooks Patch: Bug (non-breaking change which fixes an issue)
- [X] magic-entries-webpack-plugin Patch: Bug (non-breaking change which fixes an issue)
- [X] performance Patch: Bug (non-breaking change which fixes an issue)
- [X] statsd Patch: Bug (non-breaking change which fixes an issue)
- [X] web-worker Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
