### PR TITLE
Factor out an arg builder that omits null args

### DIFF
--- a/packages/koa-shopify-webhooks/CHANGELOG.md
+++ b/packages/koa-shopify-webhooks/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Omit `includeFields` arg from webhook registration mutation when it's null [[#2033](https://github.com/Shopify/quilt/pull/2033)]
+- Add support for the `includeFields` argument for webhook registrations [[#2024](https://github.com/Shopify/quilt/pull/2024)]
 
 ## 4.0.2 - 2021-08-26
 

--- a/packages/koa-shopify-webhooks/src/tests/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/tests/register.test.ts
@@ -32,7 +32,45 @@ describe('registerWebhook', () => {
 
     const webhookQuery = `
     mutation webhookSubscriptionCreate {
-      webhookSubscriptionCreate(topic: ${webhook.topic}, webhookSubscription: {callbackUrl: "${webhook.address}" , includeFields: []}) {
+      webhookSubscriptionCreate(topic: ${webhook.topic}, webhookSubscription: {callbackUrl: "${webhook.address}"}) {
+        userErrors {
+          field
+          message
+        }
+        webhookSubscription {
+          id
+        }
+      }
+    }
+  `;
+
+    await registerWebhook(webhook);
+
+    const [address, request] = fetchMock.lastCall()!;
+    expect(address).toBe(
+      `https://${webhook.shop}/admin/api/unstable/graphql.json`,
+    );
+    expect(request!.body).toBe(webhookQuery);
+    expect(request!.headers).toMatchObject({
+      [WebhookHeader.AccessToken]: webhook.accessToken,
+      [Header.ContentType]: 'application/graphql',
+    });
+  });
+
+  it('the post request includes the optional includeFields fields', async () => {
+    fetchMock.mock('*', successResponse);
+    const webhook: Options = {
+      address: 'myapp.com/webhooks',
+      topic: 'PRODUCTS_CREATE',
+      accessToken: 'some token',
+      shop: 'shop1.myshopify.io',
+      apiVersion: 'unstable',
+      includeFields: ['id', 'title'],
+    };
+
+    const webhookQuery = `
+    mutation webhookSubscriptionCreate {
+      webhookSubscriptionCreate(topic: ${webhook.topic}, webhookSubscription: {callbackUrl: "${webhook.address}", includeFields: ["id","title"]}) {
         userErrors {
           field
           message
@@ -112,7 +150,46 @@ describe('registerWebhook', () => {
 
     const webhookQuery = `
     mutation webhookSubscriptionCreate {
-      eventBridgeWebhookSubscriptionCreate(topic: ${webhook.topic}, webhookSubscription: {arn: "${webhook.address}" , includeFields: []}) {
+      eventBridgeWebhookSubscriptionCreate(topic: ${webhook.topic}, webhookSubscription: {arn: "${webhook.address}"}) {
+        userErrors {
+          field
+          message
+        }
+        webhookSubscription {
+          id
+        }
+      }
+    }
+  `;
+
+    await registerWebhook(webhook);
+
+    const [address, request] = fetchMock.lastCall()!;
+    expect(address).toBe(
+      `https://${webhook.shop}/admin/api/2020-04/graphql.json`,
+    );
+    expect(request!.body).toBe(webhookQuery);
+    expect(request!.headers).toMatchObject({
+      [WebhookHeader.AccessToken]: webhook.accessToken,
+      [Header.ContentType]: 'application/graphql',
+    });
+  });
+
+  it('the eventbridge registration includes the optional includeFields fields', async () => {
+    fetchMock.mock('*', successResponse);
+    const webhook: Options = {
+      address: 'myapp.com/webhooks',
+      topic: 'PRODUCTS_CREATE',
+      accessToken: 'some token',
+      shop: 'shop1.myshopify.io',
+      apiVersion: '2020-04',
+      deliveryMethod: DeliveryMethod.EventBridge,
+      includeFields: ['id', 'title'],
+    };
+
+    const webhookQuery = `
+    mutation webhookSubscriptionCreate {
+      eventBridgeWebhookSubscriptionCreate(topic: ${webhook.topic}, webhookSubscription: {arn: "${webhook.address}", includeFields: ["id","title"]}) {
         userErrors {
           field
           message


### PR DESCRIPTION
## Description

Follow-up to #2024

Factors out a `buildArgs` utility function that:
1. uniformly stringifies arg values
2. omits null args (and therefore making `includeFields` truly optional)

Also adds a CHANGELOG entry for #2024 whose absence I overlooked :)

## Type of change

- [x] koa-shopify-webhooks Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
