### PR TITLE
Relax version constraints for `graphql-tool-utilities`

### DIFF
--- a/packages/graphql-tool-utilities/CHANGELOG.md
+++ b/packages/graphql-tool-utilities/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
 
 ### Changed
 

--- a/packages/graphql-tool-utilities/CHANGELOG.md
+++ b/packages/graphql-tool-utilities/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Relax constraints on `apollo-codegen-core` [#2238](https://github.com/Shopify/quilt/pull/2238)
+
 ## 2.1.6 - 2022-03-09
 
 ### Changed

--- a/packages/graphql-tool-utilities/package.json
+++ b/packages/graphql-tool-utilities/package.json
@@ -24,7 +24,7 @@
     "node": ">=12.14.0"
   },
   "dependencies": {
-    "apollo-codegen-core": "0.40.4",
+    "apollo-codegen-core": "^0.40.4",
     "graphql": ">=14.5.0 <16.0.0"
   },
   "files": [


### PR DESCRIPTION
## Description

When fixing CVE-2022-24785 in the Fraud Filter app, the `graphql-tool-utilities` package was locking down to a specific version of `apollo-codegen-core`. A quick look at the history and asking on Slack doesn't reveal any particular reason why we need to be doing this so I'm relaxing the constraint. Once `apollo-language-server` removes the `moment` dependency with https://github.com/apollographql/apollo-tooling/issues/2323 that I've submitted a PR for, this change will allow users to upgrade and remove `moment` as well without this package getting in the way.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] `graphql-tool-utilities` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
