### PR TITLE
Add DeepReadonly type

### DIFF
--- a/.changeset/serious-turkeys-deny.md
+++ b/.changeset/serious-turkeys-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/useful-types': minor
+---
+
+Added DeepReadonly type

--- a/packages/useful-types/README.md
+++ b/packages/useful-types/README.md
@@ -85,7 +85,7 @@ The following type aliases are provided by this library:
   type SelectiveObj = Omit<Obj, 'foo' | 'bar'>; // {baz: number}
   ```
 
-- `DeepPartial<T>`: Recusively maps over all properties in a type and transforms them to be optional. Useful when you need to make optional all of the properties (and nested properties) of an existing type.
+- `DeepPartial<T>`: Recursively maps over all properties in a type and transforms them to be optional. Useful when you need to make optional all of the properties (and nested properties) of an existing type.
 
   ```ts
   interface Obj {
@@ -153,4 +153,17 @@ type SelectiveObj = DeepOmit<Obj, '__typename'>; // {foo: string; bar: {baz: str
   }
 
   type HalfRequiredObj = RequireSome<Obj, 'foo'>; // {foo: string, bar?: string}
+  ```
+
+- `DeepReadonly<T>`: Recursively maps over all properties in a type and transforms them to be read-only.
+
+  ```ts
+  interface Obj {
+    foo: string;
+    bar: {
+      baz: boolean;
+    };
+  }
+
+  type DeepReadonlyObj = DeepReadonly<Obj>; // {readonly foo: string; readonly bar: { readonly baz: boolean }}
   ```

--- a/packages/useful-types/src/types.ts
+++ b/packages/useful-types/src/types.ts
@@ -86,3 +86,34 @@ export type PartialSome<T, K extends keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;
 export type RequireSome<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
+
+// Reference https://github.com/ts-essentials/ts-essentials/blob/5aa1f264e77fb36bb3f673c49f00927c7c181a7f/lib/types.ts
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type IsUnknown<T> = IsAny<T> extends true
+  ? false
+  : unknown extends T
+  ? true
+  : false;
+
+export type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends Map<infer K, infer V>
+  ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>>
+  : T extends ReadonlyMap<infer K, infer V>
+  ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>>
+  : T extends WeakMap<infer K, infer V>
+  ? WeakMap<DeepReadonly<K>, DeepReadonly<V>>
+  : T extends Set<infer U>
+  ? ReadonlySet<DeepReadonly<U>>
+  : T extends ReadonlySet<infer U>
+  ? ReadonlySet<DeepReadonly<U>>
+  : T extends WeakSet<infer U>
+  ? WeakSet<DeepReadonly<U>>
+  : T extends Promise<infer U>
+  ? Promise<DeepReadonly<U>>
+  : T extends {}
+  ? {readonly [K in keyof T]: DeepReadonly<T[K]>}
+  : IsUnknown<T> extends true
+  ? unknown
+  : Readonly<T>;

--- a/packages/useful-types/test-d/types.test-d.ts
+++ b/packages/useful-types/test-d/types.test-d.ts
@@ -380,14 +380,10 @@ delete readOnly.prop;
 // @ts-expect-error read only property
 readOnly.prop = 'newValue';
 
-// @ts-expect-error read only object
-readOnly.innerObj.prop = 'newValue';
+expectType<{readonly prop: string}>(readOnly.innerObj!);
 
-// @ts-expect-error read only array
-readOnly.array.push('newValue');
+expectType<ReadonlyArray<string>>(readOnly.array!);
 
-// @ts-expect-error read only map
-readOnly.map.delete('newValue');
+expectType<ReadonlyMap<string, string>>(readOnly.map!);
 
-// @ts-expect-error read only set
-readOnly.set.add('newValue');
+expectType<ReadonlySet<string>>(readOnly.set!);

--- a/packages/useful-types/test-d/types.test-d.ts
+++ b/packages/useful-types/test-d/types.test-d.ts
@@ -10,6 +10,7 @@ import {
   DeepPartial,
   IfEmptyObject,
   DeepOmit,
+  DeepReadonly,
 } from '../build/ts/types';
 
 interface Person {
@@ -356,3 +357,37 @@ expectNotAssignable<DeepOmit<RespectOptionalProps, '__typename'>>({
 /**
  * RequireSome
  */
+
+/**
+ * DeepReadonly
+ */
+
+interface ObjectInterface {
+  prop?: string;
+  innerObj?: {
+    prop: string;
+  };
+  array?: string[];
+  map?: Map<string, string>;
+  set?: Set<string>;
+}
+
+const readOnly = {} as DeepReadonly<ObjectInterface>;
+
+// @ts-expect-error can't delete from read only
+delete readOnly.prop;
+
+// @ts-expect-error read only property
+readOnly.prop = 'newValue';
+
+// @ts-expect-error read only object
+readOnly.innerObj.prop = 'newValue';
+
+// @ts-expect-error read only array
+readOnly.array.push('newValue');
+
+// @ts-expect-error read only map
+readOnly.map.delete('newValue');
+
+// @ts-expect-error read only set
+readOnly.set.add('newValue');


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

Added a `DeepReadonly` type to `useful-types`. Plan to use this type to make the cached response from `@shopify/react-graphql` readonly to catch any accidental mutations. This type can also be useful for other purposes in application code.