### PR TITLE
[FED] Add support to namespace on @shopify/react-i18n

### DIFF
--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -74,6 +74,7 @@ export class I18n {
   readonly defaultTimezone?: string;
   readonly onError: NonNullable<I18nDetails['onError']>;
   readonly loading: boolean;
+  readonly namespace?: string;
 
   get language() {
     return languageFromLocale(this.locale);
@@ -115,6 +116,7 @@ export class I18n {
       onError,
       loading,
     }: I18nDetails & {loading?: boolean},
+    namespace?: string,
   ) {
     this.locale = locale;
     this.defaultCountry = country;
@@ -123,6 +125,7 @@ export class I18n {
     this.pseudolocalize = pseudolocalize;
     this.onError = onError || this.defaultOnError;
     this.loading = loading || false;
+    this.namespace = namespace;
   }
 
   translate(
@@ -174,7 +177,13 @@ export class I18n {
     }
 
     try {
-      return translate(id, normalizedOptions, this.translations, this.locale);
+      return translate(
+        id,
+        normalizedOptions,
+        this.translations,
+        this.locale,
+        this.namespace,
+      );
     } catch (error) {
       this.onError(error as I18nError);
       return '';

--- a/packages/react-i18n/src/manager.ts
+++ b/packages/react-i18n/src/manager.ts
@@ -20,6 +20,10 @@ export interface RegisterOptions {
   fallback?: TranslationDictionary;
 }
 
+export interface I18nOptions extends RegisterOptions {
+  namespace?: string;
+}
+
 interface TranslationState {
   loading: boolean;
   translations: TranslationDictionary[];

--- a/packages/react-i18n/src/tests/e2e/translations.test.tsx
+++ b/packages/react-i18n/src/tests/e2e/translations.test.tsx
@@ -25,7 +25,6 @@ describe('translations', () => {
         <WithI18nComponent />
       </I18nContext.Provider>,
     );
-
     expect(component.text()).toBe(frTranslations.hello);
   });
 
@@ -56,5 +55,34 @@ describe('translations', () => {
     );
 
     expect(component.text()).toBe(enTranslations.hello);
+  });
+
+  describe('namespace', () => {
+    const translationWithNamespace = {
+      Namespace: {
+        hello: 'Hello',
+      },
+    };
+
+    it('uses namespace and translation map', () => {
+      function WithI18nComponent() {
+        const [i18n] = useI18n({
+          id: 'MyComponent',
+          translations: {en: translationWithNamespace},
+          namespace: 'Namespace',
+        });
+
+        return <div>{i18n.translate('hello')}</div>;
+      }
+
+      const manager = new I18nManager({locale: 'en'});
+      const component = mount(
+        <I18nContext.Provider value={manager}>
+          <WithI18nComponent />
+        </I18nContext.Provider>,
+      );
+
+      expect(component.text()).toBe(translationWithNamespace.Namespace.hello);
+    });
   });
 });

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -243,6 +243,7 @@ describe('I18n', () => {
         {scope: 'ordinal', replacements: {amount: 0}, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
 
       i18n.ordinal(1);
@@ -251,6 +252,7 @@ describe('I18n', () => {
         {scope: 'ordinal', replacements: {amount: 1}, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
 
       i18n.ordinal(2);
@@ -259,6 +261,7 @@ describe('I18n', () => {
         {scope: 'ordinal', replacements: {amount: 2}, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
 
       i18n.ordinal(3);
@@ -267,6 +270,7 @@ describe('I18n', () => {
         {scope: 'ordinal', replacements: {amount: 3}, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
 
       i18n.ordinal(4);
@@ -275,6 +279,7 @@ describe('I18n', () => {
         {scope: 'ordinal', replacements: {amount: 4}, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
 
       i18n.ordinal(42);
@@ -283,6 +288,7 @@ describe('I18n', () => {
         {scope: 'ordinal', replacements: {amount: 42}, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
     });
   });
@@ -303,6 +309,7 @@ describe('I18n', () => {
         {...scope, replacements, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
     });
 
@@ -320,6 +327,7 @@ describe('I18n', () => {
         {replacements, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
     });
 
@@ -337,6 +345,7 @@ describe('I18n', () => {
         {...scope, pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
     });
 
@@ -353,6 +362,7 @@ describe('I18n', () => {
         {pseudotranslate: false},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
     });
 
@@ -372,6 +382,7 @@ describe('I18n', () => {
         {pseudotranslate: true},
         defaultTranslations,
         i18n.locale,
+        undefined,
       );
     });
 
@@ -1447,6 +1458,7 @@ describe('I18n', () => {
           },
           defaultTranslations,
           i18n.locale,
+          undefined,
         );
       });
 
@@ -1477,6 +1489,7 @@ describe('I18n', () => {
           },
           defaultTranslations,
           i18n.locale,
+          undefined,
         );
       });
 
@@ -1506,6 +1519,7 @@ describe('I18n', () => {
           },
           defaultTranslations,
           i18n.locale,
+          undefined,
         );
       });
 
@@ -1535,6 +1549,7 @@ describe('I18n', () => {
           },
           defaultTranslations,
           i18n.locale,
+          undefined,
         );
       });
 
@@ -1565,6 +1580,7 @@ describe('I18n', () => {
           },
           defaultTranslations,
           i18n.locale,
+          undefined,
         );
       });
 
@@ -1597,6 +1613,7 @@ describe('I18n', () => {
           },
           defaultTranslations,
           i18n.locale,
+          undefined,
         );
       });
 
@@ -1628,6 +1645,7 @@ describe('I18n', () => {
           },
           defaultTranslations,
           i18n.locale,
+          undefined,
         );
       });
 
@@ -1650,6 +1668,7 @@ describe('I18n', () => {
             {pseudotranslate: false},
             defaultTranslations,
             i18n.locale,
+            undefined,
           );
         });
 
@@ -1672,6 +1691,7 @@ describe('I18n', () => {
             {pseudotranslate: false, replacements: {count: minutesAgo}},
             defaultTranslations,
             i18n.locale,
+            undefined,
           );
         });
 
@@ -1712,6 +1732,7 @@ describe('I18n', () => {
               },
               defaultTranslations,
               i18n.locale,
+              undefined,
             );
           });
         });
@@ -1771,6 +1792,7 @@ describe('I18n', () => {
               },
               defaultTranslations,
               i18n.locale,
+              undefined,
             );
           });
         });
@@ -1801,6 +1823,7 @@ describe('I18n', () => {
             },
             defaultTranslations,
             i18n.locale,
+            undefined,
           );
         });
 
@@ -1833,6 +1856,7 @@ describe('I18n', () => {
             },
             defaultTranslations,
             i18n.locale,
+            undefined,
           );
         });
       });
@@ -1859,6 +1883,7 @@ describe('I18n', () => {
               },
               defaultTranslations,
               i18n.locale,
+              undefined,
             );
           });
 
@@ -1884,6 +1909,7 @@ describe('I18n', () => {
               },
               defaultTranslations,
               i18n.locale,
+              undefined,
             );
           });
         });
@@ -1917,6 +1943,7 @@ describe('I18n', () => {
               },
               defaultTranslations,
               i18n.locale,
+              undefined,
             );
           });
 
@@ -1948,6 +1975,7 @@ describe('I18n', () => {
               },
               defaultTranslations,
               i18n.locale,
+              undefined,
             );
           });
         });
@@ -1978,6 +2006,7 @@ describe('I18n', () => {
             },
             defaultTranslations,
             i18n.locale,
+            undefined,
           );
         });
 
@@ -2010,6 +2039,7 @@ describe('I18n', () => {
             },
             defaultTranslations,
             i18n.locale,
+            undefined,
           );
         });
 
@@ -2331,6 +2361,37 @@ describe('I18n', () => {
       const i18n = new I18n(defaultTranslations, {locale: 'en'});
 
       expect(i18n.hasEasternNameOrderFormatter()).toStrictEqual(false);
+    });
+  });
+
+  describe('#namespace', () => {
+    const translationWithNamespace = [
+      {
+        Namespace: {
+          foo: 'bar',
+        },
+      },
+    ];
+
+    it('call translate() with namespace Namespace', () => {
+      const mockResult = 'translated string';
+      translate.mockReturnValue(mockResult);
+
+      const i18n = new I18n(
+        translationWithNamespace,
+        {locale: 'en'},
+        'Namespace',
+      );
+      const result = i18n.translate('foo');
+
+      expect(result).toBe(mockResult);
+      expect(translate).toHaveBeenCalledWith(
+        'foo',
+        {pseudotranslate: false},
+        translationWithNamespace,
+        i18n.locale,
+        'Namespace',
+      );
     });
   });
 });

--- a/packages/react-i18n/src/tests/utilities.test.tsx
+++ b/packages/react-i18n/src/tests/utilities.test.tsx
@@ -265,6 +265,50 @@ describe('translate()', () => {
     });
   });
 
+  describe('namespace', () => {
+    it('looks up a translation with a namespace', () => {
+      expect(
+        translate('foo', {}, {Namespace: {foo: 'bar'}}, locale, 'Namespace'),
+      ).toBe('bar');
+    });
+
+    it('looks up a translation with a namespace and a keypath', () => {
+      expect(
+        translate(
+          'foo.bar',
+          {},
+          {Namespace: {foo: {bar: 'baz'}}},
+          locale,
+          'Namespace',
+        ),
+      ).toBe('baz');
+    });
+
+    it('looks up a translation with a namespace and a scope', () => {
+      expect(
+        translate(
+          'bar',
+          {scope: 'foo'},
+          {Namespace: {foo: {bar: 'baz'}}},
+          locale,
+          'Namespace',
+        ),
+      ).toBe('baz');
+    });
+
+    it('looks up a translation with a namespace and an array scope', () => {
+      expect(
+        translate(
+          'baz',
+          {scope: ['foo', 'bar']},
+          {Namespace: {foo: {bar: {baz: 'qux'}}}},
+          locale,
+          'Namespace',
+        ),
+      ).toBe('qux');
+    });
+  });
+
   it('looks through an array of translation dictionaries', () => {
     const dictionaries: any[] = [{foo: {baz: 'one'}}, {foo: {bar: 'two'}}];
     expect(translate('foo.bar', {}, dictionaries, locale)).toBe('two');

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -9,3 +9,4 @@ export {
 
 export type {TranslateOptions} from './translate';
 export {convertFirstSpaceToNonBreakingSpace} from './string';
+export {isObjectEmpty} from './object';

--- a/packages/react-i18n/src/utilities/object.ts
+++ b/packages/react-i18n/src/utilities/object.ts
@@ -1,0 +1,3 @@
+export function isObjectEmpty(obj: object) {
+  return Object.keys(obj).length === 0;
+}

--- a/packages/react-i18n/src/utilities/tests/object.test.ts
+++ b/packages/react-i18n/src/utilities/tests/object.test.ts
@@ -1,0 +1,11 @@
+import {isObjectEmpty} from '../object';
+
+describe('isObjectEmpty()', () => {
+  it('return true if object is empty', () => {
+    expect(isObjectEmpty({})).toBe(true);
+  });
+
+  it('return false if object is not empty', () => {
+    expect(isObjectEmpty({foo: 'bar'})).toBe(false);
+  });
+});

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -102,12 +102,14 @@ export function translate(
   options: TranslateOptions<PrimitiveReplacementDictionary>,
   translations: TranslationDictionary | TranslationDictionary[],
   locale: string,
+  namespace?: string,
 ): string;
 export function translate(
   id: string,
   options: TranslateOptions<ComplexReplacementDictionary>,
   translations: TranslationDictionary | TranslationDictionary[],
   locale: string,
+  namespace?: string,
 ): (string | React.ReactElement<any>)[];
 export function translate(
   id: string,
@@ -116,6 +118,7 @@ export function translate(
   >,
   translations: TranslationDictionary | TranslationDictionary[],
   locale: string,
+  namespace?: string,
 ): any {
   const {scope, replacements, pseudotranslate} = options;
 
@@ -123,7 +126,7 @@ export function translate(
     ? translations
     : [translations];
 
-  const normalizedId = normalizeIdentifier(id, scope);
+  const normalizedId = normalizeIdentifier(id, scope, namespace);
 
   for (const translationDictionary of normalizedTranslations) {
     const result = translateWithDictionary(
@@ -283,14 +286,27 @@ function updateStringWithReplacements(
   }
 }
 
-function normalizeIdentifier(id: string, scope?: string | string[]) {
-  if (scope == null) {
+function prependNamespace(id: string, namespace?: string) {
+  if (namespace === undefined) {
     return id;
   }
+  return `${namespace}${SEPARATOR}${id}`;
+}
 
-  return `${
+function normalizeIdentifier(
+  id: string,
+  scope?: string | string[],
+  namespace?: string,
+) {
+  if (scope == null) {
+    return prependNamespace(id, namespace);
+  }
+
+  const normalizedId = `${
     typeof scope === 'string' ? scope : scope.join(SEPARATOR)
   }${SEPARATOR}${id}`;
+
+  return prependNamespace(normalizedId, namespace);
 }
 
 function updateTreeWithReplacements(


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/shopify-markets/issues/3855

This PR aims to support namespace on `useI18n` hooks, the use of namespace is recommended [here](https://github.com/Shopify/web/blob/main/documentation/decisions/06%20-%20Deprecating%20global%20translation%20files.md#what-are-my-alternatives).

Before:
```tsx
const [i18n] = useI18n();
i18n.translation('Namespace.key1')
i18n.translation('Namespace.key2')
i18n.translation('Namespace.key3')
// or
const [i18n] = useI18n();
const scope = ['Namespace']
i18n.translation('key1', {scope})
i18n.translation('key2', {scope})
i18n.translation('key3', {scope})
```

After:
```tsx
const [i18n] = useI18n({namespace: 'Namespace');
i18n.translation('key1')
i18n.translation('key2')
i18n.translation('key3')
```

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
