### PR TITLE
Fix number replacement value returning an array instead of a string

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Passing a number replacement value was returning an array instead of a string. [[#2292](https://github.com/Shopify/quilt/pull/2292)]
 
 ## 7.1.0 - 2022-05-19
 

--- a/packages/react-i18n/src/utilities/tests/translate.test.tsx
+++ b/packages/react-i18n/src/utilities/tests/translate.test.tsx
@@ -1,4 +1,6 @@
-import {numberFormatCacheKey} from '../translate';
+import React from 'react';
+
+import {numberFormatCacheKey, translate} from '../translate';
 
 describe('numberFormatCacheKey()', () => {
   const locale = 'en-CA';
@@ -43,4 +45,38 @@ describe('numberFormatCacheKey()', () => {
       `${locale}-${otherLocale}-{}`,
     );
   });
+});
+
+describe('translate()', () => {
+  const id = 'test';
+  const translations = {
+    [id]: 'foo {bar}',
+  };
+  const locale = 'en-CA';
+
+  it('returns an array when a complex replacement is used', () => {
+    const bar = <span>bar</span>;
+    const replacements = {bar};
+    const translation = translate('test', {replacements}, translations, locale);
+
+    expect(translation).toMatchObject([
+      'foo ',
+      React.cloneElement(bar, {key: 1}),
+    ]);
+  });
+
+  it.each([2, 'bar', true, false, null, undefined, NaN])(
+    'returns a string when a simple replacement is used',
+    (replacementValue) => {
+      const replacements = {bar: replacementValue};
+      const translation = translate(
+        'test',
+        {replacements},
+        translations,
+        locale,
+      );
+
+      expect(translation).toBe(`foo ${replacementValue}`);
+    },
+  );
 });

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -273,7 +273,7 @@ function updateStringWithReplacements(
       const finalReplacement =
         replacementValue && React.isValidElement(replacementValue)
           ? React.cloneElement(replacementValue, {key: matchIndex})
-          : (replacementValue as string);
+          : String(replacementValue);
 
       // Push the previous part if it exists
       const previousString = str.substring(lastOffset, offset);
@@ -290,7 +290,8 @@ function updateStringWithReplacements(
   );
 
   // Push the last part of the source string
-  pieces.push(str.substr(lastOffset));
+  const lastPart = str.substring(lastOffset);
+  if (lastPart) pieces.push(lastPart);
 
   return pieces.every(isString) ? pieces.join('') : pieces;
 }


### PR DESCRIPTION
## Description

A regression was introduced following:
- #2267 

It was identified in another project where a test case expecting a string was failing since it was getting an array with the new `@shopify/react-i18n` version 7.1.0:

> Expected: `"Cannot be greater than 200 characters, current is 205 characters"`
> Received: `["Cannot be greater than ", 200, " characters, current is ", 205, " characters"]`

Since this function is a little complex with a different return value type based on values inside the replacement dictionary, I've added 2 tests that validates the return value of `translate`.

That way, I caught another issue where an empty string was returned in the array when passing a React element as the last replacement value.

## Type of change

- [x] `@shopify/react-i18n` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
