### PR TITLE
[@shopify/storybook-a11y-test] Use @axe-core/puppeteer

### DIFF
--- a/packages/storybook-a11y-test/CHANGELOG.md
+++ b/packages/storybook-a11y-test/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Updated to use @axe-core/puppeteer for running tests to make it compatible with storybook 6.4.x. [[#2106](https://github.com/Shopify/quilt/pull/2106)]
 
 ## 0.3.0 - 2021-09-24
 

--- a/packages/storybook-a11y-test/package.json
+++ b/packages/storybook-a11y-test/package.json
@@ -31,7 +31,8 @@
   "devDependencies": {
     "@storybook/addon-a11y": "^6.3.8",
     "@storybook/client-api": "^6.3.8",
-    "axe-core": "4.3.3"
+    "axe-core": "4.3.3",
+    "@axe-core/puppeteer": "4.3.2"
   },
   "peerDependencies": {
     "@storybook/addon-a11y": ">=6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,13 @@
   dependencies:
     tslib "~2.0.1"
 
+"@axe-core/puppeteer@4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@axe-core/puppeteer/-/puppeteer-4.3.2.tgz#196748648ce1c5bcf537395441f4ae3b8d9190e9"
+  integrity sha512-/0Od30pNxUr00cO20pndz2n/b5DyYrkAKBBXlpTAbAMPuLtz6JnavR9A1oQMDyBeoQDNbKr7B97FRYSNPPgI9Q==
+  dependencies:
+    axe-core "^4.3.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
@@ -4347,6 +4354,11 @@ axe-core@4.3.3, axe-core@^4.0.2, axe-core@^4.2.0:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
   integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
+
+axe-core@^4.3.3:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
+  integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
 axobject-query@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description

This updates the `@shopify/storybook-a11y-test` package to be compatible with the changes storybook introduced in `6.4.0`. They changed the way global variables are handled in the iframe and we can no longer access `axe` the way we were in these tests. I instead updated it to use `@axe-core/puppeteer` which handle the injection into the iframe for us.

You can see the a11y tests erroring out in this PR here: https://github.com/Shopify/polaris-react/pull/4796

And I tested the output of these changes in the build here: https://github.com/Shopify/polaris-react/runs/4471933720?check_suite_focus=true

## Type of change
- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] `@shopify/storybook-a11y-test` Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
