### PR TITLE
Run on latest 12.x

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.14', '14.x', '16.x']
+        node-version: ['12.x', '14.x', '16.x']
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Description

Tweak CI matrix to run on 12.x instead of 12.14 (Don't know the historical context of being on 12.14)

## Type of change

Just a CI environment tweak. No change to any code.