### PR TITLE
Adds `replaceJsxBody()` support for when parent node is root

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- `replaceJsxBody()` support for when parent node is root [[#xxxx])](https://github.com/Shopify/quilt/pull/xxxx)]
+- `replaceJsxBody()` support for when parent node is root [[#2085])](https://github.com/Shopify/quilt/pull/2085)]
 - `addImportSpecifier()` doesn't allow duplicate specifiers [[#2081)](https://github.com/Shopify/quilt/pull/2081)]
 
 ## 1.1.2 - 2021-11-23

--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `replaceJsxBody()` support for when parent node is root [[#xxxx])](https://github.com/Shopify/quilt/pull/xxxx)]
 - `addImportSpecifier()` doesn't allow duplicate specifiers [[#2081)](https://github.com/Shopify/quilt/pull/2081)]
 
 ## 1.1.2 - 2021-11-23

--- a/packages/ast-utilities/src/javascript/replaceJsxBody/replaceJsxBody.ts
+++ b/packages/ast-utilities/src/javascript/replaceJsxBody/replaceJsxBody.ts
@@ -4,26 +4,37 @@ import * as t from '@babel/types';
 import {astFrom} from '../utilities';
 
 export default function replaceJSXBody(parent: string, children: string) {
-  const parentJsx = astFrom(parent);
+  const newParentJsx = astFrom(parent);
 
   return {
     JSXElement(path: traverse.NodePath<t.JSXElement>) {
-      if (
-        t.isJSXIdentifier(path.node.openingElement.name) &&
-        path.node.openingElement.name.name === children &&
+      const oldParentName =
         t.isJSXElement(path.parent) &&
         t.isJSXIdentifier(path.parent.openingElement.name) &&
-        t.isExpressionStatement(parentJsx) &&
-        t.isJSXElement(parentJsx.expression) &&
-        t.isJSXIdentifier(parentJsx.expression.openingElement.name) &&
-        path.parent.openingElement.name.name !==
-          parentJsx.expression.openingElement.name.name
-      ) {
-        if (t.isJSXElement(parentJsx.expression)) {
-          const node = parentJsx.expression;
-          node.children = [path.node];
+        path.parent.openingElement.name.name;
 
-          path.replaceWith(node as any);
+      const newParentName =
+        t.isExpressionStatement(newParentJsx) &&
+        t.isJSXElement(newParentJsx.expression) &&
+        t.isJSXIdentifier(newParentJsx.expression.openingElement.name) &&
+        newParentJsx.expression.openingElement.name.name;
+
+      const nodeName =
+        t.isJSXIdentifier(path.node.openingElement.name) &&
+        path.node.openingElement.name.name;
+
+      if (
+        nodeName === children &&
+        newParentName !== nodeName &&
+        (!oldParentName || newParentName !== oldParentName)
+      ) {
+        if (
+          t.isExpressionStatement(newParentJsx) &&
+          t.isJSXElement(newParentJsx.expression)
+        ) {
+          const newNode = newParentJsx.expression;
+          newNode.children = [path.node];
+          path.replaceWith(newNode);
         }
       }
     },

--- a/packages/ast-utilities/src/javascript/replaceJsxBody/tests/replaceJsxBody.test.ts
+++ b/packages/ast-utilities/src/javascript/replaceJsxBody/tests/replaceJsxBody.test.ts
@@ -16,4 +16,19 @@ describe('replaceJsxBody', () => {
 
     expect(result).toBeFormated(expected);
   });
+
+  it('wraps a root node', async () => {
+    const initial = `
+      <Baz>{qux}</Baz>
+    `;
+
+    const result = await transform(
+      initial,
+      replaceJsxBody(`<Bar></Bar>`, 'Baz'),
+    );
+
+    const expected = `<Bar><Baz>{qux}</Baz></Bar>;`;
+
+    expect(result).toBeFormated(expected);
+  });
 });


### PR DESCRIPTION
## Description

The `replaceJsxBody` transform would fail if it was operating at the top (root) of the react tree. This PR fixes this and adds a test.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
