### PR TITLE
[react-form] ✨Add `asChoiceList` method

### DIFF
--- a/.changeset/tame-yaks-exercise.md
+++ b/.changeset/tame-yaks-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-form': minor
+---
+
+Added `asChoiceList` helper

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -510,6 +510,45 @@ return (
 );
 ```
 
+#### `asChoiceList()`
+
+A utility to convert a `Field<Value>` into a derivative that is compatible with `<ChoiceList />` from `@shopify/polaris`. The `value` member will be replaced by a new `selected` member, and the `onChange` will be replaced with a choice list compatible callback.
+
+_Note: this only works for radio button groups, not checkbox groups; `allowMultiple` will be set to false._
+
+##### Signature
+
+`asChoiceList` consumes an existing `Field<Value>`.
+
+```tsx
+enum Color {
+  Red = 'red',
+  Green = 'green',
+}
+const color = useField(Color.Red);
+
+const choiceListProps = asChoiceList(color);
+```
+
+##### Examples
+
+`asChoiceList` is used as a helper to expand an existing field into a choice component (`<ChoiceList />`).
+
+```tsx
+enum Color {
+  Red = 'red',
+  Green = 'green',
+}
+
+const choices = [
+  {label: 'Red', value: Color.Red},
+  {label: 'Green', value: Color.Green},
+];
+
+const color = useField(Color.Red);
+return <ChoiceList {...asChoiceList(color)} title="Color" choices={choices} />;
+```
+
 #### `useList()`
 
 A custom hook for handling the state and validations of fields for a list of objects.

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -246,6 +246,43 @@ export function asChoiceField<Value>(
 }
 
 /**
+ * Converts a standard `Field<Value>` into a form that is compatible
+ * with the `<ChoiceList />` component in `@shopify/polaris`.
+ *
+ * For fields that are used by both choice components and other components, it
+ * can be beneficial to retain the original `Field<Value>` shape and convert
+ * the field on the fly for the choice component.
+ *
+ * It only works with Radio buttons (single selection), not checkboxes.
+ *
+ * ```typescript
+ * enum Color { Red = "red", Green = "green" }
+ *
+ * const choices = [
+ *   { label: "Red", value: Color.Red },
+ *   { label: "Green", value: Color.Green },
+ * ]
+ *
+ * const color = useField(Color.Red);
+ * return (<ChoiceList {...asChoiceList(color)} title="Color" choices={choices} />);
+ * ```
+ */
+export function asChoiceList<Value extends string | undefined | null>({
+  value,
+  onChange,
+  ...fieldData
+}: Field<Value>) {
+  return {
+    ...fieldData,
+    selected: value === undefined || value === null ? [] : [value],
+    onChange: (selected: Exclude<Value, null | undefined>[]) => {
+      onChange(selected[0]);
+    },
+    allowMultiple: false,
+  };
+}
+
+/**
  * A simplification to `useField` that returns a `ChoiceField` by automatically
  * converting a boolean field using `asChoiceField` for direct use in choice
  * components.

--- a/packages/react-form/src/hooks/field/index.ts
+++ b/packages/react-form/src/hooks/field/index.ts
@@ -1,4 +1,4 @@
-export {asChoiceField, useChoiceField, useField} from './field';
+export {asChoiceField, asChoiceList, useChoiceField, useField} from './field';
 export type {ChoiceField, FieldConfig} from './field';
 export {reduceField, updateErrorAction, initialFieldState} from './reducer';
 export type {FieldAction} from './reducer';

--- a/packages/react-form/src/hooks/field/tests/field.test.tsx
+++ b/packages/react-form/src/hooks/field/tests/field.test.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import faker from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
-import {asChoiceField, useChoiceField, useField, FieldConfig} from '../field';
+import {
+  asChoiceField,
+  useChoiceField,
+  useField,
+  FieldConfig,
+  asChoiceList,
+} from '../field';
 import {FieldState} from '../../../types';
 import {FieldAction, reduceField, makeFieldReducer} from '../reducer';
 
@@ -823,6 +829,40 @@ describe('asChoiceField', () => {
     choiceField.onChange(false);
 
     expect(onChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('asChoiceList', () => {
+  it('replaces value with selected array', () => {
+    expect(asChoiceList({value: 'red'} as any)).toMatchObject({
+      selected: ['red'],
+    });
+  });
+
+  it('replaces undefined with empty selected array', () => {
+    expect(
+      asChoiceList<string | undefined>({value: undefined} as any),
+    ).toMatchObject({
+      selected: [],
+    });
+  });
+
+  it('replaces null with empty selected array', () => {
+    expect(
+      asChoiceList<string | null>({value: null} as any),
+    ).toMatchObject({
+      selected: [],
+    });
+  });
+
+  it('handles the <ChoiceList /> onChange which passes an array', () => {
+    const onChange = jest.fn();
+    const checkedValue = 'A';
+    const choiceField = asChoiceList({value: 'B', onChange} as any);
+
+    choiceField.onChange([checkedValue]);
+
+    expect(onChange).toHaveBeenCalledWith(checkedValue);
   });
 });
 

--- a/packages/react-form/src/hooks/index.ts
+++ b/packages/react-form/src/hooks/index.ts
@@ -1,4 +1,4 @@
-export {asChoiceField, useChoiceField, useField} from './field';
+export {asChoiceField, asChoiceList, useChoiceField, useField} from './field';
 export type {ChoiceField, FieldConfig} from './field';
 export {useList, useDynamicList} from './list';
 export {useForm} from './form';

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -3,6 +3,7 @@ export * from './validation';
 
 export {
   asChoiceField,
+  asChoiceList,
   useChoiceField,
   useField,
   useList,


### PR DESCRIPTION
## Description

Adds an `asChoiceList` helper so that you can do

```typescript
enum Color { Red = "red", Green = "green" }

const choices = [
  { label: "Red", value: Color.Red },
  { label: "Green", value: Color.Green },
]

const color = useField(Color.Red);
return <ChoiceList {...asChoiceList(color)} label="Color" choices={choices} />;
```

I also debated allowing the user to pass a labels map to `asChoiceList` so it could generate the choices but then the implementation had to use Object.keys which seemed messy and required the labels map to not have any extra keys. 


Tested that it works with Polaris, no type errors and correct types

```typescript
const choices = [{label: 'Test', value: 'test'}];

<ChoiceList
  {...asChoiceList(serviceSubType)}
  title="Sub type"
  choices={choices}
/>;
```

![image](https://user-images.githubusercontent.com/21130966/173910101-5b33bf34-1ebb-4ac5-8bdd-eff08c695cbb.png)



## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] react-form Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
