### PR TITLE
🐛 Fix setting state in IntersectionObserver render

### DIFF
--- a/packages/react-intersection-observer/CHANGELOG.md
+++ b/packages/react-intersection-observer/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fix setting state in `IntersectionObserver` render. [#2059](https://github.com/Shopify/quilt/pull/2059)
 
 ## 3.1.6 - 2021-09-24
 

--- a/packages/react-intersection-observer/src/hooks.ts
+++ b/packages/react-intersection-observer/src/hooks.ts
@@ -138,9 +138,11 @@ export function useValueTracking<T>(
   const tracked = useRef(value);
   const oldValue = tracked.current;
 
-  if (value !== oldValue) {
-    tracked.current = value;
-    onChange(value, oldValue);
-  }
+  useEffect(() => {
+    if (value !== oldValue) {
+      tracked.current = value;
+      onChange(value, oldValue);
+    }
+  }, [onChange, value, oldValue]);
 }
 /* eslint-enable react-hooks/exhaustive-deps */


### PR DESCRIPTION
## Description
Fixes https://github.com/Shopify/quilt/issues/2058

When a consumer of `@shopify/react-intersection-observer` attempts to set state in the `onIntersectionChange` callback for `<IntersectionObserver>`, React 16.13 and above will generate a warning that the consuming component cannot update state while `IntersectionObserver` is rendering. This is because the `useValueTracking` hook used by `IntersectionObserver` is updating it's tracking ref and triggering the callback during the render.

The fix is to simply wrap that logic in a `useEffect` hook so that it happens after the render.

## Type of change

- [x] `@shopify/react-intersection-observer` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
