### PR TITLE
[graphql-fixtures] Graphql fixtures/seed collision fix

### DIFF
--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -495,14 +495,14 @@ function randomEnumValue(enumType: GraphQLEnumType) {
 }
 
 function seedFromKeypath(keypath: string[]) {
-  return keypath.reduce<number>((sum, key) => sum + seedFromKey(key), 0);
+  return keypath.reduce<number>((sum, key) => hashCode(key, sum), 0);
 }
 
-function seedFromKey(key: string) {
-  return [...key].reduce<number>(
-    (sum, character) => sum + character.charCodeAt(0),
-    0,
-  );
+function hashCode(data: string, initialHash = 0) {
+  let newHash = initialHash;
+  for (let i = 0; i < data.length; i++)
+    newHash = (Math.imul(31, newHash) + data.charCodeAt(i)) | 0;
+  return newHash;
 }
 
 export function list<T = {}, Data = {}, Variables = {}, DeepPartial = {}>(

--- a/packages/graphql-fixtures/src/tests/fill.test.ts
+++ b/packages/graphql-fixtures/src/tests/fill.test.ts
@@ -1354,22 +1354,17 @@ describe('createFiller()', () => {
       `);
 
       const result = fill(document, {
-        people: [{pets: [{}, {}]}, {pets: [{}, {}]}],
+        people: Array.from(Array(100)).map(() => ({
+          pets: Array.from(Array(100)).map(() => ({})),
+        })),
       }) as any;
 
       const allIds = result.people
         .flatMap((person) => person.pets)
         .map((pet) => pet.id);
 
-      const collisions = allIds.reduce((collisions, id) => {
-        const matchingIds = allIds.filter((otherId) => otherId === id);
-        if (matchingIds.length > 1) {
-          collisions.push(id);
-        }
-        return collisions;
-      }, []);
-
-      expect(collisions).toHaveLength(0);
+      const allIdSet = new Set(allIds);
+      expect(allIdSet.size).toBe(allIds.length);
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/2311

Uses a quick hash of the strings that make up a graphQL object's keypath to generate a random seed for that object, instead of a sum of all of the characters values.

I think this is a breaking change, only if people are asserting on the random values that are already generated.

TODO: changelog, once I know if this is considered breaking.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [x] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
