### PR TITLE
Escape Unicode characters in JSON

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Fully escape JSON in HTTP header when `data` passed to `react_render` contains Unicode characters. ([#2079](https://github.com/Shopify/quilt/pull/2079))
+
 ## 3.5.1 - 2021-08-30
 
 ### Security

--- a/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
+++ b/gems/quilt_rails/lib/quilt_rails/react_renderable.rb
@@ -40,9 +40,10 @@ module Quilt
       end
 
       begin
+        data_json = JSON.generate(data.as_json, ascii_only: true)
         reverse_proxy(
           url,
-          headers: headers.merge('X-Request-ID': request.request_id, 'X-Quilt-Data': data.to_json)
+          headers: headers.merge('X-Request-ID': request.request_id, 'X-Quilt-Data': data_json)
         ) do |callbacks|
           callbacks.on_response do |status_code, _response|
             Quilt.logger.info("[ReactRenderable] #{url} returned #{status_code}")

--- a/gems/quilt_rails/test/quilt/react_renderable_test.rb
+++ b/gems/quilt_rails/test/quilt/react_renderable_test.rb
@@ -11,7 +11,7 @@ module Quilt
         render_react,
         reverse_proxy(
           url,
-          headers: { 'X-Request-ID': request.request_id, 'X-Quilt-Data': {}.to_json }
+          headers: { 'X-Request-ID': request.request_id, 'X-Quilt-Data': '{}' }
         )
       )
     end
@@ -24,7 +24,7 @@ module Quilt
       headers = {
         'x-custom-header': 'test',
         'X-Request-ID': request.request_id,
-        'X-Quilt-Data': {}.to_json,
+        'X-Quilt-Data': '{}',
       }
       proxy_result = reverse_proxy(url, headers: headers)
 
@@ -35,9 +35,20 @@ module Quilt
       Rails.env.stubs(:test?).returns(false)
       url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
 
-      headers = { 'X-Request-ID': request.request_id, 'X-Quilt-Data': { 'X-Foo': 'bar' }.to_json }
+      headers = { 'X-Request-ID': request.request_id, 'X-Quilt-Data': '{"X-Foo":"bar"}' }
       assert_equal(
         render_react(data: { 'X-Foo': 'bar' }),
+        reverse_proxy(url, headers: headers)
+      )
+    end
+
+    def test_render_react_calls_reverse_proxy_with_header_data_that_contains_unicode_characters
+      Rails.env.stubs(:test?).returns(false)
+      url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
+
+      headers = { 'X-Request-ID': request.request_id, 'X-Quilt-Data': '{"X-Foo":"Ate\u015f"}' }
+      assert_equal(
+        render_react(data: { 'X-Foo': 'Ateş' }),
         reverse_proxy(url, headers: headers)
       )
     end
@@ -65,7 +76,7 @@ module Quilt
 
       url = "#{Quilt.configuration.react_server_protocol}://#{Quilt.configuration.react_server_host}"
 
-      headers = { 'X-Request-ID': request.request_id, 'X-Quilt-Data': { 'X-Foo': 'bar' }.to_json }
+      headers = { 'X-Request-ID': request.request_id, 'X-Quilt-Data': '{"X-Foo":"bar"}' }
       assert_equal(
         render_react(data: { 'X-Foo': 'bar' }),
         reverse_proxy(url, headers: headers)


### PR DESCRIPTION
Related to: https://github.com/Shopify/shoppingmall/issues/313
May be related to: https://github.com/Shopify/banking/issues/6049


## Description
Fixing an issue when data contains non-ASCII characters. HTTP Header doesn't seem to support UTF-8 and seems to only support `ISO-8859-1`. For that reason, we are forcing the JSON string to fully escape all Unicode characters (the JSON spec support this, but doesn't mandate it) so if the JSON string contains any non-ASCII character, the node sidecar will receive the right value.

## Type of change
- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
