### PR TITLE
[react-form] add getDirtyValues utility function

### DIFF
--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -7,11 +7,17 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## 2.1.0 - 2022-05-20
+
+### Added
+
+- Add `getDirtyValues` utility function [#2270](https://github.com/Shopify/quilt/pull/2270)
+
 ## 2.0.0 - 2022-05-19
 
 ### Breaking Change
 
-- Drop support for node 12 and Safari 10, 11 and 12. Remove wildcard export in exports field. [[#2277](https://github.com/Shopify/quilt/pull/2277)]
+- # Drop support for node 12 and Safari 10, 11 and 12. Remove wildcard export in exports field. [[#2277](https://github.com/Shopify/quilt/pull/2277)]
 
 ## 1.1.19 - 2022-04-25
 

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -17,7 +17,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Breaking Change
 
-- # Drop support for node 12 and Safari 10, 11 and 12. Remove wildcard export in exports field. [[#2277](https://github.com/Shopify/quilt/pull/2277)]
+- Drop support for node 12 and Safari 10, 11 and 12. Remove wildcard export in exports field. [[#2277](https://github.com/Shopify/quilt/pull/2277)]
 
 ## 1.1.19 - 2022-04-25
 

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -1129,16 +1129,17 @@ Takes `FieldBag` and returns object with only dirty field values, similar to the
 
 ##### Signature
 
-```ts
+```tsx
 function getDirtyValues<T extends FieldBag>(fieldBag: T) {
-  return Object.entries(
-    fieldBag,
-  ).reduce((acc, [fieldName, field]: [string, Field<any>]) => {
-    return {
-      ...acc,
-      ...(field.dirty ? {[fieldName]: field.value} : {}),
-    };
-  }, {});
+  return Object.entries(fieldBag).reduce(
+    (acc, [fieldName, field]: [string, Field<any>]) => {
+      return {
+        ...acc,
+        ...(field.dirty ? {[fieldName]: field.value} : {}),
+      };
+    },
+    {},
+  );
 }
 ```
 

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -31,6 +31,7 @@ Manage React forms tersely and safely-typed with no magic using React hooks. Bui
    1. [Utilities](#utilities)
       1. [reduceFields](#utilities)
       1. [getValues](#utilities)
+      1. [getDirtyValues](#utilities)
       1. [fieldsToArray](#utilities)
       1. [makeCleanFields](#utilities)
 1. [FAQ](#faq)
@@ -1121,6 +1122,25 @@ Docs for these standalone hooks are coming soon. For now check out the `.d.ts` f
 Detailed validation docs are coming soon. For now check out the `.d.ts` files for the API.
 
 ### Utilities
+
+#### getDirtyValues
+
+Takes `FieldBag` and returns object with only dirty field values, similar to the `FormMapping` argument passed to `onSubmit`.
+
+##### Signature
+
+```ts
+function getDirtyValues<T extends FieldBag>(fieldBag: T) {
+  return Object.entries(
+    fieldBag,
+  ).reduce((acc, [fieldName, field]: [string, Field<any>]) => {
+    return {
+      ...acc,
+      ...(field.dirty ? {[fieldName]: field.value} : {}),
+    };
+  }, {});
+}
+```
 
 #### reduceFields
 

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -19,6 +19,7 @@ export type {ChoiceField, FieldConfig} from './hooks';
 export {
   fieldsToArray,
   getValues,
+  getDirtyValues,
   propagateErrors,
   validateAll,
   reduceFields,

--- a/packages/react-form/src/tests/utilities.test.ts
+++ b/packages/react-form/src/tests/utilities.test.ts
@@ -2,6 +2,7 @@ import {
   shallowArrayComparison,
   isChangeEvent,
   getValues,
+  getDirtyValues,
   noop,
   validateAll,
   fieldsToArray,
@@ -92,6 +93,35 @@ describe('getValues()', () => {
     };
 
     expect(getValues(fieldBag)).toStrictEqual(formValue);
+  });
+});
+
+describe('getDirtyValues()', () => {
+  it('returns dirty form values', () => {
+    const formValue = {
+      username: 'myUsername',
+      name: {
+        firstName: 'myFirstName',
+      },
+      emails: [
+        {
+          work: 'work@example.com',
+        },
+      ],
+    };
+    const fieldBag = {
+      username: {...mockField(formValue.username), dirty: true},
+      name: {
+        firstName: mockField(formValue.name.firstName),
+      },
+      emails: [
+        {
+          work: mockField(formValue.emails[0].work),
+        },
+      ],
+    };
+
+    expect(getDirtyValues(fieldBag)).toStrictEqual({ username: formValue.username});
   });
 });
 

--- a/packages/react-form/src/tests/utilities.test.ts
+++ b/packages/react-form/src/tests/utilities.test.ts
@@ -121,7 +121,9 @@ describe('getDirtyValues()', () => {
       ],
     };
 
-    expect(getDirtyValues(fieldBag)).toStrictEqual({ username: formValue.username});
+    expect(getDirtyValues(fieldBag)).toStrictEqual({
+      username: formValue.username,
+    });
   });
 });
 

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -174,14 +174,15 @@ export function getValues<T extends FieldBag>(fieldBag: T) {
 }
 
 export function getDirtyValues<T extends FieldBag>(fieldBag: T) {
-  return Object.entries(
-    fieldBag,
-  ).reduce((acc, [fieldName, field]: [string, Field<any>]) => {
-    return {
-      ...acc,
-      ...(field.dirty ? {[fieldName]: field.value} : {}),
-    };
-  }, {});
+  return Object.entries(fieldBag).reduce(
+    (acc, [fieldName, field]: [string, Field<any>]) => {
+      return {
+        ...acc,
+        ...(field.dirty ? {[fieldName]: field.value} : {}),
+      };
+    },
+    {},
+  );
 }
 
 export function noop() {}

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -173,6 +173,17 @@ export function getValues<T extends FieldBag>(fieldBag: T) {
   );
 }
 
+export function getDirtyValues<T extends FieldBag>(fieldBag: T) {
+  return Object.entries(
+    fieldBag,
+  ).reduce((acc, [fieldName, field]: [string, Field<any>]) => {
+    return {
+      ...acc,
+      ...(field.dirty ? {[fieldName]: field.value} : {}),
+    };
+  }, {});
+}
+
 export function noop() {}
 
 export function shallowArrayComparison(arrA: unknown[], arrB: any) {


### PR DESCRIPTION
## Description

As part of this [issue to allow users to update a notification](https://github.com/Shopify/merchant-communication/issues/515), we had to prepare a mutation payload composed of only data from dirty form fields. 

[This logic](https://github.com/Shopify/iris/pull/1232/files#diff-901f8d8116591cc7581402d92e3cee9b7fd7ad3d30b45b46852d4fbe8aca181dR165-R172) was written to get an object with the field name and value for any dirty field in the fieldBag.

This PR adds the `getDirtyFields` logic in the form of a utility function, as the logic might be useful to others.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

This PR introduces a new utility function to the `react-form` package and does not modify any existing functionality.

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->



- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x]  `react-form` Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
