### PR TITLE
Fix address mock country response

### DIFF
--- a/packages/address-mocks/CHANGELOG.md
+++ b/packages/address-mocks/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Fixed address mock for canada country requests [[#2293](https://github.com/Shopify/quilt/pull/2293)]
 
 ## 3.0.1 - 2022-05-27
 

--- a/packages/address-mocks/src/index.ts
+++ b/packages/address-mocks/src/index.ts
@@ -44,9 +44,7 @@ export function mockCountryRequests() {
       const countries = fixtures.countries[locale];
       if (operationName === 'countries') return countries;
 
-      const country = countries.data.countries.find(
-        ({code}) => code === countryCode,
-      );
+      const country = fixtures.country[locale].data.country;
       if (!country)
         return {
           errors: [

--- a/packages/address-mocks/src/index.ts
+++ b/packages/address-mocks/src/index.ts
@@ -44,7 +44,10 @@ export function mockCountryRequests() {
       const countries = fixtures.countries[locale];
       if (operationName === 'countries') return countries;
 
-      const country = fixtures.country[locale].data.country;
+      const country =
+        countryCode === 'CA'
+          ? fixtures.country[locale].data.country
+          : countries.data.countries.find(({code}) => code === countryCode);
       if (!country)
         return {
           errors: [

--- a/packages/address/src/tests/mocks.test.ts
+++ b/packages/address/src/tests/mocks.test.ts
@@ -15,6 +15,12 @@ describe('mockCountryRequests', () => {
     expect(japan.code).toBe('JP');
   });
 
+  it('fetches a expected canada locale', async () => {
+    const canada = await loadCountry('fr', 'CA');
+    expect(canada.code).toBe('CA');
+    expect(canada.zones[10].name).toBe('Terre-Neuve-et-Labrador');
+  });
+
   it('fetches a countries fixture', async () => {
     const [firstCountry] = await loadCountries('ja');
     expect(firstCountry.name).toBe('アイスランド');


### PR DESCRIPTION
## Description
This PR fixes the country mock when the country code is canada. For example the canada `fr` locale contains translated province names.

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [X] `@shopify/address-mocks` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
