### PR TITLE
Introduce DateStyle.DateTime style for formatting date and time

### DIFF
--- a/.changeset/dry-tools-wink.md
+++ b/.changeset/dry-tools-wink.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-i18n': minor
+---
+
+Add `DateStyle.DateTime`. to format dates in the style `Jun 12, 2022 at 10:34 pm`

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -141,6 +141,7 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
   - `DateStyle.Short`: e.g., `Dec 20, 2012`
   - `DateStyle.Humanize`: Adheres to [Polaris guidelines for dates with times](https://polaris.shopify.com/content/grammar-and-mechanics#section-dates-numbers-and-measurements), e.g., `Just now`, `3 minutes ago`, `4 hours ago`, `10:35 am`, `Yesterday at 10:35 am`, `Friday at 10:35 am`, or `Dec 20 at 10:35 am`, or `Dec 20, 2012`
   - `DateStyle.Time`: e.g., `11:00 AM`
+  - `DateStyle.DateTime`: Formats date and time separately and uses the translation string `date.humanize.lessThanOneYearAway` to format it according to this [Polaris guideline](https://polaris.shopify.com/foundations/content/grammar-and-mechanics#date), e.g. `Jun 12, 2022 at 10:34 pm`.
 - `weekStartDay()`: returns start day of the week according to the country.
 - `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.
 - `formatName()`: formats a name (first name and/or last name) according to the locale. e,g

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -3,6 +3,7 @@ export enum DateStyle {
   Short = 'Short',
   Humanize = 'Humanize',
   Time = 'Time',
+  DateTime = 'DateTime',
 }
 
 export const dateStyle = {
@@ -25,6 +26,13 @@ export const dateStyle = {
   [DateStyle.Time]: {
     hour: '2-digit',
     minute: '2-digit',
+  },
+  [DateStyle.DateTime]: {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
   },
 } as const;
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -308,9 +308,18 @@ export class I18n {
     const {style = undefined, ...formatOptions} = options || {};
 
     if (style) {
-      return style === DateStyle.Humanize
-        ? this.humanizeDate(date, {...formatOptions, timeZone})
-        : this.formatDate(date, {...formatOptions, ...dateStyle[style]});
+      switch (style) {
+        case DateStyle.Humanize:
+          return this.humanizeDate(date, {...formatOptions, timeZone});
+        case DateStyle.DateTime:
+          return this.formatDateTime(date, {
+            ...formatOptions,
+            timeZone,
+            ...dateStyle[style],
+          });
+        default:
+          return this.formatDate(date, {...formatOptions, ...dateStyle[style]});
+      }
     }
 
     return formatDate(date, locale, {...formatOptions, timeZone});
@@ -490,6 +499,25 @@ export class I18n {
     }
   }
 
+  private formatDateTime(
+    date: Date,
+    options: Intl.DateTimeFormatOptions,
+  ): string {
+    const {defaultTimezone} = this;
+    const {timeZone = defaultTimezone} = options;
+
+    return this.translate('date.humanize.lessThanOneYearAway', {
+      date: this.getDateFromDate(date, {
+        ...options,
+        timeZone,
+      }),
+      time: this.getTimeFromDate(date, {
+        ...options,
+        timeZone,
+      }),
+    });
+  }
+
   private humanizePastDate(date: Date, options?: Intl.DateTimeFormatOptions) {
     if (isLessThanOneMinuteAgo(date)) {
       return this.translate('date.humanize.lessThanOneMinuteAgo');
@@ -590,6 +618,34 @@ export class I18n {
     const zoneMatchGroup = /\s([\w()+\-:.]+$)/.exec(hourZone);
 
     return zoneMatchGroup ? zoneMatchGroup[1] : '';
+  }
+
+  private getDateFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {
+    const {
+      localeMatcher,
+      formatMatcher,
+      weekday,
+      day,
+      month,
+      year,
+      era,
+      timeZone,
+      timeZoneName,
+    } = options || {};
+
+    const formattedDate = this.formatDate(date, {
+      localeMatcher,
+      formatMatcher,
+      weekday,
+      day,
+      month,
+      year,
+      era,
+      timeZone,
+      timeZoneName: timeZoneName === 'short' ? undefined : timeZoneName,
+    });
+
+    return formattedDate;
   }
 
   private getTimeFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -2055,6 +2055,49 @@ describe('I18n', () => {
         }),
       ).toBe(expectedWithNewTimezone);
     });
+
+    describe('#with DateStyle.DateTime()', () => {
+      const date = new Date('2022-06-12T16:34:56Z');
+
+      const tests: [string, string, string, string, string][] = [
+        // [timezone, locale, country, expected date, expected time]
+        ['Europe/Amsterdam', 'en-US', 'US', 'Jun 12, 2022', '6:34 pm'],
+        ['Europe/Amsterdam', 'en-CA', 'CA', 'Jun 12, 2022', '6:34 p.m.'],
+        ['Europe/Amsterdam', 'es', 'ES', '12 jun 2022', '18:34'],
+        ['Europe/Amsterdam', 'fr', 'FR', '12 juin 2022', '18:34'],
+        ['Europe/Amsterdam', 'nl-NL', 'NL', '12 jun. 2022', '18:34'],
+        ['Europe/London', 'en-GB', 'GB', '12 Jun 2022', '17:34'],
+      ];
+
+      it.each(tests)(
+        'format DateTime with timezone %s and locale %s and country %s',
+        (timezone, locale, country, outputDate, outputTime) => {
+          const i18n = new I18n(defaultTranslations, {
+            locale,
+            country,
+            timezone,
+          });
+
+          i18n.formatDate(date, {
+            style: DateStyle.DateTime,
+            timeZone: timezone,
+          });
+
+          expect(translate).toHaveBeenCalledWith(
+            'date.humanize.lessThanOneYearAway',
+            {
+              pseudotranslate: false,
+              replacements: {
+                date: outputDate,
+                time: outputTime,
+              },
+            },
+            defaultTranslations,
+            i18n.locale,
+          );
+        },
+      );
+    });
   });
 
   describe('#weekStartDay()', () => {


### PR DESCRIPTION
## Description

### Fixes:
- https://github.com/Shopify/retail-international/issues/730
- https://github.com/Shopify/android-point-of-sale/issues/7356

### Why did you choose this approach?

This PR adds a way to format a date and time in one go. This allows projects using this library to format date/times as described in [this polaris doc](https://polaris.shopify.com/foundations/content/grammar-and-mechanics#date).

For the method signature, I tried to stay as close to the `formatDate` method as possible, but I did want to make a separation between the two (could use some guidance here).

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

### What reviewers should look at

- How is the changeset looking?
- The translations key is `date.humanize.datetime`, should this be in the humanize category or could I use the `lessThanOneYearAgo` translation? (that feels wrong, but contains the right text).
- Is it acceptable to have a separate method for this, or should this be included in the `formatDate` method, with a different `DateStyle` ?
- The `formatDateTime` method has a single `options` parameter which will be split up in time and date options in the method itself. This might need some more explanation in the method description?
- Wrote a couple of tests to ensure localisation of month names and date formats would work. Are these enough tests?
