### PR TITLE
Fix issues with depending on not-current versions

### DIFF
--- a/packages/address-mocks/CHANGELOG.md
+++ b/packages/address-mocks/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Remove unused devDependency on an outdated version of `@shopify/jest-dom-mocks` [[#2308](https://github.com/Shopify/quilt/pull/2308)]
 
 ## 3.1.0 - 2022-05-31
 

--- a/packages/address-mocks/package.json
+++ b/packages/address-mocks/package.json
@@ -22,9 +22,6 @@
   "engines": {
     "node": "^14.17.0 || >=16.0.0"
   },
-  "devDependencies": {
-    "@shopify/jest-dom-mocks": "^2.11.5"
-  },
   "sideEffects": false,
   "dependencies": {
     "@shopify/address-consts": "^4.1.0",

--- a/packages/graphql-fixtures/CHANGELOG.md
+++ b/packages/graphql-fixtures/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Widen peerDependency range for `graphql-typed` to include v2 [[#2308](https://github.com/Shopify/quilt/pull/2308)]
 
 ## 2.0.0 - 2022-05-19
 

--- a/packages/graphql-fixtures/package.json
+++ b/packages/graphql-fixtures/package.json
@@ -30,7 +30,7 @@
     "graphql-tool-utilities": "^3.0.0"
   },
   "peerDependencies": {
-    "graphql-typed": ">=0.6.1 <2.0.0"
+    "graphql-typed": "^0.6.1 || ^0.7.0 || ^1.0.0 || ^2.0.0"
   },
   "files": [
     "build/",

--- a/packages/graphql-typescript-definitions/CHANGELOG.md
+++ b/packages/graphql-typescript-definitions/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Widen peerDependency range for `graphql-typed` to include v2 [[#2308](https://github.com/Shopify/quilt/pull/2308)]
 
 ## 3.1.0 - 2022-05-26
 

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "@graphql-typed-document-node/core": "^3.1.1",
-    "graphql-typed": ">=0.4.0 <2.0.0"
+    "graphql-typed": "^0.6.1 || ^0.7.0 || ^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@graphql-typed-document-node/core": {


### PR DESCRIPTION
## Description

We had some cases where packages had peer/dev dependencies on
not-the-current-version. This fixes them

- Remove address-mocks' outdated devDependency on jest-dom-mocks as it is
  already has a direct dependency on the current version
- Update graphql-fixtures and graphql-typescript-definitions' peer
  dependency on graphql-typed to include the current version

This fixes [warning output we were seeing when investigating implementing changesets](https://github.com/Shopify/quilt/runs/6785343134?check_suite_focus=true#step:4:7):

## Type of change

address-mocks / graphql-fixtures / graphql-typescript-definitions: patch