### PR TITLE
Updates deprecated faker calls in react-performance

### DIFF
--- a/packages/react-performance/src/tests/utilities.ts
+++ b/packages/react-performance/src/tests/utilities.ts
@@ -107,8 +107,8 @@ export function mockNavigation() {
     },
     {
       index: faker.datatype.number(),
-      supportsDetailedEvents: faker.random.boolean(),
-      supportsDetailedTime: faker.random.boolean(),
+      supportsDetailedEvents: faker.datatype.boolean(),
+      supportsDetailedTime: faker.datatype.boolean(),
     },
   );
 }
@@ -133,6 +133,6 @@ export function randomConnection() {
     effectiveType: faker.random.arrayElement(effectiveTypes),
     onchange: null,
     rtt: faker.datatype.number(),
-    saveData: faker.random.boolean(),
+    saveData: faker.datatype.boolean(),
   };
 }


### PR DESCRIPTION
## Description

This is a follow-up to #2140, which itself was a fix to my PR for upgrading Faker at #2132.

There were still a few usages of the deprecated `faker.random.boolean()` in `react-performance` test utility code. This PR cleans up the campsite by switching to `faker.datatype.boolean()`.

## Type of change

This is a change to `react-performance`, but does not involve a change to any published library code.

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
