### PR TITLE
[React-i18n] Add case to humanize to handle less than two minutes and more than one minute (replace "1 minutes ago") output

### DIFF
--- a/packages/address-consts/index.d.ts
+++ b/packages/address-consts/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/address-mocks/index.d.ts
+++ b/packages/address-mocks/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/address/index.d.ts
+++ b/packages/address/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/admin-graphql-api-utilities/index.d.ts
+++ b/packages/admin-graphql-api-utilities/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/ast-utilities/index.d.ts
+++ b/packages/ast-utilities/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/ast-utilities/javascript.d.ts
+++ b/packages/ast-utilities/javascript.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/javascript/index";

--- a/packages/ast-utilities/markdown.d.ts
+++ b/packages/ast-utilities/markdown.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/markdown/index";

--- a/packages/async/babel.d.ts
+++ b/packages/async/babel.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/babel-plugin";
+export {default} from "./build/ts/babel-plugin";

--- a/packages/async/index.d.ts
+++ b/packages/async/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/browser/index.d.ts
+++ b/packages/browser/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/csrf-token-fetcher/index.d.ts
+++ b/packages/csrf-token-fetcher/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/css-utilities/index.d.ts
+++ b/packages/css-utilities/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/dates/README.md
+++ b/packages/dates/README.md
@@ -138,6 +138,20 @@ isLessThanOneMinuteAgo(moreThanOneMinuteAgo); // false
 isLessThanOneMinuteAgo(lessThanOneMinuteAgo); // true
 ```
 
+### `isOneMinuteAgo`
+
+Takes in a date object and an optional "now" date object (that defaults to `new Date()`). Returns a boolean indicating whether or not the date is more than one minute before the "now" date but less than two minutes from that date. Handles the singular case of "a minute ago".
+
+```ts
+import {isOneMinuteAgo} from '@shopify/dates';
+
+const moreThanTwoMinutesAgo = new Date('2018-01-01Z00:00');
+const moreThanOneMinuteAgoButLessThanTwo = new Date(Date.now() - 61 * TimeUnit.Second);
+
+isOneMinuteAgo(moreThanTwoMinutesAgo); // false
+isOneMinuteAgo(moreThanOneMinuteAgoButLessThanTwo); // true
+```
+
 ### `isLessThanOneWeekAgo`
 
 Takes in a date object and an optional "now" date object (that defaults to `new Date()`). Returns a boolean indicating whether or not the date is less than one week before the "now" date.

--- a/packages/dates/index.d.ts
+++ b/packages/dates/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/dates/src/index.ts
+++ b/packages/dates/src/index.ts
@@ -6,6 +6,7 @@ export * from './is-future-date';
 export * from './is-less-than-one-day-ago';
 export * from './is-less-than-one-hour-ago';
 export * from './is-less-than-one-minute-ago';
+export * from './is-one-minute-ago';
 export * from './is-less-than-one-week-ago';
 export * from './is-less-than-one-week-away';
 export * from './is-less-than-one-year-ago';

--- a/packages/dates/src/is-one-minute-ago.ts
+++ b/packages/dates/src/is-one-minute-ago.ts
@@ -1,0 +1,11 @@
+import {isFutureDate} from './is-future-date';
+import {TimeUnit} from './constants';
+
+export function isOneMinuteAgo(date: Date, now = new Date()) {
+  const dateDiff = now.getTime() - date.getTime();
+  return (
+    !isFutureDate(date, now) &&
+    dateDiff > TimeUnit.Minute &&
+    dateDiff < TimeUnit.Minute * 2
+  );
+}

--- a/packages/decorators/index.d.ts
+++ b/packages/decorators/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/enzyme-utilities/index.d.ts
+++ b/packages/enzyme-utilities/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/function-enhancers/index.d.ts
+++ b/packages/function-enhancers/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-config-utilities/index.d.ts
+++ b/packages/graphql-config-utilities/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-fixtures/index.d.ts
+++ b/packages/graphql-fixtures/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-mini-transforms/index.d.ts
+++ b/packages/graphql-mini-transforms/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-mini-transforms/jest-simple.d.ts
+++ b/packages/graphql-mini-transforms/jest-simple.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/jest-simple";

--- a/packages/graphql-mini-transforms/jest.d.ts
+++ b/packages/graphql-mini-transforms/jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/jest";

--- a/packages/graphql-mini-transforms/webpack-loader.d.ts
+++ b/packages/graphql-mini-transforms/webpack-loader.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/webpack-loader";
+export {default} from "./build/ts/webpack-loader";

--- a/packages/graphql-persisted/apollo.d.ts
+++ b/packages/graphql-persisted/apollo.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/apollo";

--- a/packages/graphql-persisted/koa.d.ts
+++ b/packages/graphql-persisted/koa.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/koa-middleware";

--- a/packages/graphql-testing/index.d.ts
+++ b/packages/graphql-testing/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-testing/matchers.d.ts
+++ b/packages/graphql-testing/matchers.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/matchers/index";

--- a/packages/graphql-tool-utilities/index.d.ts
+++ b/packages/graphql-tool-utilities/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-typed/index.d.ts
+++ b/packages/graphql-typed/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-typescript-definitions/index.d.ts
+++ b/packages/graphql-typescript-definitions/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/graphql-validate-fixtures/index.d.ts
+++ b/packages/graphql-validate-fixtures/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/i18n/index.d.ts
+++ b/packages/i18n/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/jest-dom-mocks/index.d.ts
+++ b/packages/jest-dom-mocks/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/jest-koa-mocks/index.d.ts
+++ b/packages/jest-koa-mocks/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/jest-mock-apollo/index.d.ts
+++ b/packages/jest-mock-apollo/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/jest-mock-router/index.d.ts
+++ b/packages/jest-mock-router/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/koa-liveness-ping/index.d.ts
+++ b/packages/koa-liveness-ping/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/koa-metrics/index.d.ts
+++ b/packages/koa-metrics/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/koa-performance/index.d.ts
+++ b/packages/koa-performance/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/koa-shopify-graphql-proxy/index.d.ts
+++ b/packages/koa-shopify-graphql-proxy/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/koa-shopify-webhooks/index.d.ts
+++ b/packages/koa-shopify-webhooks/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/logger/index.d.ts
+++ b/packages/logger/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/magic-entries-webpack-plugin/index.d.ts
+++ b/packages/magic-entries-webpack-plugin/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/mime-types/index.d.ts
+++ b/packages/mime-types/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/network/index.d.ts
+++ b/packages/network/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/performance/index.d.ts
+++ b/packages/performance/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/polyfills/base.d.ts
+++ b/packages/polyfills/base.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/base";

--- a/packages/polyfills/fetch.browser.d.ts
+++ b/packages/polyfills/fetch.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/fetch.browser";

--- a/packages/polyfills/fetch.jest.d.ts
+++ b/packages/polyfills/fetch.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/fetch.jest";

--- a/packages/polyfills/fetch.node.d.ts
+++ b/packages/polyfills/fetch.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/fetch.node";

--- a/packages/polyfills/formdata.browser.d.ts
+++ b/packages/polyfills/formdata.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/formdata.browser";

--- a/packages/polyfills/formdata.jest.d.ts
+++ b/packages/polyfills/formdata.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/formdata.jest";

--- a/packages/polyfills/formdata.node.d.ts
+++ b/packages/polyfills/formdata.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/formdata.node";

--- a/packages/polyfills/idle-callback.browser.d.ts
+++ b/packages/polyfills/idle-callback.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/idle-callback.browser";

--- a/packages/polyfills/idle-callback.jest.d.ts
+++ b/packages/polyfills/idle-callback.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/idle-callback.jest";

--- a/packages/polyfills/idle-callback.node.d.ts
+++ b/packages/polyfills/idle-callback.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/idle-callback.node";

--- a/packages/polyfills/index.d.ts
+++ b/packages/polyfills/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/polyfills/intersection-observer.browser.d.ts
+++ b/packages/polyfills/intersection-observer.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/intersection-observer.browser";

--- a/packages/polyfills/intersection-observer.jest.d.ts
+++ b/packages/polyfills/intersection-observer.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/intersection-observer.jest";

--- a/packages/polyfills/intersection-observer.node.d.ts
+++ b/packages/polyfills/intersection-observer.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/intersection-observer.node";

--- a/packages/polyfills/intl.browser.d.ts
+++ b/packages/polyfills/intl.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/intl.browser";

--- a/packages/polyfills/intl.jest.d.ts
+++ b/packages/polyfills/intl.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/intl.jest";

--- a/packages/polyfills/intl.node.d.ts
+++ b/packages/polyfills/intl.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/intl.node";

--- a/packages/polyfills/mutation-observer.browser.d.ts
+++ b/packages/polyfills/mutation-observer.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/mutation-observer.browser";

--- a/packages/polyfills/mutation-observer.jest.d.ts
+++ b/packages/polyfills/mutation-observer.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/mutation-observer.jest";

--- a/packages/polyfills/mutation-observer.node.d.ts
+++ b/packages/polyfills/mutation-observer.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/mutation-observer.node";

--- a/packages/polyfills/noop.d.ts
+++ b/packages/polyfills/noop.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/noop";

--- a/packages/polyfills/unhandled-rejection.browser.d.ts
+++ b/packages/polyfills/unhandled-rejection.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/unhandled-rejection.browser";

--- a/packages/polyfills/unhandled-rejection.jest.d.ts
+++ b/packages/polyfills/unhandled-rejection.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/unhandled-rejection.jest";

--- a/packages/polyfills/unhandled-rejection.node.d.ts
+++ b/packages/polyfills/unhandled-rejection.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/unhandled-rejection.node";

--- a/packages/polyfills/url.browser.d.ts
+++ b/packages/polyfills/url.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/url.browser";

--- a/packages/polyfills/url.jest.d.ts
+++ b/packages/polyfills/url.jest.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/url.jest";

--- a/packages/polyfills/url.node.d.ts
+++ b/packages/polyfills/url.node.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/url.node";

--- a/packages/predicates/index.d.ts
+++ b/packages/predicates/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-app-bridge-universal-provider/index.d.ts
+++ b/packages/react-app-bridge-universal-provider/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-async/index.d.ts
+++ b/packages/react-async/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-async/testing.d.ts
+++ b/packages/react-async/testing.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/testing";

--- a/packages/react-bugsnag/index.d.ts
+++ b/packages/react-bugsnag/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-compose/index.d.ts
+++ b/packages/react-compose/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/react-cookie/index.d.ts
+++ b/packages/react-cookie/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-csrf-universal-provider/index.d.ts
+++ b/packages/react-csrf-universal-provider/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-csrf/index.d.ts
+++ b/packages/react-csrf/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-effect/index.d.ts
+++ b/packages/react-effect/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-effect/server.d.ts
+++ b/packages/react-effect/server.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/server";

--- a/packages/react-form-state/index.d.ts
+++ b/packages/react-form-state/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/react-form/index.d.ts
+++ b/packages/react-form/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-google-analytics/index.d.ts
+++ b/packages/react-google-analytics/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-graphql-universal-provider/index.d.ts
+++ b/packages/react-graphql-universal-provider/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-graphql/index.d.ts
+++ b/packages/react-graphql/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-hooks/index.d.ts
+++ b/packages/react-hooks/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-html/index.d.ts
+++ b/packages/react-html/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-html/server.d.ts
+++ b/packages/react-html/server.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/server/index";

--- a/packages/react-hydrate/index.d.ts
+++ b/packages/react-hydrate/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-i18n-universal-provider/index.d.ts
+++ b/packages/react-i18n-universal-provider/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-i18n/babel.d.ts
+++ b/packages/react-i18n/babel.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/babel-plugin/index";
+export {default} from "./build/ts/babel-plugin/index";

--- a/packages/react-i18n/generate-dictionaries.d.ts
+++ b/packages/react-i18n/generate-dictionaries.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/babel-plugin/generate-dictionaries";
+export {default} from "./build/ts/babel-plugin/generate-dictionaries";

--- a/packages/react-i18n/generate-index.d.ts
+++ b/packages/react-i18n/generate-index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/babel-plugin/generate-index";
+export {default} from "./build/ts/babel-plugin/generate-index";

--- a/packages/react-i18n/index.d.ts
+++ b/packages/react-i18n/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -5,6 +5,7 @@ import {
   isLessThanOneMinuteAgo,
   isLessThanOneWeekAgo,
   isLessThanOneYearAgo,
+  isOneMinuteAgo,
   isToday,
   isTomorrow,
   isYesterday,
@@ -175,7 +176,7 @@ export class I18n {
     try {
       return translate(id, normalizedOptions, this.translations, this.locale);
     } catch (error) {
-      this.onError(error);
+      this.onError(error as I18nError);
       return '';
     }
   }
@@ -197,7 +198,7 @@ export class I18n {
         replacements,
       );
     } catch (error) {
-      this.onError(error);
+      this.onError(error as I18nError);
       return '';
     }
   }
@@ -488,6 +489,10 @@ export class I18n {
   private humanizePastDate(date: Date, options?: Intl.DateTimeFormatOptions) {
     if (isLessThanOneMinuteAgo(date)) {
       return this.translate('date.humanize.lessThanOneMinuteAgo');
+    }
+
+    if (isOneMinuteAgo(date)) {
+      return this.translate('date.humanize.aMinuteAgo');
     }
 
     if (isLessThanOneHourAgo(date)) {

--- a/packages/react-idle/index.d.ts
+++ b/packages/react-idle/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-import-remote/index.d.ts
+++ b/packages/react-import-remote/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/react-intersection-observer/index.d.ts
+++ b/packages/react-intersection-observer/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-network/index.d.ts
+++ b/packages/react-network/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-network/server.d.ts
+++ b/packages/react-network/server.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/server";

--- a/packages/react-performance/index.d.ts
+++ b/packages/react-performance/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-router/index.d.ts
+++ b/packages/react-router/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-server/index.d.ts
+++ b/packages/react-server/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-server/webpack-plugin.d.ts
+++ b/packages/react-server/webpack-plugin.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/webpack-plugin/index";

--- a/packages/react-shortcuts/index.d.ts
+++ b/packages/react-shortcuts/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-testing/index.d.ts
+++ b/packages/react-testing/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-testing/matchers.d.ts
+++ b/packages/react-testing/matchers.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/matchers/index";

--- a/packages/react-tracking-pixel/index.d.ts
+++ b/packages/react-tracking-pixel/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";

--- a/packages/react-universal-provider/index.d.ts
+++ b/packages/react-universal-provider/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/react-web-worker/index.d.ts
+++ b/packages/react-web-worker/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/rpc/index.d.ts
+++ b/packages/rpc/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/semaphore/index.d.ts
+++ b/packages/semaphore/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/sewing-kit-koa/index.d.ts
+++ b/packages/sewing-kit-koa/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/statsd/index.d.ts
+++ b/packages/statsd/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/storybook-a11y-test/index.d.ts
+++ b/packages/storybook-a11y-test/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/useful-types/index.d.ts
+++ b/packages/useful-types/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/web-worker/babel.d.ts
+++ b/packages/web-worker/babel.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/babel-plugin";
+export {default} from "./build/ts/babel-plugin";

--- a/packages/web-worker/index.d.ts
+++ b/packages/web-worker/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/index";

--- a/packages/web-worker/webpack.d.ts
+++ b/packages/web-worker/webpack.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/webpack-parts/index";

--- a/packages/web-worker/worker.d.ts
+++ b/packages/web-worker/worker.d.ts
@@ -1,0 +1,1 @@
+export * from "./build/ts/worker";

--- a/packages/with-env/index.d.ts
+++ b/packages/with-env/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./build/ts/index";
+export {default} from "./build/ts/index";


### PR DESCRIPTION
## Description

Fixes: https://github.com/Shopify/quilt/issues/2029

Implements logic to handle humanizing of a time that is between 1 and 2 minutes ago, so that `A minute ago` can be output instead of `1 minutes ago`. Reported by PSN as being awkward looking.

This addition adds a `isOneMinuteAgo` check to the `humanizePastDate` function in React-i18n

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)

## Tophat Instructions (mainly for me)

1) publish in quilt using `PKG_NAME=react-i18n yarn tophat`
2) add translation key to web
3) link in web using `yalc link --no-pure @shopify/react-i18n`, remove with `yalc remove @shopify/react-i18n`

