### PR TITLE
[react-i18n] add feature to provide clock format of locale

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -148,6 +148,9 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
 - `ordinal()`: formats a number as an ordinal according to the locale, e.g. `1st`, `2nd`, `3rd`, `4th`
 - `hasEasternNameOrderFormatter()`: returns true when an eastern name order formatter corresponding to the locale/language exists.
 - `numberSymbols()`: returns an object specifying the current locale's decimal and thousand symbols. Example: For the `es-ES` locale the output would be `{ decimalSymbol: ',', thousandSymbol: '.' }`
+- `hasTwelveHourClockFormat()`: Returns true if the locale uses 12-hour clock format. Uses the current locale if no locale is passed.
+  - `hasTwelveHourClockFormat('en-US')` will return true
+  - `hasTwelveHourClockFormat('fr-CA')` will return false
 
 Most notably, you will frequently use `i18n`’s `translate()` method. This method looks up a key in translation files that you supply based on the provided locale. This method is discussed in detail in the next section.
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -377,6 +377,19 @@ export class I18n {
     return Boolean(easternNameOrderFormatter);
   }
 
+  hasTwelveHourClockFormat(locale?: string) {
+    const afternoonDateTime = new Date(2020, 1, 1, 13);
+    try {
+      const dateParts = new Intl.DateTimeFormat(locale || this.locale, {
+        hour: 'numeric',
+      }).formatToParts(afternoonDateTime);
+      const hourValue = dateParts.find((part) => part.type === 'hour')?.value;
+      return Number(hourValue) < 13;
+    } catch {
+      return false;
+    }
+  }
+
   @memoize()
   numberSymbols() {
     const formattedNumber = this.formatNumber(123456.7, {

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -2115,4 +2115,46 @@ describe('I18n', () => {
       expect(i18n.hasEasternNameOrderFormatter()).toStrictEqual(false);
     });
   });
+
+  describe('#hasTwelveHourClockFormat', () => {
+    it('returns true for en-CA locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en-CA'});
+
+      expect(i18n.hasTwelveHourClockFormat()).toStrictEqual(true);
+    });
+
+    it('returns true for en-US locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en-US'});
+
+      expect(i18n.hasTwelveHourClockFormat()).toStrictEqual(true);
+    });
+
+    it('returns true for en-AU locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'en-AU'});
+
+      expect(i18n.hasTwelveHourClockFormat()).toStrictEqual(true);
+    });
+
+    it('returns false for fr-CA locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'fr-CA'});
+
+      expect(i18n.hasTwelveHourClockFormat()).toStrictEqual(false);
+    });
+
+    it('returns false for de locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: 'de'});
+
+      expect(i18n.hasTwelveHourClockFormat()).toStrictEqual(false);
+    });
+
+    it('defaults to false for invalid locale', () => {
+      const i18n = new I18n(defaultTranslations, {locale: ''});
+      expect(i18n.hasTwelveHourClockFormat()).toStrictEqual(false);
+    });
+
+    it('uses locale function argument when provided', () => {
+      const i18n = new I18n(defaultTranslations, {locale: ''});
+      expect(i18n.hasTwelveHourClockFormat('en-US')).toStrictEqual(true);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #2053 

Adds method that returns the clock format of the given locale. FEDs can leverage this for any use cases where a meridiem (AM/PM) timepicker is needed.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] react-i18n Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
