### PR TITLE
Add .length getter to jest-dom-mock Storage

### DIFF
--- a/packages/jest-dom-mocks/CHANGELOG.md
+++ b/packages/jest-dom-mocks/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Added `length` prop to storage mock [[#2107](https://github.com/Shopify/quilt/pull/2107)]
 
 ## 3.0.10 - 2021-12-01
 

--- a/packages/jest-dom-mocks/src/storage.ts
+++ b/packages/jest-dom-mocks/src/storage.ts
@@ -11,6 +11,10 @@ export default class Storage {
     [key: string]: string;
   } = Object.create(null);
 
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
   restore() {
     this.getItem.mockClear();
     this.getItem.mockImplementation(this.unmockedGetItem);


### PR DESCRIPTION
## Description

When trying to write tests that were trying to utilize the Storage mock, I was unable to use the length feature from the Storage object. 

This change should allow us to use the length property of Storage.

https://developer.mozilla.org/en-US/docs/Web/API/Storage/length

## Type of change

I'm not sure if this is worthy of a minor bump or just a patch, since it's functionality that exists on Storage and not in this library, I feel like a Patch is appropriate. 

- [x] `jest-dom-mock` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)