### PR TITLE
Enable/fix test typing

### DIFF
--- a/packages/react-async/CHANGELOG.md
+++ b/packages/react-async/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 4.1.5 - 2021-08-30
 

--- a/packages/react-async/src/context/tests/assets.test.ts
+++ b/packages/react-async/src/context/tests/assets.test.ts
@@ -119,6 +119,7 @@ describe('AsyncAssetManager', () => {
     asyncAssets.markAsUsed(id);
     asyncAssets.effect.betweenEachPass!({
       finished: false,
+      cancelled: false,
       index: 0,
       renderDuration: 0,
       resolveDuration: 0,

--- a/packages/react-async/src/tests/hooks.test.tsx
+++ b/packages/react-async/src/tests/hooks.test.tsx
@@ -61,6 +61,6 @@ function createAsyncComponentType({
   return AsyncComponent as any;
 }
 
-function noop() {
-  return undefined;
+function noop(_?: {}) {
+  return () => {};
 }

--- a/packages/react-async/tsconfig.json
+++ b/packages/react-async/tsconfig.json
@@ -10,7 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../async"},
     {"path": "../react-effect"},

--- a/packages/react-bugsnag/CHANGELOG.md
+++ b/packages/react-bugsnag/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 2.2.3 - 2021-08-24
 

--- a/packages/react-bugsnag/src/tests/client.test.ts
+++ b/packages/react-bugsnag/src/tests/client.test.ts
@@ -1,5 +1,3 @@
-import ReactPlugin from '@bugsnag/plugin-react';
-
 import {createBugsnagClient} from '../client';
 
 jest.mock('@bugsnag/js', () => ({

--- a/packages/react-bugsnag/tsconfig.json
+++ b/packages/react-bugsnag/tsconfig.json
@@ -9,6 +9,5 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"]
+  ]
 }

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 1.1.3 - 2021-08-24
 

--- a/packages/react-form/src/hooks/field/tests/field.test.tsx
+++ b/packages/react-form/src/hooks/field/tests/field.test.tsx
@@ -276,12 +276,12 @@ describe('useField', () => {
         wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
         wrapper.find('input')!.trigger('onBlur', blurEvent());
 
-        const allErrorsFirstValidation = wrapper.find('p').props.children;
+        const allErrorsFirstValidation = wrapper.find('p')!.props.children;
 
         wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
         wrapper.find('input')!.trigger('onBlur', blurEvent());
 
-        const allErrorsSecondValidation = wrapper.find('p').props.children;
+        const allErrorsSecondValidation = wrapper.find('p')!.props.children;
 
         expect(allErrorsFirstValidation).toStrictEqual(
           allErrorsSecondValidation,
@@ -318,17 +318,17 @@ describe('useField', () => {
         const wrapper = mount(<TestField config={fieldConfig} />);
         const newValue = faker.commerce.product();
 
-        expect(wrapper.find('p').props.children).toStrictEqual([]);
+        expect(wrapper.find('p')!.props.children).toStrictEqual([]);
 
         wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
         wrapper.find('input')!.trigger('onBlur', blurEvent());
 
-        const allErrorsFirstValidation = wrapper.find('p').props.children;
+        const allErrorsFirstValidation = wrapper.find('p')!.props.children;
 
         wrapper.find('input')!.trigger('onChange', changeEvent(newValue));
         wrapper.find('input')!.trigger('onBlur', blurEvent());
 
-        const allErrorsSecondValidation = wrapper.find('p').props.children;
+        const allErrorsSecondValidation = wrapper.find('p')!.props.children;
 
         expect(allErrorsFirstValidation).toBe(allErrorsSecondValidation);
       });

--- a/packages/react-form/src/hooks/list/tests/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/baselist.test.tsx
@@ -797,7 +797,7 @@ describe('useBaseList', () => {
             </>
           ))}
 
-          <button type="button" onClick={onNewDefault} />
+          <button type="button" onClick={onNewDefault as any} />
         </>
       );
     }
@@ -847,7 +847,7 @@ describe('useBaseList', () => {
           optionName: newDefaultOption,
           optionValue: newDefaultOptionValue,
         },
-      ]);
+      ] as any);
 
       expect(wrapper).toContainReactText(`Default: ${newDefaultPrice}`);
       expect(wrapper).toContainReactText(`Default: ${newDefaultOption}`);
@@ -881,7 +881,7 @@ describe('useBaseList', () => {
           optionName: newDefaultOption,
           optionValue: newDefaultOptionValue,
         },
-      ]);
+      ] as any);
 
       expect(wrapper).toContainReactText(
         `Default: ${newDefaultPrice}Default: ${newDefaultOption}Default: ${newDefaultOptionValue}`,

--- a/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
@@ -73,7 +73,7 @@ describe('useDynamicList', () => {
 
       const sort1 = wrapper
         .findAll('li')
-        .map((i) => i.find(TextField).props.value);
+        .map((i) => i.find(TextField)!.props.value);
 
       expect(sort1).toStrictEqual(['A', 'C', 'B']);
     });
@@ -235,7 +235,9 @@ describe('useDynamicList', () => {
       });
 
       it('handles dirty state when adding a field and resetting it', () => {
-        const wrapper = mount(<DynamicListComponent list={randomVariants()} />);
+        const wrapper = mount(
+          <DynamicListComponent list={randomVariants(1)} />,
+        );
 
         expect(wrapper).toContainReactText('Dirty: false');
 
@@ -372,7 +374,7 @@ describe('useDynamicList', () => {
             </>
           ))}
 
-          <button type="button" onClick={onNewDefault}>
+          <button type="button" onClick={onNewDefault as any}>
             Default
           </button>
           <button type="button" onClick={() => addItem()}>
@@ -430,7 +432,7 @@ describe('useDynamicList', () => {
           optionName: newDefaultOption,
           optionValue: newDefaultOptionValue,
         },
-      ]);
+      ] as any);
 
       expect(wrapper).toContainReactText(`Default: ${newDefaultPrice}`);
       expect(wrapper).toContainReactText(`Default: ${newDefaultOption}`);

--- a/packages/react-form/src/hooks/tests/form-with-dynamic-list.test.tsx
+++ b/packages/react-form/src/hooks/tests/form-with-dynamic-list.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount, Root} from '@shopify/react-testing';
+import {mount} from '@shopify/react-testing';
 
 import {submitSuccess, submitFail} from '..';
 
@@ -30,7 +30,7 @@ describe('useForm with dynamic list', () => {
         <FormWithDynamicVariantList data={fakeProduct()} />,
       );
 
-      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Add item'})!.trigger('onClick');
 
       expect(isDirty(wrapper)).toBe(true);
     });
@@ -40,7 +40,7 @@ describe('useForm with dynamic list', () => {
         <FormWithDynamicVariantList data={fakeProduct()} />,
       );
 
-      wrapper.find('button', {children: 'Remove item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Remove item'})!.trigger('onClick');
 
       expect(isDirty(wrapper)).toBe(true);
     });
@@ -51,7 +51,7 @@ describe('useForm with dynamic list', () => {
       );
 
       wrapper
-        .find(TextField, {label: 'price'})
+        .find(TextField, {label: 'price'})!
         .trigger('onChange', 'next price');
 
       expect(isDirty(wrapper)).toBe(true);
@@ -111,7 +111,7 @@ describe('useForm with dynamic list', () => {
         <FormWithDynamicVariantList data={fakeProduct()} />,
       );
 
-      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Add item'})!.trigger('onClick');
 
       expect(wrapper).toContainReactComponentTimes(TextField, 3, {
         label: 'option',
@@ -130,7 +130,7 @@ describe('useForm with dynamic list', () => {
         <FormWithDynamicVariantList data={fakeProduct()} />,
       );
 
-      wrapper.find('button', {children: 'Remove item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Remove item'})!.trigger('onClick');
 
       expect(wrapper).toContainReactComponentTimes(TextField, 1, {
         label: 'option',
@@ -147,7 +147,8 @@ describe('useForm with dynamic list', () => {
 
   describe('makeCleanAfterSubmit', () => {
     it('sets dirty to false after successful submit if makeCleanAfterSubmit is true', async () => {
-      const promise = Promise.resolve(submitSuccess());
+      // eslint-disable-next-line promise/catch-or-return
+      Promise.resolve(submitSuccess());
       const wrapper = mount(
         <FormWithDynamicVariantList
           data={fakeProduct()}
@@ -155,7 +156,7 @@ describe('useForm with dynamic list', () => {
         />,
       );
 
-      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Add item'})!.trigger('onClick');
       fillRequiredFields(wrapper);
 
       expect(isDirty(wrapper)).toBe(true);
@@ -175,7 +176,7 @@ describe('useForm with dynamic list', () => {
         />,
       );
 
-      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Add item'})!.trigger('onClick');
       fillRequiredFields(wrapper);
 
       expect(isDirty(wrapper)).toBe(true);
@@ -194,7 +195,7 @@ describe('useForm with dynamic list', () => {
         />,
       );
 
-      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Add item'})!.trigger('onClick');
       fillRequiredFields(wrapper);
 
       expect(isDirty(wrapper)).toBe(true);
@@ -211,7 +212,7 @@ describe('useForm with dynamic list', () => {
         <FormWithDynamicVariantList data={fakeProduct()} />,
       );
 
-      wrapper.find('button', {children: 'Add item'}).trigger('onClick');
+      wrapper.find('button', {children: 'Add item'})!.trigger('onClick');
       fillRequiredFields(wrapper);
 
       expect(isDirty(wrapper)).toBe(true);

--- a/packages/react-form/src/hooks/tests/form.test.tsx
+++ b/packages/react-form/src/hooks/tests/form.test.tsx
@@ -296,7 +296,6 @@ describe('useForm', () => {
   describe('makeClean', () => {
     it(`cleans the form's dirty state`, () => {
       const wrapper = mount(<ProductForm data={fakeProduct()} />);
-      const newProduct = 'Submarine full of gnomes';
 
       changeTitle(wrapper, 'tortoritos, the chip for turtles!');
 

--- a/packages/react-form/src/tests/utilities.test.ts
+++ b/packages/react-form/src/tests/utilities.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../utilities';
 import {Field} from '../types';
 
-function mockField<T>(params: Partial<Field<T>> | T): Field<T> {
+function mockField<T>(params: Partial<Field<T>> | T): Field<T | undefined> {
   const value = typeof params === 'string' ? params : undefined;
   const fieldProps = typeof params === 'string' ? {} : params;
 
@@ -151,7 +151,7 @@ describe('reduceFields()', () => {
       emails: [{work}],
     };
 
-    const fieldsArray = reduceFields(
+    const fieldsArray = reduceFields<Field<any>[]>(
       fieldBag,
       (list, field) => list.concat(field),
       [],

--- a/packages/react-form/tsconfig.json
+++ b/packages/react-form/tsconfig.json
@@ -10,6 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [{"path": "../react-hooks"}, {"path": "../predicates"}]
 }

--- a/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
@@ -63,7 +63,7 @@ describe('<GraphQLUniversalProvider />', () => {
   });
 
   it('includes a link if none are given', () => {
-    const graphQL = mount(
+    mount(
       <NetworkContext.Provider value={new NetworkManager()}>
         <GraphQLUniversalProvider createClientOptions={() => ({})} />
       </NetworkContext.Provider>,
@@ -76,7 +76,7 @@ describe('<GraphQLUniversalProvider />', () => {
 
   describe('cache', () => {
     it('includes a InMemoryCache as cache when none is given in clientOptions', () => {
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
         </NetworkContext.Provider>,
@@ -90,7 +90,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('includes the given cache from clientOptions', () => {
       const cache = new InMemoryCache({addTypename: true});
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({cache})} />
         </NetworkContext.Provider>,
@@ -187,7 +187,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('ssrMode is set to true when it is on the server', () => {
       isServer.mockReturnValue(true);
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
         </NetworkContext.Provider>,
@@ -201,7 +201,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('ssrMode is set to false when it is on the client', () => {
       isServer.mockReturnValue(false);
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
         </NetworkContext.Provider>,
@@ -215,7 +215,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('ssrMode is set to the value returend in createClientOptions', () => {
       isServer.mockReturnValue(true);
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider
             createClientOptions={() => ({ssrMode: false})}
@@ -231,7 +231,7 @@ describe('<GraphQLUniversalProvider />', () => {
 
   describe('ssrForceFetchDelay', () => {
     it('ssrForceFetchDelay is set to 100 by default', () => {
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
         </NetworkContext.Provider>,
@@ -244,7 +244,7 @@ describe('<GraphQLUniversalProvider />', () => {
 
     it('ssrForceFetchDelay is set to the value returend in createClientOptions', () => {
       const mockSsrForceFetchDelay = 500;
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider
             createClientOptions={() => ({
@@ -264,7 +264,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('connectToDevTools is set to false when it is on the server', () => {
       isServer.mockReturnValue(true);
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
         </NetworkContext.Provider>,
@@ -278,7 +278,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('connectToDevTools is set to true when it is on the client', () => {
       isServer.mockReturnValue(false);
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
         </NetworkContext.Provider>,
@@ -292,7 +292,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('connectToDevTools is set to the value returend in createClientOptions', () => {
       isServer.mockReturnValue(true);
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider
             createClientOptions={() => ({connectToDevTools: true})}
@@ -310,7 +310,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('calls createRequestIdLink if RequestId header has value', () => {
       const mockRequestId = 'request-id-value';
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider
           value={new NetworkManager({headers: {'X-Request-ID': mockRequestId}})}
         >
@@ -322,7 +322,7 @@ describe('<GraphQLUniversalProvider />', () => {
     });
 
     it('does not call createRequestIdLink if RequestId header has not value', () => {
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider value={new NetworkManager()}>
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
         </NetworkContext.Provider>,
@@ -334,7 +334,7 @@ describe('<GraphQLUniversalProvider />', () => {
     it('does not call createRequestIdLink if addRequestId is false', () => {
       const mockRequestId = 'request-id-value';
 
-      const graphQL = mount(
+      mount(
         <NetworkContext.Provider
           value={new NetworkManager({headers: {'X-Request-ID': mockRequestId}})}
         >
@@ -351,15 +351,13 @@ describe('<GraphQLUniversalProvider />', () => {
 
   describe('createCsrfLink', () => {
     it('calls createCsrfLink if quiltRails is true', () => {
-      const graphQL = mount(
-        <GraphQLUniversalProvider createClientOptions={() => ({})} />,
-      );
+      mount(<GraphQLUniversalProvider createClientOptions={() => ({})} />);
 
       expect(createCsrfLink).toHaveBeenCalledWith();
     });
 
     it('does not call createCsrfLink if quiltRails is false', () => {
-      const graphQL = mount(
+      mount(
         <GraphQLUniversalProvider
           createClientOptions={() => ({})}
           quiltRails={false}

--- a/packages/react-graphql-universal-provider/src/tests/request-id-link.test.ts
+++ b/packages/react-graphql-universal-provider/src/tests/request-id-link.test.ts
@@ -5,9 +5,10 @@ import {createRequestIdLink} from '../request-id-link';
 describe('createRequestIdLink()', () => {
   it('create a link that add request id value to the header', () => {
     const mockRequestId = '06a2f67e-b080-446f-bffa-7851ddad3a45';
-    const requestIdLink = createRequestIdLink(mockRequestId);
+    createRequestIdLink(mockRequestId);
 
-    const mockLink = new ApolloLink((operation) => {
+    // eslint-disable-next-line no-new
+    new ApolloLink((operation) => {
       expect(operation.getContext().header['X-Initiated-By-Request-ID']).toBe(
         mockRequestId,
       );

--- a/packages/react-graphql-universal-provider/tsconfig.json
+++ b/packages/react-graphql-universal-provider/tsconfig.json
@@ -10,7 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../react-graphql"},
     {"path": "../react-hooks"},

--- a/packages/react-graphql/CHANGELOG.md
+++ b/packages/react-graphql/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 7.1.6 - 2021-08-30
 

--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 2.1.3 - 2021-08-24
 

--- a/packages/react-hooks/src/hooks/tests/debounced.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/debounced.test.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {timer} from '@shopify/jest-dom-mocks';
 

--- a/packages/react-hooks/src/hooks/tests/delayed-callback.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/delayed-callback.test.tsx
@@ -32,7 +32,7 @@ describe('useDelayedCallback', () => {
       <FakeComponent callback={callbackSpy} delay={delay} />,
     );
 
-    fakeComponent.find('button').trigger('onClick');
+    fakeComponent.find('button')!.trigger('onClick');
 
     expect(callbackSpy).not.toHaveBeenCalled();
   });
@@ -45,7 +45,7 @@ describe('useDelayedCallback', () => {
       <FakeComponent callback={callbackSpy} delay={delay} />,
     );
 
-    fakeComponent.find('button').trigger('onClick');
+    fakeComponent.find('button')!.trigger('onClick');
 
     fakeComponent.act(() => {
       clock.tick(delay);
@@ -62,13 +62,13 @@ describe('useDelayedCallback', () => {
       <FakeComponent callback={callbackSpy} delay={delay} />,
     );
 
-    fakeComponent.find('button').trigger('onClick');
+    fakeComponent.find('button')!.trigger('onClick');
 
     fakeComponent.act(() => {
       clock.tick(delay);
     });
 
-    fakeComponent.find('button').trigger('onClick');
+    fakeComponent.find('button')!.trigger('onClick');
 
     fakeComponent.act(() => {
       clock.tick(delay);
@@ -85,7 +85,7 @@ describe('useDelayedCallback', () => {
       <FakeComponent callback={callbackSpy} delay={delay} />,
     );
 
-    fakeComponent.find('button').trigger('onClick');
+    fakeComponent.find('button')!.trigger('onClick');
 
     fakeComponent.unmount();
 

--- a/packages/react-hooks/src/hooks/tests/force-update.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/force-update.test.tsx
@@ -9,11 +9,11 @@ describe('useForceUpdate', () => {
 
     expect(callback).toHaveBeenCalledTimes(1);
 
-    wrapper.find('button').trigger('onClick');
+    wrapper.find('button')!.trigger('onClick');
     expect(callback).toHaveBeenCalledTimes(2);
-    wrapper.find('button').trigger('onClick');
+    wrapper.find('button')!.trigger('onClick');
     expect(callback).toHaveBeenCalledTimes(3);
-    wrapper.find('button').trigger('onClick');
+    wrapper.find('button')!.trigger('onClick');
     expect(callback).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/react-hooks/src/hooks/tests/mounted-ref.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/mounted-ref.test.tsx
@@ -5,7 +5,7 @@ import {useMountedRef} from '../mounted-ref';
 
 describe('useMountedRef()', () => {
   it('returns a ref with current value as true when the component is mounted', () => {
-    const spy = jest.fn(() => {});
+    const spy = jest.fn((_: boolean) => {});
 
     function MockComponent() {
       const mounted = useMountedRef();
@@ -19,7 +19,7 @@ describe('useMountedRef()', () => {
 
   it('returns a ref with current value as false when the component is un-mounted', async () => {
     const promise = createResolvablePromise(null);
-    const spy = jest.fn(() => {});
+    const spy = jest.fn((_: boolean) => {});
 
     function MockComponent() {
       const mounted = useMountedRef();

--- a/packages/react-hooks/src/hooks/tests/toggle.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/toggle.test.tsx
@@ -31,10 +31,10 @@ describe('useToggle', () => {
     const wrapper = mount(<MockComponent />);
     expect(wrapper).toContainReactText('Value: false');
 
-    wrapper.find('button', {id: 'toggle'}).trigger('onClick');
+    wrapper.find('button', {id: 'toggle'})!.trigger('onClick');
     expect(wrapper).toContainReactText('Value: true');
 
-    wrapper.find('button', {id: 'toggle'}).trigger('onClick');
+    wrapper.find('button', {id: 'toggle'})!.trigger('onClick');
     expect(wrapper).toContainReactText('Value: false');
   });
 
@@ -42,10 +42,10 @@ describe('useToggle', () => {
     const wrapper = mount(<MockComponent />);
     expect(wrapper).toContainReactText('Value: false');
 
-    wrapper.find('button', {id: 'forceTrue'}).trigger('onClick');
+    wrapper.find('button', {id: 'forceTrue'})!.trigger('onClick');
     expect(wrapper).toContainReactText('Value: true');
 
-    wrapper.find('button', {id: 'forceTrue'}).trigger('onClick');
+    wrapper.find('button', {id: 'forceTrue'})!.trigger('onClick');
     expect(wrapper).toContainReactText('Value: true');
   });
 
@@ -53,10 +53,10 @@ describe('useToggle', () => {
     const wrapper = mount(<MockComponent initialValueIsTrue />);
     expect(wrapper).toContainReactText('Value: true');
 
-    wrapper.find('button', {id: 'forceFalse'}).trigger('onClick');
+    wrapper.find('button', {id: 'forceFalse'})!.trigger('onClick');
     expect(wrapper).toContainReactText('Value: false');
 
-    wrapper.find('button', {id: 'forceFalse'}).trigger('onClick');
+    wrapper.find('button', {id: 'forceFalse'})!.trigger('onClick');
     expect(wrapper).toContainReactText('Value: false');
   });
 });

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -9,6 +9,5 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"]
+  ]
 }

--- a/packages/react-html/CHANGELOG.md
+++ b/packages/react-html/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 11.1.5 - 2021-08-30
 

--- a/packages/react-html/src/server/components/tests/Script.test.tsx
+++ b/packages/react-html/src/server/components/tests/Script.test.tsx
@@ -30,7 +30,7 @@ describe('<Script />', () => {
         type: 'text/javascript',
       });
       expect(script).not.toContainReactComponent('script', {
-        nomodule: expect.anything(),
+        noModule: expect.anything(),
       });
     });
 

--- a/packages/react-html/tsconfig.json
+++ b/packages/react-html/tsconfig.json
@@ -10,7 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../react-effect"},
     {"path": "../react-hydrate"},

--- a/packages/react-import-remote/CHANGELOG.md
+++ b/packages/react-import-remote/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 2.1.5 - 2021-08-30
 

--- a/packages/react-import-remote/src/tests/load.test.ts
+++ b/packages/react-import-remote/src/tests/load.test.ts
@@ -169,8 +169,10 @@ function spyOnDOM() {
     script,
     create: jest
       .spyOn(document, 'createElement')
-      .mockImplementation(() => script),
-    append: jest.spyOn(document.head, 'appendChild').mockImplementation(noop),
+      .mockImplementation(() => (script as unknown) as HTMLElement),
+    append: jest
+      .spyOn(document.head, 'appendChild')
+      .mockImplementation((noop as unknown) as (newChild: Node) => Node),
   };
 }
 

--- a/packages/react-import-remote/tsconfig.json
+++ b/packages/react-import-remote/tsconfig.json
@@ -10,7 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../async"},
     {"path": "../react-hooks"},

--- a/packages/react-network/CHANGELOG.md
+++ b/packages/react-network/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 4.1.5 - 2021-08-30
 

--- a/packages/react-network/src/tests/NetworkUniversalProvider.test.tsx
+++ b/packages/react-network/src/tests/NetworkUniversalProvider.test.tsx
@@ -20,7 +20,7 @@ function generateTestKey(index) {
   return `key-${index}`;
 }
 
-function TestApp({headers = []}) {
+function TestApp({headers = []}: {headers: string[]}) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const headerValues = headers.map((header) => useRequestHeader(header));
 
@@ -120,8 +120,7 @@ describe('NetworkUniversalProvider', () => {
         'x-some-header-2': 'header-value-2',
       };
       const htmlManager = new HtmlManager();
-
-      await extract(null, {
+      await extract(<div />, {
         decorate: (element: React.ReactNode) => (
           <HtmlContext.Provider value={htmlManager}>
             <NetworkContext.Provider value={new NetworkManager({headers})}>

--- a/packages/react-network/tsconfig.json
+++ b/packages/react-network/tsconfig.json
@@ -10,7 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../jest-koa-mocks"},
     {"path": "../network"},

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 1.1.5 - 2021-08-30
 

--- a/packages/react-router/src/tests/utilities.ts
+++ b/packages/react-router/src/tests/utilities.ts
@@ -7,22 +7,23 @@ export interface PartialRouterContext {
     match?: Partial<RouterChildContext<any>['router']['route']['match']>;
   };
 }
-
 export function createDefaultHistory(): RouterChildContext<
   any
 >['router']['history'] {
   return {
-    length: 0,
-    action: 'POP',
-    location: createDefaultLocation(),
+    listenBefore: jest.fn(),
+    listen: jest.fn(),
+    transitionTo: jest.fn(),
     push: jest.fn(),
     replace: jest.fn(),
     go: jest.fn(),
     goBack: jest.fn(),
     goForward: jest.fn(),
-    block: jest.fn(),
-    listen: jest.fn(),
+    createKey: jest.fn(),
+    createPath: jest.fn(),
     createHref: jest.fn(),
+    createLocation: jest.fn(),
+    getCurrentLocation: createDefaultLocation,
   };
 }
 
@@ -40,6 +41,9 @@ export function createDefaultLocation(): RouterChildContext<
     search: '',
     state: '',
     hash: '',
+    action: 'POP',
+    key: '',
+    query: {key: ''},
   };
 }
 

--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -10,6 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [{"path": "../react-network"}]
 }

--- a/packages/react-server/CHANGELOG.md
+++ b/packages/react-server/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 1.2.5 - 2021-08-30
 

--- a/packages/react-server/src/render/tests/render.test.tsx
+++ b/packages/react-server/src/render/tests/render.test.tsx
@@ -33,7 +33,9 @@ describe('createRender', () => {
     const renderFunction = createRender(() => <>{myCoolApp}</>);
     await renderFunction(ctx, noop);
 
-    expect(await readStream(ctx.body)).toContain(myCoolApp);
+    expect(await readStream(ctx.body as NodeJS.ReadableStream)).toContain(
+      myCoolApp,
+    );
   });
 
   it.each([
@@ -55,7 +57,7 @@ describe('createRender', () => {
     ],
   ])(
     'response contains data passed in through htmlProps (%s)',
-    async (style, htmlProps) => {
+    async (_style, htmlProps) => {
       const myCoolApp = 'My cool app';
       const ctx = createMockContext();
 
@@ -64,7 +66,7 @@ describe('createRender', () => {
       });
       await renderFunction(ctx, noop);
 
-      const bodyResult = await readStream(ctx.body);
+      const bodyResult = await readStream(ctx.body as NodeJS.ReadableStream);
 
       // Assets from manifest are still present
       expect(bodyResult).toContain(
@@ -99,7 +101,7 @@ describe('createRender', () => {
     const renderFunction = createRender(() => <>{myCoolApp}</>);
     await renderFunction(ctx, noop);
 
-    const response = await readStream(ctx.body);
+    const response = await readStream(ctx.body as NodeJS.ReadableStream);
     expect(response).toContain('quilt-data');
     expect(response).toContain(JSON.stringify(data));
   });
@@ -111,7 +113,9 @@ describe('createRender', () => {
     const renderFunction = createRender((ctx) => <>{ctx.get('some-header')}</>);
     await renderFunction(ctx, noop);
 
-    expect(await readStream(ctx.body)).toContain(headerValue);
+    expect(await readStream(ctx.body as NodeJS.ReadableStream)).toContain(
+      headerValue,
+    );
   });
 
   it('calls the sewing-kit-koa middleware with the passed in assetPrefix', async () => {
@@ -165,8 +169,12 @@ describe('createRender', () => {
         const renderFunction = createRender(() => <BrokenApp />);
         await renderFunction(ctx, noop);
 
-        expect(await readStream(ctx.body)).toContain(error.message);
-        expect(await readStream(ctx.body)).toContain(error.stack);
+        expect(await readStream(ctx.body as NodeJS.ReadableStream)).toContain(
+          error.message,
+        );
+        expect(await readStream(ctx.body as NodeJS.ReadableStream)).toContain(
+          error.stack,
+        );
       });
     });
 

--- a/packages/react-server/src/server/tests/server.test.tsx
+++ b/packages/react-server/src/server/tests/server.test.tsx
@@ -21,10 +21,12 @@ describe('createServer()', () => {
   afterAll(unsaddle);
 
   it('configurable as koa proxy', async () => {
-    function MockApp() {}
+    function MockApp() {
+      return null;
+    }
     const app = new Koa();
 
-    const wrapper = await saddle((port, host) =>
+    await saddle((port, host) =>
       createServer({
         app,
         proxy: true,
@@ -142,7 +144,9 @@ describe('createServer()', () => {
       const oldReactServerIP = process.env.REACT_SERVER_IP;
       process.env.REACT_SERVER_IP = mockIP;
 
-      function MockApp() {}
+      function MockApp() {
+        return null;
+      }
       const app = new Koa();
       const spy = jest.spyOn(app, 'listen');
 
@@ -164,11 +168,13 @@ describe('createServer()', () => {
       const oldReactServerIP = process.env.REACT_SERVER_IP;
       process.env.REACT_SERVER_IP = undefined;
 
-      function MockApp() {}
+      function MockApp() {
+        return null;
+      }
       const app = new Koa();
       const spy = jest.spyOn(app, 'listen');
 
-      const wrapper = await saddle((port) =>
+      await saddle((port) =>
         createServer({app, port, render: () => <MockApp />}),
       );
 
@@ -189,7 +195,9 @@ describe('createServer()', () => {
       const oldReactServerPort = process.env.REACT_SERVER_PORT;
       process.env.REACT_SERVER_PORT = mockPort;
 
-      function MockApp() {}
+      function MockApp() {
+        return null;
+      }
       const app = new Koa();
       const spy = jest.spyOn(app, 'listen');
 
@@ -211,11 +219,13 @@ describe('createServer()', () => {
       const oldReactServerPort = process.env.REACT_SERVER_PORT;
       process.env.REACT_SERVER_PORT = undefined;
 
-      function MockApp() {}
+      function MockApp() {
+        return null;
+      }
       const app = new Koa();
       const spy = jest.spyOn(app, 'listen');
 
-      const wrapper = await saddle((_port, host) =>
+      await saddle((_port, host) =>
         createServer({app, ip: host, render: () => <MockApp />}),
       );
 

--- a/packages/react-server/src/webpack-plugin/tests/webpack-plugin.test.ts
+++ b/packages/react-server/src/webpack-plugin/tests/webpack-plugin.test.ts
@@ -351,7 +351,7 @@ function runBuild(configPath: string): Promise<any[]> {
       }
 
       const statsObject = stats.toJson();
-      resolve(statsObject.children);
+      resolve(statsObject.children!);
     });
   });
 }

--- a/packages/react-server/tsconfig.json
+++ b/packages/react-server/tsconfig.json
@@ -10,7 +10,6 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [
     {"path": "../jest-koa-mocks"},
     {"path": "../react-async"},

--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enable type checking in tests and fix type errors. [[#2034](https://github.com/Shopify/quilt/pull/2034)]
 
 ## 3.2.4 - 2021-08-24
 

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -467,7 +467,9 @@ describe('@shopify/react-testing', () => {
         return <div>{message}</div>;
       }
 
-      const wrapperPromise = mountWithContext(<ContextMessage />);
+      const wrapperPromise = mountWithContext(<ContextMessage />, {
+        message: 'an unused message',
+      });
       const wrapper = await wrapperPromise;
       expect(wrapper.context.message).toBe('a different message');
       expect(wrapper.html()).toBe(`<div>${wrapper.context.message}</div>`);

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -458,9 +458,7 @@ describe('Element', () => {
     it('finds all matching nodes', () => {
       const element = new Element(defaultTree, [divOne], defaultRoot);
       expect(
-        element.findAllWhere(
-          (element) => ((element as unknown) as Element<{}>) === componentTwo,
-        ),
+        element.findAllWhere((element) => element.type === componentTwo.type),
       ).toHaveLength(0);
 
       expect(

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -198,7 +198,6 @@ describe('Element', () => {
     it('concatenates the text contents of all child elements and child text', () => {
       const childTextOne = 'foo ';
       const childTextTwo = 'bar';
-      const descendantText = ' baz?';
 
       const elementChild = new Element(defaultTree, [], defaultRoot);
       jest.spyOn(elementChild, 'text').mockImplementation(() => childTextOne);
@@ -458,9 +457,10 @@ describe('Element', () => {
   describe('#findAllWhere()', () => {
     it('finds all matching nodes', () => {
       const element = new Element(defaultTree, [divOne], defaultRoot);
-
       expect(
-        element.findAllWhere((element) => element === componentTwo),
+        element.findAllWhere(
+          (element) => ((element as unknown) as Element<{}>) === componentTwo,
+        ),
       ).toHaveLength(0);
 
       expect(

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -248,7 +248,7 @@ describe('createMount()', () => {
       const options = {foo: 'bar'};
 
       const afterMountSpy = jest.fn();
-      const additionalAfterMountSpy = jest.fn(
+      const additionalAfterMountSpy = jest.fn<any, any>(
         () => new Promise((resolve) => setTimeout(resolve, 1)),
       );
 

--- a/packages/react-testing/src/tests/root.test.tsx
+++ b/packages/react-testing/src/tests/root.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {Root} from '../root';
 import {Element} from '../element';
-import {Tag, ReactInstance} from '../types';
+import {Tag} from '../types';
 import {destroyAll} from '../destroy';
 
 describe('Root', () => {

--- a/packages/react-testing/tsconfig.json
+++ b/packages/react-testing/tsconfig.json
@@ -10,6 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "exclude": ["**/test/**/*", "**/tests/**/*"],
   "references": [{"path": "../useful-types"}]
 }


### PR DESCRIPTION
## Description

Enable type-checking and fix type errors for a batch of packages.

### Changes

- react-async
  - add missing `cancelled` property.
  - changed `noop()` to match expected type.
- react-bugsnag
  - removed unused `ReactPlugin` plugin
- react-form
  - Change return type for `mockField` to allow for `Field<undefined>`
  - cast `onClick` callbacks to `any` in a test where the event is programmatically triggered.
  - add non-null assertions to controlled `Root.find()` returns.
  - add missing argument to `randomVariants()` call
- react-import-remote
  - Used unsafe type casts to mock parts of the DOM.
- react-graphql-universal-provider
  - Removed unused variables
    - In one case, eslint `disable-next-line no-new` was suppressed for a test that with `new ApolloLink()`
- react-hooks
  - define argument types for mock functions
  - add non-null assertions to controlled `Root.find()` returns
- react-html
  - fix typo `nomodule` -> `noModule`
- react-network
  - Correct function return type. 
- react-router
  - Aligned the types returned by `createDefaultHistory` and `createDefaultLocation`. **NOTE:** These functions aren't used within Quilt so it's not clear how to test the changes.
- react-server
  - Import saddle-up matcher in `src/tests/setup.ts`
  - cast Context.body as `NodeJS.ReadableStream` after `createRender` is called.
  - Changed `MockApp` to return `null` instead of `void` in order to make it a valid JSX component.
- react-testing
  - Added missing `options: MountOptions` argument for `mountWithContext` being used in `e2e.test.tsx`. **NOTE:** It's possible `options` SHOULD be an optional parameter. If that's the case, `.createMount` typing should be changed instead.
  - Used hard cast for a case where `Node<unknown>` was being compared to `Element<{}> `

## Type of change

- [X] react-testing  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-server  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-router  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-network  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-import-remote  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-html  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-hooks  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-graphql-universal-provider  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-form  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-bugsnag  Patch: Bug (non-breaking change which fixes an issue)
- [X] react-async  Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
