### PR TITLE
use typescript native types

### DIFF
--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Breaking Change
+
+- `Omit` has been removed. Remove any `import { Omit } from '@shopify/useful-types';` and use the built-in [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys) type
+- `ThenType` has been removed. You should use the built-in `Awaited` type instead
+- `Arguments`, `ArgumentsAtIndex` and `FirstArgument` have been removed. Replace usage of `Arguments` with the built-in [`Parameters`](https://www.typescriptlang.org/docs/handbook/utility-types.html#parameterstype) type. Replace usage of `ArgumentAtIndex` with `Parameters<T>[i]` and `FirstArgument<T>` with `Parameters<T>[0]`.
+- `ConstructorArguments`, `ConstructorArgumentAtIndex` and `FirstConstructorArgument` have been removed. Replace usage of `ConstructorArguments` with the built-in [`ConstructorParameters`](https://www.typescriptlang.org/docs/handbook/utility-types.html#constructorparameterstype) type. Replace usage of `ConstructorArgumentAtIndex` with `ConstructorParameters<T>[i]` and `FirstConstructorArgument<T>` with `ConstructorParameters<T>[0]`
+- `MaybeFunctionReturnType` has been removed. Replace usage of `MaybeFunctionReturnType` with the built-in `ReturnType` type
 
 ## 3.1.0 - 2022-02-09
 

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -1,19 +1,4 @@
-export type ThenType<T> = T extends Promise<infer U> ? U : T;
-
-export type Arguments<T> = T extends (...args: infer U) => any ? U : never;
-export type ArgumentAtIndex<
-  Func,
-  Index extends keyof Arguments<Func>
-> = Arguments<Func>[Index];
-export type FirstArgument<T> = ArgumentAtIndex<T, 0>;
-
-export type MaybeFunctionReturnType<T> = T extends (...args: any[]) => infer U
-  ? U
-  : never;
-
 export type ArrayElement<T> = T extends (infer U)[] ? U : never;
-
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
@@ -66,19 +51,6 @@ type ReactStatics =
 export type NonReactStatics<T> = Pick<T, Exclude<keyof T, ReactStatics>>;
 
 export type ExtendedWindow<T> = Window & typeof globalThis & T;
-
-export type ConstructorArguments<T> = T extends {
-  new (...args: infer U): any;
-}
-  ? U
-  : never;
-
-export type ConstructorArgumentAtIndex<
-  T,
-  I extends keyof ConstructorArguments<T>
-> = ConstructorArguments<T>[I];
-
-export type FirstConstructorArgument<T> = ConstructorArgumentAtIndex<T, 0>;
 
 // Reference https://stackoverflow.com/questions/55539387/deep-omit-with-typescript
 type Primitive =


### PR DESCRIPTION
## Description

This PR removes `ThenType`, `Omit`, `Arguments`, `ArgumentAtIndex`, `FirstArgument`, `MaybeFunctionReturnType`, `ConstructorArguments`, `ConstructorArgumentAtIndex` and `FirstConstructorArgument` as can all be trivially replaced by built-in typescript types (Awaited, Omit, Parameters, ConstructorParameters, ReturnType)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [x] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
