### PR TITLE
Update In-Memory Cache options to match Apollo 3 types

### DIFF
--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -1,4 +1,4 @@
-import {ApolloReducerConfig, InMemoryCache} from '@apollo/client/cache';
+import {InMemoryCache, InMemoryCacheConfig} from '@apollo/client/cache';
 import {ApolloClient, ApolloLink, GraphQLRequest} from '@apollo/client';
 
 import {MockLink, InflightLink} from './links';
@@ -8,7 +8,7 @@ import {GraphQLMock, MockRequest, FindOptions} from './types';
 
 export interface Options {
   possibleTypes?: any;
-  cacheOptions?: ApolloReducerConfig;
+  cacheOptions?: InMemoryCacheConfig;
 }
 
 interface Wrapper {


### PR DESCRIPTION
## Description

This PR aims to update the in-memory cache configuration type to [match the options provided by the Apollo 3 client](https://github.com/apollographql/apollo-client/blob/a3aefcb310ea1451ee494077cbde98171169d8d0/src/cache/inmemory/inMemoryCache.ts#L58).

**Example:**
```ts
// This should be possible and currently isn't
export const createGraphQL = createGraphQLFactory({
  cacheOptions: {
    possibleTypes: {
      PricingValue: ['MoneyV2', 'PricingPercentageValue'],
    },
  },
});
```

For context: the `InMemoryCacheConfig` interface extends from the current `ApolloReducerConfig` but since the `IntrospectionFragmentMatcher` [has been removed](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/#breaking-cache-changes), we have to rely on the `cacheOptions::possibleTypes` property to [configure supertype-subtype relationships](https://www.apollographql.com/docs/react/data/fragments/#defining-possibletypes-manually).

## Type of change

- [x] `graphql-testing` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
