### PR TITLE
Add import specifier prevent duplicates

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- `addImportSpecifier()` doesn't allow duplicate specifiers
 
 ## 1.1.0 - 2021-11-15
 

--- a/packages/ast-utilities/src/javascript/addImportSpecifier/addImportSpecifier.ts
+++ b/packages/ast-utilities/src/javascript/addImportSpecifier/addImportSpecifier.ts
@@ -16,11 +16,32 @@ export default function addImportSpecifier(
   return {
     ImportDeclaration(path: traverse.NodePath<t.ImportDeclaration>) {
       if (path.node.source.value === importSource) {
-        newSpecifiers.forEach((specifier) => {
-          path.node.specifiers.push(
-            t.importSpecifier(t.identifier(specifier), t.identifier(specifier)),
-          );
-        });
+        const existingSpecifiers = path.node.specifiers.reduce(
+          (acc, specifier) => {
+            if (t.isImportSpecifier(specifier)) {
+              const imported = t.isIdentifier(specifier.imported)
+                ? specifier.imported.name
+                : specifier.imported;
+              return [...acc, imported, specifier.local.name];
+            }
+
+            return acc;
+          },
+          [],
+        );
+
+        newSpecifiers
+          .filter((specifier) =>
+            existingSpecifiers ? !existingSpecifiers.includes(specifier) : true,
+          )
+          .forEach((specifier) => {
+            path.node.specifiers.push(
+              t.importSpecifier(
+                t.identifier(specifier),
+                t.identifier(specifier),
+              ),
+            );
+          });
         added = true;
       }
     },

--- a/packages/ast-utilities/src/javascript/addImportSpecifier/tests/addImportSpecifier.test.ts
+++ b/packages/ast-utilities/src/javascript/addImportSpecifier/tests/addImportSpecifier.test.ts
@@ -45,4 +45,20 @@ describe('addImportSpecifier', () => {
 		`;
     expect(result).toBeFormated(expected);
   });
+
+  it('doesn’t allow duplicate specifiers', async () => {
+    const initial = `
+      import {foo} from './bar';
+    `;
+
+    const result = await transform(
+      initial,
+      addImportSpecifier('./bar', ['foo']),
+    );
+
+    const expected = `
+			import {foo} from './bar';
+		`;
+    expect(result).toBeFormated(expected);
+  });
 });

--- a/packages/ast-utilities/src/javascript/addImportStatement/addImportStatement.ts
+++ b/packages/ast-utilities/src/javascript/addImportStatement/addImportStatement.ts
@@ -19,5 +19,19 @@ export default function addImportStatement(statement: string | string[]) {
         path.node.body.unshift(ast);
       });
     },
+    File(path: traverse.NodePath<t.Program>) {
+      if (path.node.body.length === 0) {
+        path.node.body = [...path.node.body, ...addImports(statements)];
+      }
+    },
   };
+}
+
+function addImports(statements: string[]) {
+  return statements.map((statement) => {
+    const ast = astFrom(`${statement}
+    `);
+
+    return ast!;
+  });
 }

--- a/packages/ast-utilities/src/javascript/addImportStatement/tests/addImportStatement.test.ts
+++ b/packages/ast-utilities/src/javascript/addImportStatement/tests/addImportStatement.test.ts
@@ -2,7 +2,7 @@ import {transform} from '../../transform';
 import addImportStatement from '../addImportStatement';
 
 describe('addImportStatement', () => {
-  it('adds an import statement before an exisiting import statement', async () => {
+  it('adds an import statement before an existing import statement', async () => {
     const initial = `
       import {foo} from './bar'
     `;
@@ -20,7 +20,7 @@ describe('addImportStatement', () => {
     expect(result).toBeFormated(expected);
   });
 
-  it('adds multiple import statements before an exisiting import statement', async () => {
+  it('adds multiple import statements before an existing import statement', async () => {
     const initial = `
       import {foo} from './bar'
     `;


### PR DESCRIPTION
## Description

This PR prevents duplicate specifiers from being added when using the `addImportSpecifier` transform. If duplicates end up in the source, they cause a syntax error for transforms down the line.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
