### PR TITLE
[useful-types] Update Deep Partial

### DIFF
--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Updated `DeepPartial`. [[#2078](https://github.com/Shopify/quilt/pull/2094)]
 
 ## 3.0.5 - 2021-09-24
 

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -15,13 +15,13 @@ export type ArrayElement<T> = T extends (infer U)[] ? U : never;
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? DeepPartial<U>[]
-    : T[P] extends ReadonlyArray<infer U>
-    ? ReadonlyArray<DeepPartial<U>>
-    : DeepPartial<T[P]>;
-};
+export type DeepPartial<T> = T extends Function
+  ? T
+  : T extends object
+  ? T extends unknown[]
+    ? DeepPartial<T[number]>[]
+    : {[P in keyof T]?: DeepPartial<T[P]>}
+  : T;
 
 export type IfEmptyObject<Obj, If, Else = never> = keyof Obj extends {
   length: 0;


### PR DESCRIPTION
Co-authored-by: Pedro Durek <pedro.durek@shopify.com>

## Description

The way `DeepPartial` is implemented doesn’t work as it should when we have nested objects with array elements. In some cases, we don't expect `undefined` in array elements.

For example, `DeepPartial` for `{ bar: (string | number)[] | null }` resolves to 
`{ bar?: (string | number | undefined)[] | null | undefined }`
 rather than
 `{ bar?: (string | number)[] | null | undefined }`

Here is the full example: https://tsplay.dev/mAv88W

This PR aims to solve cases like this, but still turn all elements partial.

Here is the final result: https://tsplay.dev/mpv0xw

This approach will only work for typescript 3.7+, where `Recursive Type Aliases` was implemented. Right now, our helpers support typescript 3.5+.

Alternatively, If we want to support people who rely on old TS versions (3.5 and 3.6), we can use `typesVersions` to keep both versions. https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
