### PR TITLE
[react-hooks] initialize Media hooks with correct matches value

### DIFF
--- a/.changeset/four-days-type.md
+++ b/.changeset/four-days-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-hooks': major
+---
+
+Media hooks initialized with correct matches value

--- a/packages/react-hooks/src/hooks/media.ts
+++ b/packages/react-hooks/src/hooks/media.ts
@@ -4,7 +4,11 @@ type EffectHook = typeof useEffect | typeof useLayoutEffect;
 
 function createUseMediaFactory(useEffectHook: EffectHook) {
   return (query: string) => {
-    const [match, setMatch] = useState(false);
+    const [match, setMatch] = useState(() =>
+      typeof window !== 'undefined' && window.matchMedia
+        ? window.matchMedia(query).matches
+        : false,
+    );
 
     useEffectHook(() => {
       if (!window || !window.matchMedia) {

--- a/packages/react-hooks/src/hooks/tests/media.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/media.test.tsx
@@ -5,8 +5,11 @@ import {mount} from '@shopify/react-testing';
 import {useMedia, useMediaLayout} from '../media';
 
 describe('useMedia and useMediaLayout', () => {
+  let matches: boolean[] = [];
+
   beforeEach(() => {
     matchMedia.mock();
+    matches = [];
   });
 
   afterEach(() => {
@@ -19,6 +22,7 @@ describe('useMedia and useMediaLayout', () => {
   ])('%s', (_, useEffectHook) => {
     function MockComponent({mediaQuery}: {mediaQuery: string}) {
       const matchedQuery = useEffectHook(mediaQuery);
+      matches.push(matchedQuery);
       const message = matchedQuery ? 'matched' : 'did not match';
       return <div>{message}</div>;
     }
@@ -66,6 +70,7 @@ describe('useMedia and useMediaLayout', () => {
       );
 
       const mockComponent = mount(<MockComponent mediaQuery="print" />);
+      expect(matches).toStrictEqual([true]);
       expect(mockComponent.text()).toContain('matched');
     });
 
@@ -77,6 +82,7 @@ describe('useMedia and useMediaLayout', () => {
       );
 
       const mockComponent = mount(<MockComponent mediaQuery="print" />);
+      expect(matches).toStrictEqual([false]);
       expect(mockComponent.text()).toContain('did not match');
     });
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

This PR addresses an issue with the media hooks where the initial render will always return the value of `false` regardless if the media matches or not, only on subsequent renders will the correct value be set. This causes a needless re-render if the media matches as well as could cause issues when using the results in a `useEffect` (for example when using tracking  events but only when media matches)

Note: I've set this is a breaking change that requires a major version bump as it technically a change in behaviour and it's possible that there is code relying on the old behaviour. 