### PR TITLE
Only add the SSR link on the server

### DIFF
--- a/packages/react-graphql-universal-provider/CHANGELOG.md
+++ b/packages/react-graphql-universal-provider/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Only add the SSR link on the server. [[#2037](https://github.com/Shopify/quilt/pull/2037)]
 
 ## 4.1.6 - 2021-08-30
 


### PR DESCRIPTION
## Description
We don't need the SSR link on the client. We don't need to keep track of those promises on the client. Let's save some memory.

## Type of change
- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
