### PR TITLE
Chore add more tests (DeepPartial, IfEmptyObject, DeepOmit)

### DIFF
--- a/packages/useful-types/CHANGELOG.md
+++ b/packages/useful-types/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Bugs in `DeepPartial`, `IfEmptyObject`, and `DeepOmit` fixed with tests. [[#2195](https://github.com/Shopify/quilt/pull/2195)]
 
 ## 4.0.2 - 2022-03-09
 

--- a/packages/useful-types/test-d/types.test-d.ts
+++ b/packages/useful-types/test-d/types.test-d.ts
@@ -1,6 +1,16 @@
-import {expectType, expectAssignable, expectNotAssignable} from 'tsd';
+import {
+  expectType,
+  expectAssignable,
+  expectNotAssignable,
+  expectNotType,
+} from 'tsd';
 
-import {ArrayElement} from '../build/ts/types';
+import {
+  ArrayElement,
+  DeepPartial,
+  IfEmptyObject,
+  DeepOmit,
+} from '../build/ts/types';
 
 interface Person {
   firstName: string;
@@ -18,3 +28,331 @@ expectAssignable<ArrayElement<(string | boolean)[]>>(false);
 expectAssignable<ArrayElement<string>>('string' as never);
 
 expectNotAssignable<ArrayElement<string>>('string');
+
+/**
+ * DeepPartial<T>
+ */
+
+interface Base {
+  required: string;
+  optional?: string;
+  nested?: Base;
+}
+
+expectAssignable<DeepPartial<Base>>({});
+expectAssignable<DeepPartial<Base>>({optional: 'test'});
+expectAssignable<DeepPartial<Base>>({required: undefined});
+expectAssignable<DeepPartial<Base>>({
+  nested: {nested: {nested: {required: 'test'}}},
+});
+
+interface ListObj {
+  list: Base[];
+}
+
+expectAssignable<DeepPartial<ListObj>>({list: []});
+expectAssignable<DeepPartial<ListObj>>({list: undefined});
+expectAssignable<DeepPartial<ListObj>>({
+  list: [{nested: {required: undefined}}],
+});
+
+interface ReadOnlyListObj {
+  list: ReadonlyArray<Base>;
+}
+
+expectAssignable<DeepPartial<ReadOnlyListObj>>({list: []});
+expectAssignable<DeepPartial<ReadOnlyListObj>>({list: undefined});
+
+expectAssignable<DeepPartial<ReadOnlyListObj>>({
+  list: [{}],
+});
+
+expectNotAssignable<DeepPartial<ReadOnlyListObj>>({
+  list: [undefined],
+});
+
+expectAssignable<DeepPartial<string>>('test');
+
+interface RespectArrayElements {
+  list: (string | number)[] | null;
+}
+
+/**
+ * valid types ar null or any array with string, number, or both
+ */
+expectAssignable<DeepPartial<RespectArrayElements>>({list: null});
+expectAssignable<DeepPartial<RespectArrayElements>>({list: []});
+expectAssignable<DeepPartial<RespectArrayElements>>({list: ['string']});
+expectAssignable<DeepPartial<RespectArrayElements>>({list: [2]});
+expectAssignable<DeepPartial<RespectArrayElements>>({list: ['string', 2]});
+
+/**
+ * handles ReadOnly objects
+ */
+
+type PresetOption = Readonly<{
+  name?: string;
+  id: string;
+}>;
+
+type Preset = Readonly<{
+  options: ReadonlyArray<PresetOption>;
+  editableOptions: PresetOption[];
+}>;
+
+type PresetState = Readonly<{
+  list?: ReadonlyArray<Preset>;
+}>;
+type State = Readonly<{
+  preset: PresetState;
+}>;
+
+expectAssignable<DeepPartial<State>>({});
+expectAssignable<DeepPartial<State>>({
+  preset: {
+    list: [{options: [{name: 'string'}]}],
+  },
+});
+expectAssignable<DeepPartial<State>>({
+  preset: undefined,
+});
+
+expectNotAssignable<DeepPartial<State>>({
+  preset: {
+    list: [undefined],
+  },
+});
+
+expectNotAssignable<DeepPartial<State>>({
+  preset: {
+    list: [{options: [undefined]}],
+  },
+});
+expectNotAssignable<DeepPartial<State>>({
+  preset: {
+    list: [{editableOptions: [undefined]}],
+  },
+});
+
+/**
+ * should not be able to add undefined, need to fix this
+ */
+expectNotAssignable<DeepPartial<RespectArrayElements>>({
+  // this should error, undefined is not a valid type for list
+  list: [undefined, 'stable', 2],
+});
+
+/**
+ * IfEmptyObject<T>
+ */
+
+expectType<IfEmptyObject<{}, true>>(true);
+expectType<IfEmptyObject<{foo: string}, never, false>>(false);
+
+expectNotType<IfEmptyObject<{foo: string}, true>>(true);
+expectNotType<IfEmptyObject<boolean, true>>(true);
+
+/**
+ * IfAllOptionalKeys
+ */
+
+/**
+ * IfAllNullableKeys
+ */
+
+/**
+ * NonOptionalKeys
+ */
+
+/**
+ * NonNullableKeys
+ */
+
+/**
+ * NoInfer
+ */
+
+/**
+ * NonReactStatics
+ */
+
+/**
+ * ExtendedWindow
+ */
+
+/**
+ * DeepOmit
+ */
+
+/**
+ * should return primitives unaltered
+ */
+expectAssignable<DeepOmit<string, '__typename'>>('string');
+expectAssignable<DeepOmit<string, string>>('string');
+expectAssignable<DeepOmit<() => void, 'toString'>>(() => {});
+expectAssignable<DeepOmit<number, 'toString'>>(2);
+expectAssignable<DeepOmit<boolean, 'valueOf'>>(Boolean(0));
+expectAssignable<DeepOmit<undefined, 'toString'>>(undefined);
+expectAssignable<DeepOmit<null, 'toString'>>(null);
+expectAssignable<DeepOmit<Symbol, 'toString'>>(Symbol('string'));
+
+/**
+ * does not omit on primitive types
+ */
+const test: DeepOmit<number, 'toString'> = Number(2);
+expectType<typeof test.toString>((_radix?: number) => '');
+
+expectNotAssignable<DeepOmit<string, 'string'>>(undefined);
+
+interface Obj {
+  __typename: string;
+  foo: string;
+  bar: {
+    __typename: string;
+    baz: string;
+  };
+}
+
+/**
+ * should omit key at any level of nesting
+ * will recurse on {__typename: string; baz: string;}
+ * should omit __typename
+ */
+expectAssignable<DeepOmit<Obj, '__typename'>>({
+  foo: 'string',
+  bar: {
+    baz: 'string',
+  },
+});
+
+expectAssignable<DeepOmit<Obj, 'baz'>>({
+  __typename: 'string',
+  foo: 'string',
+  bar: {
+    __typename: 'string',
+  },
+});
+
+expectNotAssignable<DeepOmit<Obj, '__typename'>>({
+  __typename: 'string',
+});
+
+/**
+ * DeepOmit<Obj>
+ * will recurse on {__typename: string; baz: string;}
+ * should omit __typename
+ */
+
+expectNotAssignable<DeepOmit<Obj, '__typename'>>({
+  __typename: 'string',
+  foo: 'string',
+  bar: {
+    baz: 'string',
+  },
+});
+
+expectNotAssignable<DeepOmit<Obj, '__typename'>>({
+  foo: 'string',
+  bar: {
+    __typename: 'string',
+    baz: 'string',
+  },
+});
+
+type NullableUnionArray = DeepOmit<
+  {bar: (string | number)[] | null; __typename: string},
+  '__typename'
+>;
+
+/**
+ * will recurse on (string | number)[] | null
+ * we want to allow null
+ */
+expectAssignable<NullableUnionArray>({bar: null});
+
+/**
+ * will recurse on (string | number)[] | null
+ * we want to allow empty or valid arrays
+ */
+expectAssignable<NullableUnionArray>({bar: []});
+expectAssignable<NullableUnionArray>({bar: ['string']});
+expectAssignable<NullableUnionArray>({bar: [2]});
+expectAssignable<NullableUnionArray>({bar: ['string', 2]});
+
+/**
+ * should not allow invalid array elements
+ */
+expectNotAssignable<NullableUnionArray>({bar: [undefined]});
+expectNotAssignable<NullableUnionArray>({bar: [null]});
+
+expectNotAssignable<NullableUnionArray>({bar: undefined});
+
+/**
+ * handles readonly arrays
+ */
+
+interface Node {
+  __typename: 'string';
+  title: string;
+}
+
+type ReadOnlyNullableUnionArray = DeepOmit<
+  {bar: ReadonlyArray<Node>; __typename: string},
+  '__typename'
+>;
+
+expectNotAssignable<ReadOnlyNullableUnionArray>({
+  bar: [undefined],
+});
+expectNotAssignable<ReadOnlyNullableUnionArray>({
+  bar: [{__typename: 'string'}],
+});
+
+/**
+ * DeepOmit of type {bar: (string| number)[]}
+ * will recurse on (string | number)[]
+ * will recurse on (string| number)
+ * we want to allow string or number
+ */
+expectAssignable<DeepOmit<string | number, 'toString'>>('string');
+expectAssignable<DeepOmit<string | number, 'toString'>>(2);
+expectNotAssignable<DeepOmit<string | number, 'toString'>>(null);
+expectNotAssignable<DeepOmit<string | number, 'toString'>>(undefined);
+
+interface RespectOptionalProps {
+  __typename: string;
+  foo: string;
+  bar?: {
+    __typename: string;
+    baz: number;
+  };
+}
+
+/**
+ * respects optional bar
+ */
+expectAssignable<DeepOmit<RespectOptionalProps, '__typename'>>({
+  foo: 'string',
+});
+
+expectAssignable<DeepOmit<RespectOptionalProps, '__typename'>>({
+  foo: 'string',
+  bar: undefined,
+});
+
+expectNotAssignable<DeepOmit<RespectOptionalProps, '__typename'>>({
+  __typename: 'string',
+  foo: 'string',
+});
+
+/**
+ * DeepOmitArray
+ */
+
+/**
+ * PartialSome
+ */
+
+/**
+ * RequireSome
+ */


### PR DESCRIPTION
## Description

Fixes (issue #)

Continuing https://github.com/Shopify/quilt/pull/2185 adding tests for most types in useful-types

## Bug found in `DeepOmit<T, K>` [demo](https://www.typescriptlang.org/play?#code/PTAEFpK6dv4YpyWrY0IBQJQBUBTAZwBdQARAQxMqywEsA7EggJwDNKBjA0AJWIAHAlxIB5QSXoB7RpQA2ABVbTBRUAG8soUAH1dJAJ7C5AWwIAuUKVZMA5gG5todtOlWb9pzoBGlVgD8Vlo6OvpGJpTmHiS2jI7OvpQAXlaMAK6mPmzeoAC+Tnl0uOilZeUVleWYwDi12CVVTc0trQg1daAAQioA1gSMoBJSsgoUItKs1JNEnQDuABYDoLGUjESurKb2oGugTCwc3AQANKBzvAQAHsKiK9KggqzEbABuvCRLjyrCrFLEKwW1F2z1AqhGcnkYNYoGeAEd0vRngATYpgQSUIhEHafXgHNicHi7dT9QzSdjWAgEUzqEgPTyCMGSGSQ0DIiZTOmsWYRXg9aT9RhibYkAA8eDOAGkAHygAC8mmcAG1FPtBgBRK5ceTpdmi0nk-BS6UAXSseBVJsKaNAAAM-KxbdYFtJ0vJkdYpPIodkmRCFFhroJJmQuLJSKAfH0BsL6CQrPzBbGxQIiLdxMzRkofkQzgBycLGAZRAh52UKkIuNxWPOeeJ5k5YIpYXnjAiCZMACQI8l+4uN8sVOhVatABopeDN+EtoGuLEYyPUTHYbHwikSoACa9nV3ni9AAApl6uAKoASiVJo3Oi35CpHZFopPxsv19AVjv7eT4sUxo35stQonE6AQV2eRgiQWEgSDUCwQFIbhemkd4OHkaQ5gAOjDUxgARYgISIYAAFYSIAZgATlIgAOAB2YB2XbcBpBFcA5jjBZwF5IguFsSQWyLUBlHoEV6HeeVnAAH09OI7Ek0AADF0ggiE5IyLI2Dknw3HkAg1jkgBlQwsmkeQ5KU9l2CYAhUR0KSMm9YCgxDFYBM-B8437UAZUHPAdz3dQhJE95nC3PBnCsSU-IGfdx3wEKhkfNyux7PsJS86U-x0D972S3s2E8mVgNwe1-Cdeh1HBFkAycv5QDDdYyEsq5rOTbKv0fVN02GKrs1UXNQALAwizMUtyyHKt3AGus7AbJsHCAA)

DeepOmit was removing the optional decorator from properties, resulting in non-homomorphic transforms for interface types.

We need to exclude the use of Exclude<T, K> as it strips optional decorators from interface properties. We can extract the primitive conditional to the top layer and omit the helper return instead.

## Bug found in `DeepPartial<T>` [demo](https://www.typescriptlang.org/play?#code/PTAEFpK6dv4YpyWrY0IBQJQBUBTAZwBdQARAQxMqywIA8AHAewCcySBPJg0ASQB2JAmyIEAxiQCWLQQHlBfALygAFKTbTBAc1AAfUIICuAWwBGogJQBtALqgAZKBsByTdp2u7AbnrN2Th4+IRExSRk5PAB3FlBVDRItXQMjM0s2WwdnROS9QxMLUVTzFhYAGwJKQSyfUH9WDlBuXlAAVUFZBSV49Q8UgvTre1STcvK-Rkag1o6umLjVfp0RwaK2ez8sbTCAM0oJPgAlYl4pAEE2NkouAFFK0wJhIgAePF65uUUCAD5QAG8sKBQAB9EEtJ6UR4ALlAyz8wPK0lIsLwfgAvnRcOgcbi8fiCXjMMAcCTsNjCZSqdSaQhiaTQAAhNgsADWT1Al2uXFATEoHGklHKRAZ0QAFhyktUiLt2KZPKACA8niQiKAWLtQNUtVcbryWbwODyNCxHiQxZ4sqK+EQxSxjOUACagUyUHZuwTNCXqrQ6bRC5rBNUar18fncugNQKB1rMtlPcgEAhMAAK-JkQref1UgOBNhToG0oHZXBDeDsAH5UfmHIwRIJHWq1NpdsU2lbgcCK0yWezBInk2mBZm2j97EDO9WU7WGPXG6ATpRHXJylwuTcXi22z8J12F1Vl4JV+uuC8432B6n04Lyi9RzvO6BYeeE0mr8Pb3gaz8MVsptGJDkUhQHMXtX0Ha8hWfMD+zfIcM1vE4iDOEgT3uAhHmebMAQnXByBYYgjBYMhRBZNhQGiaRzXaToviUCckRRFxjAbAhdm0AhHQAGlAVxYmiVweIAJjsLisHRLZcH4UwmGVYRqC6ZpKD7UBdhZUxQDFEgSCYIhoRAP1zWMcwADpANMYAAGU7SYaRdi4YAAEdjGkcoSGAJgHXKYAhIABgATgAFmAdjKjVWVyPMvktCIOQsAhUAADFpAYTjEvUlM2AIAA3WRjCIFMjizXp3jrJ550SlipC6CduzwCdUUVWdyuDcwACsIlq-AmrnNUWNZQQWGiQRx0fbtktSx10tNTKcrygqiq-QoMjsMc7F3J8AXzQtPRLMtK1hCa0oyrLcvtBa3m-TFgVRP8AiaQDBGA9jJum0xMsOlLjpm075sKl4kJQtC5NVbDc2JL1kQo9hWT0pqUMVK52AY5ESFhGwWMdNiOO43jSEocxKkE0ARLEzEoyaBLL3gm9ipzCdtqLPbNXLKt8BrHqWp21tyLwFMNrqgsyobJst3I9tRsfUBu2pyDb1HSXH1RIXmpF-clxXNddVPMX2gfKXu0XQ9j21l5ZY-O8fn1pWKDguXLuna3Nq-adfzof8HqAsgsYgj9YXNhCAdOCJgYwlUiDB3CwHNKHYjYWHYSmCJEbIlGmLcZZiaEnjMexpRHVE8SfCAA)

Deep partial is adding `undefined` as a valid type to union array types.

It seems DeepPartial cannot handle union array types. inferring the base type, and inferring the array type seems to solve the issue.

## Type of change

- [X] useful-types Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
