### PR TITLE
graphql-typescript-definitions performance improvements

### DIFF
--- a/packages/graphql-typescript-definitions/CHANGELOG.md
+++ b/packages/graphql-typescript-definitions/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Performance improvements [[#2035](https://github.com/Shopify/quilt/pull/2035)]
 
 ## 2.1.2 - 2021-09-03
 

--- a/packages/graphql-typescript-definitions/src/filesystem/graphql-filesystem.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/graphql-filesystem.ts
@@ -62,7 +62,7 @@ export abstract class AbstractGraphQLFilesystem extends EventEmitter {
     config: GraphQLProjectConfig,
   ): boolean;
 
-  emit(event: 'change:schema', path: string): boolean;
+  emit(event: 'change:schema', input: string | string[]): boolean;
   emit(event: string, ...args: any[]): boolean {
     return super.emit(event, ...args);
   }


### PR DESCRIPTION
## Description
Prevent `graphql-typescript-definitions` queuing up a bunch of mostly redundant work. tl;dr is that local/Spin workspaces may take 2+ minutes of 100% CPU to complete type def work.

Examples of the churn generated are provided below in collapsed `details` blocks.

### What impact does this have?
I ran through before/after for a couple of scenarios in Shopify's largest app. All scenarios start with sewing-kit running a development server using:

```sh
yarn dev --focus Home
```

#### Schema refresh (`yarn refresh-graphql --mode production --no-definitions`)

Without these improvements:
* `Unable to find any GraphQL type definitions for` is output 90 times
* `Built GraphQL type definitions` is output 20 times
* JS compilation is initiated 11 times, including one 26 second client compile

With these improvements:
* `Unable to find any GraphQL type definitions for` no longer appears
* `Built GraphQL type definitions` appears once
* Still a couple of `no such file or directory` errors (fixed by https://github.com/Shopify/sewing-kit/pull/2846)
* 4 compilations initiated (2 seconds max compile time)

<details>
<summary>Dev server output before this PR</summary>

```
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/hsCodesService.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/mailbox.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/shopifyChat.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/appStore.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/bourgeois.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/banking.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/argus.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/merchantRisk.json
[client] Compiling
[server] Compiling
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
./build/graphql/schemas/core-schema-unions-and-interfaces.json
Module build failed: Error: ENOENT: no such file or directory, open './build/graphql/schemas/core-schema-unions-and-interfaces.json'

[server] Build failed.
[server] Compiling
./build/graphql/schemas/core-schema-unions-and-interfaces.json
Module build failed: Error: ENOENT: no such file or directory, open './build/graphql/schemas/core-schema-unions-and-interfaces.json'

[client] Build failed.
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
./build/graphql/schemas/core-schema-unions-and-interfaces.json
Module build failed: Error: ENOENT: no such file or directory, open './build/graphql/schemas/core-schema-unions-and-interfaces.json'

[server] Build failed.
[client] Compiling
[graphql] Built GraphQL schema types
[error]
      Unable to find any GraphQL type definitions for the following pointers:
          - build/graphql/schemas/core.json
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
./build/graphql/schemas/core-schema-unions-and-interfaces.json
Module build failed: Error: ENOENT: no such file or directory, open './build/graphql/schemas/core-schema-unions-and-interfaces.json'

[client] Build failed.
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[server] Compiling
[client] Compiling
[server] Compiled with latest changes (2s)
[graphql] Built GraphQL schema types
[server] Compiling
[graphql] Built GraphQL type definitions
[client] Compiled with latest changes (16s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[client] Compiling
[server] Running with latest changes
[server] Compiled with latest changes (9s)
[init] listening on 192.168.64.1:40020
[server] Compiling
[graphql] Built GraphQL type definitions
[server] Compiled with latest changes (4s)
[client] Compiled with latest changes (26s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[server] Compiling
[server] Running with latest changes
[client] Compiling
[init] listening on 192.168.64.1:40020
[server] Compiled with latest changes (6s)
[client] Compiled with latest changes (2s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[server] Running with latest changes
[init] listening on 192.168.64.1:40020
```
</details>

<details>
<summary>Dev server output after this PR</summary>

```
[server] Compiling
./build/graphql/schemas/core-schema-unions-and-interfaces.json
Module build failed: Error: ENOENT: no such file or directory, open '/Users/gord/src/github.com/Shopify/web/build/graphql/schemas/core-schema-unions-and-interfaces.json'

[server] Build failed.
[client] Compiling
./build/graphql/schemas/core-schema-unions-and-interfaces.json
Module build failed: Error: ENOENT: no such file or directory, open '/Users/gord/src/github.com/Shopify/web/build/graphql/schemas/core-schema-unions-and-interfaces.json'

[client] Build failed.
[graphql] Built GraphQL type definitions
[server] Compiling
[client] Compiling
[server] Compiled with latest changes (2s)
[client] Compiled with latest changes (2s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[server] Running with latest changes
[graphql] Built GraphQL type definitions
[init] listening on 192.168.64.1:40020
```
</details>

#### Fast-forward from stale head
To simulate a pull on a stale branch, I did this:
```
git reset --hard HEAD~20
git pull
```

Without these improvements:
* `Built GraphQL type definitions` is output 31 times
* Almost 6 minutes is spent compiling client JS (compilation is _very_ slow because so much GQL type generation is silently churning in the background)

After these improvements:
* `Built GraphQL type definitions` appears twice
* More compilations are triggered! (this is expected because they last ~4 seconds, so Chokidar has more time to pick up changes as Git churns through commits)
* A few JS compilation errors are thrown (expected because files appear/disappear during pulls 🤷 ) 

<details>
<summary>Dev server output before these improvements</summary>

```
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[server] Compiling
[client] Compiling
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[graphql] Built GraphQL type definitions
[server] Compiled with latest changes (2m52s)
[server] Compiling
[server] Compiled with latest changes (1s)
[client] Compiled with latest changes (2m54s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[client] Compiling
[server] Running with latest changes
[client] Compiled with latest changes (2s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[init] listening on 192.168.64.1:40020
```
</details>

<details>
<summary>Dev server output before these improvements</summary>

```
[server] Compiling
[client] Compiling
./app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts'

./app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts'

[server] Build failed.
[server] Compiling
./app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts'

./app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts'

[client] Build failed.
[client] Compiling
[server] Compiled with latest changes (3s)
[client] Compiled with latest changes (4s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[server] Running with latest changes
[graphql] Built GraphQL type definitions
[init] listening on 192.168.64.1:40020
[server] Compiling
[client] Compiling
[server] Compiled with latest changes (2s)
[client] Compiled with latest changes (2s)
[client] Creating consolidated manifest
[client] Completed manifest creation
[server] Running with latest changes
[server] Compiling
[client] Compiling
[server] Compiled with latest changes (3s)
[client] Compiled with latest changes (3s)
[client] Creating consolidated manifest
[init] listening on 192.168.64.1:40020
[client] Completed manifest creation
[server] Running with latest changes
[init] listening on 192.168.64.1:40020
[server] Compiling
[client] Compiling
./app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts'

./app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts'

[server] Build failed.
./app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/components/index.ts'

./app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts
Error: ENOENT: no such file or directory, open './app/sections/Home/HomeIndex/components/MerchantCoachingButton/const.ts'

[client] Build failed.
[graphql] Built GraphQL type definitions
```
</details>

### Is this its final form?
This isn't a comprehensive fix. It addresses the big pain points in a fairly scrappy fashion. Future improvements may include:
* Make this library smarter about what work needs to be performed to get everything in sync (e.g., if a single fragment updates, only regenerate importing documents)
* Exposing `sewing-kit refresh-graphql`'s functionality as a callable function (this would avoid a costly `getSchema` call)
* Turn `graphql-typescript-definitions` into a completely detached service (language server, even?), and have it function independently of sewing-kit / spinx
* Rewrite in Rust :)

## Type of change

- [x] `graphql-typescript-definitions` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
