### PR TITLE
Graphql fixtures/seed collision fix alt

### DIFF
--- a/.changeset/honest-pugs-dance.md
+++ b/.changeset/honest-pugs-dance.md
@@ -1,0 +1,5 @@
+---
+'graphql-fixtures': major
+---
+
+Updated seed generation for fillGraphQL nodes to ensure unique seeds for each object

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -495,14 +495,14 @@ function randomEnumValue(enumType: GraphQLEnumType) {
 }
 
 function seedFromKeypath(keypath: string[]) {
-  return keypath.reduce<number>((sum, key) => sum + seedFromKey(key), 0);
+  return keypath.reduce<number>((sum, key) => hashCode(key, sum), 0);
 }
 
-function seedFromKey(key: string) {
-  return [...key].reduce<number>(
-    (sum, character) => sum + character.charCodeAt(0),
-    0,
-  );
+function hashCode(data: string, initialHash = 0) {
+  let newHash = initialHash;
+  for (let i = 0; i < data.length; i++)
+    newHash = (Math.imul(31, newHash) + data.charCodeAt(i)) | 0;
+  return newHash;
 }
 
 export function list<T = {}, Data = {}, Variables = {}, DeepPartial = {}>(

--- a/packages/graphql-fixtures/src/tests/fill.test.ts
+++ b/packages/graphql-fixtures/src/tests/fill.test.ts
@@ -1354,22 +1354,17 @@ describe('createFiller()', () => {
       `);
 
       const result = fill(document, {
-        people: [{pets: [{}, {}]}, {pets: [{}, {}]}],
+        people: Array.from(Array(100)).map(() => ({
+          pets: Array.from(Array(100)).map(() => ({})),
+        })),
       }) as any;
 
       const allIds = result.people
         .flatMap((person) => person.pets)
         .map((pet) => pet.id);
 
-      const collisions = allIds.reduce((collisions, id) => {
-        const matchingIds = allIds.filter((otherId) => otherId === id);
-        if (matchingIds.length > 1) {
-          collisions.push(id);
-        }
-        return collisions;
-      }, []);
-
-      expect(collisions).toHaveLength(0);
+      const allIdSet = new Set(allIds);
+      expect(allIdSet.size).toBe(allIds.length);
     });
   });
 });

--- a/packages/graphql-fixtures/src/utilities.ts
+++ b/packages/graphql-fixtures/src/utilities.ts
@@ -1,7 +1,7 @@
 import faker from '@faker-js/faker/locale/en';
 
 export function chooseNull() {
-  return faker.datatype.boolean();
+  return !faker.datatype.boolean();
 }
 
 export function randomFromArray<T>(array: T[] | ReadonlyArray<T>) {


### PR DESCRIPTION
## Description

Cutting a version of graphql-fixtures with alternate randomly selected value for `chooseNull` to expose incorrect use of `fillGraphQL` in web

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
