### PR TITLE
update deprecated export pattern

### DIFF
--- a/packages/address-consts/package.json
+++ b/packages/address-consts/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/admin-graphql-api-utilities/package.json
+++ b/packages/admin-graphql-api-utilities/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/ast-utilities/package.json
+++ b/packages/ast-utilities/package.json
@@ -68,12 +68,6 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
-    ".": {
-      "esnext": "./index.esnext",
-      "import": "./index.mjs",
-      "require": "./index.js"
-    },
     "./javascript": {
       "esnext": "./javascript.esnext",
       "import": "./javascript.mjs",
@@ -83,6 +77,12 @@
       "esnext": "./markdown.esnext",
       "import": "./markdown.mjs",
       "require": "./markdown.js"
-    }
+    },
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./*": "./"
   }
 }

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -52,7 +52,6 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     "./babel": {
       "esnext": "./babel.esnext",
       "import": "./babel.mjs",
@@ -62,6 +61,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -37,11 +37,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/csrf-token-fetcher/package.json
+++ b/packages/csrf-token-fetcher/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/css-utilities/package.json
+++ b/packages/css-utilities/package.json
@@ -37,11 +37,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -40,11 +40,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -37,11 +37,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/function-enhancers/package.json
+++ b/packages/function-enhancers/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/graphql-config-utilities/package.json
+++ b/packages/graphql-config-utilities/package.json
@@ -38,12 +38,12 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   },
   "tags": [
     "graphql",

--- a/packages/graphql-fixtures/package.json
+++ b/packages/graphql-fixtures/package.json
@@ -44,11 +44,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -75,12 +75,6 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
-    ".": {
-      "esnext": "./index.esnext",
-      "import": "./index.mjs",
-      "require": "./index.js"
-    },
     "./jest": {
       "esnext": "./jest.esnext",
       "import": "./jest.mjs",
@@ -95,7 +89,13 @@
       "esnext": "./webpack-loader.esnext",
       "import": "./webpack-loader.mjs",
       "require": "./webpack-loader.js"
-    }
+    },
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./*": "./"
   },
   "tags": [
     "graphql",

--- a/packages/graphql-persisted/package.json
+++ b/packages/graphql-persisted/package.json
@@ -60,7 +60,6 @@
     "koa": ">=2.0.0"
   },
   "exports": {
-    "./": "./",
     "./apollo": {
       "esnext": "./apollo.esnext",
       "import": "./apollo.mjs",
@@ -70,6 +69,7 @@
       "esnext": "./koa.esnext",
       "import": "./koa.mjs",
       "require": "./koa.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -54,16 +54,16 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
+    "./matchers": {
+      "esnext": "./matchers.esnext",
+      "import": "./matchers.mjs",
+      "require": "./matchers.js"
+    },
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./matchers": {
-      "esnext": "./matchers.esnext",
-      "import": "./matchers.mjs",
-      "require": "./matchers.js"
-    }
+    "./*": "./"
   }
 }

--- a/packages/graphql-tool-utilities/package.json
+++ b/packages/graphql-tool-utilities/package.json
@@ -38,12 +38,12 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   },
   "tags": [
     "graphql",

--- a/packages/graphql-typed/package.json
+++ b/packages/graphql-typed/package.json
@@ -37,11 +37,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -60,11 +60,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/graphql-validate-fixtures/package.json
+++ b/packages/graphql-validate-fixtures/package.json
@@ -46,11 +46,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/jest-dom-mocks/package.json
+++ b/packages/jest-dom-mocks/package.json
@@ -42,11 +42,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -42,11 +42,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/koa-liveness-ping/package.json
+++ b/packages/koa-liveness-ping/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/koa-metrics/package.json
+++ b/packages/koa-metrics/package.json
@@ -43,11 +43,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/koa-performance/package.json
+++ b/packages/koa-performance/package.json
@@ -50,11 +50,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/koa-shopify-graphql-proxy/package.json
+++ b/packages/koa-shopify-graphql-proxy/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/koa-shopify-webhooks/package.json
+++ b/packages/koa-shopify-webhooks/package.json
@@ -49,11 +49,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -39,11 +39,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/mime-types/package.json
+++ b/packages/mime-types/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -173,7 +173,6 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     "./base": {
       "esnext": "./base.esnext",
       "import": "./base.mjs",
@@ -224,11 +223,6 @@
       "import": "./idle-callback.node.mjs",
       "require": "./idle-callback.node.js"
     },
-    ".": {
-      "esnext": "./index.esnext",
-      "import": "./index.mjs",
-      "require": "./index.js"
-    },
     "./intersection-observer.browser": {
       "esnext": "./intersection-observer.browser.esnext",
       "import": "./intersection-observer.browser.mjs",
@@ -278,6 +272,12 @@
       "esnext": "./noop.esnext",
       "import": "./noop.mjs",
       "require": "./noop.js"
-    }
+    },
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./*": "./"
   }
 }

--- a/packages/predicates/package.json
+++ b/packages/predicates/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-app-bridge-universal-provider/package.json
+++ b/packages/react-app-bridge-universal-provider/package.json
@@ -44,11 +44,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -56,16 +56,16 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
+    "./testing": {
+      "esnext": "./testing.esnext",
+      "import": "./testing.mjs",
+      "require": "./testing.js"
+    },
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./testing": {
-      "esnext": "./testing.esnext",
-      "import": "./testing.mjs",
-      "require": "./testing.js"
-    }
+    "./*": "./"
   }
 }

--- a/packages/react-bugsnag/package.json
+++ b/packages/react-bugsnag/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -43,11 +43,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-csrf-universal-provider/package.json
+++ b/packages/react-csrf-universal-provider/package.json
@@ -45,11 +45,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-csrf/package.json
+++ b/packages/react-csrf/package.json
@@ -37,11 +37,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -51,16 +51,16 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
+    "./server": {
+      "esnext": "./server.esnext",
+      "import": "./server.mjs",
+      "require": "./server.js"
+    },
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./server": {
-      "esnext": "./server.esnext",
-      "import": "./server.mjs",
-      "require": "./server.js"
-    }
+    "./*": "./"
   }
 }

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -43,11 +43,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-google-analytics/package.json
+++ b/packages/react-google-analytics/package.json
@@ -40,11 +40,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -50,11 +50,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -54,11 +54,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -37,12 +37,12 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   },
   "devDependencies": {
     "@shopify/react-testing": "^3.3.5"

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -59,16 +59,16 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
+    "./server": {
+      "esnext": "./server.esnext",
+      "import": "./server.mjs",
+      "require": "./server.js"
+    },
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./server": {
-      "esnext": "./server.esnext",
-      "import": "./server.mjs",
-      "require": "./server.js"
-    }
+    "./*": "./"
   }
 }

--- a/packages/react-hydrate/package.json
+++ b/packages/react-hydrate/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-i18n-universal-provider/package.json
+++ b/packages/react-i18n-universal-provider/package.json
@@ -45,11 +45,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -90,7 +90,6 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     "./babel": {
       "esnext": "./babel.esnext",
       "import": "./babel.mjs",
@@ -110,6 +109,7 @@
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-idle/package.json
+++ b/packages/react-idle/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-import-remote/package.json
+++ b/packages/react-import-remote/package.json
@@ -44,11 +44,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -37,11 +37,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-network/package.json
+++ b/packages/react-network/package.json
@@ -62,16 +62,16 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
+    "./server": {
+      "esnext": "./server.esnext",
+      "import": "./server.mjs",
+      "require": "./server.js"
+    },
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./server": {
-      "esnext": "./server.esnext",
-      "import": "./server.mjs",
-      "require": "./server.js"
-    }
+    "./*": "./"
   }
 }

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -43,11 +43,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -43,11 +43,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -82,16 +82,16 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
+    "./webpack-plugin": {
+      "esnext": "./webpack-plugin.esnext",
+      "import": "./webpack-plugin.mjs",
+      "require": "./webpack-plugin.js"
+    },
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./webpack-plugin": {
-      "esnext": "./webpack-plugin.esnext",
-      "import": "./webpack-plugin.mjs",
-      "require": "./webpack-plugin.js"
-    }
+    "./*": "./"
   }
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -37,11 +37,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -53,16 +53,16 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
+    "./matchers": {
+      "esnext": "./matchers.esnext",
+      "import": "./matchers.mjs",
+      "require": "./matchers.js"
+    },
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./matchers": {
-      "esnext": "./matchers.esnext",
-      "import": "./matchers.mjs",
-      "require": "./matchers.js"
-    }
+    "./*": "./"
   }
 }

--- a/packages/react-tracking-pixel/package.json
+++ b/packages/react-tracking-pixel/package.json
@@ -40,11 +40,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-universal-provider/package.json
+++ b/packages/react-universal-provider/package.json
@@ -41,11 +41,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/react-web-worker/package.json
+++ b/packages/react-web-worker/package.json
@@ -43,11 +43,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/semaphore/package.json
+++ b/packages/semaphore/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/sewing-kit-koa/package.json
+++ b/packages/sewing-kit-koa/package.json
@@ -54,11 +54,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -38,11 +38,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/storybook-a11y-test/package.json
+++ b/packages/storybook-a11y-test/package.json
@@ -48,11 +48,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/useful-types/package.json
+++ b/packages/useful-types/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -21,12 +21,6 @@
     }
   },
   "exports": {
-    ".": {
-      "esnext": "./index.esnext",
-      "import": "./index.mjs",
-      "require": "./index.js"
-    },
-    "./": "./",
     "./babel": {
       "esnext": "./babel.esnext",
       "import": "./babel.mjs",
@@ -41,7 +35,13 @@
       "esnext": "./worker.esnext",
       "import": "./worker.mjs",
       "require": "./worker.js"
-    }
+    },
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./*": "./"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/with-env/package.json
+++ b/packages/with-env/package.json
@@ -34,11 +34,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/templates/package.hbs.json
+++ b/templates/package.hbs.json
@@ -36,11 +36,11 @@
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {
-    "./": "./",
     ".": {
       "esnext": "./index.esnext",
       "import": "./index.mjs",
       "require": "./index.js"
-    }
+    },
+    "./*": "./"
   }
 }

--- a/tests/consistent-package-json.test.ts
+++ b/tests/consistent-package-json.test.ts
@@ -28,6 +28,8 @@ const KNOWN_TEMPLATE_KEYS = [
   'version',
 ];
 
+const GLOB_PATH = './*';
+
 const SINGLE_ENTRYPOINT_EXCEPTIONS = ['graphql-persisted'];
 
 const ROOT_PATH = resolve(__dirname, '..');
@@ -142,7 +144,7 @@ packages.forEach(
 
           it('specifies esnext, import, and require as the ordered keys in the exports map', () => {
             Object.keys(packageJSON.exports)
-              .filter((key) => key !== './')
+              .filter((key) => key !== GLOB_PATH)
               .forEach((key) => {
                 expect(Object.keys(packageJSON.exports[key])).toStrictEqual([
                   'esnext',


### PR DESCRIPTION
## Description

Fixes (issue https://github.com/Shopify/web/issues/56743)

The `./` pattern for package exports is deprecated and ignored https://webpack.js.org/guides/package-exports/#support

Updated too `./*` which is viable. Also sorted the exported order to reflect: https://webpack.js.org/guides/package-exports/#notes-about-ordering

## Type of change

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [x] (All packages) Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
