### PR TITLE
Fix refetch error and add tests

### DIFF
--- a/.changeset/pink-doors-think.md
+++ b/.changeset/pink-doors-think.md
@@ -1,0 +1,6 @@
+---
+'@shopify/graphql-testing': patch
+'@shopify/react-graphql': patch
+---
+
+Update useQuery refetch so that it can recover from a network error. Add more tests.

--- a/packages/graphql-testing/README.md
+++ b/packages/graphql-testing/README.md
@@ -128,6 +128,39 @@ graphQL.operations.all({mutation: addPetMutation});
 
 The `query` and `mutation` options both accept either a regular `DocumentNode`, or an async GraphQL component created with [`@shopify/react-graphql`’s `createAsyncQueryComponent` function](../react-graphql).
 
+### Errors
+
+You can use `createGraphQL` to test error states.
+
+#### Network Errors
+
+You can test network errors by throwing an `Error`.
+
+```tsx
+const graphQL = createGraphQL({
+  Pet: () => {
+    throw new Error('Network Error');
+  },
+});
+```
+
+#### GraphQL Errors
+
+You can test the graphql api returning an error state by returning an `Error` or `GraphQLError`.
+
+```tsx
+const graphQL = createGraphQL({
+  Pet: new Error('Error message'),
+});
+```
+
+```tsx
+import {GraphQLError} from 'graphql';
+const graphQL = createGraphQL({
+  Pet: new GraphQLError('Error message'),
+});
+```
+
 ### Matchers
 
 This library provides a [Jest matcher](https://jestjs.io/docs/en/using-matchers). To use this matcher, you’ll need to include `@shopify/graphql-testing/matchers` in your Jest setup file. The following matcher will then be available:

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -38,7 +38,8 @@
     "graphql-typed": "^2.0.0"
   },
   "devDependencies": {
-    "@shopify/react-testing": "^4.1.0"
+    "@shopify/react-testing": "^4.1.0",
+    "@types/zen-observable": "^0.8.3"
   },
   "files": [
     "build/",

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import gql from 'graphql-tag';
+import {DocumentNode} from 'graphql-typed';
 import {ApolloClient, NetworkStatus} from 'apollo-client';
 import {ApolloLink} from 'apollo-link';
 import {InMemoryCache} from 'apollo-cache-inmemory';
@@ -15,6 +16,22 @@ const petQuery = gql`
     pets {
       name
     }
+  }
+`;
+
+const peopleQuery: DocumentNode<
+  {people?: {name: string; friends?: {name: string}[] | null} | null},
+  {id: string}
+> = gql`
+  query People($id: ID!) {
+    people(id: $id) {
+      ...PeopleInfo
+    }
+  }
+
+  fragment PeopleInfo on People {
+    name
+    friends
   }
 `;
 
@@ -317,6 +334,126 @@ describe('useQuery', () => {
       });
 
       expect(watchQuerySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refetch', () => {
+    const lukeMock = {
+      people: [
+        {
+          __typename: 'People',
+          name: 'Luke',
+          friends: [],
+        },
+      ],
+    };
+
+    const hanMock = {
+      people: [
+        {
+          __typename: 'People',
+          name: 'Han',
+          friends: [],
+        },
+      ],
+    };
+
+    function MyComponent({id = '1'} = {}) {
+      const {data, loading, error, refetch} = useQuery(peopleQuery, {
+        variables: {id},
+      });
+
+      const errorMarkup = error ? <p>Error</p> : null;
+      const networkErrorMarkup =
+        error && error.networkError ? <p>NetworkError</p> : null;
+      const graphqlErrorMarkup =
+        error && error.graphQLErrors.length ? <p>GraphQLError</p> : null;
+      const loadingMarkup = loading ? <p>Loading</p> : null;
+      const peopleMarkup =
+        data != null && data.people != null ? (
+          <p>{data.people[0].name}</p>
+        ) : null;
+
+      console.log('data', data, error);
+      const handleButtonClick = React.useCallback(
+        () => refetch().catch((_) => {}),
+        [refetch],
+      );
+
+      return (
+        <>
+          {loadingMarkup}
+          {peopleMarkup}
+          {errorMarkup}
+          {networkErrorMarkup}
+          {graphqlErrorMarkup}
+          <button onClick={handleButtonClick} type="button">
+            Refetch!
+          </button>
+        </>
+      );
+    }
+
+    it.only('something something darkside', async () => {
+      const graphQL = createGraphQL({People: lukeMock});
+
+      const wrapper = await mountWithGraphQL(<MyComponent />, {
+        graphQL,
+      });
+
+      expect(wrapper).toContainReactText('Luke');
+
+      graphQL.update({
+        People: () => {
+          throw new Error('Connection');
+        },
+      });
+
+      const firstClick = wrapper.find('button').trigger('onClick');
+      await graphQL.resolveAll();
+      await firstClick;
+
+      expect(wrapper).toContainReactText('NetworkError');
+
+      graphQL.update({
+        People: lukeMock,
+      });
+
+      const secondClick = wrapper.find('button').trigger('onClick');
+      await graphQL.resolveAll();
+      await secondClick;
+
+      expect(wrapper).toContainReactText('Luke');
+    });
+
+    it.only('updates the component when response changes', async () => {
+      const graphQL = createGraphQL({People: lukeMock});
+
+      const wrapper = await mountWithGraphQL(<MyComponent />, {
+        graphQL,
+      });
+
+      expect(wrapper).toContainReactText('Luke');
+
+      graphQL.update({
+        People: hanMock,
+      });
+
+      const firstClick = wrapper.find('button').trigger('onClick');
+      await graphQL.resolveAll();
+      await firstClick;
+
+      expect(wrapper).toContainReactText('Han');
+
+      graphQL.update({
+        People: lukeMock,
+      });
+
+      const secondClick = wrapper.find('button').trigger('onClick');
+      await graphQL.resolveAll();
+      await secondClick;
+
+      expect(wrapper).toContainReactText('Luke');
     });
   });
 });

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -374,7 +374,6 @@ describe('useQuery', () => {
           <p>{data.people[0].name}</p>
         ) : null;
 
-      console.log('data', data, error);
       const handleButtonClick = React.useCallback(
         () => refetch().catch((_) => {}),
         [refetch],
@@ -394,7 +393,7 @@ describe('useQuery', () => {
       );
     }
 
-    it.only('something something darkside', async () => {
+    it('recovers and renders from a network error', async () => {
       const graphQL = createGraphQL({People: lukeMock});
 
       const wrapper = await mountWithGraphQL(<MyComponent />, {
@@ -426,7 +425,7 @@ describe('useQuery', () => {
       expect(wrapper).toContainReactText('Luke');
     });
 
-    it.only('updates the component when response changes', async () => {
+    it('updates the component when response changes', async () => {
       const graphQL = createGraphQL({People: lukeMock});
 
       const wrapper = await mountWithGraphQL(<MyComponent />, {

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -374,6 +374,10 @@ describe('useQuery', () => {
           <p>{data.people[0].name}</p>
         ) : null;
 
+      // apollo will surpress thrown ApolloErrors except
+      // when fetchPolicy is network-only which is what
+      // refetch uses, so for the test we catch and ignore
+      // the thrown error, the error is still returned
       const handleButtonClick = React.useCallback(
         () => refetch().catch((_) => {}),
         [refetch],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3832,10 +3832,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/zen-observable@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
-  integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
+"@types/zen-observable@^0.8.0", "@types/zen-observable@^0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
+  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
 "@typescript-eslint/eslint-plugin@^5.4.0":
   version "5.12.0"


### PR DESCRIPTION
## Description
This PR updates `useQuery` hook to be able to recover from network errors. Previously if `refetch` encountered an error it would be able to fetch the request, but would not re-render. This PR address that bug and also updates `graphql-testing` with tests for error states and updates it's documentation.

Fixes (issue #) #1157

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish new version)
