### PR TITLE
Fix object replacement values being cast as strings

### DIFF
--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed regression where object replacement values were being cast as strings. [[#2295](https://github.com/Shopify/quilt/pull/2295)]
 
 ## 7.1.1 - 2022-05-30
 

--- a/packages/react-i18n/src/utilities/interpolate.ts
+++ b/packages/react-i18n/src/utilities/interpolate.ts
@@ -14,4 +14,4 @@ export const MUSTACHE_FORMAT = /{{\s*(\w+)\s*}}/g;
  * Similar to Ruby ERB templating system.
  * `<%= key %>` will be replaced with `replacements[key]`.
  */
-export const ERB_FORMAT = /<%=\s*(\w+)\s*%>/g;
+export const ERB_FORMAT = /<%=\s+(\w+)\s+%>/g;

--- a/packages/react-i18n/src/utilities/tests/interpolate.test.ts
+++ b/packages/react-i18n/src/utilities/tests/interpolate.test.ts
@@ -1,0 +1,77 @@
+import {DEFAULT_FORMAT, ERB_FORMAT, MUSTACHE_FORMAT} from '../interpolate';
+
+describe('DEFAULT_FORMAT', () => {
+  it.each([
+    // Matches
+    ['{foo}', ['foo']],
+    ['{f}', ['f']],
+    ['{{foo}}', ['foo']],
+    ['test {foo }', ['foo']],
+    ['{ foo} test', ['foo']],
+    ['test {     foo   } test', ['foo']],
+    ['test {foo} test {bar}', ['foo', 'bar']],
+    // No matches
+    ['{}', []],
+    ['{     }', []],
+    ['{ test {}', []],
+  ])('matches "%s" with keys %p', (input, keys) => {
+    expect.assertions(keys.length);
+    Array.from(input.matchAll(DEFAULT_FORMAT)).forEach(
+      ([_, key], matchIndex) => {
+        expect(key).toBe(keys[matchIndex]);
+      },
+    );
+  });
+});
+
+describe('MUSTACHE_FORMAT', () => {
+  it.each([
+    // Matches
+    ['{{foo}}', ['foo']],
+    ['{{f}}', ['f']],
+    ['test {{foo }}', ['foo']],
+    ['{{ foo}} test', ['foo']],
+    ['{{{foo}}} test', ['foo']],
+    ['test {{     foo   }} test', ['foo']],
+    ['test {{foo}} test {{bar}}', ['foo', 'bar']],
+    // No matches
+    ['{{}}', []],
+    ['{{   }}', []],
+    ['{{ {foo}}} test', []],
+    ['{{ foo{ }}', []],
+    ['{{foo}', []],
+    ['{foo}}', []],
+    ['{foo}', []],
+  ])('matches "%s" with keys %p', (input, keys) => {
+    expect.assertions(keys.length);
+    Array.from(input.matchAll(MUSTACHE_FORMAT)).forEach(
+      ([_, key], matchIndex) => {
+        expect(key).toBe(keys[matchIndex]);
+      },
+    );
+  });
+});
+
+describe('ERB_FORMAT', () => {
+  it.each([
+    // Matches
+    ['<%= foo %>', ['foo']],
+    ['<%= f %>', ['f']],
+    ['test <%= foo  %>', ['foo']],
+    ['<%=  foo %> test', ['foo']],
+    ['test <%=      foo    %> test', ['foo']],
+    ['test <%= foo %> test <%= bar %>', ['foo', 'bar']],
+    // No matches
+    ['<%=foo%>', []],
+    ['<%= %>', []],
+    ['<%= foo%>', []],
+    ['<%= foo% %>', []],
+    ['<% foo %>', []],
+    ['<%= foo %%>', []],
+  ])('matches "%s" with keys %p', (input, keys) => {
+    expect.assertions(keys.length);
+    Array.from(input.matchAll(ERB_FORMAT)).forEach(([_, key], matchIndex) => {
+      expect(key).toBe(keys[matchIndex]);
+    });
+  });
+});

--- a/packages/react-i18n/src/utilities/tests/translate.test.tsx
+++ b/packages/react-i18n/src/utilities/tests/translate.test.tsx
@@ -50,11 +50,12 @@ describe('numberFormatCacheKey()', () => {
 describe('translate()', () => {
   const id = 'test';
   const translations = {
-    [id]: 'foo {bar}',
+    // Lots of spaces to make sure we're taking the whole match length into account.
+    [id]: 'foo {    bar     } baz',
   };
   const locale = 'en-CA';
 
-  it('returns an array when a complex replacement is used', () => {
+  it('returns an array when a React node replacement is used', () => {
     const bar = <span>bar</span>;
     const replacements = {bar};
     const translation = translate('test', {replacements}, translations, locale);
@@ -62,10 +63,30 @@ describe('translate()', () => {
     expect(translation).toMatchObject([
       'foo ',
       React.cloneElement(bar, {key: 1}),
+      ' baz',
     ]);
   });
 
-  it.each([2, 'bar', true, false, null, undefined, NaN])(
+  it('returns an array when a complex replacement is used', () => {
+    const bar = [<span>bar</span>];
+    const replacements = {bar};
+    const translation = translate('test', {replacements}, translations, locale);
+
+    expect(translation).toMatchObject(['foo ', bar, ' baz']);
+  });
+
+  it('returns an array when null is used as a replacement value', () => {
+    const translation = translate(
+      'test',
+      {replacements: {bar: null}},
+      translations,
+      locale,
+    );
+
+    expect(translation).toMatchObject(['foo ', null, ' baz']);
+  });
+
+  it.each([2, 'bar', true, false, undefined, NaN])(
     'returns a string when a simple replacement is used',
     (replacementValue) => {
       const replacements = {bar: replacementValue};
@@ -76,7 +97,7 @@ describe('translate()', () => {
         locale,
       );
 
-      expect(translation).toBe(`foo ${replacementValue}`);
+      expect(translation).toBe(`foo ${replacementValue} baz`);
     },
   );
 });

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -246,7 +246,7 @@ function updateStringWithReplacements(
     | PrimitiveReplacementDictionary = {},
   {interpolate}: UpdateStringWithReplacementsOptions = {},
 ): any {
-  const pieces: (string | React.ReactElement<any>)[] = [];
+  const pieces: (string | React.ReactNode)[] = [];
 
   const replaceFinder = new RegExp(interpolate || DEFAULT_FORMAT, 'g');
 
@@ -269,20 +269,22 @@ function updateStringWithReplacements(
 
       matchIndex += 1;
 
-      const replacementValue = replacements[replacementKey];
-      const finalReplacement =
-        replacementValue && React.isValidElement(replacementValue)
-          ? React.cloneElement(replacementValue, {key: matchIndex})
-          : String(replacementValue);
-
       // Push the previous part if it exists
       const previousString = str.substring(lastOffset, offset);
       if (previousString) pieces.push(previousString);
 
-      // Push the new part with the replacement
-      pieces.push(finalReplacement);
-
       lastOffset = offset + match.length;
+
+      // Push the new part with the replacement
+      const replacementValue = replacements[replacementKey];
+
+      if (React.isValidElement(replacementValue)) {
+        pieces.push(React.cloneElement(replacementValue, {key: matchIndex}));
+      } else if (typeof replacementValue === 'object') {
+        pieces.push(replacementValue);
+      } else {
+        pieces.push(String(replacementValue));
+      }
 
       // to satisfy the typechecker
       return '';


### PR DESCRIPTION
## Description

New regression uncovered today:

```diff
With text content:
+  "To create this market, countries will be removed from your [object Object],, ,[object Object],, and ,[object Object] markets, and those markets will be deleted. Any settings for these markets will also be permanently deleted."
To contain string:
-  "countries will be removed from your Canada, United States, and United Kingdom markets"
```

I assumed all objects were going to be valid React elements [when I refactored the translation code](https://github.com/Shopify/quilt/pull/2267), but I was wrong as it could be an array of React nodes.

So I fixed the tests and the replacement logic, then **I made sure tests were passing with both the old and the new implementation**.

I also added a bunch of tests for the available format regexes, to make sure we do not break them if we ever update them.

## Type of change

- [x] `@shopify/react-i18n` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
