### PR TITLE
🐛 react-i18n: Make unformatCurrency callable by its own result

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed `unformatCurrency` to be callable on its own result for locales like `vi` and `it` when a period is a thousands separator. [[#2139](https://github.com/Shopify/quilt/pull/2139)]
 
 ## 6.3.2 - 2022-01-19
 

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -1123,11 +1123,16 @@ describe('I18n', () => {
       it('handles currencies with 3 decimal places', () => {
         const i18n = new I18n(defaultTranslations, {...defaultDetails});
         expect(i18n.unformatCurrency('JOD 123.34', 'JOD')).toBe('123.340');
+        expect(i18n.unformatCurrency('JOD 123.345', 'JOD')).toBe('123.345');
+        expect(i18n.unformatCurrency('JOD 67,123.345', 'JOD')).toBe(
+          '67123.345',
+        );
       });
 
       it('rounds currencies with 3 decimal places', () => {
         const i18n = new I18n(defaultTranslations, {...defaultDetails});
         expect(i18n.unformatCurrency('123.9999', 'JOD')).toBe('124.000');
+        expect(i18n.unformatCurrency('123.4567', 'JOD')).toBe('123.457');
       });
 
       it('handles EUR currency with fr locale', () => {
@@ -1192,6 +1197,54 @@ describe('I18n', () => {
             locale: 'it',
           });
           expect(i18n.unformatCurrency('1,234.50', 'USD')).toBe('1234.50');
+        });
+
+        it('treats . as the decimal symbol if the currency has 3 decimal places and 3 or fewer decimal places are used', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'it',
+          });
+          expect(i18n.unformatCurrency('JOD 123.4', 'JOD')).toBe('123.400');
+          expect(i18n.unformatCurrency('JOD 123.34', 'JOD')).toBe('123.340');
+          expect(i18n.unformatCurrency('JOD 123.345', 'JOD')).toBe('123.345');
+          expect(i18n.unformatCurrency('JOD 67,123.345', 'JOD')).toBe(
+            '67123.345',
+          );
+        });
+
+        it('treats , as the decimal symbol if the currency has 3 decimal places and 4 or more decimal places are used', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'it',
+          });
+          expect(i18n.unformatCurrency('JOD 123.4567', 'JOD')).toBe(
+            '1234567.000',
+          );
+          expect(i18n.unformatCurrency('JOD 123.345678', 'JOD')).toBe(
+            '123345678.000',
+          );
+        });
+
+        it('treats , as the decimal symbol when , is used as the decimal separator and currency has 3 decimal places', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'it',
+          });
+          expect(i18n.unformatCurrency('JOD 123,34', 'JOD')).toBe('123.340');
+          expect(i18n.unformatCurrency('JOD 123,345', 'JOD')).toBe('123.345');
+          expect(i18n.unformatCurrency('JOD 67.123,345', 'JOD')).toBe(
+            '67123.345',
+          );
+          expect(i18n.unformatCurrency('JOD 7.123,34', 'JOD')).toBe('7123.340');
+        });
+
+        it('rounds currencies with 3 decimal places when , is used as the decuaml symbol', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'it',
+          });
+          expect(i18n.unformatCurrency('123,9999', 'JOD')).toBe('124.000');
+          expect(i18n.unformatCurrency('123,4567', 'JOD')).toBe('123.457');
         });
       });
 

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -718,12 +718,13 @@ describe('I18n', () => {
         expect(i18n.unformatNumber('1.234.567,56')).toBe('1234567.56');
       });
 
-      it('does not treat . as the decimal symbol if , is not used as a decimal symbol', () => {
+      it('treats . as the decimal symbol if . is used as a decimal symbol', () => {
         const i18n = new I18n(defaultTranslations, {
           ...defaultDetails,
           locale: 'it',
         });
-        expect(i18n.unformatNumber('1234.50')).toBe('123450');
+        expect(i18n.unformatNumber('1234.50')).toBe('1234.5');
+        expect(i18n.unformatNumber('1234.5')).toBe('1234.5');
       });
     });
 
@@ -738,12 +739,13 @@ describe('I18n', () => {
         expect(i18n.unformatNumber('1.234,56')).toBe('1234.56');
       });
 
-      it('does not treat . as the decimal symbol if , is not used as a decimal symbol', () => {
+      it('treats . as the decimal symbol if . is used as a decimal symbol', () => {
         const i18n = new I18n(defaultTranslations, {
           ...defaultDetails,
           locale: 'vi',
         });
-        expect(i18n.unformatNumber('1234.50')).toBe('123450');
+        expect(i18n.unformatNumber('1234.50')).toBe('1234.5');
+        expect(i18n.unformatNumber('1234.5')).toBe('1234.5');
       });
     });
   });
@@ -1175,12 +1177,13 @@ describe('I18n', () => {
           );
         });
 
-        it('does not treat . as the decimal symbol if , is not used as a thousand symbol and . is used as a decimal symbol', () => {
+        it('treats . as the decimal symbol if , is not used as a thousand symbol and . is used as a decimal symbol', () => {
           const i18n = new I18n(defaultTranslations, {
             ...defaultDetails,
             locale: 'it',
           });
-          expect(i18n.unformatCurrency('1234.50', 'USD')).toBe('123450.00');
+          expect(i18n.unformatCurrency('1234.50', 'USD')).toBe('1234.50');
+          expect(i18n.unformatCurrency('1234.5', 'USD')).toBe('1234.50');
         });
 
         it('treats . as the decimal symbol if , is used as a thousand symbol and . is used as a decimal symbol', () => {
@@ -1202,14 +1205,17 @@ describe('I18n', () => {
           expect(i18n.unformatCurrency('123.456.789', 'VND')).toBe(
             '123456789.00',
           );
+          expect(i18n.unformatCurrency('1.234.56', 'VND')).toBe('123456.00');
         });
 
-        it('does not treat . as the decimal symbol if , is not used as a thousand symbol and . is used as a decimal symbol', () => {
+        it('treats . as the decimal symbol if . is used as a decimal symbol', () => {
           const i18n = new I18n(defaultTranslations, {
             ...defaultDetails,
             locale: 'vi',
           });
-          expect(i18n.unformatCurrency('234.56', 'VND')).toBe('23456.00');
+          expect(i18n.unformatCurrency('234.56', 'VND')).toBe('235.00');
+          expect(i18n.unformatCurrency('1234.56', 'VND')).toBe('1235.00');
+          expect(i18n.unformatCurrency('23.5', 'VND')).toBe('24.00');
         });
 
         it('treats . as the decimal symbol if , is used as a thousand symbol and . is used as a decimal symbol', () => {


### PR DESCRIPTION
## Description

Fixes #2137 

With the [latest change in 6.3.1](https://github.com/Shopify/quilt/pull/2126), if the locale uses a period as a thousands separator, you could not safely call `unformatCurrency` on the original value and its result and get the same result.

Example with Danish locale:
```ts
unformatCurrency('16,32', 'EUR') // '16.32'
unformatCurrency('16.32', 'EUR') // '1632.00'
```

Because some downstream code has this expectation of being able to use `unformatCurrency` on values with English locale formatting, even for locales that use different thousand and decimal separators, the library needs to maintain backwards-compatibility. 

It also needs to support locales like Vietnamese with the Vietnamese đồng currency, which uses a period as a thousands separator and zero decimal places.

### What approach did you choose and why?

I updated `normalizedNumber` to override with English locale number formatting rules in the following circumstances:
- The locale's decimal symbol is not `.` AND
  - The input string has exactly one period AND
  - The input string has `maxDecimalPlaces` or fewer numerals after the period

The `maxDecimalPlaces` variable is the currency's number of decimal places or 2, whichever is higher.
This covers the scenario where `unformatCurrency` is being called for a currency with three digits (e.g. `BHD`) and with a locale that uses a period as a thousands separator (e.g. Italian). In this case, if the input doesn't supply decimal places, the period is assumed to be a decimal symbol with English locale formatting.

For example, in the `it` locale:
```ts
unformatCurrency('123.456', 'BHD') // '123.456'
unformatCurrency('123.456,000', 'BHD') // '123456.000'
unformatCurrency('9.123.456', 'BHD') // '9123456.000'
```

### What should reviewers look for?

I think this PR hits closer to the mark of being backwards-compatible and recognizing English locale formatting while also respecting locales that don't use periods as decimal separators.

Is there anything I might be missing in terms of unanticipated negative impact for other locales and currencies? 
Any missing use cases or test cases?

### Examples

| Locale | Thousand | Decimal | Currency (places) | Value to unformat | Result |
|---|---|---|---|---|---|
| `vi` | `.` | `,` |  |  |  |
|  |  |  | VND (0) | `20.000` | `20000.00` |
|  |  |  | VND (0) | `2.000,00` | `2000.00` |
|  |  |  | VND (0) | `2.000.0` | `20000.00` |
|  |  |  | VND (0) | `2.000.00` | `200000.00` |
|  |  |  | VND (0) | `2000,00` | `2000.00` |
|  |  |  | VND (0) | `200.00` | `200.00` |
|  |  |  | VND (0) | `2000.0` | `2000.00` |
|  |  |  | VND (0) | `2,000.00` | `2000.00` |
|  |  |  | VND (0) | `2,345.67` | `2346.00` |
|  |  |  | USD (2) | `2.345,67` | `2345.67` |
|  |  |  | USD (2) | `2,345.67` | `2345.67` |
|  |  |  | BHD (3) | `2.000` | `2.000` |
|  |  |  | BHD (3) | `2.000.0` | `20000.000` |
|  |  |  | BHD (3) | `2.000,0` | `2000.000` |
|  |  |  | BHD (3) | `2,000.000` | `2000.000` |
|  |  |  | BHD (3) | `2.00` | `2.000` |
| `fr` | ` ` | `,` |  |  |  |
|  |  |  | USD (2) | `1 234,50` | `1234.50` |
|  |  |  | USD (2) | `1234,50` | `1234.50` |
|  |  |  | USD (2) | `1234.50` | `1234.50` |
|  |  |  | USD (2) | `1,234.50` | `1234.50` |
|  |  |  | USD (2) | `1,234` | `1.23` |
|  |  |  | BHD (3) | `1 234,567` | `1234.567` |
|  |  |  | BHD (3) | `1234.50` | `1234.500` |
|  |  |  | BHD (3) | `1,234.567` | `1234.567` |
| `en` | `,` | `.` |  |  |  |
|  |  |  | USD (2) | `1234.50` | `1234.50` |
|  |  |  | USD (2) | `1,234.50` | `1234.50` |
|  |  |  | USD (2) | `1234` | `1234.00` |
|  |  |  | USD (2) | `1.234` | `1.23` |
|  |  |  | BHD (3) | `1.234` | `1.234` |
|  |  |  | BHD (3) | `1.2345` | `1.235` |
|  |  |  | BHD (3) | `1.1` | `1.100` |
|  |  |  | BHD (3) | `1234` | `1234.000` |
|  |  |  | BHD (3) | `1,234.5` | `1234.500` |

## Type of change

- [x] react-i18n Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
