### PR TITLE
Fixing a memory issue with a type

### DIFF
--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -151,13 +151,13 @@ export class Element<Props> implements Node<Props> {
     );
   }
 
-  is<Type extends React.ComponentType<any> | string>(
+  is<Type extends React.ElementType>(
     type: Type,
   ): this is Element<PropsFor<Type>> {
     return isMatchingType(this.type, type);
   }
 
-  find<Type extends React.ComponentType<any> | string>(
+  find<Type extends React.ElementType>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Element<PropsFor<Type>> | null {
@@ -168,7 +168,7 @@ export class Element<Props> implements Node<Props> {
     ) || null) as Element<PropsFor<Type>> | null;
   }
 
-  findAll<Type extends React.ComponentType<any> | string>(
+  findAll<Type extends React.ElementType>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Element<PropsFor<Type>>[] {
@@ -179,16 +179,16 @@ export class Element<Props> implements Node<Props> {
     ) as Element<PropsFor<Type>>[];
   }
 
-  findWhere<Type extends React.ComponentType<any> | string | unknown = unknown>(
+  findWhere<Type extends React.ElementType | unknown = unknown>(
     predicate: Predicate,
   ): Element<UnknowablePropsFor<Type>> | null {
     return (this.elementDescendants.find((element) => predicate(element)) ||
       null) as Element<UnknowablePropsFor<Type>> | null;
   }
 
-  findAllWhere<
-    Type extends React.ComponentType<any> | string | unknown = unknown
-  >(predicate: Predicate): Element<UnknowablePropsFor<Type>>[] {
+  findAllWhere<Type extends React.ElementType | unknown = unknown>(
+    predicate: Predicate,
+  ): Element<UnknowablePropsFor<Type>>[] {
     return this.elementDescendants.filter((element) =>
       predicate(element),
     ) as Element<UnknowablePropsFor<Type>>[];

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -1,4 +1,3 @@
-import {ComponentType} from 'react';
 import {
   matcherHint,
   printExpected,
@@ -16,9 +15,7 @@ import {
   printType,
 } from './utilities';
 
-export function toContainReactComponent<
-  Type extends string | ComponentType<any>
->(
+export function toContainReactComponent<Type extends React.ElementType>(
   this: jest.MatcherUtils,
   node: Node<unknown>,
   type: Type,
@@ -80,9 +77,7 @@ export function toContainReactComponent<
   return {pass, message};
 }
 
-export function toContainReactComponentTimes<
-  Type extends string | ComponentType<any>
->(
+export function toContainReactComponentTimes<Type extends React.ElementType>(
   this: jest.MatcherUtils,
   node: Node<unknown>,
   type: Type,

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,4 +1,4 @@
-import {ComponentType, Context as ReactContext} from 'react';
+import {Context as ReactContext} from 'react';
 
 import {Node, PropsFor} from '../types';
 
@@ -18,11 +18,11 @@ declare global {
     interface Matchers<R, T = {}> {
       toHaveReactProps(props: Partial<PropsFromNode<T>>): void;
       toHaveReactDataProps(data: {[key: string]: string}): void;
-      toContainReactComponent<Type extends string | ComponentType<any>>(
+      toContainReactComponent<Type extends React.ElementType>(
         type: Type,
         props?: Partial<PropsFor<Type>>,
       ): void;
-      toContainReactComponentTimes<Type extends string | ComponentType<any>>(
+      toContainReactComponentTimes<Type extends React.ElementType>(
         type: Type,
         times: number,
         props?: Partial<PropsFor<Type>>,

--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -117,7 +117,7 @@ export function createMount<
   Async
 > {
   function mount<Props>(
-    element: React.ReactElement<Props>,
+    element: React.ReactElement<Props, React.ElementType>,
     options: MountOptions = {} as any,
   ) {
     const context = createContext(options);

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -136,9 +136,7 @@ export class Root<Props> implements Node<Props> {
     return this.withRoot((root) => root.text());
   }
 
-  is<Type extends React.ComponentType<any> | string>(
-    type: Type,
-  ): this is Root<PropsFor<Type>> {
+  is<Type extends React.ElementType>(type: Type): this is Root<PropsFor<Type>> {
     return this.withRoot((root) => root.is(type));
   }
 
@@ -150,29 +148,29 @@ export class Root<Props> implements Node<Props> {
     return this.withRoot((root) => root.data(key));
   }
 
-  find<Type extends React.ComponentType<any> | string>(
+  find<Type extends React.ElementType>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ) {
     return this.withRoot((root) => root.find(type, props));
   }
 
-  findAll<Type extends React.ComponentType<any> | string>(
+  findAll<Type extends React.ElementType>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ) {
     return this.withRoot((root) => root.findAll(type, props));
   }
 
-  findWhere<Type extends React.ComponentType<any> | string | unknown = unknown>(
+  findWhere<Type extends React.ElementType | unknown = unknown>(
     predicate: Predicate,
   ) {
     return this.withRoot((root) => root.findWhere<Type>(predicate));
   }
 
-  findAllWhere<
-    Type extends React.ComponentType<any> | string | unknown = unknown
-  >(predicate: Predicate) {
+  findAllWhere<Type extends React.ElementType | unknown = unknown>(
+    predicate: Predicate,
+  ) {
     return this.withRoot((root) => root.findAllWhere<Type>(predicate));
   }
 

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -2,18 +2,12 @@ import React from 'react';
 import {Arguments, MaybeFunctionReturnType} from '@shopify/useful-types';
 
 export type PropsFor<
-  T extends string | React.ComponentType<any>
-> = T extends string
-  ? T extends keyof JSX.IntrinsicElements
-    ? JSX.IntrinsicElements[T]
-    : React.HTMLAttributes<T>
-  : T extends React.ComponentType<any>
-  ? React.ComponentPropsWithoutRef<T>
-  : never;
+  T extends React.ElementType
+> = React.ComponentPropsWithoutRef<T>;
 
 export type UnknowablePropsFor<
-  T extends string | React.ComponentType<any> | unknown
-> = T extends string | React.ComponentType<any> ? PropsFor<T> : unknown;
+  T extends React.ElementType | unknown
+> = T extends React.ElementType ? PropsFor<T> : unknown;
 
 export type FunctionKeys<T> = {
   [K in keyof T]-?: NonNullable<T[K]> extends (...args: any[]) => any
@@ -101,15 +95,13 @@ export interface Node<Props> {
   text(): string;
   html(): string;
 
-  is<Type extends React.ComponentType<any> | string>(
-    type: Type,
-  ): this is Node<PropsFor<Type>>;
+  is<Type extends React.ElementType>(type: Type): this is Node<PropsFor<Type>>;
 
-  find<Type extends React.ComponentType<any> | string>(
+  find<Type extends React.ElementType>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Node<PropsFor<Type>> | null;
-  findAll<Type extends React.ComponentType<any> | string>(
+  findAll<Type extends React.ElementType>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Node<PropsFor<Type>>[];


### PR DESCRIPTION
## Description
Fixing a memory issue with our `PropsFor` type. I expect this small change to have a massive impact on project like `shopify/web` or `shopify/online-store-web`.

I ran the type check manually in `shopify/web`, `shopify/online-store-web`, `quilt` and `online-store-ui` and only found type issue in some super edge cases.

## Type of change
- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
