### PR TITLE
[Quilt Rails]: Ignore any problem with performance report and process in background

### DIFF
--- a/gems/quilt_rails/CHANGELOG.md
+++ b/gems/quilt_rails/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- quilt_rails: Make performance report always success and process in background ([3226](https://github.com/Shopify/shopstatus/pull/3226))
+
 ## 3.5.4 - 2021-11-22
 
 ### Fixed

--- a/gems/quilt_rails/app/controllers/quilt/performance_report_controller.rb
+++ b/gems/quilt_rails/app/controllers/quilt/performance_report_controller.rb
@@ -5,12 +5,15 @@ module Quilt
     include Quilt::Performance::Reportable
     protect_from_forgery with: :null_session
 
-    def create
-      process_report
+    MAX_THREADS = 25
 
-      render(json: { result: 'success' }, status: 200)
-    rescue ActionController::ParameterMissing => error
-      render(json: { error: error.message, status: 422 })
+    def create
+      Thread.new do
+        process_report
+      rescue # rubocop:disable Lint/SuppressedException
+      end if Thread.list.count < MAX_THREADS
+
+      render(plain: '{"result":"success"}', status: 200)
     end
   end
 end


### PR DESCRIPTION
## Description

Performance report is a proxy controller that broke shopstatus' SLO
when users tried to send bad request.

Update the code to ignore any exceptions from reporting and run process in background.

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)