### PR TITLE
[react-server] Pass isServer to the react element created on the server

### DIFF
--- a/packages/react-server/src/webpack-plugin/webpack-plugin.ts
+++ b/packages/react-server/src/webpack-plugin/webpack-plugin.ts
@@ -93,6 +93,7 @@ function serverSource(options: Options, compiler: Compiler) {
       return React.createElement(App, {
         url: ctx.request.URL,
         data: ctx.state.quiltData,
+        isServer: true,
       });
     }
 


### PR DESCRIPTION
## Description

`[react-server]`

Convenience? 

When using quilt and you do not provide your own server we still get server side rendering for free thanks to this plugin, feels like this might add some convenience to checking whether or not you are on the server. 

We probably have some util already for this so please tell me if we do!

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
