### PR TITLE
Use type when using buffered: true

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed the "The PerformanceObserver does not support buffered flag with the entryTypes argument" warnings [[#2089](https://github.com/Shopify/quilt/pull/2089)]
 
 ## 2.0.8 - 2021-11-23
 

--- a/packages/performance/src/utilities.ts
+++ b/packages/performance/src/utilities.ts
@@ -42,7 +42,7 @@ export function withEntriesOfType<T extends keyof EntryMap>(
     });
 
     observer.observe({
-      entryTypes: [type],
+      type,
       buffered: true,
     });
   } catch (error) {


### PR DESCRIPTION
## Description

Part of #1090

In Chrome's DevTools console, we're getting a bunch of these errors:

```
The PerformanceObserver does not support buffered flag with the entryTypes argument.
```

We're using a single type, and wrapping it in an array to pass to `entryTypes` while we have `buffered: true`. We should just use the `type` property.

https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe

> - entryTypes: An array of DOMString objects, each specifying one performance entry type to observe. May not be used together with the "type" or "buffered" options.
> - type: A single DOMString specifying exactly one performance entry type to observe. May not be used together with the entryTypes option.
> - buffered: A boolean flag to indicate whether buffered entries should be queued into the observer's buffer. Must be used only with the "type" option.

## Type of change

- [x] `performance` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
