### PR TITLE
Add date functions from @shopify/javascript-utils/dates

### DIFF
--- a/packages/dates/CHANGELOG.md
+++ b/packages/dates/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added getDateDiff and isPastDate functions [[#2099](https://github.com/Shopify/quilt/pull/2099)]
 
 ## 1.0.11 - 2021-12-01
 

--- a/packages/dates/src/get-date-diff.ts
+++ b/packages/dates/src/get-date-diff.ts
@@ -1,0 +1,9 @@
+import {TimeUnit} from './constants';
+
+export function getDateDiff(
+  resolution: TimeUnit,
+  date: Date,
+  today = new Date(),
+) {
+  return Math.floor((today.getTime() - date.getTime()) / resolution);
+}

--- a/packages/dates/src/index.ts
+++ b/packages/dates/src/index.ts
@@ -1,5 +1,6 @@
 export * from './apply-time-zone-offset';
 export * from './constants';
+export * from './get-date-diff';
 export * from './get-date-time-parts';
 export * from './get-time-zone-offset';
 export * from './is-future-date';
@@ -10,6 +11,7 @@ export * from './is-less-than-one-week-ago';
 export * from './is-less-than-one-week-away';
 export * from './is-less-than-one-year-ago';
 export * from './is-less-than-one-year-away';
+export * from './is-past-date';
 export * from './is-same-day';
 export * from './is-same-month';
 export * from './is-same-year';

--- a/packages/dates/src/is-past-date.ts
+++ b/packages/dates/src/is-past-date.ts
@@ -1,0 +1,3 @@
+export function isPastDate(date: Date, now = new Date()) {
+  return now > date;
+}

--- a/packages/dates/src/tests/get-date-diff.test.ts
+++ b/packages/dates/src/tests/get-date-diff.test.ts
@@ -1,0 +1,79 @@
+import {TimeUnit} from '../constants';
+import {getDateDiff} from '../get-date-diff';
+
+describe('getDateDiff()', () => {
+  const now = new Date(2019, 1, 1);
+  const testDate = new Date(now.getTime());
+  testDate.setFullYear(now.getFullYear() - 1);
+
+  it('returns expected diff in seconds', () => {
+    const diff = getDateDiff(TimeUnit.Second, testDate, now);
+    expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Second);
+  });
+
+  it('returns expected diff in minutes', () => {
+    const diff = getDateDiff(TimeUnit.Minute, testDate, now);
+    expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Minute);
+  });
+
+  it('returns expected diff in hours', () => {
+    const diff = getDateDiff(TimeUnit.Hour, testDate, now);
+    expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Hour);
+  });
+
+  it('returns expected diff in days', () => {
+    const diff = getDateDiff(TimeUnit.Day, testDate, now);
+    expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Day);
+  });
+
+  it('returns expected diff in weeks', () => {
+    const diff = getDateDiff(TimeUnit.Week, testDate, now);
+    expect(diff).toStrictEqual(Math.floor(TimeUnit.Year / TimeUnit.Week));
+  });
+
+  it('returns expected diff in years', () => {
+    const diff = getDateDiff(TimeUnit.Year, testDate, now);
+    expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Year);
+  });
+
+  describe('second date defaults to today', () => {
+    beforeEach(() => {
+      jest.useFakeTimers('modern');
+      jest.setSystemTime(now);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('returns expected diff in seconds', () => {
+      const diff = getDateDiff(TimeUnit.Second, testDate);
+      expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Second);
+    });
+
+    it('returns expected diff in minutes', () => {
+      const diff = getDateDiff(TimeUnit.Minute, testDate);
+      expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Minute);
+    });
+
+    it('returns expected diff in hours', () => {
+      const diff = getDateDiff(TimeUnit.Hour, testDate);
+      expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Hour);
+    });
+
+    it('returns expected diff in days', () => {
+      const diff = getDateDiff(TimeUnit.Day, testDate);
+      expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Day);
+    });
+
+    it('returns expected diff in weeks', () => {
+      const diff = getDateDiff(TimeUnit.Week, testDate);
+      expect(diff).toStrictEqual(Math.floor(TimeUnit.Year / TimeUnit.Week));
+    });
+
+    it('returns expected diff in years', () => {
+      const diff = getDateDiff(TimeUnit.Year, testDate);
+      expect(diff).toStrictEqual(TimeUnit.Year / TimeUnit.Year);
+    });
+  });
+});

--- a/packages/dates/src/tests/is-past-date.test.ts
+++ b/packages/dates/src/tests/is-past-date.test.ts
@@ -1,0 +1,29 @@
+import {clock} from '@shopify/jest-dom-mocks';
+
+import {isPastDate} from '../is-past-date';
+
+describe('isPastDate()', () => {
+  it('returns false if input date is the same as present datetime', () => {
+    clock.mock(new Date('2018-01-01T00:00:00.000+00:00'));
+    const date = new Date('2018-01-01T00:00:00.000+00:00');
+
+    expect(isPastDate(date)).toBe(false);
+    clock.restore();
+  });
+
+  it('returns false if input date is after present datetime', () => {
+    clock.mock(new Date('2018-01-01T00:00:00.000+00:00'));
+    const date = new Date('2018-01-02T00:00:00.000+00:00');
+
+    expect(isPastDate(date)).toBe(false);
+    clock.restore();
+  });
+
+  it('returns true if input date is before present datetime', () => {
+    clock.mock(new Date('2018-01-02T00:00:00.000+00:00'));
+    const date = new Date('2018-01-01T00:00:00.000+00:00');
+
+    expect(isPastDate(date)).toBe(true);
+    clock.restore();
+  });
+});


### PR DESCRIPTION
## Description

Added functionality from [@shopiyfy/javascript-utilities/dates](https://github.com/Shopify/javascript-utilities/blob/master/src/dates.ts) so that it's easier to replace those dependencies with `@shopify/dates`.

 - `getDateDiff()` added to `/get-date-diff.ts`
   - Tests use [fake timers](https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers) because typescript takes issue with `spyOn(global, 'Date')`
 - `isPastDate()` added in `/is-past-date.ts`
   - Replaces isDateBefore() from javascript-utilities
   - Named to be the reverse of existing `isFutureDate()` 
<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] @shopify/dates Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
