### PR TITLE
Allow `createGraphQL` pass links to test client

### DIFF
--- a/.changeset/silly-flowers-smash.md
+++ b/.changeset/silly-flowers-smash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/graphql-testing': minor
+---
+
+Allow ApolloLinks to be passed to createGraphQL

--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -15,6 +15,7 @@ import {GraphQLMock, MockRequest, FindOptions} from './types';
 export interface Options {
   unionOrIntersectionTypes?: any[];
   cacheOptions?: ApolloReducerConfig;
+  links?: ApolloLink[];
 }
 
 interface Wrapper {
@@ -31,7 +32,11 @@ export class GraphQL {
 
   constructor(
     mock: GraphQLMock | undefined,
-    {unionOrIntersectionTypes = [], cacheOptions = {}}: Options = {},
+    {
+      unionOrIntersectionTypes = [],
+      cacheOptions = {},
+      links = [],
+    }: Options = {},
   ) {
     const cache = new InMemoryCache({
       fragmentMatcher: new IntrospectionFragmentMatcher({
@@ -46,6 +51,7 @@ export class GraphQL {
 
     this.mockLink = new MockLink(mock || defaultGraphQLMock);
     const link = ApolloLink.from([
+      ...links,
       new InflightLink({
         onCreated: this.handleCreate,
         onResolved: this.handleResolve,


### PR DESCRIPTION
## Description
This PR allows `createGraphQL` to pass `ApolloLink` to be passed to the ApolloClient. 

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
