### PR TITLE
No duplicates in addComponentProps()

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fix: missing dependency errors on babel-plugins [[#2072](https://github.com/Shopify/quilt/pull/2072)]
 
 ## 1.0.7 - 2021-09-24
 

--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Options object with `noDuplicates` boolean to third argument in `addComponentProps()` (true by default)
+
 ### Fixed
 
 - Fix: missing dependency errors on babel-plugins [[#2072](https://github.com/Shopify/quilt/pull/2072)]

--- a/packages/ast-utilities/README.md
+++ b/packages/ast-utilities/README.md
@@ -27,9 +27,9 @@ Each language provides a `transform` function with the same signature. The first
 
 `@shopify/ast-transforms/javascript`
 
-### `addComponentProps(props, componentName)`
+### `addComponentProps(props, componentName, options)`
 
-Takes the first argument array of props and adds them to any component name that match the given second argument string.
+Takes the first argument array of props and adds them to any component name that matches the given second argument string. Use the optional third arguments object to enable duplicate props.
 
 ```tsx
 import {transform, addComponentProps} from '@shopify/ast-transforms/javascript';
@@ -45,6 +45,25 @@ const result = await transform(
 );
 
 console.log(result); // <Foo someProp={someValue} />
+```
+
+```tsx
+import {transform, addComponentProps} from '@shopify/ast-transforms/javascript';
+
+const initial = `<Foo someProp={someValue} />`;
+
+const result = await transform(
+  initial,
+  addComponentProps(
+    [{name: 'someProp', value: t.identifier('someValue')}],
+    'Foo',
+    {
+      noDuplicates: false, // true by default
+    },
+  ),
+);
+
+console.log(result); // <Foo someProp={someValue} someProp={someValue} />
 ```
 
 ### `addImportSpecifier(importSource, newSpecifier)`

--- a/packages/ast-utilities/package.json
+++ b/packages/ast-utilities/package.json
@@ -35,8 +35,6 @@
   },
   "devDependencies": {
     "@babel/core": ">=7.0.0",
-    "@babel/plugin-transform-react-jsx": ">=7.0.0",
-    "@babel/plugin-transform-typescript": ">=7.0.0",
     "@types/babel__core": ">=7.0.0",
     "@types/babel__traverse": ">=7.0.0",
     "@types/unist": "^2.0.3"
@@ -59,6 +57,8 @@
     "@babel/template": "^7.14.5",
     "@babel/traverse": ">=7.0.0",
     "@babel/types": ">=7.0.0",
+    "@babel/plugin-transform-react-jsx": ">=7.0.0",
+    "@babel/plugin-transform-typescript": ">=7.0.0",
     "jest-matcher-utils": "^26.6.2",
     "remark-parse": "^9.0.0",
     "remark-stringify": "^7.0.3",

--- a/packages/ast-utilities/src/javascript/addComponentProps/addComponentProps.ts
+++ b/packages/ast-utilities/src/javascript/addComponentProps/addComponentProps.ts
@@ -1,9 +1,14 @@
 import * as traverse from '@babel/traverse';
 import * as t from '@babel/types';
 
+interface Options {
+  noDuplicates: boolean;
+}
+
 export default function addComponentProps(
   props: {name: string; value: t.StringLiteral | t.Identifier}[],
   component: string,
+  options: Options = {noDuplicates: true},
 ) {
   return {
     JSXElement(path: traverse.NodePath<t.JSXElement>) {
@@ -13,6 +18,28 @@ export default function addComponentProps(
         t.isJSXIdentifier(openingElement.name) &&
         openingElement.name.name === component
       ) {
+        const hasExistingProp = openingElement.attributes.filter((attr) =>
+          Boolean(
+            props.filter((prop) => {
+              if (
+                t.isJSXAttribute(attr) &&
+                t.isJSXExpressionContainer(attr.value) &&
+                t.isIdentifier(attr.value.expression) &&
+                t.isIdentifier(prop.value)
+              ) {
+                return (
+                  prop.name === attr.name.name &&
+                  prop.value.name === attr.value.expression.name
+                );
+              }
+            }).length,
+          ),
+        );
+
+        if (options.noDuplicates && hasExistingProp.length) {
+          return;
+        }
+
         props.forEach((prop) => {
           const value = t.isStringLiteral(prop.value)
             ? prop.value

--- a/packages/ast-utilities/src/javascript/addComponentProps/tests/addComponentProps.test.ts
+++ b/packages/ast-utilities/src/javascript/addComponentProps/tests/addComponentProps.test.ts
@@ -83,4 +83,43 @@ describe('addComponentProps', () => {
 
     expect(result).toBeFormated(expected);
   });
+
+  it('does not add a prop to a component if the prop already exists', async () => {
+    const initial = `
+      <Test someProp={someValue} />
+    `;
+
+    const result = await transform(
+      initial,
+      addComponentProps(
+        [{name: 'someProp', value: t.identifier('someValue')}],
+        'Test',
+      ),
+    );
+
+    expect(result).toStrictEqual(
+      expect.stringMatching(/<Test someProp={someValue} \/>/),
+    );
+  });
+
+  it('allows duplicate props when the noDuplicates option is false', async () => {
+    const initial = `
+      <Test someProp={someValue} />
+    `;
+
+    const result = await transform(
+      initial,
+      addComponentProps(
+        [{name: 'someProp', value: t.identifier('someValue')}],
+        'Test',
+        {noDuplicates: false},
+      ),
+    );
+
+    expect(result).toStrictEqual(
+      expect.stringMatching(
+        /<Test someProp={someValue} someProp={someValue} \/>/,
+      ),
+    );
+  });
 });


### PR DESCRIPTION
## Description

This PR ads an `options` configuration argument to addComponentProps. This is used to tell the function whether to allow duplicate props and this is true by default.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
