### PR TITLE
Reorder exports map in @shopify/react-i18n

### DIFF
--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/react-i18n-universal-provider",
-  "version": "2.1.21",
+  "version": "2.1.21-remove-exports-beta.1",
   "license": "MIT",
   "description": "A self-serializing/deserializing i18n provider that works for isomorphic applications",
   "main": "index.js",
@@ -26,7 +26,7 @@
   "dependencies": {
     "@shopify/react-hooks": "^2.1.10",
     "@shopify/react-html": "^11.1.12",
-    "@shopify/react-i18n": "^6.3.2"
+    "@shopify/react-i18n": "^6.3.2-remove-exports-beta.1"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <18.0.0"

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Reorder exports map to prioritize the `esnext` condition. [[#2142](https://github.com/Shopify/quilt/pull/2142)]
 
 ## 6.3.2 - 2022-01-19
 

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/react-i18n",
-  "version": "6.3.2",
+  "version": "6.3.2-remove-exports-beta.1",
   "license": "MIT",
   "description": "i18n utilities for React handling translations, formatting, and more",
   "main": "index.js",
@@ -92,24 +92,24 @@
   "exports": {
     "./": "./",
     "./babel": {
+      "esnext": "./babel.esnext",
       "import": "./babel.mjs",
-      "require": "./babel.js",
-      "esnext": "./babel.esnext"
+      "require": "./babel.js"
     },
     "./generate-dictionaries": {
+      "esnext": "./generate-dictionaries.esnext",
       "import": "./generate-dictionaries.mjs",
-      "require": "./generate-dictionaries.js",
-      "esnext": "./generate-dictionaries.esnext"
+      "require": "./generate-dictionaries.js"
     },
     "./generate-index": {
+      "esnext": "./generate-index.esnext",
       "import": "./generate-index.mjs",
-      "require": "./generate-index.js",
-      "esnext": "./generate-index.esnext"
+      "require": "./generate-index.js"
     },
     ".": {
+      "esnext": "./index.esnext",
       "import": "./index.mjs",
-      "require": "./index.js",
-      "esnext": "./index.esnext"
+      "require": "./index.js"
     }
   }
 }


### PR DESCRIPTION
## Description

https://github.com/Shopify/web/issues/56636

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

Webpack 5 can resolve exports from package.json. Reordering the exports map in `@shopify/react-i18n` ensures that when libraries ship with only commonjs, esm is still compiled.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
