### PR TITLE
New transform `wrapJsxChildren()`

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- New transform `wrapJsxChildren()` that wraps a JSX node’s children with a given JSX Element
+
 ### Fixed
 
 - `replaceJsxBody()` support for when parent node is root [[#2085])](https://github.com/Shopify/quilt/pull/2085)]

--- a/packages/ast-utilities/README.md
+++ b/packages/ast-utilities/README.md
@@ -190,6 +190,22 @@ const result = await transform(
 console.log(result);
 ```
 
+### `wrapJsxChildren(wrapper, parent)`
+
+Given the wrapper JSX string, will find and wrap a tree of JSX, beginning with the parent element that maches the second argument, string.
+
+```tsx
+import {transform, wrapJsxChildren} from '@shopify/ast-transforms/javascript';
+
+const initial = `
+  <Foo>{qux}</Foo>
+`;
+
+const result = await transform(initial, wrapJsxChildren(`<Bar></Bar>`, 'Foo'));
+
+console.log(result); // <Foo><Bar>{qux}</Bar></Foo>;
+```
+
 ## Markdown
 
 ### `addReleaseToChangelog(object)`

--- a/packages/ast-utilities/src/javascript/index.ts
+++ b/packages/ast-utilities/src/javascript/index.ts
@@ -1,10 +1,11 @@
-export {default as addInterface} from './addInterface';
+export {default as addComponentProps} from './addComponentProps';
 export {default as addImportSpecifier} from './addImportSpecifier';
 export {default as addImportStatement} from './addImportStatement';
-export {default as addComponentProps} from './addComponentProps';
+export {default as addInterface} from './addInterface';
+export {default as addVariableDeclaratorProps} from './addVariableDeclaratorProps';
 export {default as replaceJsxBody} from './replaceJsxBody';
 export {default as replaceStrings} from './replaceStrings';
-export {default as addVariableDeclaratorProps} from './addVariableDeclaratorProps';
+export {default as wrapJsxChildren} from './wrapJsxChildren';
 export {transform, transformSync} from './transform';
 export {parse, parseSync} from './parse';
 export {compose, astFrom} from './utilities';

--- a/packages/ast-utilities/src/javascript/wrapJsxChildren/index.ts
+++ b/packages/ast-utilities/src/javascript/wrapJsxChildren/index.ts
@@ -1,0 +1,3 @@
+import wrapJsxChildren from './wrapJsxChildren';
+
+export default wrapJsxChildren;

--- a/packages/ast-utilities/src/javascript/wrapJsxChildren/tests/wrapJsxChildren.test.ts
+++ b/packages/ast-utilities/src/javascript/wrapJsxChildren/tests/wrapJsxChildren.test.ts
@@ -1,0 +1,34 @@
+import {transform} from '../../transform';
+import wrapJsxChildren from '../wrapJsxChildren';
+
+describe('wrapJsxChildren', () => {
+  it('wraps a child JSX element with a parent', async () => {
+    const initial = `
+      <Foo><Baz>{qux}</Baz></Foo>
+    `;
+
+    const result = await transform(
+      initial,
+      wrapJsxChildren(`<Bar></Bar>`, 'Foo'),
+    );
+
+    const expected = `<Foo><Bar><Baz>{qux}</Baz></Bar></Foo>;`;
+
+    expect(result).toBeFormated(expected);
+  });
+
+  it('wraps a root node', async () => {
+    const initial = `
+      <Baz>{qux}</Baz>
+    `;
+
+    const result = await transform(
+      initial,
+      wrapJsxChildren(`<Bar></Bar>`, 'Baz'),
+    );
+
+    const expected = `<Baz><Bar>{qux}</Bar></Baz>;`;
+
+    expect(result).toBeFormated(expected);
+  });
+});

--- a/packages/ast-utilities/src/javascript/wrapJsxChildren/wrapJsxChildren.ts
+++ b/packages/ast-utilities/src/javascript/wrapJsxChildren/wrapJsxChildren.ts
@@ -1,0 +1,45 @@
+import * as traverse from '@babel/traverse';
+import * as t from '@babel/types';
+
+import {astFrom} from '../utilities';
+
+export default function wrapJsxChildren(
+  children: string,
+  parentNodeName: string,
+) {
+  const newChildrenJsx = astFrom(children);
+
+  return {
+    JSXElement(path: traverse.NodePath<t.JSXElement>) {
+      const oldParentName =
+        t.isJSXElement(path.parent) &&
+        t.isJSXIdentifier(path.parent.openingElement.name) &&
+        path.parent.openingElement.name.name;
+
+      const newChildName =
+        t.isExpressionStatement(newChildrenJsx) &&
+        t.isJSXElement(newChildrenJsx.expression) &&
+        t.isJSXIdentifier(newChildrenJsx.expression.openingElement.name) &&
+        newChildrenJsx.expression.openingElement.name.name;
+
+      const nodeName =
+        t.isJSXIdentifier(path.node.openingElement.name) &&
+        path.node.openingElement.name.name;
+
+      if (
+        nodeName === parentNodeName &&
+        newChildName !== nodeName &&
+        (!oldParentName || newChildName !== oldParentName)
+      ) {
+        if (
+          t.isExpressionStatement(newChildrenJsx) &&
+          t.isJSXElement(newChildrenJsx.expression)
+        ) {
+          const newNode = newChildrenJsx.expression;
+          newNode.children = path.node.children;
+          path.node.children = [newNode];
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Description

Adds a new transform for wrapping a the children of a React JSX Element with a new React JSX Element. For example, if you wanted to wrap everything under a `<Suspense>` tag with a new `<Provider>` component.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
