### PR TITLE
[storybook-a11y-test] Update docs with with config parameters

### DIFF
--- a/packages/storybook-a11y-test/README.md
+++ b/packages/storybook-a11y-test/README.md
@@ -104,8 +104,8 @@ MyStory.parameters = {
     // 🙌 Instead, override single rules on specific elements.
     // 👇 see guidelines below
 
-    // @see axe-core optionsParameter (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter)
-    options: {
+    // @see axe-core configParameter (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#parameters-1)
+    config: {
       rules: [
         {
           // False positives on specific elements
@@ -142,7 +142,7 @@ MyStory.parameters = {
 ```ts
 AutocompleteField.parameters = {
   a11y: {
-    options: {
+    config: {
       rules: [
         {
           // Add support for `autocomplete="nope"`, a workaround to prevent autocomplete in Chrome
@@ -161,7 +161,7 @@ AutocompleteField.parameters = {
 ```ts
 DisabledButton.parameters = {
   a11y: {
-    options: {
+    config: {
       rules: [
         {
           // Color contrast ratio doesn't need to meet 4.5:1, as the element is disabled
@@ -179,7 +179,7 @@ DisabledButton.parameters = {
 ```ts
 PrototypeComponent.parameters = {
   a11y: {
-    options: {
+    config: {
       rules: [
         {
           // Page-level semantics cause a violation and need to be reworked.


### PR DESCRIPTION
## Description
It updates the docs after the last update. As discussed in https://github.com/Shopify/web/pull/50146, the current docs use the [config.rules format](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#parameters-1) instead of the [options.rules format](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter). However the rules as referenced as **options.rules**

This PR just replaces the a11y **options** paremeters with **config**.
<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change
It updates the usage examples in the README file
<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
