### PR TITLE
Get all entries and filter them ourselves

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed the "Deprecated API for given entry type." warnings [[#2093](https://github.com/Shopify/quilt/pull/2093)]
 - Fixed the "The PerformanceObserver does not support buffered flag with the entryTypes argument" warnings [[#2089](https://github.com/Shopify/quilt/pull/2089)]
 
 ## 2.0.8 - 2021-11-23

--- a/packages/performance/src/utilities.ts
+++ b/packages/performance/src/utilities.ts
@@ -28,7 +28,11 @@ export function withEntriesOfType<T extends keyof EntryMap>(
   handler: (entry: EntryMap[T]) => void,
 ) {
   try {
-    const initialEntries = performance.getEntriesByType(type);
+    // Can't use getEntriesByType() without causing deprecation warnings on
+    // Chrome with some types, so we get all and filter it ourselves
+    const initialEntries = performance
+      .getEntries()
+      .filter((entry) => entry.entryType === type);
     initialEntries.forEach((entry) => handler(entry as EntryMap[T]));
 
     if (!hasGlobal('PerformanceObserver')) {


### PR DESCRIPTION
## Description

Closes #1090

Get rid of a deprecation warning that gets logged by Chrome when certain types like `longtask` are used with `window.performance.getEntriesByType()` by using `window.performance.getEntries()` and doing the filtering ourselves.

## Type of change

- [x] `performance` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
