### PR TITLE
Fix dependencies in storybook-a11y-test

### DIFF
--- a/packages/storybook-a11y-test/CHANGELOG.md
+++ b/packages/storybook-a11y-test/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Added `@axe-core/puppeteer` as a direct dependency, rather than relying on consumers having it installed. [[#2116](https://github.com/Shopify/quilt/pull/2116)]
 
 ## 0.4.0 - 2022-01-06
 

--- a/packages/storybook-a11y-test/package.json
+++ b/packages/storybook-a11y-test/package.json
@@ -24,15 +24,14 @@
     "node": ">=12.14.0"
   },
   "dependencies": {
+    "@axe-core/puppeteer": "^4.3.2",
     "chalk": "^4.1.0",
     "p-map": "^4.0.0",
     "puppeteer": "^10.4.0"
   },
   "devDependencies": {
-    "@axe-core/puppeteer": "4.3.2",
     "@storybook/addon-a11y": "^6.3.8",
-    "@storybook/client-api": "^6.3.8",
-    "axe-core": "4.3.3"
+    "@storybook/client-api": "^6.3.8"
   },
   "peerDependencies": {
     "@storybook/addon-a11y": ">=6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@
   dependencies:
     tslib "~2.0.1"
 
-"@axe-core/puppeteer@4.3.2":
+"@axe-core/puppeteer@^4.3.2":
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@axe-core/puppeteer/-/puppeteer-4.3.2.tgz#196748648ce1c5bcf537395441f4ae3b8d9190e9"
   integrity sha512-/0Od30pNxUr00cO20pndz2n/b5DyYrkAKBBXlpTAbAMPuLtz6JnavR9A1oQMDyBeoQDNbKr7B97FRYSNPPgI9Q==
@@ -4349,11 +4349,6 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-
-axe-core@4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
-  integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
 
 axe-core@^4.0.2, axe-core@^4.2.0, axe-core@^4.3.3:
   version "4.3.5"


### PR DESCRIPTION
## Description

I tried to use `@shopify/storybook-a11y-test`  but it broke because it depends on `@axe-core/puppeteer` but that is was only marked as a dev dependency.

This PR:

- Moves @axe-core/puppeteer to be a direct dependency
- Removes the dev dependency on axe-core, by extracting the types from the
  call signature of @axe-core/puppeteer's analyze command.

## Type of change
 
- `@shopify/storybook-a11y-test`: patch
