### PR TITLE
♻️📝 Expose match function in ShortcutManager

### DIFF
--- a/packages/react-shortcuts/CHANGELOG.md
+++ b/packages/react-shortcuts/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Exposed internal method `allModifiersAreHeld` on the `ShortcutManager` to allow calling it directly [[#2237](https://github.com/Shopify/quilt/pull/2237)]
 
 ## 4.2.4 - 2022-03-09
 

--- a/packages/react-shortcuts/README.md
+++ b/packages/react-shortcuts/README.md
@@ -249,3 +249,7 @@ describe('my-component', () => {
   });
 });
 ```
+
+#### Manually checking a matching shortcut
+
+`ShortcutManager` uses the `allModifiersAreHeld` class function in order to determine if a group of keys are found within a keyboard event. If you need to manually check a keyboard event against a group of keys, you can call this function directly on an instance of `ShortcutManager`.

--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -38,6 +38,23 @@ export default class ShortcutManager {
     };
   }
 
+  allModifiersAreHeld(heldKeys: HeldKey, event: KeyboardEvent) {
+    function hasKeyGroups(groups: HeldKey): groups is HeldKey {
+      return groups.every((key) => Array.isArray(key));
+    }
+
+    function keyGroupIsHeld(keyGroup: ModifierKey[]) {
+      return keyGroup.every(
+        (key: ModifierKey) =>
+          event.getModifierState && event.getModifierState(key),
+      );
+    }
+
+    return hasKeyGroups(heldKeys)
+      ? heldKeys.some(keyGroupIsHeld)
+      : keyGroupIsHeld(heldKeys);
+  }
+
   private resetKeys() {
     this.keysPressed = [];
     this.shortcutsMatched = [];
@@ -62,23 +79,6 @@ export default class ShortcutManager {
         }, ON_MATCH_DELAY);
     }
   };
-
-  private allModifiersAreHeld(heldKeys: HeldKey, event: KeyboardEvent) {
-    function hasKeyGroups(groups: HeldKey): groups is HeldKey {
-      return groups.every((key) => Array.isArray(key));
-    }
-
-    function keyGroupIsHeld(keyGroup: ModifierKey[]) {
-      return keyGroup.every(
-        (key: ModifierKey) =>
-          event.getModifierState && event.getModifierState(key),
-      );
-    }
-
-    return hasKeyGroups(heldKeys)
-      ? heldKeys.some(keyGroupIsHeld)
-      : keyGroupIsHeld(heldKeys);
-  }
 
   private updateMatchingShortcuts(event: KeyboardEvent) {
     const shortcuts =


### PR DESCRIPTION
## Description

This PR exposes a previously-internal method on `ShortcutManager` which enables consumers to check which modifier keys are held.

<details>
<summary>Full context on slack (<a href="https://shopify.slack.com/archives/C01H7LC0EEL/p1649691079537249">link</a>)</summary>

<img width="2095" alt="image" src="https://user-images.githubusercontent.com/9555730/163230574-b36518c8-00b5-4f43-b6d0-d79d0b1a5673.png">

</details>

I thought about specifically adding a test for the exposed function, but because there was complete overlap with existing tests, I decided against it.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
