### PR TITLE
Added isAndroid method

### DIFF
--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## 3.1.0 - 2022-06-03
 
 ### Changed
+
 - Added new method `isAndroid` to correctly identify Android devices [[#2299](https://github.com/Shopify/quilt/pull/2299)]
 
 ## 3.0.0 - 2022-05-19

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
+## 3.1.0 - 2022-06-03
+
+### Changed
+- Added new method `isAndroid` to correctly identify Android devices [[#2299](https://github.com/Shopify/quilt/pull/2299)]
 
 ## 3.0.0 - 2022-05-19
 

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
+
 ## 3.1.0 - 2022-06-03
 
 ### Changed

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
-
-## 3.1.0 - 2022-06-03
+## Unreleased
 
 ### Changed
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/browser",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "license": "MIT",
   "description": "Utilities for extracting browser information from user-agents",
   "main": "index.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/browser",
-  "version": "3.1.0",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Utilities for extracting browser information from user-agents",
   "main": "index.js",

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -1,4 +1,4 @@
-import { UAParser } from 'ua-parser-js';
+import {UAParser} from 'ua-parser-js';
 
 const MOBILE_DEVICE_TYPES = ['mobile', 'tablet'];
 
@@ -22,7 +22,7 @@ export class Browser {
   }
 
   get majorVersion() {
-    const { version } = this;
+    const {version} = this;
 
     if (version === '') {
       return undefined;
@@ -72,6 +72,11 @@ export class Browser {
     return this.ua.getUA().includes('Android') && this.name.includes('Chrome');
   }
 
+  get isAndroid() {
+    const os = this.ua.getOS();
+    return os.name && os.name.includes('Android');
+  }
+
   get isFirefox() {
     return this.name === 'Firefox';
   }
@@ -84,11 +89,6 @@ export class Browser {
     return this.name === 'Edge';
   }
 
-  get isAndroid() {
-    const os = this.ua.getOS();
-    return os.name && os.name.includes('Android');
-  }
-
   get isIOS() {
     const os = this.ua.getOS();
     const isStandardiOS = os.name && os.name.includes('iOS');
@@ -98,7 +98,7 @@ export class Browser {
     return isStandardiOS || isShopifyiOS;
   }
 
-  constructor({ userAgent, supported = true }: Options) {
+  constructor({userAgent, supported = true}: Options) {
     this.userAgent = userAgent;
     this.supported = supported;
     this.ua = new UAParser(userAgent);

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -1,4 +1,4 @@
-import {UAParser} from 'ua-parser-js';
+import { UAParser } from 'ua-parser-js';
 
 const MOBILE_DEVICE_TYPES = ['mobile', 'tablet'];
 
@@ -22,7 +22,7 @@ export class Browser {
   }
 
   get majorVersion() {
-    const {version} = this;
+    const { version } = this;
 
     if (version === '') {
       return undefined;
@@ -84,6 +84,11 @@ export class Browser {
     return this.name === 'Edge';
   }
 
+  get isAndroid() {
+    const os = this.ua.getOS();
+    return os.name && os.name.includes('Android');
+  }
+
   get isIOS() {
     const os = this.ua.getOS();
     const isStandardiOS = os.name && os.name.includes('iOS');
@@ -93,7 +98,7 @@ export class Browser {
     return isStandardiOS || isShopifyiOS;
   }
 
-  constructor({userAgent, supported = true}: Options) {
+  constructor({ userAgent, supported = true }: Options) {
     this.userAgent = userAgent;
     this.supported = supported;
     this.ua = new UAParser(userAgent);

--- a/packages/browser/src/tests/browser.test.ts
+++ b/packages/browser/src/tests/browser.test.ts
@@ -1,12 +1,12 @@
-import { Browser, asPlainObject } from '../browser';
+import {Browser, asPlainObject} from '../browser';
 
 describe('Browser', () => {
   describe('supported', () => {
     it('uses the value supplied by the user', () => {
-      expect(new Browser({ userAgent: 'fake', supported: false }).supported).toBe(
+      expect(new Browser({userAgent: 'fake', supported: false}).supported).toBe(
         false,
       );
-      expect(new Browser({ userAgent: 'fake', supported: true }).supported).toBe(
+      expect(new Browser({userAgent: 'fake', supported: true}).supported).toBe(
         true,
       );
     });
@@ -17,13 +17,13 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      expect(new Browser({ userAgent }).majorVersion).toBe(69);
+      expect(new Browser({userAgent}).majorVersion).toBe(69);
     });
 
     it('returns undefined if a major version cannot be found', () => {
       const userAgent = 'Shopify Mobile/';
 
-      expect(new Browser({ userAgent }).majorVersion).toBeUndefined();
+      expect(new Browser({userAgent}).majorVersion).toBeUndefined();
     });
   });
 
@@ -32,7 +32,7 @@ describe('Browser', () => {
       const userAgent =
         'Shopify Mobile/Android/8.12.0 (Build 12005 with API 28 on Google Android SDK built for x86) MobileMiddlewareSupported Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv)  AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      expect(new Browser({ userAgent }).isNativeApp).toBe(true);
+      expect(new Browser({userAgent}).isNativeApp).toBe(true);
     });
 
     it('returns false for other UA strings', () => {
@@ -41,7 +41,7 @@ describe('Browser', () => {
         'completely bogus UA',
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36',
       ].forEach((userAgent) => {
-        expect(new Browser({ userAgent }).isNativeApp).toBe(false);
+        expect(new Browser({userAgent}).isNativeApp).toBe(false);
       });
     });
   });
@@ -51,21 +51,21 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      expect(new Browser({ userAgent }).isAndroidChrome).toBe(true);
+      expect(new Browser({userAgent}).isAndroidChrome).toBe(true);
     });
 
     it('returns false when using a non-Chrome browser on Android', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; U; Android 4.4.2; es-es; SM-T210R Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30';
 
-      expect(new Browser({ userAgent }).isAndroidChrome).toBe(false);
+      expect(new Browser({userAgent}).isAndroidChrome).toBe(false);
     });
 
     it('returns false for iOS userAgents', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({ userAgent }).isAndroidChrome).toBe(false);
+      expect(new Browser({userAgent}).isAndroidChrome).toBe(false);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({ userAgent }).os).toBe('iOS');
+      expect(new Browser({userAgent}).os).toBe('iOS');
     });
   });
 
@@ -83,21 +83,21 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({ userAgent }).isMobile).toBe(true);
+      expect(new Browser({userAgent}).isMobile).toBe(true);
     });
 
     it('returns true when device type is tablet', () => {
       const userAgent =
         'Mozilla/5.0 (iPad; CPU OS 9_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13E230 Safari/601.1';
 
-      expect(new Browser({ userAgent }).isMobile).toBe(true);
+      expect(new Browser({userAgent}).isMobile).toBe(true);
     });
 
     it('returns false when device is a desktop', () => {
       const userAgent =
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0';
 
-      expect(new Browser({ userAgent }).isMobile).toBe(false);
+      expect(new Browser({userAgent}).isMobile).toBe(false);
     });
   });
 
@@ -106,77 +106,77 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns true on Mobile Shopify when iOS version is 9 and app version is not 9', () => {
       const userAgent =
         'Shopify Mobile/iOS/5.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns true on Mobile Shopify when iOS version is 9 and app version is 9', () => {
       const userAgent =
         'Shopify Mobile/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns false on Mobile Shopify when iOS version is not 9 but app version is 9', () => {
       const userAgent =
         'Shopify Mobile/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/10.1.2)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns true on POS when iOS version is 9 and app version is not 9', () => {
       const userAgent =
         'com.jadedpixel.pos Shopify POS/5.11.0 (iPad; iOS 9.3; Scale/2.00)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns true on POS when iOS version is 9 and app version is 9', () => {
       const userAgent =
         'com.jadedpixel.pos Shopify POS/9.11.0 (iPad; iOS 9.3; Scale/2.00)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns false on POS when iOS version is not 9 but app version is 9', () => {
       const userAgent =
         'com.jadedpixel.pos Shopify POS/9.11.0 (iPad; iOS 10.3; Scale/2.00)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns true on Shopify Ping when iOS version is 9 and app version is not 9', () => {
       const userAgent =
         'Shopify Ping/iOS/5.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns true on Shopify Ping when iOS version is 9 and app version is 9', () => {
       const userAgent =
         'Shopify Ping/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns false on Shopify Ping when iOS version is not 9 but app version is 9', () => {
       const userAgent =
         'Shopify Ping/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/10.1.2)';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(true);
+      expect(new Browser({userAgent}).isIOS).toBe(true);
     });
 
     it('returns false for an Android browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 7.0; SM-G892A Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36';
 
-      expect(new Browser({ userAgent }).isIOS).toBe(false);
+      expect(new Browser({userAgent}).isIOS).toBe(false);
     });
   });
 
@@ -185,20 +185,20 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 7.0; SM-G892A Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36';
 
-      expect(new Browser({ userAgent }).isAndroid).toBe(true);
+      expect(new Browser({userAgent}).isAndroid).toBe(true);
     });
 
     it('returns true with a standard Android Firefox browser', () => {
       const userAgent = 'Mozilla/5.0 (Android 12; Mobile; rv:94.0) Gecko/94.0 Firefox/94.0';
 
-      expect(new Browser({ userAgent }).isAndroid).toBe(true);
+      expect(new Browser({userAgent}).isAndroid).toBe(true);
     });
 
     it('returns false with an iOS device browser', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({ userAgent }).isAndroid).toBe(false);
+      expect(new Browser({userAgent}).isAndroid).toBe(false);
     });
   });
 
@@ -207,7 +207,7 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      const browser = asPlainObject(new Browser({ userAgent }));
+      const browser = asPlainObject(new Browser({userAgent}));
 
       expect(browser).toMatchObject({
         name: 'Chrome',

--- a/packages/browser/src/tests/browser.test.ts
+++ b/packages/browser/src/tests/browser.test.ts
@@ -1,12 +1,12 @@
-import {Browser, asPlainObject} from '../browser';
+import { Browser, asPlainObject } from '../browser';
 
 describe('Browser', () => {
   describe('supported', () => {
     it('uses the value supplied by the user', () => {
-      expect(new Browser({userAgent: 'fake', supported: false}).supported).toBe(
+      expect(new Browser({ userAgent: 'fake', supported: false }).supported).toBe(
         false,
       );
-      expect(new Browser({userAgent: 'fake', supported: true}).supported).toBe(
+      expect(new Browser({ userAgent: 'fake', supported: true }).supported).toBe(
         true,
       );
     });
@@ -17,13 +17,13 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      expect(new Browser({userAgent}).majorVersion).toBe(69);
+      expect(new Browser({ userAgent }).majorVersion).toBe(69);
     });
 
     it('returns undefined if a major version cannot be found', () => {
       const userAgent = 'Shopify Mobile/';
 
-      expect(new Browser({userAgent}).majorVersion).toBeUndefined();
+      expect(new Browser({ userAgent }).majorVersion).toBeUndefined();
     });
   });
 
@@ -32,7 +32,7 @@ describe('Browser', () => {
       const userAgent =
         'Shopify Mobile/Android/8.12.0 (Build 12005 with API 28 on Google Android SDK built for x86) MobileMiddlewareSupported Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv)  AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      expect(new Browser({userAgent}).isNativeApp).toBe(true);
+      expect(new Browser({ userAgent }).isNativeApp).toBe(true);
     });
 
     it('returns false for other UA strings', () => {
@@ -41,7 +41,7 @@ describe('Browser', () => {
         'completely bogus UA',
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36',
       ].forEach((userAgent) => {
-        expect(new Browser({userAgent}).isNativeApp).toBe(false);
+        expect(new Browser({ userAgent }).isNativeApp).toBe(false);
       });
     });
   });
@@ -51,21 +51,21 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      expect(new Browser({userAgent}).isAndroidChrome).toBe(true);
+      expect(new Browser({ userAgent }).isAndroidChrome).toBe(true);
     });
 
     it('returns false when using a non-Chrome browser on Android', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; U; Android 4.4.2; es-es; SM-T210R Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30';
 
-      expect(new Browser({userAgent}).isAndroidChrome).toBe(false);
+      expect(new Browser({ userAgent }).isAndroidChrome).toBe(false);
     });
 
     it('returns false for iOS userAgents', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({userAgent}).isAndroidChrome).toBe(false);
+      expect(new Browser({ userAgent }).isAndroidChrome).toBe(false);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({userAgent}).os).toBe('iOS');
+      expect(new Browser({ userAgent }).os).toBe('iOS');
     });
   });
 
@@ -83,21 +83,21 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({userAgent}).isMobile).toBe(true);
+      expect(new Browser({ userAgent }).isMobile).toBe(true);
     });
 
     it('returns true when device type is tablet', () => {
       const userAgent =
         'Mozilla/5.0 (iPad; CPU OS 9_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13E230 Safari/601.1';
 
-      expect(new Browser({userAgent}).isMobile).toBe(true);
+      expect(new Browser({ userAgent }).isMobile).toBe(true);
     });
 
     it('returns false when device is a desktop', () => {
       const userAgent =
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0';
 
-      expect(new Browser({userAgent}).isMobile).toBe(false);
+      expect(new Browser({ userAgent }).isMobile).toBe(false);
     });
   });
 
@@ -106,77 +106,99 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns true on Mobile Shopify when iOS version is 9 and app version is not 9', () => {
       const userAgent =
         'Shopify Mobile/iOS/5.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns true on Mobile Shopify when iOS version is 9 and app version is 9', () => {
       const userAgent =
         'Shopify Mobile/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns false on Mobile Shopify when iOS version is not 9 but app version is 9', () => {
       const userAgent =
         'Shopify Mobile/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/10.1.2)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns true on POS when iOS version is 9 and app version is not 9', () => {
       const userAgent =
         'com.jadedpixel.pos Shopify POS/5.11.0 (iPad; iOS 9.3; Scale/2.00)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns true on POS when iOS version is 9 and app version is 9', () => {
       const userAgent =
         'com.jadedpixel.pos Shopify POS/9.11.0 (iPad; iOS 9.3; Scale/2.00)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns false on POS when iOS version is not 9 but app version is 9', () => {
       const userAgent =
         'com.jadedpixel.pos Shopify POS/9.11.0 (iPad; iOS 10.3; Scale/2.00)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns true on Shopify Ping when iOS version is 9 and app version is not 9', () => {
       const userAgent =
         'Shopify Ping/iOS/5.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns true on Shopify Ping when iOS version is 9 and app version is 9', () => {
       const userAgent =
         'Shopify Ping/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/9.1.2)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns false on Shopify Ping when iOS version is not 9 but app version is 9', () => {
       const userAgent =
         'Shopify Ping/iOS/9.3.1 (iPad8,1 Simulator/com.shopify.ShopifyInternal/10.1.2)';
 
-      expect(new Browser({userAgent}).isIOS).toBe(true);
+      expect(new Browser({ userAgent }).isIOS).toBe(true);
     });
 
     it('returns false for an Android browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 7.0; SM-G892A Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36';
 
-      expect(new Browser({userAgent}).isIOS).toBe(false);
+      expect(new Browser({ userAgent }).isIOS).toBe(false);
+    });
+  });
+
+  describe('isAndroid', () => {
+    it('returns true with a standard Android Chrome browser', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; Android 7.0; SM-G892A Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36';
+
+      expect(new Browser({ userAgent }).isAndroid).toBe(true);
+    });
+
+    it('returns true with a standard Android Firefox browser', () => {
+      const userAgent = 'Mozilla/5.0 (Android 12; Mobile; rv:94.0) Gecko/94.0 Firefox/94.0';
+
+      expect(new Browser({ userAgent }).isAndroid).toBe(true);
+    });
+
+    it('returns false with an iOS device browser', () => {
+      const userAgent =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1';
+
+      expect(new Browser({ userAgent }).isAndroid).toBe(false);
     });
   });
 
@@ -185,7 +207,7 @@ describe('Browser', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; Android 6.0; ALE-L23 Build/HuaweiALE-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36';
 
-      const browser = asPlainObject(new Browser({userAgent}));
+      const browser = asPlainObject(new Browser({ userAgent }));
 
       expect(browser).toMatchObject({
         name: 'Chrome',

--- a/packages/browser/src/tests/browser.test.ts
+++ b/packages/browser/src/tests/browser.test.ts
@@ -189,7 +189,8 @@ describe('Browser', () => {
     });
 
     it('returns true with a standard Android Firefox browser', () => {
-      const userAgent = 'Mozilla/5.0 (Android 12; Mobile; rv:94.0) Gecko/94.0 Firefox/94.0';
+      const userAgent =
+        'Mozilla/5.0 (Android 12; Mobile; rv:94.0) Gecko/94.0 Firefox/94.0';
 
       expect(new Browser({userAgent}).isAndroid).toBe(true);
     });


### PR DESCRIPTION
## Description

Adds a `isAndroid` method that will help identify browser's OS better (the previous alternative was to compare the string of the os === 'Android'

## Type of change
- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] @shopify/browser Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
