### PR TITLE
:bug: added check in unformatCurrency for invalid use of '-'

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed `unformatNumber` and `unformatCurrency` to return `''` when only non-digits are provided in the input string. [[#2176](https://github.com/Shopify/quilt/pull/2176)]
 
 ## 6.3.8 - 2022-02-14
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -64,7 +64,7 @@ export interface TranslateOptions {
 // Used for currencies that don't use fractional units (eg. JPY)
 const PERIOD = '.';
 const NEGATIVE_SIGN = '-';
-const REGEX_DECIMALS = /^-?([0-9]\d*(\.\d+)?|(\.\d+)+)$/g;
+const REGEX_DIGITS = /\d/g;
 const REGEX_NON_DIGITS = /\D/g;
 const REGEX_PERIODS = /\./g;
 
@@ -663,9 +663,7 @@ export class I18n {
     const normalizedDecimal = lastIndexOfDecimal === -1 ? '' : PERIOD;
     const normalizedValue = `${negativeSign}${integerValue}${normalizedDecimal}${decimalValue}`;
 
-    return (normalizedValue.match(REGEX_DECIMALS) || []).length === 1
-      ? normalizedValue
-      : '';
+    return normalizedValue.match(REGEX_DIGITS) ? normalizedValue : '';
   }
 
   private integerValue(input: string, lastIndexOfDecimal: number) {

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -612,6 +612,7 @@ describe('I18n', () => {
     it('handles value starting with .', () => {
       const i18n = new I18n(defaultTranslations, defaultDetails);
       expect(i18n.unformatNumber('.12')).toBe('0.12');
+      expect(i18n.unformatNumber('.')).toBe('');
     });
 
     it("handles value starting with '", () => {
@@ -623,6 +624,7 @@ describe('I18n', () => {
       const i18n = new I18n(defaultTranslations, defaultDetails);
       expect(i18n.unformatNumber('-12')).toBe('-12');
       expect(i18n.unformatNumber('-')).toBe('');
+      expect(i18n.unformatNumber('-.')).toBe('');
     });
 
     describe('en-ca locale', () => {
@@ -1090,6 +1092,7 @@ describe('I18n', () => {
     it('handles value starting with .', () => {
       const i18n = new I18n(defaultTranslations, defaultDetails);
       expect(i18n.unformatCurrency('.12', 'USD')).toBe('0.12');
+      expect(i18n.unformatCurrency('.', 'USD')).toBe('');
     });
 
     it("handles value starting with '", () => {
@@ -1101,6 +1104,7 @@ describe('I18n', () => {
       const i18n = new I18n(defaultTranslations, defaultDetails);
       expect(i18n.unformatCurrency('-12', 'USD')).toBe('-12.00');
       expect(i18n.unformatCurrency('-', 'USD')).toBe('');
+      expect(i18n.unformatCurrency('-.', 'USD')).toBe('');
     });
 
     describe('unique currencies or locales', () => {


### PR DESCRIPTION
## Description

Fixes issue #2174

 - addresses the bug in the listed issue so that '-' returns an expected string value from `unformatCurrency`
 - addresses the bug in the listed issue so that '-' returns an expected string value from `unformatNumber`

## Type of change

- [x] react-i18n Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
