### PR TITLE
[react-shortcuts]Fix node and allow to override ignored input tags

### DIFF
--- a/packages/react-shortcuts/CHANGELOG.md
+++ b/packages/react-shortcuts/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- **Minor** Expose `acceptedDefaultIgnoredTags` to flag which default ignored tags you want to bypass (textarea, select, input) [#2125](https://github.com/Shopify/quilt/pull/2125)
+
+### Fixed
+
+- Fix issue with shortcuts not triggered when `node` is provided and focused [#2125](https://github.com/Shopify/quilt/pull/2125)
 
 ## 4.1.7 - 2021-11-23
 

--- a/packages/react-shortcuts/README.md
+++ b/packages/react-shortcuts/README.md
@@ -65,6 +65,10 @@ export interface Props {
     a boolean that lets you opt out of swallowing the key event and let it propagate
   */
   allowDefault?: boolean;
+  /*
+    an array of DefaultIgnoredTag allowing you to flag which default ignored tags you want to bypass (textarea, input, select)
+  */
+  acceptedDefaultIgnoredTags?: DefaultIgnoredTag[];
 }
 ```
 

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,12 +1,13 @@
 import Key, {HeldKey} from '../keys';
 
-import useShortcut from './hooks';
+import useShortcut, {DefaultIgnoredTag} from './hooks';
 
 export interface Props {
   ordered: Key[];
   held?: HeldKey;
   node?: HTMLElement | null;
   ignoreInput?: boolean;
+  acceptedDefaultIgnoredTags?: DefaultIgnoredTag[];
   onMatch(matched: {ordered: Key[]; held?: HeldKey}): void;
   allowDefault?: boolean;
 }

--- a/packages/react-shortcuts/src/Shortcut/hooks.ts
+++ b/packages/react-shortcuts/src/Shortcut/hooks.ts
@@ -3,6 +3,10 @@ import React from 'react';
 import {ShortcutContext} from '../ShortcutProvider';
 import Key, {HeldKey} from '../keys';
 
+const DEFAULT_IGNORED_TAGS = ['INPUT', 'SELECT', 'TEXTAREA'] as const;
+
+export type DefaultIgnoredTag = typeof DEFAULT_IGNORED_TAGS[number];
+
 export interface Subscription {
   unsubscribe(): void;
 }
@@ -11,6 +15,7 @@ export interface Options {
   held?: HeldKey;
   node?: HTMLElement | null;
   ignoreInput?: boolean;
+  acceptedDefaultIgnoredTags?: DefaultIgnoredTag[];
   allowDefault?: boolean;
 }
 
@@ -21,13 +26,15 @@ export default function useShortcut(
 ) {
   const shortcutManager = React.useContext(ShortcutContext);
   const subscription = React.useRef<Subscription | null>(null);
-  const {node, held, ignoreInput, allowDefault} = options;
+  const {
+    node,
+    held,
+    ignoreInput,
+    acceptedDefaultIgnoredTags,
+    allowDefault,
+  } = options;
 
   React.useEffect(() => {
-    if (node != null) {
-      return;
-    }
-
     if (shortcutManager == null) {
       return;
     }
@@ -38,6 +45,7 @@ export default function useShortcut(
       node,
       held,
       ignoreInput: ignoreInput || false,
+      ignoredTags: getIgnoredTags(acceptedDefaultIgnoredTags),
       allowDefault: allowDefault || false,
     });
 
@@ -51,10 +59,21 @@ export default function useShortcut(
   }, [
     node,
     ordered,
-    onMatch,
     held,
     ignoreInput,
+    acceptedDefaultIgnoredTags,
     allowDefault,
     shortcutManager,
+    onMatch,
   ]);
+}
+
+function getIgnoredTags(acceptedDefaultIgnoredTags?: DefaultIgnoredTag[]) {
+  if (!acceptedDefaultIgnoredTags?.length) {
+    return (DEFAULT_IGNORED_TAGS as unknown) as DefaultIgnoredTag[];
+  }
+
+  return DEFAULT_IGNORED_TAGS.filter(
+    (tag) => !acceptedDefaultIgnoredTags.includes(tag),
+  );
 }

--- a/packages/react-shortcuts/src/Shortcut/index.ts
+++ b/packages/react-shortcuts/src/Shortcut/index.ts
@@ -1,5 +1,6 @@
 import Shortcut from './Shortcut';
 
 export {default as useShortcut} from './hooks';
+export type {DefaultIgnoredTag} from './hooks';
 export * from './Shortcut';
 export default Shortcut;

--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -1,4 +1,5 @@
 import Key, {HeldKey, ModifierKey} from '../keys';
+import {DefaultIgnoredTag} from '../Shortcut';
 
 const ON_MATCH_DELAY = 500;
 
@@ -7,8 +8,9 @@ export interface Data {
   ordered: Key[];
   held?: HeldKey;
   ignoreInput: boolean;
-  onMatch(matched: {ordered: Key[]; held?: HeldKey}): void;
+  ignoredTags: DefaultIgnoredTag[];
   allowDefault: boolean;
+  onMatch(matched: {ordered: Key[]; held?: HeldKey}): void;
 }
 
 export default class ShortcutManager {
@@ -83,8 +85,8 @@ export default class ShortcutManager {
       this.shortcutsMatched.length > 0 ? this.shortcutsMatched : this.shortcuts;
 
     this.shortcutsMatched = shortcuts.filter(
-      ({ordered, held, node, ignoreInput}) => {
-        if (isFocusedInput() && !ignoreInput) {
+      ({ordered, held, node, ignoreInput, ignoredTags}) => {
+        if (isFocusedInput(ignoredTags) && !ignoreInput) {
           return false;
         }
 
@@ -131,7 +133,7 @@ export default class ShortcutManager {
   }
 }
 
-function isFocusedInput() {
+function isFocusedInput(ignoredTags: string[]) {
   const target = document.activeElement;
 
   if (target == null || target.tagName == null) {
@@ -139,9 +141,7 @@ function isFocusedInput() {
   }
 
   return (
-    target.tagName === 'INPUT' ||
-    target.tagName === 'SELECT' ||
-    target.tagName === 'TEXTAREA' ||
+    ignoredTags.includes(target.tagName) ||
     target.hasAttribute('contenteditable')
   );
 }

--- a/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
@@ -1,26 +1,44 @@
 import React from 'react';
 
-import Shortcut from '../Shortcut';
+import Shortcut, {DefaultIgnoredTag} from '../Shortcut';
 
 interface Props {
   spy: jest.Mock<{}>;
+  focusNode?: boolean;
+  tagName?: HTMLElement['tagName'];
+  acceptedDefaultIgnoredTags?: DefaultIgnoredTag[];
 }
 
-export default function ShortcutWithFocus(props: Props) {
-  const {spy} = props;
-  const node = React.useRef<HTMLButtonElement | null>(null);
+export default function ShortcutWithFocus({
+  spy,
+  focusNode = true,
+  tagName = 'button',
+  acceptedDefaultIgnoredTags,
+}: Props) {
+  const [node, setNode] = React.useState<HTMLElement | null>(null);
+  const elementWithFocus = React.createElement(tagName, {
+    ref: (element: HTMLElement) => setNode(element),
+  });
 
   React.useEffect(() => {
-    if (!node || !node.current) {
+    if (!node) {
       return;
     }
 
-    node.current.focus();
-  }, [node]);
+    if (focusNode) {
+      node.focus();
+    }
+  }, [node, focusNode]);
+
   return (
     <div className="app">
-      <button type="button" ref={node} />
-      <Shortcut ordered={['z']} onMatch={spy} node={node.current} />
+      {elementWithFocus}
+      <Shortcut
+        ordered={['z']}
+        onMatch={spy}
+        node={node}
+        acceptedDefaultIgnoredTags={acceptedDefaultIgnoredTags}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description

_Taking over for @moimael_ (@loic-d)

This PR fixes:
- A false positive with following test: `calls shortcuts that are scoped to a specific node only when that node is focused`
- Fixes issue with early return in `useShortcut()` preventing shortcut to be registered when `node` is provided
- Exposes a new `ignoreTags` flag allowing consumers to override the default ignored tags (`textarea`, `select`, `input`)

🎩  ping me for links to the Web Admin PR consuming these changes + Spin URL

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
