### PR TITLE
Move babel-plugins to dependencies in ast-utilities package

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
 - Fix: missing dependency errors on babel-plugins [[#2072](https://github.com/Shopify/quilt/pull/2072)]
 
 ## 1.0.7 - 2021-09-24

--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix: missing dependency errors on babel-plugins [[#2072](https://github.com/Shopify/quilt/pull/2072)]
 
 ## 1.0.7 - 2021-09-24
 

--- a/packages/ast-utilities/package.json
+++ b/packages/ast-utilities/package.json
@@ -35,8 +35,6 @@
   },
   "devDependencies": {
     "@babel/core": ">=7.0.0",
-    "@babel/plugin-transform-react-jsx": ">=7.0.0",
-    "@babel/plugin-transform-typescript": ">=7.0.0",
     "@types/babel__core": ">=7.0.0",
     "@types/babel__traverse": ">=7.0.0",
     "@types/unist": "^2.0.3"
@@ -59,6 +57,8 @@
     "@babel/template": "^7.14.5",
     "@babel/traverse": ">=7.0.0",
     "@babel/types": ">=7.0.0",
+    "@babel/plugin-transform-react-jsx": ">=7.0.0",
+    "@babel/plugin-transform-typescript": ">=7.0.0",
     "jest-matcher-utils": "^26.6.2",
     "remark-parse": "^9.0.0",
     "remark-stringify": "^7.0.3",


### PR DESCRIPTION
## Description

This PR moves the babel plugin dependencies that are required in consuming projects to `dependencies` from `devDependencies`.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
