### PR TITLE
Clean graphql config utilities test output

### DIFF
--- a/packages/graphql-config-utilities/CHANGELOG.md
+++ b/packages/graphql-config-utilities/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Clean test output. [[#2091](https://github.com/Shopify/quilt/pull/2091)]
 
 ## 3.0.6 - 2021-11-22
 

--- a/packages/graphql-config-utilities/src/tests/config.test.ts
+++ b/packages/graphql-config-utilities/src/tests/config.test.ts
@@ -58,6 +58,10 @@ describe('resolvePathRelativeToConfig()', () => {
 });
 
 describe('resolveProjectName()', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
   it('resolves a named project name', () => {
     expect(resolveProjectName(projectConfig.getProject('project-one'))).toBe(
       'project-one',

--- a/packages/graphql-config-utilities/src/tests/config.test.ts
+++ b/packages/graphql-config-utilities/src/tests/config.test.ts
@@ -62,6 +62,10 @@ describe('resolveProjectName()', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('resolves a named project name', () => {
     expect(resolveProjectName(projectConfig.getProject('project-one'))).toBe(
       'project-one',


### PR DESCRIPTION
## Description
Tests for `graphql-config-utilities` outputs warnings when testing `resolveProjectName`. This PR disables them because they are expected.

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [X] `graphql-config-utilities` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
