### PR TITLE
Update `react-graphql` to Apollo 3

### DIFF
--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -24,17 +24,13 @@
     "node": ">=12.14.0"
   },
   "dependencies": {
-    "@apollo/react-common": ">=3.0.0 <4.0.0",
-    "@apollo/react-hooks": ">=3.0.0 <4.0.0",
+    "@apollo/client": "^3.5.10",
     "@shopify/async": "^3.1.3",
     "@shopify/react-async": "^4.1.20",
     "@shopify/react-effect": "^4.1.10",
     "@shopify/react-hooks": "^2.1.16",
     "@shopify/react-idle": "^2.1.11",
     "@shopify/useful-types": "^4.0.0",
-    "apollo-cache-inmemory": ">=1.0.0 <2.0.0",
-    "apollo-client": ">=2.0.0 <3.0.0",
-    "apollo-link": ">=1.0.0 <2.0.0",
     "graphql-typed": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/react-graphql/src/ApolloContext.ts
+++ b/packages/react-graphql/src/ApolloContext.ts
@@ -1,10 +1,10 @@
 import React from 'react';
-import { ApolloClient } from '@apollo/client';
-import { DocumentNode } from 'graphql-typed';
+import {ApolloClient} from '@apollo/client';
+import {DocumentNode} from 'graphql-typed';
 
 export interface ApolloContextValue<CacheShape = any> {
   client?: ApolloClient<CacheShape>;
-  operations?: Map<string, { query: DocumentNode; variables: any }>;
+  operations?: Map<string, {query: DocumentNode; variables: any}>;
 }
 
 export const ApolloContext = React.createContext<

--- a/packages/react-graphql/src/ApolloContext.ts
+++ b/packages/react-graphql/src/ApolloContext.ts
@@ -1,10 +1,10 @@
 import React from 'react';
-import {ApolloClient} from 'apollo-client';
-import {DocumentNode} from 'graphql-typed';
+import { ApolloClient } from '@apollo/client';
+import { DocumentNode } from 'graphql-typed';
 
 export interface ApolloContextValue<CacheShape = any> {
   client?: ApolloClient<CacheShape>;
-  operations?: Map<string, {query: DocumentNode; variables: any}>;
+  operations?: Map<string, { query: DocumentNode; variables: any }>;
 }
 
 export const ApolloContext = React.createContext<

--- a/packages/react-graphql/src/ApolloProvider.tsx
+++ b/packages/react-graphql/src/ApolloProvider.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {ApolloClient} from 'apollo-client';
-import {ApolloProvider as OriginalApolloProvider} from '@apollo/react-common';
+import { ApolloClient, ApolloProvider as OriginalApolloProvider } from '@apollo/client';
 
-import {ApolloContext} from './ApolloContext';
+import { ApolloContext } from './ApolloContext';
 
 export interface Props<CacheShape> {
   readonly client: ApolloClient<CacheShape>;

--- a/packages/react-graphql/src/ApolloProvider.tsx
+++ b/packages/react-graphql/src/ApolloProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { ApolloClient, ApolloProvider as OriginalApolloProvider } from '@apollo/client';
+import {ApolloClient, ApolloProvider as OriginalApolloProvider} from '@apollo/client';
 
-import { ApolloContext } from './ApolloContext';
+import {ApolloContext} from './ApolloContext';
 
 export interface Props<CacheShape> {
   readonly client: ApolloClient<CacheShape>;

--- a/packages/react-graphql/src/Query.tsx
+++ b/packages/react-graphql/src/Query.tsx
@@ -1,8 +1,8 @@
-import { IfAllNullableKeys, NoInfer } from '@shopify/useful-types';
-import { OperationVariables } from '@apollo/client';
-import { DocumentNode } from 'graphql-typed';
+import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
+import {OperationVariables} from '@apollo/client';
+import {DocumentNode} from 'graphql-typed';
 
-import { useQuery, QueryHookResult, QueryHookOptions } from './hooks';
+import {useQuery, QueryHookResult, QueryHookOptions} from './hooks';
 
 interface QueryComponentOptions<Data, Variables> extends QueryHookOptions {
   children: (result: QueryHookResult<Data, Variables>) => JSX.Element | null;

--- a/packages/react-graphql/src/Query.tsx
+++ b/packages/react-graphql/src/Query.tsx
@@ -1,8 +1,8 @@
-import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
-import {OperationVariables} from 'apollo-client';
-import {DocumentNode} from 'graphql-typed';
+import { IfAllNullableKeys, NoInfer } from '@shopify/useful-types';
+import { OperationVariables } from '@apollo/client';
+import { DocumentNode } from 'graphql-typed';
 
-import {useQuery, QueryHookResult, QueryHookOptions} from './hooks';
+import { useQuery, QueryHookResult, QueryHookOptions } from './hooks';
 
 interface QueryComponentOptions<Data, Variables> extends QueryHookOptions {
   children: (result: QueryHookResult<Data, Variables>) => JSX.Element | null;

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -1,9 +1,6 @@
 import React, {ReactElement} from 'react';
 import faker from '@faker-js/faker/locale/en';
-import gql from 'graphql-tag';
-import {ApolloClient} from 'apollo-client';
-import {ApolloLink} from 'apollo-link';
-import {InMemoryCache} from 'apollo-cache-inmemory';
+import {ApolloClient, ApolloLink, InMemoryCache, gql} from '@apollo/client';
 import {getUsedAssets as baseGetUsedAssets} from '@shopify/react-async/testing';
 import {createMount} from '@shopify/react-testing';
 import {

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -1,6 +1,7 @@
 import React, {ReactElement} from 'react';
 import faker from '@faker-js/faker/locale/en';
-import {ApolloClient, ApolloLink, InMemoryCache, gql} from '@apollo/client';
+import {ApolloClient, ApolloLink, gql} from '@apollo/client';
+import {InMemoryCache} from '@apollo/client/cache';
 import {getUsedAssets as baseGetUsedAssets} from '@shopify/react-async/testing';
 import {createMount} from '@shopify/react-testing';
 import {
@@ -142,7 +143,7 @@ describe('createAsyncQueryComponent()', () => {
 
       const client = createMockApolloClient();
       const watchQuerySpy = jest.spyOn(client, 'watchQuery');
-      watchQuerySpy.mockImplementation(() => ({subscribe() {}} as any));
+      watchQuerySpy.mockImplementation(() => ({subscribe() {} } as any));
 
       const variables = {name: faker.name.firstName()};
       const asyncQuery = mount(<AsyncQuery.Prefetch variables={variables} />, {
@@ -201,7 +202,7 @@ describe('createAsyncQueryComponent()', () => {
 
       const client = createMockApolloClient();
       const watchQuerySpy = jest.spyOn(client, 'watchQuery');
-      watchQuerySpy.mockImplementation(() => ({subscribe() {}} as any));
+      watchQuerySpy.mockImplementation(() => ({subscribe() {} } as any));
 
       const variables = {name: faker.name.firstName()};
       const asyncQuery = mount(<AsyncQuery.KeepFresh variables={variables} />, {

--- a/packages/react-graphql/src/hooks/apollo-client.tsx
+++ b/packages/react-graphql/src/hooks/apollo-client.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ApolloClient} from 'apollo-client';
+import {ApolloClient} from '@apollo/client';
 
 import {ApolloContext} from '../ApolloContext';
 

--- a/packages/react-graphql/src/hooks/background-query.ts
+++ b/packages/react-graphql/src/hooks/background-query.ts
@@ -1,12 +1,12 @@
 import {useEffect, useRef, useCallback} from 'react';
 import {DocumentNode} from 'graphql-typed';
-import {WatchQueryOptions} from 'apollo-client';
+import {WatchQueryOptions} from '@apollo/client';
 
 import useApolloClient from './apollo-client';
 
 type Subscription = ReturnType<
   ReturnType<
-    import('apollo-client').default<unknown>['watchQuery']
+    import('@apollo/client').ApolloClient<unknown>['watchQuery']
   >['subscribe']
 >;
 

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -1,5 +1,5 @@
 import {useState, useEffect, useCallback} from 'react';
-import {OperationVariables} from 'apollo-client';
+import {OperationVariables} from '@apollo/client';
 import {DocumentNode} from 'graphql-typed';
 import {useMountedRef} from '@shopify/react-hooks';
 import {useAsyncAsset} from '@shopify/react-async';

--- a/packages/react-graphql/src/hooks/mutation.ts
+++ b/packages/react-graphql/src/hooks/mutation.ts
@@ -1,4 +1,4 @@
-import {OperationVariables} from 'apollo-client';
+import {OperationVariables} from '@apollo/client';
 import {DocumentNode} from 'graphql-typed';
 import {useCallback} from 'react';
 import {NoInfer} from '@shopify/useful-types';

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -7,7 +7,7 @@ import {
   ApolloError,
   WatchQueryOptions,
   ObservableQuery,
-} from 'apollo-client';
+} from '@apollo/client';
 import {DocumentNode} from 'graphql-typed';
 import {useServerEffect} from '@shopify/react-effect';
 import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';

--- a/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
@@ -4,8 +4,7 @@
 
 import React from 'react';
 import {renderToString} from 'react-dom/server';
-import gql from 'graphql-tag';
-import {FetchPolicy} from 'apollo-client';
+import {FetchPolicy, gql} from '@apollo/client';
 import {extract} from '@shopify/react-effect/server';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { ApolloClient, ApolloLink, NetworkStatus, InMemoryCache, gql } from '@apollo/client';
-import { createGraphQLFactory } from '@shopify/graphql-testing';
+import {ApolloClient, ApolloLink, NetworkStatus, InMemoryCache, gql} from '@apollo/client';
+import {createGraphQLFactory} from '@shopify/graphql-testing';
 
-import { createAsyncQueryComponent } from '../../async';
+import {createAsyncQueryComponent} from '../../async';
 import useQuery from '../query';
 
-import { mountWithGraphQL, createResolvablePromise } from './utilities';
+import {mountWithGraphQL, createResolvablePromise} from './utilities';
 
 const petQuery = gql`
   query PetQuery {
@@ -28,12 +28,12 @@ const mockData = {
 describe('useQuery', () => {
   describe('document', () => {
     it('returns loading=true and networkStatus=loading during the loading of query', async () => {
-      function MockQuery({ children }) {
+      function MockQuery({children}) {
         const results = useQuery(petQuery);
         return children(results);
       }
 
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
@@ -50,12 +50,12 @@ describe('useQuery', () => {
     });
 
     it('returns loading=true and networkStatus=loading during the loading of query when ssr option is false', async () => {
-      function MockQuery({ children }) {
-        const results = useQuery(petQuery, { ssr: false });
+      function MockQuery({children}) {
+        const results = useQuery(petQuery, {ssr: false});
         return children(results);
       }
 
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
@@ -72,20 +72,20 @@ describe('useQuery', () => {
     });
 
     it('return loading=false, networkStatus and the data once the query resolved', async () => {
-      function MockQuery({ children }) {
+      function MockQuery({children}) {
         const results = useQuery(petQuery);
         return children(results);
       }
 
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
         graphQL,
       });
 
-      const lastQuery = graphQL.operations.last({ operationName: 'PetQuery' });
-      expect(lastQuery).toMatchObject({ operationName: 'PetQuery' });
+      const lastQuery = graphQL.operations.last({operationName: 'PetQuery'});
+      expect(lastQuery).toMatchObject({operationName: 'PetQuery'});
 
       expect(renderPropSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -106,13 +106,13 @@ describe('useQuery', () => {
         ) => React.ReactElement | null;
         variables?: object;
       }) {
-        const results = useQuery(petQuery, { variables });
+        const results = useQuery(petQuery, {variables});
         return children(results);
       }
 
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
-      const variables = { foo: 'bar' };
+      const variables = {foo: 'bar'};
 
       const mockQuery = await mountWithGraphQL(
         <MockQuery variables={variables}>{renderPropSpy}</MockQuery>,
@@ -121,7 +121,7 @@ describe('useQuery', () => {
         },
       );
 
-      mockQuery.setProps({ variables: { ...variables } });
+      mockQuery.setProps({variables: {...variables}});
 
       expect(graphQL.operations.all()).toHaveLength(1);
 
@@ -139,11 +139,11 @@ describe('useQuery', () => {
       mockClient.watchQuery = watchQuerySpy;
 
       function MockQuery() {
-        useQuery(petQuery, { client: mockClient, skip: true });
+        useQuery(petQuery, {client: mockClient, skip: true});
         return null;
       }
 
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       await mountWithGraphQL(<MockQuery />, {
         graphQL,
       });
@@ -152,12 +152,12 @@ describe('useQuery', () => {
     });
 
     it('returns previous data if the fetchPolicy=no-cache and the current query has error', async () => {
-      function MockQuery({ children }) {
-        const results = useQuery(petQuery, { fetchPolicy: 'no-cache' });
+      function MockQuery({children}) {
+        const results = useQuery(petQuery, {fetchPolicy: 'no-cache'});
         return children(results);
       }
 
-      const graphQL = createGraphQL({ PetQuery: new Error() });
+      const graphQL = createGraphQL({PetQuery: new Error()});
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
@@ -178,11 +178,11 @@ describe('useQuery', () => {
       const MockQueryComponent = createAsyncQueryComponent({
         load: () => resolvableQuery.promise,
       });
-      function MockQuery({ children }) {
+      function MockQuery({children}) {
         const results = useQuery(MockQueryComponent);
         return children(results);
       }
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
         graphQL,
@@ -202,11 +202,11 @@ describe('useQuery', () => {
         load: () => Promise.resolve(petQuery),
       });
 
-      function MockQuery({ children }) {
+      function MockQuery({children}) {
         const results = useQuery(MockQueryComponent);
         return children(results);
       }
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
 
       const wrapper = await mountWithGraphQL(
@@ -234,11 +234,11 @@ describe('useQuery', () => {
         load: () => Promise.resolve(petQuery),
       });
 
-      function MockQuery({ children }) {
-        const results = useQuery(MockQueryComponent, { ssr: false });
+      function MockQuery({children}) {
+        const results = useQuery(MockQueryComponent, {ssr: false});
         return children(results);
       }
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
 
       const wrapper = await mountWithGraphQL(
@@ -266,11 +266,11 @@ describe('useQuery', () => {
         load: () => Promise.resolve(petQuery),
       });
 
-      function MockQuery({ children }) {
+      function MockQuery({children}) {
         const results = useQuery(MockQueryComponent);
         return children(results);
       }
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       const renderPropSpy = jest.fn(() => null);
 
       const wrapper = await mountWithGraphQL(
@@ -304,11 +304,11 @@ describe('useQuery', () => {
       });
 
       function MockQuery() {
-        useQuery(MockQueryComponent, { client: mockClient, skip: true });
+        useQuery(MockQueryComponent, {client: mockClient, skip: true});
         return null;
       }
 
-      const graphQL = createGraphQL({ PetQuery: mockData });
+      const graphQL = createGraphQL({PetQuery: mockData});
       await mountWithGraphQL(<MockQuery />, {
         graphQL,
       });

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {ApolloClient, ApolloLink, NetworkStatus, InMemoryCache, gql} from '@apollo/client';
+import {ApolloClient, ApolloLink, NetworkStatus, gql} from '@apollo/client';
+import {InMemoryCache} from '@apollo/client/cache';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 
 import {createAsyncQueryComponent} from '../../async';

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import gql from 'graphql-tag';
-import {ApolloClient, NetworkStatus} from 'apollo-client';
-import {ApolloLink} from 'apollo-link';
-import {InMemoryCache} from 'apollo-cache-inmemory';
-import {createGraphQLFactory} from '@shopify/graphql-testing';
+import { ApolloClient, ApolloLink, NetworkStatus, InMemoryCache, gql } from '@apollo/client';
+import { createGraphQLFactory } from '@shopify/graphql-testing';
 
-import {createAsyncQueryComponent} from '../../async';
+import { createAsyncQueryComponent } from '../../async';
 import useQuery from '../query';
 
-import {mountWithGraphQL, createResolvablePromise} from './utilities';
+import { mountWithGraphQL, createResolvablePromise } from './utilities';
 
 const petQuery = gql`
   query PetQuery {
@@ -31,12 +28,12 @@ const mockData = {
 describe('useQuery', () => {
   describe('document', () => {
     it('returns loading=true and networkStatus=loading during the loading of query', async () => {
-      function MockQuery({children}) {
+      function MockQuery({ children }) {
         const results = useQuery(petQuery);
         return children(results);
       }
 
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
@@ -53,12 +50,12 @@ describe('useQuery', () => {
     });
 
     it('returns loading=true and networkStatus=loading during the loading of query when ssr option is false', async () => {
-      function MockQuery({children}) {
-        const results = useQuery(petQuery, {ssr: false});
+      function MockQuery({ children }) {
+        const results = useQuery(petQuery, { ssr: false });
         return children(results);
       }
 
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
@@ -75,20 +72,20 @@ describe('useQuery', () => {
     });
 
     it('return loading=false, networkStatus and the data once the query resolved', async () => {
-      function MockQuery({children}) {
+      function MockQuery({ children }) {
         const results = useQuery(petQuery);
         return children(results);
       }
 
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
         graphQL,
       });
 
-      const lastQuery = graphQL.operations.last({operationName: 'PetQuery'});
-      expect(lastQuery).toMatchObject({operationName: 'PetQuery'});
+      const lastQuery = graphQL.operations.last({ operationName: 'PetQuery' });
+      expect(lastQuery).toMatchObject({ operationName: 'PetQuery' });
 
       expect(renderPropSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -109,13 +106,13 @@ describe('useQuery', () => {
         ) => React.ReactElement | null;
         variables?: object;
       }) {
-        const results = useQuery(petQuery, {variables});
+        const results = useQuery(petQuery, { variables });
         return children(results);
       }
 
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
-      const variables = {foo: 'bar'};
+      const variables = { foo: 'bar' };
 
       const mockQuery = await mountWithGraphQL(
         <MockQuery variables={variables}>{renderPropSpy}</MockQuery>,
@@ -124,7 +121,7 @@ describe('useQuery', () => {
         },
       );
 
-      mockQuery.setProps({variables: {...variables}});
+      mockQuery.setProps({ variables: { ...variables } });
 
       expect(graphQL.operations.all()).toHaveLength(1);
 
@@ -142,11 +139,11 @@ describe('useQuery', () => {
       mockClient.watchQuery = watchQuerySpy;
 
       function MockQuery() {
-        useQuery(petQuery, {client: mockClient, skip: true});
+        useQuery(petQuery, { client: mockClient, skip: true });
         return null;
       }
 
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       await mountWithGraphQL(<MockQuery />, {
         graphQL,
       });
@@ -155,12 +152,12 @@ describe('useQuery', () => {
     });
 
     it('returns previous data if the fetchPolicy=no-cache and the current query has error', async () => {
-      function MockQuery({children}) {
-        const results = useQuery(petQuery, {fetchPolicy: 'no-cache'});
+      function MockQuery({ children }) {
+        const results = useQuery(petQuery, { fetchPolicy: 'no-cache' });
         return children(results);
       }
 
-      const graphQL = createGraphQL({PetQuery: new Error()});
+      const graphQL = createGraphQL({ PetQuery: new Error() });
       const renderPropSpy = jest.fn(() => null);
 
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
@@ -181,11 +178,11 @@ describe('useQuery', () => {
       const MockQueryComponent = createAsyncQueryComponent({
         load: () => resolvableQuery.promise,
       });
-      function MockQuery({children}) {
+      function MockQuery({ children }) {
         const results = useQuery(MockQueryComponent);
         return children(results);
       }
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
       await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
         graphQL,
@@ -205,11 +202,11 @@ describe('useQuery', () => {
         load: () => Promise.resolve(petQuery),
       });
 
-      function MockQuery({children}) {
+      function MockQuery({ children }) {
         const results = useQuery(MockQueryComponent);
         return children(results);
       }
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
 
       const wrapper = await mountWithGraphQL(
@@ -237,11 +234,11 @@ describe('useQuery', () => {
         load: () => Promise.resolve(petQuery),
       });
 
-      function MockQuery({children}) {
-        const results = useQuery(MockQueryComponent, {ssr: false});
+      function MockQuery({ children }) {
+        const results = useQuery(MockQueryComponent, { ssr: false });
         return children(results);
       }
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
 
       const wrapper = await mountWithGraphQL(
@@ -269,11 +266,11 @@ describe('useQuery', () => {
         load: () => Promise.resolve(petQuery),
       });
 
-      function MockQuery({children}) {
+      function MockQuery({ children }) {
         const results = useQuery(MockQueryComponent);
         return children(results);
       }
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       const renderPropSpy = jest.fn(() => null);
 
       const wrapper = await mountWithGraphQL(
@@ -307,11 +304,11 @@ describe('useQuery', () => {
       });
 
       function MockQuery() {
-        useQuery(MockQueryComponent, {client: mockClient, skip: true});
+        useQuery(MockQueryComponent, { client: mockClient, skip: true });
         return null;
       }
 
-      const graphQL = createGraphQL({PetQuery: mockData});
+      const graphQL = createGraphQL({ PetQuery: mockData });
       await mountWithGraphQL(<MockQuery />, {
         graphQL,
       });

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -1,23 +1,27 @@
 import {
   ApolloClient,
   MutationOptions as ClientMutationOptions,
-} from 'apollo-client';
-import {
   QueryResult,
-  ExecutionResult,
+  FetchResult,
+  MutationOptions,
+  NormalizedCacheObject,
   OperationVariables,
-} from '@apollo/react-common';
-import {QueryOptions, MutationOptions} from '@apollo/react-hooks';
-import {IfAllNullableKeys} from '@shopify/useful-types';
+  QueryOptions,
+  WatchQueryFetchPolicy
+} from '@apollo/client';
+import { IfAllNullableKeys } from '@shopify/useful-types';
 
-import {VariableOptions} from '../types';
+import { VariableOptions } from '../types';
 
 export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<
   QueryOptions<Data, Variables>,
-  'query' | 'partialRefetch' | 'children' | 'variables'
+  'query' | 'partialRefetch' | 'variables' | 'fetchPolicy'
 > &
   VariableOptions<Variables> & {
+    client?: ApolloClient<NormalizedCacheObject>;
+    fetchPolicy?: WatchQueryFetchPolicy;
     skip?: boolean;
+    ssr?: boolean;
   };
 
 export interface QueryHookResult<Data, Variables>
@@ -29,10 +33,10 @@ export interface QueryHookResult<Data, Variables>
 export type MutationHookOptions<
   Data = any,
   Variables = OperationVariables
-> = Omit<
-  MutationOptions<Data, Variables>,
-  'variables' | 'mutation' | 'fetchPolicy'
-> &
+  > = Omit<
+    MutationOptions<Data, Variables>,
+    'variables' | 'mutation' | 'fetchPolicy'
+  > &
   VariableOptions<Variables> &
   Pick<ClientMutationOptions<Data, Variables>, 'fetchPolicy'> & {
     client?: ApolloClient<object>;
@@ -44,4 +48,4 @@ export type MutationHookResult<Data, Variables> = (
     [MutationHookOptions<Data, Variables>?],
     [MutationHookOptions<Data, Variables>]
   >
-) => Promise<ExecutionResult<Data>>;
+) => Promise<FetchResult<Data>>;

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -25,9 +25,13 @@ export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<
   };
 
 export interface QueryHookResult<Data, Variables>
-  extends Omit<QueryResult<Data, Variables>, 'networkStatus' | 'variables'> {
+extends Omit<
+  QueryResult<Data, Variables>,
+  'networkStatus' | 'variables' | 'called'
+> {
   networkStatus: QueryResult<Data, Variables>['networkStatus'] | undefined;
   variables: QueryResult<Data, Variables>['variables'] | undefined;
+  called: QueryResult<Data, Variables>['called'] | false;
 }
 
 export type MutationHookOptions<

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -9,9 +9,9 @@ import {
   QueryOptions,
   WatchQueryFetchPolicy
 } from '@apollo/client';
-import { IfAllNullableKeys } from '@shopify/useful-types';
+import {IfAllNullableKeys} from '@shopify/useful-types';
 
-import { VariableOptions } from '../types';
+import {VariableOptions} from '../types';
 
 export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<
   QueryOptions<Data, Variables>,
@@ -33,10 +33,10 @@ export interface QueryHookResult<Data, Variables>
 export type MutationHookOptions<
   Data = any,
   Variables = OperationVariables
-  > = Omit<
-    MutationOptions<Data, Variables>,
-    'variables' | 'mutation' | 'fetchPolicy'
-  > &
+> = Omit<
+  MutationOptions<Data, Variables>,
+  'variables' | 'mutation' | 'fetchPolicy'
+> &
   VariableOptions<Variables> &
   Pick<ClientMutationOptions<Data, Variables>, 'fetchPolicy'> & {
     client?: ApolloClient<object>;

--- a/packages/react-graphql/src/links.ts
+++ b/packages/react-graphql/src/links.ts
@@ -4,7 +4,7 @@ import {
   NextLink,
   Observable,
   FetchResult,
-} from 'apollo-link';
+} from '@apollo/client';
 
 export function createSsrExtractableLink() {
   return new SsrExtractableLink();

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -14,10 +14,10 @@ import {
   WatchQueryFetchPolicy,
   QueryResult,
 } from '@apollo/client';
-import { IfEmptyObject, IfAllNullableKeys } from '@shopify/useful-types';
-import { AsyncComponentType, AsyncHookTarget } from '@shopify/react-async';
+import {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
+import {AsyncComponentType, AsyncHookTarget} from '@shopify/react-async';
 
-import { QueryHookOptions } from './hooks';
+import {QueryHookOptions} from './hooks';
 
 export type {
   GraphQLData,
@@ -28,8 +28,8 @@ export type {
 
 export type VariableOptions<Variables> = IfEmptyObject<
   Variables,
-  { variables?: never },
-  IfAllNullableKeys<Variables, { variables?: Variables }, { variables: Variables }>
+  {variables?: never},
+  IfAllNullableKeys<Variables, {variables?: Variables}, {variables: Variables}>
 >;
 
 export type QueryProps<Data = any, Variables = OperationVariables> = {
@@ -43,7 +43,7 @@ export type QueryProps<Data = any, Variables = OperationVariables> = {
   displayName?: string;
   skip?: boolean;
   client?: ApolloClient<object>;
-  context?: { [key: string]: any };
+  context?: {[key: string]: any};
   partialRefetch?: boolean;
   onCompleted?: (data: Data | {}) => void;
   onError?: (error: ApolloError) => void;
@@ -51,22 +51,22 @@ export type QueryProps<Data = any, Variables = OperationVariables> = {
 
 export interface AsyncDocumentNode<Data, Variables, DeepPartial>
   extends GraphQLOperation<Data, Variables, DeepPartial>,
-  AsyncHookTarget<
-  DocumentNode<Data, Variables, DeepPartial>,
-  {},
-  VariableOptions<Variables>,
-  VariableOptions<Variables> &
-  Pick<QueryProps<Data, Variables>, 'pollInterval'>
-  > { }
+    AsyncHookTarget<
+      DocumentNode<Data, Variables, DeepPartial>,
+      {},
+      VariableOptions<Variables>,
+      VariableOptions<Variables> &
+        Pick<QueryProps<Data, Variables>, 'pollInterval'>
+    > {}
 
 export interface AsyncQueryComponentType<Data, Variables, DeepPartial>
   extends GraphQLOperation<Data, Variables, DeepPartial>,
-  AsyncComponentType<
-  DocumentNode<Data, Variables, DeepPartial>,
-  QueryHookOptions<Data, Variables> &
-  Pick<QueryProps<Data, Variables>, 'children'>,
-  {},
-  VariableOptions<Variables>,
-  VariableOptions<Variables> &
-  Pick<QueryProps<Data, Variables>, 'pollInterval'>
-  > { }
+    AsyncComponentType<
+      DocumentNode<Data, Variables, DeepPartial>,
+      QueryHookOptions<Data, Variables> &
+        Pick<QueryProps<Data, Variables>, 'children'>,
+      {},
+      VariableOptions<Variables>,
+      VariableOptions<Variables> &
+        Pick<QueryProps<Data, Variables>, 'pollInterval'>
+    > {}

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -6,18 +6,18 @@ import {
   GraphQLVariables,
   GraphQLDeepPartial,
 } from 'graphql-typed';
-import {QueryResult} from '@apollo/react-common';
 import {
   ErrorPolicy,
   OperationVariables,
   ApolloError,
   ApolloClient,
   WatchQueryFetchPolicy,
-} from 'apollo-client';
-import {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
-import {AsyncComponentType, AsyncHookTarget} from '@shopify/react-async';
+  QueryResult,
+} from '@apollo/client';
+import { IfEmptyObject, IfAllNullableKeys } from '@shopify/useful-types';
+import { AsyncComponentType, AsyncHookTarget } from '@shopify/react-async';
 
-import {QueryHookOptions} from './hooks';
+import { QueryHookOptions } from './hooks';
 
 export type {
   GraphQLData,
@@ -28,8 +28,8 @@ export type {
 
 export type VariableOptions<Variables> = IfEmptyObject<
   Variables,
-  {variables?: never},
-  IfAllNullableKeys<Variables, {variables?: Variables}, {variables: Variables}>
+  { variables?: never },
+  IfAllNullableKeys<Variables, { variables?: Variables }, { variables: Variables }>
 >;
 
 export type QueryProps<Data = any, Variables = OperationVariables> = {
@@ -43,7 +43,7 @@ export type QueryProps<Data = any, Variables = OperationVariables> = {
   displayName?: string;
   skip?: boolean;
   client?: ApolloClient<object>;
-  context?: {[key: string]: any};
+  context?: { [key: string]: any };
   partialRefetch?: boolean;
   onCompleted?: (data: Data | {}) => void;
   onError?: (error: ApolloError) => void;
@@ -51,22 +51,22 @@ export type QueryProps<Data = any, Variables = OperationVariables> = {
 
 export interface AsyncDocumentNode<Data, Variables, DeepPartial>
   extends GraphQLOperation<Data, Variables, DeepPartial>,
-    AsyncHookTarget<
-      DocumentNode<Data, Variables, DeepPartial>,
-      {},
-      VariableOptions<Variables>,
-      VariableOptions<Variables> &
-        Pick<QueryProps<Data, Variables>, 'pollInterval'>
-    > {}
+  AsyncHookTarget<
+  DocumentNode<Data, Variables, DeepPartial>,
+  {},
+  VariableOptions<Variables>,
+  VariableOptions<Variables> &
+  Pick<QueryProps<Data, Variables>, 'pollInterval'>
+  > { }
 
 export interface AsyncQueryComponentType<Data, Variables, DeepPartial>
   extends GraphQLOperation<Data, Variables, DeepPartial>,
-    AsyncComponentType<
-      DocumentNode<Data, Variables, DeepPartial>,
-      QueryHookOptions<Data, Variables> &
-        Pick<QueryProps<Data, Variables>, 'children'>,
-      {},
-      VariableOptions<Variables>,
-      VariableOptions<Variables> &
-        Pick<QueryProps<Data, Variables>, 'pollInterval'>
-    > {}
+  AsyncComponentType<
+  DocumentNode<Data, Variables, DeepPartial>,
+  QueryHookOptions<Data, Variables> &
+  Pick<QueryProps<Data, Variables>, 'children'>,
+  {},
+  VariableOptions<Variables>,
+  VariableOptions<Variables> &
+  Pick<QueryProps<Data, Variables>, 'pollInterval'>
+  > { }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@apollo/client@^3.5.10":
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.10.tgz#43463108a6e07ae602cca0afc420805a19339a71"
+  integrity sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.9.4"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.0"
+
 "@apollo/federation@0.27.0":
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/@apollo/federation/-/federation-0.27.0.tgz#2ee13b28cff94817ff07bb02215aa764d8becba3"
@@ -10,7 +28,7 @@
     apollo-graphql "^0.9.3"
     lodash.xorby "^4.7.0"
 
-"@apollo/react-common@>=3.0.0 <4.0.0", "@apollo/react-common@^3.1.3", "@apollo/react-common@^3.1.4":
+"@apollo/react-common@^3.1.3", "@apollo/react-common@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.4.tgz#ec13c985be23ea8e799c9ea18e696eccc97be345"
   integrity sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==
@@ -18,7 +36,7 @@
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-hooks@>=3.0.0 <4.0.0", "@apollo/react-hooks@^3.1.3":
+"@apollo/react-hooks@^3.1.3":
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.5.tgz#7e710be52461255ae7fc0b3b9c2ece64299c10e6"
   integrity sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==
@@ -1472,6 +1490,11 @@
     "@graphql-tools/utils" "^7.2.1"
     is-promise "4.0.0"
     tslib "~2.0.1"
+
+"@graphql-typed-document-node/core@^3.0.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"
@@ -3887,12 +3910,33 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
+"@wry/context@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
 "@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
   integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
   dependencies:
     tslib "^1.9.3"
+
+"@wry/equality@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
+  integrity sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
+  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
+  dependencies:
+    tslib "^2.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -7254,6 +7298,13 @@ graphql-tag@^2.10.1, graphql-tag@^2.10.3:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
   integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
 
+graphql-tag@^2.12.3:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
 graphql-upload@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-11.0.0.tgz#24b245ff18f353bab6715e8a055db9fd73035e10"
@@ -7436,7 +7487,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hoist-non-react-statics@^3.0.1, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.1, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10379,6 +10430,14 @@ optimism@^0.10.0:
   dependencies:
     "@wry/context" "^0.4.0"
 
+optimism@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
+  dependencies:
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -12464,6 +12523,11 @@ symbol-observable@^1.0.2:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -12790,6 +12854,13 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   dependencies:
     tslib "^1.9.3"
 
+ts-invariant@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
+  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-node@^8, ts-node@^8.0.3:
   version "8.10.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
@@ -12840,7 +12911,7 @@ tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -13824,7 +13895,14 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0:
+zen-observable-ts@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
+  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15, zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
## Description

Resolves https://github.com/Shopify/web/issues/59425

Following the migration guide [here](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/), this PR removes the following dependencies from the `react-graphql` package and replaces them with `@apollo/client`:

- `@apollo/react-common`
- `@apollo/react-hooks`
- `apollo-cache-inmemory`
- `apollo-client`
- `apollo-link`

All existing imports are updated to point to the new paths from `@apollo/client`

NOTE: As `react-graphql` is used by the `react-graphql-universal-provider` package and as its dependencies are the old ones, CI will fail due to type issues. 

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
