### PR TITLE
Update react-network to support node http IncomingHttpHeaders type

### DIFF
--- a/packages/react-network/CHANGELOG.md
+++ b/packages/react-network/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Updated types to support nodes http IncomingHttpHeaders types [[#2082](https://github.com/Shopify/quilt/pull/2082)]
 
 ## 4.1.12 - 2021-12-07
 

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -1,3 +1,5 @@
+import {IncomingHttpHeaders} from 'http';
+
 import {StatusCode, CspDirective, Header} from '@shopify/network';
 import {EffectKind} from '@shopify/react-effect';
 
@@ -8,7 +10,7 @@ export {NetworkContext} from './context';
 export const EFFECT_ID = Symbol('network');
 
 interface Options {
-  headers?: {[key: string]: string};
+  headers?: {[key: string]: string} | IncomingHttpHeaders;
   cookies?: Cookie | string;
 }
 
@@ -113,7 +115,9 @@ export class NetworkManager {
   }
 }
 
-function normalizeHeaders(headers: undefined | {[key: string]: string}) {
+function normalizeHeaders(
+  headers: undefined | {[key: string]: string} | IncomingHttpHeaders,
+) {
   if (!headers) {
     return {};
   }


### PR DESCRIPTION
## Description
`@shopify/react-network` NetworkManager header typescript type is currently an object, koa updated it's header signature to be nodes IncomingHttpHeaders type. 
This PR updates the type signature to accept it as well as an object.

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [X] `@shopify/network` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
