### PR TITLE
[WIP] update react to v18 rc

### DIFF
--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -9,6 +9,7 @@
     "strictBindCallApply": false,
     "strictFunctionTypes": false,
     "noImplicitAny": false,
-    "typeRoots": ["../../node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types"],
+    "types": ["react/next", "react-dom/next"]
   }
 }

--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -9,7 +9,6 @@
     "strictBindCallApply": false,
     "strictFunctionTypes": false,
     "noImplicitAny": false,
-    "typeRoots": ["../../node_modules/@types"],
-    "types": ["react/next", "react-dom/next"]
+    "typeRoots": ["../../node_modules/@types"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "plop": "^2.6.0",
     "prettier": "~2.0.4",
     "puppeteer": "^10.4.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.0.0-rc.0",
+    "react-dom": "18.0.0-rc.0",
     "rimraf": "^2.6.2",
     "typescript": "^4.3.5",
     "yalc": "^1.0.0-pre.50"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "@shopify/loom-plugin-typescript": "^0.8.0",
     "@shopify/typescript-configs": "^5.0.0",
     "@types/faker": "^4.1.5",
-    "@types/react": "17.0.13",
-    "@types/react-dom": "^17.0.8",
+    "@types/react": "^17.0.37",
+    "@types/react-dom": "^17.0.11",
     "apollo-cache-inmemory": "^1.3.6",
     "apollo-client": "^2.3.8",
     "babel-loader": "^8.0.6",
@@ -79,8 +79,6 @@
     "yalc": "^1.0.0-pre.50"
   },
   "resolutions": {
-    "@types/react": "17.0.13",
-    "@types/react-dom": "17.0.8",
     "get-port": "^5.1.0"
   }
 }

--- a/packages/react-app-bridge-universal-provider/package.json
+++ b/packages/react-app-bridge-universal-provider/package.json
@@ -28,7 +28,7 @@
     "@shopify/react-html": "^11.1.11"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^3.0.10",

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -40,7 +40,7 @@
     "@shopify/useful-types": "^3.0.5"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-bugsnag/package.json
+++ b/packages/react-bugsnag/package.json
@@ -28,7 +28,7 @@
     "@bugsnag/plugin-react": "^7.1.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -27,7 +27,7 @@
     "hoist-non-react-statics": "^3.0.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -29,8 +29,8 @@
     "cookie": "^0.4.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-csrf-universal-provider/package.json
+++ b/packages/react-csrf-universal-provider/package.json
@@ -29,7 +29,7 @@
     "@shopify/react-universal-provider": "^2.1.11"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@shopify/react-effect": "^4.1.7",

--- a/packages/react-csrf/package.json
+++ b/packages/react-csrf/package.json
@@ -24,7 +24,7 @@
     "node": ">=12.14.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -30,9 +30,6 @@
   "engines": {
     "node": ">=12.14.0"
   },
-  "devDependencies": {
-    "@types/react-dom": "^16.0.11"
-  },
   "files": [
     "build/",
     "!build/*.tsbuildinfo",

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -45,8 +45,8 @@
     "server.esnext"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -27,7 +27,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@shopify/useful-types": "^3.0.5",

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -24,7 +24,7 @@
     "node": ">=12.14.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@types/faker": "^4.1.5",

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -27,7 +27,7 @@
     "@shopify/react-import-remote": "^2.1.13"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -34,7 +34,7 @@
     "apollo-link-context": ">=1.0.0 <2.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@shopify/react-effect": "^4.1.7"

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -49,7 +49,7 @@
     "index.esnext"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Shopify/quilt/issues"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "homepage": "https://github.com/Shopify/quilt/blob/main/packages/react-hooks/README.md",
   "engines": {

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -38,8 +38,8 @@
     "serialize-javascript": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@shopify/react-testing": "^3.3.0",

--- a/packages/react-hydrate/package.json
+++ b/packages/react-hydrate/package.json
@@ -31,7 +31,7 @@
     "faker": "^4.1.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -29,7 +29,7 @@
     "@shopify/react-i18n": "^6.2.8"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@shopify/react-effect": "^4.1.7",

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -63,7 +63,7 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "optionalDependencies": {
     "@babel/template": "^7.0.0",

--- a/packages/react-idle/package.json
+++ b/packages/react-idle/package.json
@@ -28,7 +28,7 @@
     "@shopify/useful-types": "^3.0.5"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -30,7 +30,7 @@
     "@shopify/useful-types": "^3.0.5"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -32,7 +32,7 @@
     "index.esnext"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "koa": "^2.5.0",
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -27,7 +27,7 @@
     "@shopify/performance": "^2.0.10"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "@shopify/network": "^2.0.4"

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -29,8 +29,8 @@
     "react-router-dom": ">=5.1.0 <6.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -54,16 +54,16 @@
     "get-port": "^5.0.0",
     "memfs": "^3.2.2",
     "node-loader": "^1.0.0",
-    "react": "^17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.0.0-rc.0",
+    "react-dom": "18.0.0-rc.0",
     "saddle-up": "^0.5.4",
     "setimmediate": "^1.0.5",
     "webpack": "^5.38.0"
   },
   "peerDependencies": {
     "cross-fetch": ">=3.0.0",
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "optionalDependencies": {
     "@babel/types": ">=7.0.0",

--- a/packages/react-server/src/webpack-plugin/error/utilities.ts
+++ b/packages/react-server/src/webpack-plugin/error/utilities.ts
@@ -14,7 +14,7 @@ export function errorClientSource() {
     import {showPage} from '@shopify/react-html';
     import Error from 'error';
     const appContainer = document.getElementById('app');
-    ReactDOM.hydrate(React.createElement(Error), appContainer);
+    ReactDOM.hydrateRoot(appContainer, React.createElement(Error));
     showPage();
   `;
 }

--- a/packages/react-server/src/webpack-plugin/webpack-plugin.ts
+++ b/packages/react-server/src/webpack-plugin/webpack-plugin.ts
@@ -132,7 +132,7 @@ function clientSource() {
     const data = getSerialized('quilt-data');
     const url = new URL(window.location.href);
 
-    ReactDOM.hydrate(React.createElement(App, {data, url}), appContainer);
+    ReactDOM.hydrateRoot(appContainer, React.createElement(App, {data, url}));
     showPage();
   `;
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -23,7 +23,7 @@
     "node": ">=12.14.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -50,8 +50,8 @@
     "matchers.esnext"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "module": "index.mjs",
   "esnext": "index.esnext",

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type {} from 'react-dom/next';
 import {createRoot, unmountComponentAtNode} from 'react-dom';
 import {act} from 'react-dom/test-utils';
 import {

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, unmountComponentAtNode} from 'react-dom';
+import {createRoot, unmountComponentAtNode} from 'react-dom';
 import {act} from 'react-dom/test-utils';
 import {
   Arguments,
@@ -197,7 +197,8 @@ export class Root<Props> implements Node<Props> {
     }
 
     this.act(() => {
-      render(
+      const root = createRoot(this.element);
+      root.render(
         <TestWrapper<Props>
           render={this.render}
           ref={(wrapper) => {
@@ -206,7 +207,6 @@ export class Root<Props> implements Node<Props> {
         >
           {this.tree}
         </TestWrapper>,
-        this.element,
       );
     });
   }

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {} from 'react-dom/next';
-import {createRoot, unmountComponentAtNode} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {act} from 'react-dom/test-utils';
 import {
   Arguments,
@@ -197,8 +197,22 @@ export class Root<Props> implements Node<Props> {
       connected.add(this);
     }
 
-    this.act(() => {
-      const root = createRoot(this.element);
+    if (typeof ReactDOM.createRoot === 'undefined') {
+      this.act(() => {
+        ReactDOM.render(
+          <TestWrapper<Props>
+            render={this.render}
+            ref={(wrapper) => {
+              this.wrapper = wrapper;
+            }}
+          >
+            {this.tree}
+          </TestWrapper>,
+          this.element,
+        );
+      });
+    } else {
+      const root = ReactDOM.createRoot(this.element);
       root.render(
         <TestWrapper<Props>
           render={this.render}
@@ -209,7 +223,7 @@ export class Root<Props> implements Node<Props> {
           {this.tree}
         </TestWrapper>,
       );
-    });
+    }
   }
 
   unmount() {
@@ -220,7 +234,7 @@ export class Root<Props> implements Node<Props> {
     }
 
     this.ensureRoot();
-    this.act(() => unmountComponentAtNode(this.element));
+    this.act(() => ReactDOM.unmountComponentAtNode(this.element));
   }
 
   destroy() {

--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -26,7 +26,7 @@
     "@shopify/react-html": "^11.1.11"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-universal-provider/package.json
+++ b/packages/react-universal-provider/package.json
@@ -28,7 +28,7 @@
     "@shopify/react-html": "^11.1.11"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
     "faker": "^4.1.0"

--- a/packages/react-web-worker/package.json
+++ b/packages/react-web-worker/package.json
@@ -29,8 +29,8 @@
     "@shopify/web-worker": "^4.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "files": [
     "build/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,13 +3422,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^16.0.11":
-  version "16.9.14"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
-  integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
-  dependencies:
-    "@types/react" "^16"
-
 "@types/react-dom@^17.0.11":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
@@ -3460,25 +3453,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.13"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.13.tgz#6b7c9a8f2868586ad87d941c02337c6888fb874f"
-  integrity sha512-D/G3PiuqTfE3IMNjLn/DCp6umjVCSvtZTPdtAFy5+Ved6CsdRvivfKeCzw79W4AatShtU4nGqgvOv5Gro534vQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16":
-  version "16.14.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a"
-  integrity sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.37":
+"@types/react@*", "@types/react@^17.0.37":
   version "17.0.37"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
   integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,10 +3422,17 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@17.0.8", "@types/react-dom@^16.0.11", "@types/react-dom@^17.0.8":
-  version "17.0.8"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.8.tgz#3180de6d79bf53762001ad854e3ce49f36dd71fc"
-  integrity sha512-0ohAiJAx1DAUEcY9UopnfwCE9sSMDGnY/oXjWMax6g3RpzmTt2GMyMVAXcbn0mo8XAff0SbQJl2/SBU+hjSZ1A==
+"@types/react-dom@^16.0.11":
+  version "16.9.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
+  integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
+  dependencies:
+    "@types/react" "^16"
+
+"@types/react-dom@^17.0.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
   dependencies:
     "@types/react" "*"
 
@@ -3453,10 +3460,28 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.13":
+"@types/react@*":
   version "17.0.13"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.13.tgz#6b7c9a8f2868586ad87d941c02337c6888fb874f"
   integrity sha512-D/G3PiuqTfE3IMNjLn/DCp6umjVCSvtZTPdtAFy5+Ved6CsdRvivfKeCzw79W4AatShtU4nGqgvOv5Gro534vQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16":
+  version "16.14.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a"
+  integrity sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.37":
+  version "17.0.37"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
+  integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10997,14 +10997,14 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.4.0.tgz#e05e602469f9768234f29c1bad9ec1f4e86145a2"
   integrity sha512-k7QJXuQGWevr/V8hoMJ1wBW9i2CVhBdDXpBf3jy/AAtzVyYtsFqEAT+y+NOGiSG1cmnGTreqm5EFLXlVaKbPLQ==
 
-react-dom@17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@18.0.0-rc.0:
+  version "18.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-rc.0.tgz#aa07044bdd6399ff94c664b2985e2e25948fbf3e"
+  integrity sha512-tdD1n0svTndHBQvVAq/f2Kx7FgQ30CpSLp87/neQKAHPW5WtdgW1sBSwmFAcMQOrmstTuP0M+zRlH86f9kMX/A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.21.0-rc.0"
 
 react-fast-compare@^3.0.1:
   version "3.2.0"
@@ -11111,10 +11111,10 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@17.0.2, react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@18.0.0-rc.0:
+  version "18.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-rc.0.tgz#60bfcf1edd0b35fbeeeca852515c6cc2ce06a6eb"
+  integrity sha512-PawosMBgF8k5Nlc3++ibzjFqPvo1XKv80MNtVYqz3abHHB2w3IpU65sSdSmBd2ooCwVhcp9b1vkx/twqhakNtA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -11645,6 +11645,14 @@ scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
   integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.21.0-rc.0:
+  version "0.21.0-rc.0-next-f2a59df48-20211208"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-rc.0-next-f2a59df48-20211208.tgz#54e18e1d360194fd54b47a00616e46403fcabdf1"
+  integrity sha512-x0oLd3YIih9GHqWTaFYejVe6Au+4TadOWZciAq8m4+Fuo5qCi4/3M35a9irVSIP3+qcg/fCqHKJETT9G0ejD1A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## Description

WIP branch for react v18 rc

Done:
1. Install react & react-dom using the latest rc branch
2. Add rc support for type https://blog.logrocket.com/how-to-use-typescript-with-react-18-alpha/
3. replace ReactDOM.hydrate with ReactDOM.hydrateRoot https://github.com/reactwg/react-18/discussions/5
4. Changes to `act` https://github.com/reactwg/react-18/discussions/102

Todo:
- Libraries that potentially are using external store and need to be updated to support concurrent rendering https://github.com/reactwg/react-18/discussions/86
  - react-html
  - react-graphl
  - react-shortcuts
  - react-i18n
  - react-form
  - react-hooks
  - react-intersection-observer
  - react-idle
  - react-import-remotes

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
