### PR TITLE
feat: new markdown transform `addBaseLinkUrl`

### DIFF
--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- New transform `addBaseLinkUrl()` that transforms relative links to absolute
+- New transform `addBaseLinkUrl()` add a base URL string to web links [[#2105])](https://github.com/Shopify/quilt/pull/2105)]
 
 ## 1.2.0 - 2021-11-24
 

--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- New transform `addBaseLinkUrl()` add a base URL string to web links [[#2105])](https://github.com/Shopify/quilt/pull/2105)]
+- New transform `addBaseLinkUrl()` adds a base URL string to web links [[#2105])](https://github.com/Shopify/quilt/pull/2105)]
 
 ## 1.2.0 - 2021-11-24
 

--- a/packages/ast-utilities/CHANGELOG.md
+++ b/packages/ast-utilities/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- New transform `addBaseLinkUrl()` that transforms relative links to absolute
 
 ## 1.2.0 - 2021-11-24
 

--- a/packages/ast-utilities/README.md
+++ b/packages/ast-utilities/README.md
@@ -208,4 +208,18 @@ console.log(result); // <Foo><Bar>{qux}</Bar></Foo>;
 
 ## Markdown
 
+### `addBaseLinkUrl(base: string)`
+
+Use this transform to add a base URL string to web links beginning with a slash (`/`).
+
+```tsx
+import {transform, addBaseLinkUrl} from '@shopify/ast-transforms/markdown';
+
+const initial = `This is a sentence [this is a link](/path/to/dir).`;
+
+const result = await transform(initial, addBaseLinkUrl('https://shopify.dev'));
+
+console.log(result); // This is a sentence [this is a link](https://shopify.dev/path/to/dir).
+```
+
 ### `addReleaseToChangelog(object)`

--- a/packages/ast-utilities/src/markdown/index.ts
+++ b/packages/ast-utilities/src/markdown/index.ts
@@ -1,2 +1,2 @@
 export {transform} from './transform';
-export {addReleaseToChangelog} from './transforms';
+export {addReleaseToChangelog, addBaseLinkUrl} from './transforms';

--- a/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/addBaseLinkUrl.ts
+++ b/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/addBaseLinkUrl.ts
@@ -1,0 +1,33 @@
+import {isAbsolute} from 'path';
+
+import build from 'unist-builder';
+
+export default function addBaseLinkUrl(base: string) {
+  return function addBaseLinkUrlPlugin() {
+    const transformer = transformLinks(base);
+
+    return (tree) => transformer(tree);
+  };
+}
+
+const transformLinks = (base) => (node) => {
+  if (Array.isArray(node.children) && node.children.length > 0) {
+    node.children = node.children.map(transformLinks(base)).filter((x) => x);
+  }
+
+  if (node.type === 'link' && !isWebLink(node.url) && isAbsolute(node.url)) {
+    const newLinkNode = build('link', {
+      ...node,
+      url: `${base}${node.url}`,
+    });
+
+    return newLinkNode;
+  }
+
+  return node;
+};
+
+const isWebLink = (url) => {
+  const regex = new RegExp('^(?:[a-z]+:)?//', 'i');
+  return regex.test(url);
+};

--- a/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/addBaseLinkUrl.ts
+++ b/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/addBaseLinkUrl.ts
@@ -15,7 +15,7 @@ const transformLinks = (base) => (node) => {
     node.children = node.children.map(transformLinks(base)).filter((x) => x);
   }
 
-  if (node.type === 'link' && !isWebLink(node.url) && isAbsolute(node.url)) {
+  if (node.type === 'link' && !hasProtocol(node.url) && isAbsolute(node.url)) {
     const newLinkNode = build('link', {
       ...node,
       url: `${base}${node.url}`,
@@ -27,7 +27,8 @@ const transformLinks = (base) => (node) => {
   return node;
 };
 
-const isWebLink = (url) => {
-  const regex = new RegExp('^(?:[a-z]+:)?//', 'i');
-  return regex.test(url);
+const PROTOCOL_REGEX = /^(?:[a-z]+:)?\/\//i;
+
+const hasProtocol = (url) => {
+  return PROTOCOL_REGEX.test(url);
 };

--- a/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/index.ts
+++ b/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/index.ts
@@ -1,0 +1,3 @@
+import addBaseLinkUrl from './addBaseLinkUrl';
+
+export default addBaseLinkUrl;

--- a/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/tests/addBaseLinkUrl.test.ts
+++ b/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/tests/addBaseLinkUrl.test.ts
@@ -7,8 +7,8 @@ describe('addBaseLinkUrl', () => {
     const initial = `This is a sentence [this is a relative link](/path/to/dir).`;
     const result = await transform(initial, addBaseLinkUrl(base));
 
-    expect(format(result.toString())).toBe(
-      format(
+    expect(strip(result.toString())).toBe(
+      strip(
         `This is a sentence [this is a relative link](https://shopify.dev/path/to/dir).`,
       ),
     );
@@ -19,7 +19,7 @@ describe('addBaseLinkUrl', () => {
     const initial = `This is a sentence [this is an absolute link](https://www.shopify.com).`;
     const result = await transform(initial, addBaseLinkUrl(base));
 
-    expect(format(result.toString())).toBe(format(initial));
+    expect(strip(result.toString())).toBe(strip(initial));
   });
 
   it('does not transform a relative paths', async () => {
@@ -27,7 +27,7 @@ describe('addBaseLinkUrl', () => {
     const initial = `This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).`;
     const result = await transform(initial, addBaseLinkUrl(base));
 
-    expect(format(result.toString())).toBe(format(initial));
+    expect(strip(result.toString())).toBe(strip(initial));
   });
 
   it('supports multiple links', async () => {
@@ -43,8 +43,8 @@ This is a sentence [this is a relative link](/path/to/dir).
 `;
     const result = await transform(initial, addBaseLinkUrl(base));
 
-    expect(format(result.toString())).toBe(
-      format(`
+    expect(strip(result.toString())).toBe(
+      strip(`
 This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).
 
 This is a sentence [this is a relative link](https://shopify.dev/path/to/dir).
@@ -57,17 +57,6 @@ This is a sentence [this is a relative link](https://shopify.dev/path/to/dir).
   });
 });
 
-function format(str: string) {
-  return (
-    str
-      // outdent
-      .replace(/(^\s+|\s+$)/g, '')
-      // replace line breaks
-      .replace(/(\r\n|\n|\r)/gm, '')
-      // replace spaces in curly braces
-      .replace(/{ /g, '{')
-      .replace(/ }/g, '}')
-      // replace double with single quotes
-      .replace(/"/g, `'`)
-  );
+function strip(str: string) {
+  return str.replace(/(^\s+|\s+$)/g, '');
 }

--- a/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/tests/addBaseLinkUrl.test.ts
+++ b/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/tests/addBaseLinkUrl.test.ts
@@ -22,7 +22,7 @@ describe('addBaseLinkUrl', () => {
     expect(strip(result.toString())).toBe(strip(initial));
   });
 
-  it('does not transform a relative paths', async () => {
+  it('does not transform relative paths', async () => {
     const base = 'https://shopify.dev';
     const initial = `This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).`;
     const result = await transform(initial, addBaseLinkUrl(base));

--- a/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/tests/addBaseLinkUrl.test.ts
+++ b/packages/ast-utilities/src/markdown/transforms/addBaseLinkUrl/tests/addBaseLinkUrl.test.ts
@@ -1,0 +1,73 @@
+import {transform} from '../../../transform';
+import addBaseLinkUrl from '../addBaseLinkUrl';
+
+describe('addBaseLinkUrl', () => {
+  it('adds a base to url paths', async () => {
+    const base = 'https://shopify.dev';
+    const initial = `This is a sentence [this is a relative link](/path/to/dir).`;
+    const result = await transform(initial, addBaseLinkUrl(base));
+
+    expect(format(result.toString())).toBe(
+      format(
+        `This is a sentence [this is a relative link](https://shopify.dev/path/to/dir).`,
+      ),
+    );
+  });
+
+  it('does not transform absolute URLs', async () => {
+    const base = 'https://shopify.dev';
+    const initial = `This is a sentence [this is an absolute link](https://www.shopify.com).`;
+    const result = await transform(initial, addBaseLinkUrl(base));
+
+    expect(format(result.toString())).toBe(format(initial));
+  });
+
+  it('does not transform a relative paths', async () => {
+    const base = 'https://shopify.dev';
+    const initial = `This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).`;
+    const result = await transform(initial, addBaseLinkUrl(base));
+
+    expect(format(result.toString())).toBe(format(initial));
+  });
+
+  it('supports multiple links', async () => {
+    const base = 'https://shopify.dev';
+    const initial = `
+This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).
+
+This is a sentence [this is a relative link](/path/to/dir).
+
+- This is a sentence [this is an absolute link](https://www.shopify.com).
+- This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).
+- This is a sentence [this is a relative link](/path/to/dir).
+`;
+    const result = await transform(initial, addBaseLinkUrl(base));
+
+    expect(format(result.toString())).toBe(
+      format(`
+This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).
+
+This is a sentence [this is a relative link](https://shopify.dev/path/to/dir).
+
+- This is a sentence [this is an absolute link](https://www.shopify.com).
+- This is a sentence [this is a relative link with leading dot dots](../../path/to/dir).
+- This is a sentence [this is a relative link](https://shopify.dev/path/to/dir).
+    `),
+    );
+  });
+});
+
+function format(str: string) {
+  return (
+    str
+      // outdent
+      .replace(/(^\s+|\s+$)/g, '')
+      // replace line breaks
+      .replace(/(\r\n|\n|\r)/gm, '')
+      // replace spaces in curly braces
+      .replace(/{ /g, '{')
+      .replace(/ }/g, '}')
+      // replace double with single quotes
+      .replace(/"/g, `'`)
+  );
+}

--- a/packages/ast-utilities/src/markdown/transforms/index.ts
+++ b/packages/ast-utilities/src/markdown/transforms/index.ts
@@ -1,1 +1,2 @@
 export {default as addReleaseToChangelog} from './addReleaseToChangelog';
+export {default as addBaseLinkUrl} from './addBaseLinkUrl';


### PR DESCRIPTION
## Description

Adds a new markdown transform `addBaseLinkUrl(base: string)`  to add a base URL string to web links beginning with a slash (`/`).


#### Example
```tsx
import {transform, addBaseLinkUrl} from '@shopify/ast-transforms/markdown';

const initial = `This is a sentence [this is a link](/path/to/dir).`;
const result = await transform(initial, addBaseLinkUrl('https://shopify.dev'));

console.log(result); // This is a sentence [this is a link](https://shopify.dev/path/to/dir).
```

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
