### PR TITLE
Increase buffer for i18n dictionary generation again

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Patch - `generateTranslationIndexes` no longer fails with `ENOBUFS` errors in projects with tens of thousands of translation files [[#2269](https://github.com/Shopify/quilt/pull/2269)]
 
 ## 6.4.0 - 2022-04-25
 

--- a/packages/react-i18n/src/babel-plugin/shared.ts
+++ b/packages/react-i18n/src/babel-plugin/shared.ts
@@ -30,7 +30,7 @@ export function findTranslationBuckets(rootDir) {
   // (20s vs 1s in web with ~750 translation folders and 21 langs)
   const files = execSync(
     `find ${rootDir} -type d \\( -path ${rootDir}/node_modules -o -path ${rootDir}/build -o -path ${rootDir}/tmp -o -path ${rootDir}/.git -o -path ${rootDir}/public \\) -prune -o -name '*.json' -print | grep /${TRANSLATION_DIRECTORY_NAME}/`,
-    {maxBuffer: 1_000_000 * 10},
+    {maxBuffer: 2_000_000 * 10},
   )
     .toString()
     .trim()


### PR DESCRIPTION
## Description
Increase the buffer for the shell out to `find` when generating translation dictionaries.  I bumped it up a couple of weeks ago, but it still wasn't enough to contain web's translations 😬 

## Type of change

- [x] react-i18n Patch: Bug

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
