### PR TITLE
Fix tests in react-form to work with coming react-18 updates

### DIFF
--- a/packages/react-form/src/hooks/tests/form-with-dynamic-list.test.tsx
+++ b/packages/react-form/src/hooks/tests/form-with-dynamic-list.test.tsx
@@ -59,7 +59,7 @@ describe('useForm with dynamic list', () => {
   });
 
   describe('submit', () => {
-    it('validates dynamic list fields with their latest values before submitting and bails out if any fail', () => {
+    it('validates dynamic list fields with their latest values before submitting and bails out if any fail', async () => {
       const submitSpy = jest.fn(() => Promise.resolve(submitSuccess()));
       const product = fakeProduct();
       const wrapper = mount(
@@ -69,7 +69,7 @@ describe('useForm with dynamic list', () => {
       const textFields = wrapper.findAll(TextField, {label: 'option'});
 
       textFields.forEach((textField) => textField.trigger('onChange', ''));
-      hitSubmit(wrapper);
+      await hitSubmit(wrapper);
 
       expect(submitSpy).not.toHaveBeenCalled();
 

--- a/packages/react-form/src/hooks/tests/form-with-dynamic-list.test.tsx
+++ b/packages/react-form/src/hooks/tests/form-with-dynamic-list.test.tsx
@@ -98,6 +98,7 @@ describe('useForm with dynamic list', () => {
       );
 
       await waitForSubmit(wrapper, promise);
+      wrapper.forceUpdate();
 
       expect(wrapper).toContainReactComponent(TextField, {
         error: errors[0].message,

--- a/packages/react-form/src/hooks/tests/form.test.tsx
+++ b/packages/react-form/src/hooks/tests/form.test.tsx
@@ -67,6 +67,7 @@ describe('useForm', () => {
 
       changeTitle(wrapper, 'tortoritos, the chip for turtles!');
       await waitForSubmit(wrapper, promise);
+      wrapper.forceUpdate();
 
       expect(wrapper).not.toContainReactComponent('p', {
         children: 'loading...',
@@ -118,6 +119,7 @@ describe('useForm', () => {
       );
 
       await waitForSubmit(wrapper, promise);
+      wrapper.forceUpdate();
 
       expect(wrapper).toContainReactComponent('p', {
         children: error.message,
@@ -137,6 +139,7 @@ describe('useForm', () => {
       );
 
       await waitForSubmit(wrapper, promise);
+      wrapper.forceUpdate();
 
       expect(wrapper).toContainReactComponent(TextField, {
         error: errors[0].message,
@@ -156,6 +159,7 @@ describe('useForm', () => {
       );
 
       await waitForSubmit(wrapper, promise);
+      wrapper.forceUpdate();
 
       expect(wrapper).toContainReactComponent('p', {
         children: errors[0].message,

--- a/packages/react-form/src/hooks/tests/utilities/index.ts
+++ b/packages/react-form/src/hooks/tests/utilities/index.ts
@@ -26,11 +26,13 @@ export function changeTitle(wrapper, newTitle) {
 }
 
 export function hitSubmit(wrapper) {
-  wrapper.find('button', {type: 'submit'})!.trigger('onClick', clickEvent());
+  return wrapper
+    .find('button', {type: 'submit'})!
+    .trigger('onClick', clickEvent());
 }
 
 export async function waitForSubmit(wrapper, successPromise) {
-  hitSubmit(wrapper);
+  await hitSubmit(wrapper);
 
   await wrapper.act(async () => {
     await successPromise;


### PR DESCRIPTION
## Description

Fixes #2256

With the coming upgrade to `react-18` from `react-17`, we noticed in `react-form` there were some failing tests when bumping to `react-18`. In some tests when calling `hitSubmit`, the function would trigger async calls which some would not yet finish before the jest `expect`. So we have decided to await on the `hitSubmit` function before any jest `expect`.

These test changes are backwards compatible so it would be fine to merge this in `main` now, which we can then rebase onto our `react-18-react-testing` branch and have the failing tests fixed.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
**This is not needed since it is a change in tests.**
~~- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)~~
