### PR TITLE
:wrench: @Shopify/react-html make script tag  more configurable

### DIFF
--- a/.changeset/pretty-rings-destroy.md
+++ b/.changeset/pretty-rings-destroy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-html': minor
+---
+
+Makes script tag more configurable in the <Html> component

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -18,6 +18,8 @@ export interface Asset {
 
 export interface ScriptAsset extends Asset {
   type?: 'module' | 'nomodule' | 'script';
+  disableCrossOrigin?: boolean;
+  async?: boolean | undefined;
 }
 
 export interface InlineStyle {
@@ -107,25 +109,31 @@ export default function Html({
   });
 
   const blockingScriptsMarkup = blockingScripts.map((script) => {
+    const crossOrigin = script.disableCrossOrigin ? undefined : 'anonymous';
+
     return (
       <Script
         key={script.path}
         src={script.path}
         integrity={script.integrity}
         type={script.type}
-        crossOrigin="anonymous"
+        crossOrigin={crossOrigin}
+        async={script.async}
       />
     );
   });
 
   const deferredScriptsMarkup = scripts.map((script) => {
+    const crossOrigin = script.disableCrossOrigin ? undefined : 'anonymous';
+
     return (
       <Script
         key={script.path}
         src={script.path}
         integrity={script.integrity}
         type={script.type}
-        crossOrigin="anonymous"
+        crossOrigin={crossOrigin}
+        async={script.async}
         defer
       />
     );

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -84,6 +84,36 @@ describe('<Html />', () => {
       }
     });
 
+    it('generates a script tag in the head with crossOrigin anonymous by default', () => {
+      const scripts = [{path: 'foo.js'}, {path: 'bar.js'}];
+      const html = mount(<Html {...mockProps} scripts={scripts} />);
+      const head = html.find('head')!;
+
+      for (const script of scripts) {
+        expect(head).toContainReactComponent(Script, {
+          src: script.path,
+          crossOrigin: 'anonymous',
+        });
+      }
+    });
+
+    it('generates a script tag in the head without crossOrigin when disabled', () => {
+      const scripts = [
+        {path: 'foo.js', disableCrossOrigin: true},
+        {path: 'bar.js', disableCrossOrigin: true},
+      ];
+
+      const html = mount(<Html {...mockProps} scripts={scripts} />);
+      const head = html.find('head')!;
+
+      for (const script of scripts) {
+        expect(head).toContainReactComponent(Script, {
+          src: script.path,
+          crossOrigin: undefined,
+        });
+      }
+    });
+
     it('includes `type` attributes', () => {
       const script = {path: 'foo.js', type: 'nomodule' as const};
       const html = mount(<Html {...mockProps} scripts={[script]} />);
@@ -91,6 +121,29 @@ describe('<Html />', () => {
 
       expect(head).toContainReactComponent(Script, {
         type: 'nomodule',
+      });
+    });
+
+    it('does not include async attribute by default', () => {
+      const scripts = [{path: 'foo.js'}, {path: 'bar.js'}];
+      const html = mount(<Html {...mockProps} scripts={scripts} />);
+      const head = html.find('head')!;
+
+      expect(head).not.toContainReactComponent(Script, {
+        async: true,
+      });
+    });
+
+    it('includes async attribute when enabled', () => {
+      const scripts = [
+        {path: 'foo.js', async: true},
+        {path: 'bar.js', async: true},
+      ];
+      const html = mount(<Html {...mockProps} scripts={scripts} />);
+      const head = html.find('head')!;
+
+      expect(head).toContainReactComponent(Script, {
+        async: true,
       });
     });
   });
@@ -104,6 +157,36 @@ describe('<Html />', () => {
       for (const script of scripts) {
         expect(head).toContainReactComponent(Script, {
           src: script.path,
+        });
+      }
+    });
+
+    it('generates a script tag in the head with crossOrigin anonymous by default', () => {
+      const scripts = [{path: 'foo.js'}, {path: 'bar.js'}];
+      const html = mount(<Html {...mockProps} blockingScripts={scripts} />);
+      const head = html.find('head')!;
+
+      for (const script of scripts) {
+        expect(head).toContainReactComponent(Script, {
+          src: script.path,
+          crossOrigin: 'anonymous',
+        });
+      }
+    });
+
+    it('generates a script tag in the head without crossOrigin when disabled', () => {
+      const scripts = [
+        {path: 'foo.js', disableCrossOrigin: true},
+        {path: 'bar.js', disableCrossOrigin: true},
+      ];
+
+      const html = mount(<Html {...mockProps} blockingScripts={scripts} />);
+      const head = html.find('head')!;
+
+      for (const script of scripts) {
+        expect(head).toContainReactComponent(Script, {
+          src: script.path,
+          crossOrigin: undefined,
         });
       }
     });


### PR DESCRIPTION
## Description

The `<Hml>` component in [@shopify/react-html](https://github.com/Shopify/quilt/tree/main/packages/react-html#html-) sets up a script tag with the [following default attributes](https://github.com/Shopify/quilt/blob/main/packages/react-html/src/server/components/Html.tsx#L121-L132). This component is only available from the server entrypoint of the [@shopify/react-html/server](https://github.com/Shopify/quilt/tree/main/packages/react-server) package and when using it we can't configure a script tag with the attributes that we need/don't need. 

Fixes (issue #)

This PR makes the script tag a little more configurable and allows you to disable [crossOrigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) and add the [async attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attributes) to the script. It does not change any default values of the script, it only adds additional props to be able to pass in and change the attributes. 

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
