### PR TITLE
Fix export path for webpack-loader

### DIFF
--- a/packages/graphql-mini-transforms/CHANGELOG.md
+++ b/packages/graphql-mini-transforms/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fix importing `graphql-mini-transforms/webpack-loader` failing to import. `webpack-loader` and `webpack` both import the same thing, for backwards compatability reasons. `webpack-loader` should be preferred name going forwards, to match preferred historic usage. [[#2284](https://github.com/Shopify/quilt/pull/2284)]
 
 ## 5.0.0 - 2022-05-19
 

--- a/packages/graphql-mini-transforms/README.md
+++ b/packages/graphql-mini-transforms/README.md
@@ -26,7 +26,7 @@ module.exports = {
     rules: [
       {
         test: /\.(graphql|gql)$/,
-        use: 'graphql-mini-transforms/webpack',
+        use: 'graphql-mini-transforms/webpack-loader',
         exclude: /node_modules/,
       },
     ],
@@ -67,7 +67,7 @@ module.exports = {
     rules: [
       {
         test: /\.(graphql|gql)$/,
-        use: 'graphql-mini-transforms/webpack',
+        use: 'graphql-mini-transforms/webpack-loader',
         exclude: /node_modules/,
         options: {simple: true},
       },

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -77,6 +77,7 @@
   "exports": {
     "./jest": "./jest.js",
     "./jest-simple": "./jest-simple.js",
+    "./webpack-loader": "./webpack-loader.js",
     "./webpack": "./webpack-loader.js",
     ".": {
       "esnext": "./index.esnext",


### PR DESCRIPTION
## Description

In web and sewing-kit we use the webpack loader by importing "graphql-mini-transforms/webpack-loader", however that path stopped working in the major version bump because we removed the `./*` key in the exports field and there was no explicit  "webpack-loader" key.

This PR adds a "webpack-loader" export key, and updates our documentation state consumers should use "webpack-loader" instead of "webpack" - matching historic usage.

In a future PR when we do the next major version, we should remove the "webpack" exports key.

## Type of change

- graphql-mini-transforms: patch
