### PR TITLE
Fixes typo in jest-dom-mocks README

### DIFF
--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -31,7 +31,7 @@ afterEach(() => {
 });
 ```
 
-this will ensure that appropriate error messages are shown if a DOM object is mocked without beign restored for the next test.
+this will ensure that appropriate error messages are shown if a DOM object is mocked without being restored for the next test.
 
 ### `installMockStorage`
 


### PR DESCRIPTION
## Description

Fixes a typo in the `jest-dom-mocks` README: `beign` --> `being`

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
