### PR TITLE
Update ua-parser-js minor version to be ^0.7.30 as 0.7.29 was hijacked and contained malicious code.

### DIFF
--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- updated ua-parser-js dependency to `^0.7.30`
 
 ## 2.0.4 - 2021-09-24
 

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,7 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-- updated ua-parser-js dependency to `^0.7.30` [[#2061](https://github.com/Shopify/quilt/pull/2061)]
+### Changed
+
+- Updated ua-parser-js dependency to `^0.7.30` [[#2061](https://github.com/Shopify/quilt/pull/2061)]
 
 ## 2.0.4 - 2021-09-24
 

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-- updated ua-parser-js dependency to `^0.7.30`
+- updated ua-parser-js dependency to `^0.7.30` [[#2061](https://github.com/Shopify/quilt/pull/2061)]
 
 ## 2.0.4 - 2021-09-24
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -32,7 +32,7 @@
     "index.esnext"
   ],
   "dependencies": {
-    "ua-parser-js": "^0.7.17"
+    "ua-parser-js": "^0.7.30"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13646,10 +13646,10 @@ typescript@^4.3.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
-ua-parser-js@^0.7.17:
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
-  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
+ua-parser-js@^0.7.30:
+  version "0.7.30"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.30.tgz#4cf5170e8b55ac553fe8b38df3a82f0669671f0b"
+  integrity sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==
 
 uglify-js@^3.1.4:
   version "3.10.4"


### PR DESCRIPTION
## Description

Making this dependency move from being able to use an affected version.

Affected versions:
= 0.7.29
= 0.8.0
= 1.0.0

Patched versions:
0.7.30
0.8.1
1.0.1

More information here:
https://github.com/advisories/GHSA-pjwm-rvh2-c87w



## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
