### PR TITLE
Update node-mocks-http

### DIFF
--- a/.changeset/beige-steaks-divide.md
+++ b/.changeset/beige-steaks-divide.md
@@ -1,0 +1,11 @@
+---
+'@shopify/jest-koa-mocks': major
+---
+
+Update node-mocks-http, fixing response.getHeaders() behaviour
+
+response.getHeaders() had a flawed implementation where it exposed the
+underlying headers object, allowing it to be mutated in tests directly.
+https://github.com/howardabrams/node-mocks-http/pull/217 fixes that issue by
+returning a shallow copy so that the underlying headers object cannot be
+directly mutated.

--- a/packages/jest-koa-mocks/package.json
+++ b/packages/jest-koa-mocks/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "koa": "^2.13.4",
-    "node-mocks-http": "^1.5.8"
+    "node-mocks-http": "^1.11.0"
   },
   "devDependencies": {
     "@types/express": "^4.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6094,7 +6094,7 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-content-disposition@0.5.4, content-disposition@~0.5.2:
+content-disposition@0.5.4, content-disposition@^0.5.3, content-disposition@~0.5.2:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
@@ -11298,12 +11298,13 @@ node-loader@^1.0.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-node-mocks-http@^1.5.8:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.8.0.tgz#201a882bd1f8473de6a14bf41850d373404fde32"
-  integrity sha512-A6YB8+sTiHZPTPf1KfwZ3sAQYSSNJTWd762IOptAmM2d6XUQ9Q1wMh+uJ7a7n2Vy6NKmODfZArqX6Rbmlg+8Fw==
+node-mocks-http@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.11.0.tgz#defc0febf6b935f08245397d47534a8de592996e"
+  integrity sha512-jS/WzSOcKbOeGrcgKbenZeNhxUNnP36Yw11+hL4TTxQXErGfqYZ+MaYNNvhaTiGIJlzNSqgQkk9j8dSu1YWSuw==
   dependencies:
     accepts "^1.3.7"
+    content-disposition "^0.5.3"
     depd "^1.1.0"
     fresh "^0.5.2"
     merge-descriptors "^1.0.1"


### PR DESCRIPTION
## Description

Updates node-mocks-http to pick up a fix to `response.getHeaders()` (it should be a shallow copy).

https://github.com/howardabrams/node-mocks-http/pull/217