### PR TITLE
fix(connection): include missing props

### DIFF
--- a/packages/jest-dom-mocks/src/connection.ts
+++ b/packages/jest-dom-mocks/src/connection.ts
@@ -1,13 +1,15 @@
 import {set} from './utilities';
 
+interface BrowserConnection extends NetworkInformation {
+  downlink: number;
+  effectiveType: string;
+  onchange: null | Function;
+  rtt: number;
+  saveData: boolean;
+}
+
 export interface NavigatorWithConnection extends Navigator {
-  connection: {
-    downlink: number;
-    effectiveType: string;
-    onchange: null | Function;
-    rtt: number;
-    saveData: boolean;
-  };
+    connection: BrowserConnection;
 }
 
 export class Connection {

--- a/packages/jest-dom-mocks/tsconfig.json
+++ b/packages/jest-dom-mocks/tsconfig.json
@@ -10,5 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "references": [{"path": "../async"}]
+  "references": [{"path": "../async"}],
+  "lib": ["dom"],
 }


### PR DESCRIPTION
use named interface BrowserConnection to inherit missing props from Navigator, allowing us to extend the interface without breaking compatibility with other .d.ts definitions of Navigator.*

## Description

Fixes (issue #) https://github.com/Shopify/handshake-web/pull/3393

Upgrading to typescript 4.4 results in an error where Navigator.connection has incompatible properties between different definitions.

Making this library definition extend the actual `NetworkInformation` interface should reduce this.

## Type of change

- [X] jest-dom-mocks Minor: Patch: update Navigator.connection typing.

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
