### PR TITLE
Expose address formatting functions publicly so they can be used synchronously

### DIFF
--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Exposes `formatAddress`, `buildOrderedFields` formatting functions publicly so they can be used synchronously [[#2178](https://github.com/Shopify/quilt/pull/2178)]
 
 ## 3.0.16 - 2022-02-25
 

--- a/packages/address/README.md
+++ b/packages/address/README.md
@@ -17,49 +17,7 @@ $ yarn add @shopify/address
 
 - `country` field in Address is expected to be of format ISO 3166-1 alpha-2, eg. CA / FR / JP
 
-#### `constructor(private locale: string)`
-
-Instantiate the AddressFormatter by passing it a locale.
-
-#### `updateLocale(locale: string)`
-
-Update the current locale of the formatter. Following requests will be in the given locale.
-
-#### `async .getCountry(countryCode: string): Promise<Country>`
-
-Loads and returns data about a given country in the current locale. Country and province names are localized. Province names are sorted based on the locale.
-
-#### `async .getCountries(): Promise<Country[]>`
-
-Loads and returns data for all countries in the current locale. Countries are sorted based on the locale. Zones are also ordered based on the locale.
-
-#### `async .getOrderedFields(countryCode): FieldName[][]`
-
-Returns how to order address fields.
-
-Eg.:
-
-```typescript
-[
-  ['firstName', 'lastName'],
-  ['company'],
-  ['address1'],
-  ['address2'],
-  ['city'],
-  ['country', 'province', 'zip'],
-  ['phone'],
-];
-```
-
-#### `async .format(address: Address): string[]`
-
-Given an address, returns the address ordered for multiline rendering. e.g.:
-
-```typescript
-['Shopify', 'Lindenstraße 9-14', '10969 Berlin', 'Germany'];
-```
-
-#### Example Usage
+### `AddressFormatter` class
 
 Show an address:
 
@@ -100,6 +58,62 @@ await addressFormatter.getOrderedFields('CA');
     ['phone']
   ]
  */
+```
+
+#### `constructor(private locale: string)`
+
+Instantiate the AddressFormatter by passing it a locale.
+
+#### `updateLocale(locale: string)`
+
+Update the current locale of the formatter. Following requests will be in the given locale.
+
+#### `async .getCountry(countryCode: string): Promise<Country>`
+
+Loads and returns data about a given country in the current locale. Country and province names are localized. Province names are sorted based on the locale.
+
+#### `async .getCountries(): Promise<Country[]>`
+
+Loads and returns data for all countries in the current locale. Countries are sorted based on the locale. Zones are also ordered based on the locale.
+
+#### `async .getOrderedFields(countryCode): Promise<FieldName[][]>`
+
+Returns how to order address fields for a country code. Fetches the country if not already cached.
+
+#### `async .format(address: Address): Promise<string[]>`
+
+Given an address, returns the address ordered for multiline rendering. Uses the `formatAddress` sync API in the background.
+
+### Sync API
+
+If you already have the input data ready, like a `Country` object, you can use the sync API to get the result right away.
+
+The following functions can be imported as stand-alone utilities.
+
+#### `formatAddress(address: Address, country: Country): string[]`
+
+Given an address and a country, returns the address ordered for multiline rendering. e.g.:
+
+```typescript
+['Shopify', 'Lindenstraße 9-14', '10969 Berlin', 'Germany'];
+```
+
+#### `buildOrderedFields(country: Country): FieldName[][]`
+
+Returns how to order address fields for a specific country.
+
+Eg.:
+
+```typescript
+[
+  ['firstName', 'lastName'],
+  ['company'],
+  ['address1'],
+  ['address2'],
+  ['city'],
+  ['country', 'province', 'zip'],
+  ['phone'],
+];
 ```
 
 ## Testing

--- a/packages/address/src/format.ts
+++ b/packages/address/src/format.ts
@@ -1,0 +1,55 @@
+import {Address, Country, FieldName} from '@shopify/address-consts';
+
+import {FIELDS_MAPPING, FIELD_REGEXP, renderLineTemplate} from './utilities';
+
+const LINE_DELIMITER = '_';
+const DEFAULT_FORM_LAYOUT =
+  '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}{province}{zip}_{phone}';
+const DEFAULT_SHOW_LAYOUT =
+  '{lastName} {firstName}_{company}_{address1} {address2}_{city} {province} {zip}_{country}_{phone}';
+
+/**
+ * When it's time to render any address, use this function so that it's properly
+ * formatted for the country's locale.
+ *
+ * ```typescript
+ * ['Shopify', 'Lindenstraße 9-14', '10969 Berlin', 'Germany'];
+ * ```
+ * @returns all lines of a formatted address as an array of strings.
+ */
+export function formatAddress(address: Address, country: Country): string[] {
+  const layout = country.formatting.show || DEFAULT_SHOW_LAYOUT;
+  return layout
+    .split(LINE_DELIMITER)
+    .map((lineTemplate) =>
+      renderLineTemplate(country, lineTemplate, address).trim(),
+    );
+}
+
+/**
+ * In an edit form, this function can be used to properly order all the input
+ * fields.
+ *
+ * ```typescript
+ * [
+ *   ['firstName', 'lastName'],
+ *   ['company'],
+ *   ['address1'],
+ *   ['address2'],
+ *   ['city'],
+ *   ['country', 'province', 'zip'],
+ *   ['phone'],
+ * ];
+ * ```
+ */
+export function buildOrderedFields(country: Country): FieldName[][] {
+  const format = country ? country.formatting.edit : DEFAULT_FORM_LAYOUT;
+
+  return format.split(LINE_DELIMITER).map((lineTemplate) => {
+    const result = lineTemplate.match(FIELD_REGEXP);
+    if (!result) {
+      return [];
+    }
+    return result.map((field) => FIELDS_MAPPING[field]);
+  });
+}

--- a/packages/address/src/index.ts
+++ b/packages/address/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@shopify/address-consts';
 
 export * from './loader';
+export * from './format';
 export {default} from './AddressFormatter';

--- a/packages/address/src/tests/format.test.ts
+++ b/packages/address/src/tests/format.test.ts
@@ -1,0 +1,70 @@
+import {Address} from '@shopify/address-consts';
+import {fixtures} from '@shopify/address-mocks';
+
+import {buildOrderedFields, formatAddress} from '../format';
+
+const Japan = fixtures.countries.JA.data.countries.find(
+  ({code}) => code === 'JP',
+)!;
+
+const address: Address = {
+  company: 'Shopify',
+  firstName: '',
+  lastName: '',
+  address1: '八重洲1-5-3',
+  address2: '',
+  city: '目黒区',
+  province: 'JP-13',
+  zip: '100-8994',
+  country: 'JP',
+  phone: '514 xxx xxxx',
+};
+
+describe('formatAddress()', () => {
+  it('returns an array of parts of the address', () => {
+    const result = formatAddress(address, Japan);
+
+    expect(result).toStrictEqual([
+      '日本',
+      '〒100-8994 東京都 目黒区 八重洲1-5-3',
+      'Shopify',
+      '',
+      '514 xxx xxxx',
+    ]);
+  });
+
+  it('does not return {province} if the address does not have it', () => {
+    const result = formatAddress(
+      {
+        ...address,
+        province: '',
+      },
+      Japan,
+    );
+
+    expect(result).toStrictEqual([
+      '日本',
+      '〒100-8994 目黒区 八重洲1-5-3',
+      'Shopify',
+      '',
+      '514 xxx xxxx',
+    ]);
+  });
+});
+
+describe('buildOrderedFields()', () => {
+  it('return fields ordered based on the country', () => {
+    const result = buildOrderedFields(Japan);
+
+    expect(result).toMatchObject([
+      ['company'],
+      ['lastName', 'firstName'],
+      ['zip'],
+      ['country'],
+      ['province', 'city'],
+      ['address1'],
+      ['address2'],
+      ['phone'],
+    ]);
+  });
+});

--- a/packages/address/src/tests/utilities.test.ts
+++ b/packages/address/src/tests/utilities.test.ts
@@ -1,10 +1,11 @@
+import {Address} from '@shopify/address-consts';
 import {fixtures} from '@shopify/address-mocks';
 
 import {renderLineTemplate} from '../utilities';
 
 const Canada = fixtures.country.EN.data.country;
 
-const address = {
+const address: Address = {
   company: 'Shopify',
   firstName: '',
   lastName: '',

--- a/packages/address/src/utilities.ts
+++ b/packages/address/src/utilities.ts
@@ -1,6 +1,6 @@
 import {Address, FieldName, Country, Zone} from '@shopify/address-consts';
 
-const FIELD_REGEXP = /({\w+})/g;
+export const FIELD_REGEXP = /({\w+})/g;
 export const FIELDS_MAPPING: {
   [key: string]: FieldName;
 } = {


### PR DESCRIPTION
## Description

These changes were recycled from #1843, which were abandoned at the time since the motivation behind the changes had changed, but I believe that the changes themselves are still relevant regardless.

When formatting address and rendering an address edition form, there's an obligatory async operation from the `AddressFormatter` API. To overcome this issue, we've started to cache the countries and ordered fields, but can't really cache the formatting operation itself, so we still suffer a flash of skeleton.

Exposing a synchronous API would really simplify the implementation.

## Type of change

- [x] `@shopify/address` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
