### PR TITLE
Adjust DeepThunk type for changes in typescript 4.5

### DIFF
--- a/packages/graphql-fixtures/CHANGELOG.md
+++ b/packages/graphql-fixtures/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
 
 ### Changed
 

--- a/packages/graphql-fixtures/CHANGELOG.md
+++ b/packages/graphql-fixtures/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Adjusted DeepThunk type in response to breaking changes in Typescript 4.5 [[#2087](https://github.com/Shopify/quilt/pull/2087)]
+
 ## 1.1.4 - 2021-11-22
 
 ### Changed

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -53,40 +53,45 @@ export type Thunk<T, Data, Variables, DeepPartial> =
   | T
   | Resolver<T, Data, Variables, DeepPartial>;
 
-export type DeepThunk<T, Data, Variables, DeepPartial> = T extends object
-  ? {
-      [P in keyof T]: Thunk<
-        T[P] extends (infer U)[] | null | undefined
-          ?
-              | Thunk<
-                  DeepThunk<U, Data, Variables, DeepPartial>,
-                  Data,
-                  Variables,
-                  DeepPartial
-                >[]
-              | null
-              | undefined
-          : T[P] extends ReadonlyArray<infer U> | null | undefined
-          ?
-              | ReadonlyArray<
-                  Thunk<
+export type DeepThunk<T, Data, Variables, DeepPartial> =
+  | (T extends object
+      ? {
+          [P in keyof T]: Thunk<
+            | (T[P] extends (infer U)[]
+                ? Thunk<
                     DeepThunk<U, Data, Variables, DeepPartial>,
                     Data,
                     Variables,
                     DeepPartial
-                  >
-                >
-              | null
-              | undefined
-          : T[P] extends infer U | null | undefined
-          ? DeepThunk<U, Data, Variables, DeepPartial> | null | undefined
-          : T[P],
-        Data,
-        Variables,
-        DeepPartial
-      >;
-    }
-  : T;
+                  >[]
+                :
+                    | (T[P] extends ReadonlyArray<infer U>
+                        ? ReadonlyArray<
+                            Thunk<
+                              DeepThunk<U, Data, Variables, DeepPartial>,
+                              Data,
+                              Variables,
+                              DeepPartial
+                            >
+                          >
+                        :
+                            | (T[P] extends infer U
+                                ? DeepThunk<U, Data, Variables, DeepPartial>
+                                : T[P])
+                            | null
+                            | undefined)
+                    | null
+                    | undefined)
+            | null
+            | undefined,
+            Data,
+            Variables,
+            DeepPartial
+          >;
+        }
+      : T)
+  | null
+  | undefined;
 
 export type GraphQLFillerData<
   Operation extends GraphQLOperation


### PR DESCRIPTION
## Description

Changes `DeepThunk` type to support new [Restrictions on Assignability to Conditional Types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#restrictions-on-assignability-to-conditional-types) in Typescript 4.5.

These changes address errors being faced updating [shopify/web to 4.5](https://github.com/Shopify/web/pull/53227).

`DeepThunk` was changed to separate `| null | undefined` from the conditional types `a?b:c`. It should be equivalent to the previous definition.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] graphql-fixtures Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
