### PR TITLE
Include offsets in humanized timezones

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Updated regex for humanized timezones to include offsets [#2077](https://github.com/Shopify/quilt/pull/2077)
 
 ## 6.2.3 - 2021-09-24
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -582,7 +582,7 @@ export class I18n {
       hour: 'numeric',
     });
 
-    const zoneMatchGroup = /\s(\w*$)/i.exec(hourZone);
+    const zoneMatchGroup = /\s([\w ()+-:]*$)/i.exec(hourZone);
 
     return zoneMatchGroup ? zoneMatchGroup[1] : '';
   }

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -582,7 +582,7 @@ export class I18n {
       hour: 'numeric',
     });
 
-    const zoneMatchGroup = /\s([\w(+\-:.)]+$)/.exec(hourZone);
+    const zoneMatchGroup = /\s([\w()+\-:.]+$)/.exec(hourZone);
 
     return zoneMatchGroup ? zoneMatchGroup[1] : '';
   }

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -582,7 +582,7 @@ export class I18n {
       hour: 'numeric',
     });
 
-    const zoneMatchGroup = /\s([\w ()+-:]*$)/i.exec(hourZone);
+    const zoneMatchGroup = /\s([\w()+-:]*$)/i.exec(hourZone);
 
     return zoneMatchGroup ? zoneMatchGroup[1] : '';
   }

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -582,7 +582,7 @@ export class I18n {
       hour: 'numeric',
     });
 
-    const zoneMatchGroup = /\s([\w()+-:]*$)/i.exec(hourZone);
+    const zoneMatchGroup = /\s([\w(+\-:.)]+$)/.exec(hourZone);
 
     return zoneMatchGroup ? zoneMatchGroup[1] : '';
   }

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -1455,6 +1455,33 @@ describe('I18n', () => {
         );
       });
 
+      it('formats short timezone when there is a decimal offset from GMT', () => {
+        const today = new Date('2012-12-20T05:00:00-00:00');
+        clock.mock(today);
+
+        const date = new Date('2012-12-18T05:00:00-00:00');
+        const defaultTimezone = 'Asia/Tehran';
+        const i18n = new I18n(defaultTranslations, {
+          ...defaultDetails,
+          timezone: defaultTimezone,
+        });
+
+        i18n.formatDate(date, {
+          timeZoneName: 'short',
+          style: DateStyle.Humanize,
+        });
+
+        expect(translate).toHaveBeenCalledWith(
+          'date.humanize.lessThanOneWeekAgo',
+          {
+            pseudotranslate: false,
+            replacements: {weekday: 'Tuesday', time: '8:30 a.m. GMT+3:30'},
+          },
+          defaultTranslations,
+          i18n.locale,
+        );
+      });
+
       it('formats a date with a full timezone name in lowercase', () => {
         const today = new Date('2012-12-20T05:00:00-00:00');
         clock.mock(today);

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -1428,6 +1428,33 @@ describe('I18n', () => {
         );
       });
 
+      it('formats short timezone when it does not have an abbreviation in the locale', () => {
+        const today = new Date('2012-12-20T05:00:00-00:00');
+        clock.mock(today);
+
+        const date = new Date('2012-12-18T05:00:00-00:00');
+        const defaultTimezone = 'Europe/Berlin';
+        const i18n = new I18n(defaultTranslations, {
+          ...defaultDetails,
+          timezone: defaultTimezone,
+        });
+
+        i18n.formatDate(date, {
+          timeZoneName: 'short',
+          style: DateStyle.Humanize,
+        });
+
+        expect(translate).toHaveBeenCalledWith(
+          'date.humanize.lessThanOneWeekAgo',
+          {
+            pseudotranslate: false,
+            replacements: {weekday: 'Tuesday', time: '6:00 a.m. GMT+1'},
+          },
+          defaultTranslations,
+          i18n.locale,
+        );
+      });
+
       it('formats a date with a full timezone name in lowercase', () => {
         const today = new Date('2012-12-20T05:00:00-00:00');
         clock.mock(today);


### PR DESCRIPTION
## Description
Closes https://github.com/Shopify/web/issues/52384

Old regex only included word characters (excluded `+`/`-`) which caused offset timezones (i.e. `GMT+1`) to not be matched. These timezones are used in from `Intl.DateTimeFormat` when there is no timezone abbreviation in that language.

## Tophat instructions
note: there are tests for this in the PR 

1. https://regex101.com/
2. use the pattern from below `\s([\w()+\-:.]+$)`
3. make sure it selects the timezone for these cases:
- `6:00pm EST`
- `10:00am GMT+1`
- `4:30pm UTC-2:30`
- `4:30pm UTC+1.5`

## Type of change

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
