### PR TITLE
[graphql-fixtures] Remove unused call to faker.seed()

### DIFF
--- a/packages/graphql-fixtures/CHANGELOG.md
+++ b/packages/graphql-fixtures/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Removes call to `faker.seed()` that uses `Math.random()` as a seed value [[#2161]](https://github.com/Shopify/quilt/pull/2161)
 
 ## 1.4.1 - 2022-02-09
 

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -299,9 +299,7 @@ function withRandom<T>(keypath: FieldDetails[], func: () => T, seedOffset = 0) {
       ),
     ) + seedOffset,
   );
-  const value = func();
-  faker.seed(Math.random() * 10000);
-  return value;
+  return func();
 }
 
 function createValue<T>(


### PR DESCRIPTION
## Description

Hi! We're seeing _lots_ of calls to `faker.seed()` when using this library, and it turns out (predictably) that's because we call it a lot in some situations! 😱

The problem here, is that `init_genrand()` is quite an expensive operation ([source](https://github.com/faker-js/faker/blob/f1884becbc108c3ddbad952d879cec0fc5196e08/src/vendor/mersenne.ts#L104-L125)). It was showing to be using 2-4% of time spent in test suites!

As a starting point, this PR cuts the calls to `init_genrand()` to around 50%, without any noticeable negative side effect.

Discussion: For future, we could replace the Mersenne Twister implementation for less cryptographically secure but cheaper + good enough for our needs. For example, [an implementation](https://github.com/chrisakroyd/random-seedable/blob/b23fce2e77cc17c3bf3964688e80a5456045ab95/src/lcg.js#L46-L48) of an LCG with an essentially free seeding function. I have a patch for this that I used in profiling to swap out the implementation in Faker.js, but a) it's obviously fragile to patch a core function like that, and b) it _will_ break existing tests relying on specific seeded output.

(This ventures deep into "should we even still use Faker?" territory though, but it's food for thought)

## Type of change

- [x] `graphql-fixtures` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
