### PR TITLE
Update `react-graphql-universal-provider` to Apollo 3

### DIFF
--- a/packages/react-graphql-universal-provider/package.json
+++ b/packages/react-graphql-universal-provider/package.json
@@ -24,14 +24,11 @@
     "node": ">=12.14.0"
   },
   "dependencies": {
-    "@shopify/react-graphql": "^7.1.23",
-    "@shopify/react-hooks": "^2.1.17",
-    "@shopify/react-html": "^11.1.19",
-    "@shopify/react-network": "^4.2.9",
-    "apollo-cache-inmemory": ">=1.0.0 <2.0.0",
-    "apollo-client": ">=2.0.0 <3.0.0",
-    "apollo-link": ">=1.0.0 <2.0.0",
-    "apollo-link-context": ">=1.0.0 <2.0.0"
+    "@shopify/react-graphql": "^7.1.22",
+    "@shopify/react-hooks": "^2.1.16",
+    "@shopify/react-html": "^11.1.18",
+    "@shopify/react-network": "^4.2.8",
+    "@apollo/client": "^3.5.10"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <18.0.0"

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -32,7 +32,7 @@ export function GraphQLUniversalProvider<
 
   const [client, ssrLink] = useLazyRef<
     [
-      import('@apollo/client').ApolloClient<any>,
+      ApolloClient<any>,
       ReturnType<typeof createSsrExtractableLink> | undefined,
     ]
   >(() => {

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -31,10 +31,7 @@ export function GraphQLUniversalProvider<
   const requestID = useRequestHeader('X-Request-ID');
 
   const [client, ssrLink] = useLazyRef<
-    [
-      ApolloClient<any>,
-      ReturnType<typeof createSsrExtractableLink> | undefined,
-    ]
+    [ApolloClient<any>, ReturnType<typeof createSsrExtractableLink> | undefined]
   >(() => {
     const server = isServer();
 

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {ApolloClient, ApolloClientOptions} from 'apollo-client';
-import {ApolloLink} from 'apollo-link';
-import {InMemoryCache, NormalizedCacheObject} from 'apollo-cache-inmemory';
+import {ApolloClient, ApolloClientOptions, ApolloLink} from '@apollo/client';
+import {InMemoryCache, NormalizedCacheObject} from '@apollo/client/cache';
 import {useSerialized} from '@shopify/react-html';
 import {ApolloProvider, createSsrExtractableLink} from '@shopify/react-graphql';
 import {useLazyRef} from '@shopify/react-hooks';
@@ -33,7 +32,7 @@ export function GraphQLUniversalProvider<
 
   const [client, ssrLink] = useLazyRef<
     [
-      import('apollo-client').ApolloClient<any>,
+      import('@apollo/client').ApolloClient<any>,
       ReturnType<typeof createSsrExtractableLink> | undefined,
     ]
   >(() => {

--- a/packages/react-graphql-universal-provider/src/csrf-link.ts
+++ b/packages/react-graphql-universal-provider/src/csrf-link.ts
@@ -1,4 +1,4 @@
-import {setContext} from 'apollo-link-context';
+import {setContext} from '@apollo/client/link/context';
 
 export const SAME_SITE_HEADER = 'x-shopify-react-xhr';
 export const SAME_SITE_VALUE = '1';

--- a/packages/react-graphql-universal-provider/src/request-id-link.ts
+++ b/packages/react-graphql-universal-provider/src/request-id-link.ts
@@ -1,4 +1,4 @@
-import {setContext} from 'apollo-link-context';
+import {setContext} from '@apollo/client/link/context';
 
 export function createRequestIdLink(requestId: string) {
   return setContext((_, {headers}) => ({

--- a/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {InMemoryCache} from 'apollo-cache-inmemory';
-import {ApolloLink} from 'apollo-link';
+import {ApolloLink} from '@apollo/client';
+import {InMemoryCache} from '@apollo/client/cache';
 import {extract} from '@shopify/react-effect/server';
 import {mount} from '@shopify/react-testing';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';
@@ -9,12 +9,12 @@ import {NetworkContext, NetworkManager} from '@shopify/react-network';
 
 import {GraphQLUniversalProvider} from '../GraphQLUniversalProvider';
 
-jest.mock('apollo-client', () => {
-  const ApolloClient = jest.requireActual('apollo-client').ApolloClient;
+jest.mock('@apollo/client', () => {
+  const ApolloClient = jest.requireActual('@apollo/client').ApolloClient;
   const mockApolloClient = jest.fn((options) => new ApolloClient(options));
 
   return {
-    ...jest.requireActual('apollo-client'),
+    ...jest.requireActual('@apollo/client'),
     default: mockApolloClient,
     ApolloClient: mockApolloClient,
   };
@@ -38,7 +38,7 @@ jest.mock('../csrf-link', () => ({
 }));
 const {createCsrfLink} = jest.requireMock('../csrf-link');
 
-const ApolloClient = jest.requireMock('apollo-client').default;
+const ApolloClient = jest.requireMock('@apollo/client').default;
 
 describe('<GraphQLUniversalProvider />', () => {
   beforeEach(() => {
@@ -58,7 +58,7 @@ describe('<GraphQLUniversalProvider />', () => {
     );
 
     expect(graphQL).toContainReactComponent(ApolloProvider, {
-      client: expect.any(jest.requireActual('apollo-client').ApolloClient),
+      client: expect.any(jest.requireActual('@apollo/client').ApolloClient),
     });
   });
 

--- a/packages/react-graphql-universal-provider/src/tests/request-id-link.test.ts
+++ b/packages/react-graphql-universal-provider/src/tests/request-id-link.test.ts
@@ -1,4 +1,4 @@
-import {ApolloLink, Observable} from 'apollo-link';
+import {ApolloLink, Observable} from '@apollo/client';
 
 import {createRequestIdLink} from '../request-id-link';
 

--- a/packages/react-graphql/src/ApolloProvider.tsx
+++ b/packages/react-graphql/src/ApolloProvider.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import {ApolloClient, ApolloProvider as OriginalApolloProvider} from '@apollo/client';
+import {
+  ApolloClient,
+  ApolloProvider as OriginalApolloProvider,
+} from '@apollo/client';
 
 import {ApolloContext} from './ApolloContext';
 

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -143,7 +143,7 @@ describe('createAsyncQueryComponent()', () => {
 
       const client = createMockApolloClient();
       const watchQuerySpy = jest.spyOn(client, 'watchQuery');
-      watchQuerySpy.mockImplementation(() => ({subscribe() {} } as any)); s
+      watchQuerySpy.mockImplementation(() => ({subscribe() {}} as any));
 
       const variables = {name: faker.name.firstName()};
       const asyncQuery = mount(<AsyncQuery.Prefetch variables={variables} />, {
@@ -202,7 +202,7 @@ describe('createAsyncQueryComponent()', () => {
 
       const client = createMockApolloClient();
       const watchQuerySpy = jest.spyOn(client, 'watchQuery');
-      watchQuerySpy.mockImplementation(() => ({subscribe() {} } as any));
+      watchQuerySpy.mockImplementation(() => ({subscribe() {}} as any));
 
       const variables = {name: faker.name.firstName()};
       const asyncQuery = mount(<AsyncQuery.KeepFresh variables={variables} />, {

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -143,7 +143,7 @@ describe('createAsyncQueryComponent()', () => {
 
       const client = createMockApolloClient();
       const watchQuerySpy = jest.spyOn(client, 'watchQuery');
-      watchQuerySpy.mockImplementation(() => ({subscribe() {} } as any));
+      watchQuerySpy.mockImplementation(() => ({subscribe() {} } as any)); s
 
       const variables = {name: faker.name.firstName()};
       const asyncQuery = mount(<AsyncQuery.Prefetch variables={variables} />, {

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -7,7 +7,7 @@ import {
   NormalizedCacheObject,
   OperationVariables,
   QueryOptions,
-  WatchQueryFetchPolicy
+  WatchQueryFetchPolicy,
 } from '@apollo/client';
 import {IfAllNullableKeys} from '@shopify/useful-types';
 
@@ -25,10 +25,10 @@ export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<
   };
 
 export interface QueryHookResult<Data, Variables>
-extends Omit<
-  QueryResult<Data, Variables>,
-  'networkStatus' | 'variables' | 'called'
-> {
+  extends Omit<
+    QueryResult<Data, Variables>,
+    'networkStatus' | 'variables' | 'called'
+  > {
   networkStatus: QueryResult<Data, Variables>['networkStatus'] | undefined;
   variables: QueryResult<Data, Variables>['variables'] | undefined;
   called: QueryResult<Data, Variables>['called'] | false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4231,7 +4231,7 @@ apollo-language-server@^1.26.4:
     vscode-languageserver "^5.1.0"
     vscode-uri "1.0.6"
 
-"apollo-link-context@>=1.0.0 <2.0.0", apollo-link-context@^1.0.9:
+apollo-link-context@^1.0.9:
   version "1.0.20"
   resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.20.tgz#1939ac5dc65d6dff0c855ee53521150053c24676"
   integrity sha512-MLLPYvhzNb8AglNsk2NcL9AvhO/Vc9hn2ZZuegbhRHGet3oGr0YH9s30NS9+ieoM0sGT11p7oZ6oAILM/kiRBA==


### PR DESCRIPTION
## Description

Resolves https://github.com/Shopify/web/issues/59426

Following the migration guide [here](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/), this PR removes the following dependencies from the `react-graphql-universal-provider` package and replaces them with `@apollo/client`:

- `apollo-cache-inmemory`
- `apollo-client`
- `apollo-link`
- `apollo-link-context`

All existing imports are updated to point to the new paths from `@apollo/client`


## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
