### PR TITLE
fix node.tigger to accept undefined values

### DIFF
--- a/packages/react-testing/CHANGELOG.md
+++ b/packages/react-testing/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Fix `Node.trigger()` not resolving values that can be `undefined`
 
 ## 3.3.6 - 2022-02-25
 

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -194,7 +194,9 @@ export class Element<Props> implements Node<Props> {
     prop: K,
     ...args: DeepPartialArguments<Props[K]>
   ): ReturnType<
-    NonNullable<Props[K] extends (...args: any[]) => any ? Props[K] : never>
+    NonNullable<
+      Props[K] extends ((...args: any[]) => any) | undefined ? Props[K] : never
+    >
   > {
     return this.root.act(() => {
       const propValue = this.props[prop];

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -175,7 +175,9 @@ export class Root<Props> implements Node<Props> {
     prop: K,
     ...args: DeepPartialArguments<Props[K]>
   ): ReturnType<
-    NonNullable<Props[K] extends (...args: any[]) => any ? Props[K] : never>
+    NonNullable<
+      Props[K] extends ((...args: any[]) => any) | undefined ? Props[K] : never
+    >
   > {
     return this.withRoot((root) => root.trigger(prop, ...(args as any)));
   }

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -119,7 +119,9 @@ export interface Node<Props> {
     prop: K,
     ...args: DeepPartialArguments<Props[K]>
   ): ReturnType<
-    NonNullable<Props[K] extends (...args: any[]) => any ? Props[K] : never>
+    NonNullable<
+      Props[K] extends ((...args: any[]) => any) | undefined ? Props[K] : never
+    >
   >;
   triggerKeypath<T = unknown>(keypath: string, ...args: unknown[]): T;
 


### PR DESCRIPTION
## Description

Fixes (issue #)

After the changes made lately to the typings of `.trigger`, a `Function | undefined` would not be resolved. This PR adds support for that to properly resolve it. Hacking that in the typings of `react-testing` in `web`'s `node_modules` made `yarn type-check` pass properly.

Note that I _could've_ removed the `NonNullable<>` syntax, but I figured we still want to exclude null. Happy to change if it makes more sense though

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
