### PR TITLE
Replacing the space for non breaking space when we format time

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Transforming the space for a non-breaking space on formatted time. [[#2041](https://github.com/Shopify/quilt/pull/2041)]
 
 ## 6.2.8 - 2021-12-07
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -45,6 +45,7 @@ import {
   TranslateOptions as RootTranslateOptions,
   memoizedNumberFormatter,
   memoizedPluralRules,
+  convertFirstSpaceToNonBreakingSpace,
 } from './utilities';
 
 export interface NumberFormatOptions extends Intl.NumberFormatOptions {
@@ -601,9 +602,12 @@ export class I18n {
       minute: '2-digit',
     }).toLocaleLowerCase();
 
-    return timeZoneName === 'short'
-      ? `${formattedTime} ${this.getTimeZone(date, options)}`
-      : formattedTime;
+    const time =
+      timeZoneName === 'short'
+        ? `${formattedTime} ${this.getTimeZone(date, options)}`
+        : formattedTime;
+
+    return convertFirstSpaceToNonBreakingSpace(time);
   }
 
   private getWeekdayFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -6,6 +6,7 @@ import {I18n} from '../i18n';
 import {LanguageDirection} from '../types';
 import {DateStyle, Weekday} from '../constants';
 import {MissingTranslationError} from '../errors';
+import {convertFirstSpaceToNonBreakingSpace} from '../utilities';
 
 jest.mock('../utilities', () => ({
   ...jest.requireActual('../utilities'),
@@ -1340,7 +1341,10 @@ describe('I18n', () => {
           'date.humanize.lessThanOneYearAgo',
           {
             pseudotranslate: false,
-            replacements: {date: 'Nov. 20', time: '12:00 a.m. EST'},
+            replacements: {
+              date: 'Nov. 20',
+              time: `${convertFirstSpaceToNonBreakingSpace('12:00 a.m.')} EST`,
+            },
           },
           defaultTranslations,
           i18n.locale,
@@ -1367,7 +1371,10 @@ describe('I18n', () => {
           'date.humanize.lessThanOneWeekAgo',
           {
             pseudotranslate: false,
-            replacements: {weekday: 'Tuesday', time: '12:00 a.m. EST'},
+            replacements: {
+              weekday: 'Tuesday',
+              time: `${convertFirstSpaceToNonBreakingSpace('12:00 a.m.')} EST`,
+            },
           },
           defaultTranslations,
           i18n.locale,
@@ -1394,7 +1401,9 @@ describe('I18n', () => {
           'date.humanize.yesterday',
           {
             pseudotranslate: false,
-            replacements: {time: '12:00 a.m. EST'},
+            replacements: {
+              time: `${convertFirstSpaceToNonBreakingSpace('12:00 a.m.')} EST`,
+            },
           },
           defaultTranslations,
           i18n.locale,
@@ -1421,7 +1430,9 @@ describe('I18n', () => {
           'date.humanize.today',
           {
             pseudotranslate: false,
-            replacements: {time: '1:00 a.m. EST'},
+            replacements: {
+              time: `${convertFirstSpaceToNonBreakingSpace('1:00 a.m.')} EST`,
+            },
           },
           defaultTranslations,
           i18n.locale,
@@ -1448,7 +1459,10 @@ describe('I18n', () => {
           'date.humanize.lessThanOneWeekAgo',
           {
             pseudotranslate: false,
-            replacements: {weekday: 'Tuesday', time: '6:00 a.m. GMT+1'},
+            replacements: {
+              weekday: 'Tuesday',
+              time: `${convertFirstSpaceToNonBreakingSpace('6:00 a.m.')} GMT+1`,
+            },
           },
           defaultTranslations,
           i18n.locale,
@@ -1475,7 +1489,12 @@ describe('I18n', () => {
           'date.humanize.lessThanOneWeekAgo',
           {
             pseudotranslate: false,
-            replacements: {weekday: 'Tuesday', time: '8:30 a.m. GMT+3:30'},
+            replacements: {
+              weekday: 'Tuesday',
+              time: `${convertFirstSpaceToNonBreakingSpace(
+                '8:30 a.m.',
+              )} GMT+3:30`,
+            },
           },
           defaultTranslations,
           i18n.locale,
@@ -1502,7 +1521,11 @@ describe('I18n', () => {
           'date.humanize.today',
           {
             pseudotranslate: false,
-            replacements: {time: '1:00 a.m. eastern standard time'},
+            replacements: {
+              time: `${convertFirstSpaceToNonBreakingSpace(
+                '1:00 a.m.',
+              )} eastern standard time`,
+            },
           },
           defaultTranslations,
           i18n.locale,
@@ -1567,7 +1590,7 @@ describe('I18n', () => {
 
             expect(
               i18n.formatDate(moreThanOneHourAgo, {style: DateStyle.Humanize}),
-            ).toBe('5:00 a.m.');
+            ).toBe(convertFirstSpaceToNonBreakingSpace('5:00 a.m.'));
           });
 
           it('formats a date from yesterday', () => {
@@ -1582,7 +1605,12 @@ describe('I18n', () => {
             i18n.formatDate(yesterday, {style: DateStyle.Humanize});
             expect(translate).toHaveBeenCalledWith(
               'date.humanize.yesterday',
-              {pseudotranslate: false, replacements: {time: '11:00 a.m.'}},
+              {
+                pseudotranslate: false,
+                replacements: {
+                  time: convertFirstSpaceToNonBreakingSpace('11:00 a.m.'),
+                },
+              },
               defaultTranslations,
               i18n.locale,
             );
@@ -1613,7 +1641,7 @@ describe('I18n', () => {
                 style: DateStyle.Humanize,
                 timeZone: timezone,
               }),
-            ).toBe('1:00 p.m.');
+            ).toBe(convertFirstSpaceToNonBreakingSpace('1:00 p.m.'));
           });
 
           it('formats a date for yesterday if it is yesterday relative to the locale time zone', () => {
@@ -1636,7 +1664,12 @@ describe('I18n', () => {
 
             expect(translate).toHaveBeenCalledWith(
               'date.humanize.yesterday',
-              {pseudotranslate: false, replacements: {time: '9:00 p.m.'}},
+              {
+                pseudotranslate: false,
+                replacements: {
+                  time: convertFirstSpaceToNonBreakingSpace('9:00 p.m.'),
+                },
+              },
               defaultTranslations,
               i18n.locale,
             );
@@ -1662,7 +1695,10 @@ describe('I18n', () => {
             'date.humanize.lessThanOneWeekAgo',
             {
               pseudotranslate: false,
-              replacements: {weekday: 'Saturday', time: '11:00 a.m.'},
+              replacements: {
+                weekday: 'Saturday',
+                time: convertFirstSpaceToNonBreakingSpace('11:00 a.m.'),
+              },
             },
             defaultTranslations,
             i18n.locale,
@@ -1691,7 +1727,10 @@ describe('I18n', () => {
             'date.humanize.lessThanOneYearAgo',
             {
               pseudotranslate: false,
-              replacements: {date: 'Jul. 20', time: '10:00 a.m.'},
+              replacements: {
+                date: 'Jul. 20',
+                time: convertFirstSpaceToNonBreakingSpace('10:00 a.m.'),
+              },
             },
             defaultTranslations,
             i18n.locale,
@@ -1713,7 +1752,12 @@ describe('I18n', () => {
             i18n.formatDate(tomorrow, {style: DateStyle.Humanize});
             expect(translate).toHaveBeenCalledWith(
               'date.humanize.tomorrow',
-              {pseudotranslate: false, replacements: {time: '11:00 a.m.'}},
+              {
+                pseudotranslate: false,
+                replacements: {
+                  time: convertFirstSpaceToNonBreakingSpace('11:00 a.m.'),
+                },
+              },
               defaultTranslations,
               i18n.locale,
             );
@@ -1733,7 +1777,12 @@ describe('I18n', () => {
             i18n.formatDate(todayInTheFuture, {style: DateStyle.Humanize});
             expect(translate).toHaveBeenCalledWith(
               'date.humanize.today',
-              {pseudotranslate: false, replacements: {time: '4:00 p.m.'}},
+              {
+                pseudotranslate: false,
+                replacements: {
+                  time: convertFirstSpaceToNonBreakingSpace('4:00 p.m.'),
+                },
+              },
               defaultTranslations,
               i18n.locale,
             );
@@ -1761,7 +1810,12 @@ describe('I18n', () => {
 
             expect(translate).toHaveBeenCalledWith(
               'date.humanize.today',
-              {pseudotranslate: false, replacements: {time: '3:00 p.m.'}},
+              {
+                pseudotranslate: false,
+                replacements: {
+                  time: convertFirstSpaceToNonBreakingSpace('3:00 p.m.'),
+                },
+              },
               defaultTranslations,
               i18n.locale,
             );
@@ -1787,7 +1841,12 @@ describe('I18n', () => {
 
             expect(translate).toHaveBeenCalledWith(
               'date.humanize.tomorrow',
-              {pseudotranslate: false, replacements: {time: '5:00 a.m.'}},
+              {
+                pseudotranslate: false,
+                replacements: {
+                  time: convertFirstSpaceToNonBreakingSpace('5:00 a.m.'),
+                },
+              },
               defaultTranslations,
               i18n.locale,
             );
@@ -1813,7 +1872,10 @@ describe('I18n', () => {
             'date.humanize.lessThanOneWeekAway',
             {
               pseudotranslate: false,
-              replacements: {weekday: 'Tuesday', time: '11:00 a.m.'},
+              replacements: {
+                weekday: 'Tuesday',
+                time: convertFirstSpaceToNonBreakingSpace('11:00 a.m.'),
+              },
             },
             defaultTranslations,
             i18n.locale,
@@ -1842,7 +1904,10 @@ describe('I18n', () => {
             'date.humanize.lessThanOneYearAway',
             {
               pseudotranslate: false,
-              replacements: {date: 'May 22', time: '10:00 a.m.'},
+              replacements: {
+                date: 'May 22',
+                time: convertFirstSpaceToNonBreakingSpace('10:00 a.m.'),
+              },
             },
             defaultTranslations,
             i18n.locale,

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -8,3 +8,4 @@ export {
 } from './translate';
 
 export type {TranslateOptions} from './translate';
+export {convertFirstSpaceToNonBreakingSpace} from './string';

--- a/packages/react-i18n/src/utilities/string.ts
+++ b/packages/react-i18n/src/utilities/string.ts
@@ -1,0 +1,3 @@
+export function convertFirstSpaceToNonBreakingSpace(str: string) {
+  return str.replace(' ', '\u00A0');
+}

--- a/packages/react-i18n/src/utilities/tests/string.test.ts
+++ b/packages/react-i18n/src/utilities/tests/string.test.ts
@@ -1,0 +1,9 @@
+import {convertFirstSpaceToNonBreakingSpace} from '../string';
+
+describe('convertFirstSpaceToNonBreakingSpace()', () => {
+  it('converts first space into non breaking spaces', () => {
+    expect(convertFirstSpaceToNonBreakingSpace('8:30 am PST')).toBe(
+      `8:30\u00A0am PST`,
+    );
+  });
+});


### PR DESCRIPTION
## Description
When we are formating time, we never want to render the time like this: 
```
8:00
am
```

To avoid that, we can replace the space with a non-breaking space. This is what this PR implement.
Question: Should we add an option to the format function instead?


## Type of change
I'm not sure if it's a breaking change OR a Minor change?
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
