### PR TITLE
[react-testing] Release act promises when root wrapper is destroyed

### DIFF
--- a/.changeset/wise-apples-call.md
+++ b/.changeset/wise-apples-call.md
@@ -1,0 +1,7 @@
+---
+'@shopify/react-testing': major
+---
+
+WHAT: Release act promises when root wrapper is destroyed
+WHY: To prevent unresolved promises from failing subsequent act calls
+HOW: `destroyAll` in `afterEach` will now have to be awaited as well as `Root.prototype.destroy`

--- a/packages/react-testing/src/destroy.ts
+++ b/packages/react-testing/src/destroy.ts
@@ -1,7 +1,11 @@
 import {connected} from './root';
 
 export function destroyAll() {
+  const promises: Promise<void>[] = [];
+
   for (const wrapper of [...connected]) {
-    wrapper.destroy();
+    promises.push(wrapper.destroy());
   }
+
+  return Promise.all(promises);
 }

--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -137,7 +137,7 @@ export function createMount<
       const originalDestroy = wrapper.destroy.bind(wrapper);
       wrapper.destroy = () => {
         cleanup(wrapper, options);
-        originalDestroy();
+        return originalDestroy();
       };
     }
 

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -74,6 +74,9 @@ export class Root<Props> implements Node<Props> {
   private reactRoot: ReactRoot | null = null;
   private root: Element<Props> | null = null;
   private acting = false;
+  private destroyed = false;
+  private actPromise!: Promise<void>;
+  private actPromiseResolver!: () => void;
 
   private render: Render;
   private resolveRoot: ResolveRoot;
@@ -88,10 +91,20 @@ export class Root<Props> implements Node<Props> {
   ) {
     this.render = render;
     this.resolveRoot = resolveRoot;
+    this.actPromise = new Promise((resolve) => {
+      this.actPromiseResolver = resolve;
+    });
     this.mount();
   }
 
   act<T>(action: () => T, {update = true} = {}): T {
+    if (this.destroyed) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Warning: attempting to perform an act on a destroyed root. This can lead to state changes not being applied',
+      );
+    }
+
     const updateWrapper = update ? this.update.bind(this) : noop;
     let result!: T;
 
@@ -123,7 +136,14 @@ export class Root<Props> implements Node<Props> {
       });
 
       if (isPromise(result)) {
-        return result as unknown as Promise<void>;
+        if (this.destroyed) {
+          return result as unknown as Promise<void>;
+        }
+
+        return Promise.race([
+          result,
+          this.actPromise,
+        ]) as unknown as Promise<void>;
       }
 
       return undefined as unknown as Promise<void>;
@@ -257,15 +277,18 @@ export class Root<Props> implements Node<Props> {
     this.act(() => this.reactRoot!.unmount());
   }
 
-  destroy() {
+  async destroy() {
     const {element, mounted} = this;
 
     if (mounted) {
       this.unmount();
     }
-
     element.remove();
     connected.delete(this);
+    this.destroyed = true;
+    this.actPromiseResolver();
+    // flush the micro task to wait until react commits all pending updates.
+    await this.actPromise;
   }
 
   setProps(props: Partial<Props>) {

--- a/packages/react-testing/src/tests/destroy.test.tsx
+++ b/packages/react-testing/src/tests/destroy.test.tsx
@@ -4,8 +4,8 @@ import {mount} from '../mount';
 import {destroyAll} from '../destroy';
 
 describe('destroyAll()', () => {
-  afterEach(() => {
-    destroyAll();
+  afterEach(async () => {
+    await destroyAll();
   });
 
   it('destroys all constructed root elements that have not already been destroyed', () => {

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -173,6 +173,32 @@ describe('@shopify/react-testing', () => {
       );
     }
 
+    it('releases any stale promises when component is destroyed', async () => {
+      const wrapper = mount(<Counter />);
+      wrapper.act(() => new Promise(() => {}));
+      wrapper.act(() => new Promise(() => {}));
+      await wrapper.destroy();
+
+      // React 17 will fail without this await
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      function EffectChangeComponent({children}: {children?: ReactNode}) {
+        const [counter, setCounter] = useState(0);
+        useEffect(() => setCounter(100), []);
+
+        return (
+          // eslint-disable-next-line @shopify/jsx-prefer-fragment-wrappers
+          <div>
+            <Message>{counter}</Message>
+            {children}
+          </div>
+        );
+      }
+      const newWrapper = mount(<EffectChangeComponent />);
+
+      expect(newWrapper.find(Message)!.html()).toBe('<span>100</span>');
+    });
+
     it('updates element tree when state is changed', () => {
       const wrapper = mount(<Counter />);
 

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -14,7 +14,7 @@ const defaultTree = {
   props: {},
 };
 
-const defaultRoot = new Root(<DummyComponent />);
+const getDefaultRoot = () => new Root(<DummyComponent />);
 const divTwo = new Element(
   {
     ...defaultTree,
@@ -23,7 +23,7 @@ const divTwo = new Element(
     instance: document.createElement('div'),
   },
   [],
-  defaultRoot,
+  getDefaultRoot(),
 );
 
 const divOne = new Element(
@@ -34,26 +34,30 @@ const divOne = new Element(
     instance: document.createElement('div'),
   },
   [divTwo],
-  defaultRoot,
+  getDefaultRoot(),
 );
 
 const componentTwo = new Element(
   {...defaultTree, type: DummyComponent},
   [],
-  defaultRoot,
+  getDefaultRoot(),
 );
 
 const componentOne = new Element(
   {...defaultTree, type: DummyComponent},
   [divOne, componentTwo],
-  defaultRoot,
+  getDefaultRoot(),
 );
 
 describe('Element', () => {
   describe('#props', () => {
     it('returns the props from the tree', () => {
       const props = {foo: 'bar'};
-      const element = new Element({...defaultTree, props}, [], defaultRoot);
+      const element = new Element(
+        {...defaultTree, props},
+        [],
+        getDefaultRoot(),
+      );
       expect(element).toHaveProperty('props', props);
     });
   });
@@ -61,7 +65,7 @@ describe('Element', () => {
   describe('#type', () => {
     it('returns the type from the tree', () => {
       const type = DummyComponent;
-      const element = new Element({...defaultTree, type}, [], defaultRoot);
+      const element = new Element({...defaultTree, type}, [], getDefaultRoot());
       expect(element).toHaveProperty('type', type);
     });
   });
@@ -69,7 +73,11 @@ describe('Element', () => {
   describe('#instance', () => {
     it('returns the type from the tree', () => {
       const instance = {};
-      const element = new Element({...defaultTree, instance}, [], defaultRoot);
+      const element = new Element(
+        {...defaultTree, instance},
+        [],
+        getDefaultRoot(),
+      );
       expect(element).toHaveProperty('instance', instance);
     });
   });
@@ -79,7 +87,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.MemoComponent},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
       expect(element).toHaveProperty('isDOM', false);
     });
@@ -88,7 +96,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
       expect(element).toHaveProperty('isDOM', true);
     });
@@ -96,7 +104,11 @@ describe('Element', () => {
 
   describe('#children', () => {
     it('returns element children', () => {
-      const element = new Element(defaultTree, [divOne, divTwo], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [divOne, divTwo],
+        getDefaultRoot(),
+      );
 
       expect(element).toHaveProperty('children', [divOne, divTwo]);
     });
@@ -105,7 +117,7 @@ describe('Element', () => {
       const element = new Element(
         defaultTree,
         [divOne, 'Some text', divTwo],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element).toHaveProperty('children', [divOne, divTwo]);
@@ -114,7 +126,7 @@ describe('Element', () => {
 
   describe('#descendants', () => {
     it('returns element descendants', () => {
-      const element = new Element(defaultTree, [divOne], defaultRoot);
+      const element = new Element(defaultTree, [divOne], getDefaultRoot());
 
       expect(element).toHaveProperty('descendants', [divOne, divTwo]);
     });
@@ -126,7 +138,11 @@ describe('Element', () => {
     });
 
     it('returns the instances associated with each child DOM element', () => {
-      const element = new Element(defaultTree, [divOne, divTwo], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [divOne, divTwo],
+        getDefaultRoot(),
+      );
 
       expect(element.domNodes).toStrictEqual([
         divOne.instance,
@@ -135,13 +151,17 @@ describe('Element', () => {
     });
 
     it('does not return descendant DOM nodes', () => {
-      const element = new Element(defaultTree, [divOne], defaultRoot);
+      const element = new Element(defaultTree, [divOne], getDefaultRoot());
 
       expect(element.domNodes).not.toContain(divTwo.instance);
     });
 
     it('does not return instances for non-DOM nodes', () => {
-      const element = new Element(defaultTree, [componentOne], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [componentOne],
+        getDefaultRoot(),
+      );
 
       expect(element.domNodes).not.toContain(componentOne.instance);
     });
@@ -153,19 +173,27 @@ describe('Element', () => {
     });
 
     it('returns null if there is no direct child DOM node', () => {
-      const element = new Element(defaultTree, [componentOne], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [componentOne],
+        getDefaultRoot(),
+      );
 
       expect(element.domNode).toBeNull();
     });
 
     it('returns the DOM node if there is a single DOM child', () => {
-      const element = new Element(defaultTree, [divOne], defaultRoot);
+      const element = new Element(defaultTree, [divOne], getDefaultRoot());
 
       expect(element.domNode).toBe(divOne.instance);
     });
 
     it('throws an error if there are multiple top-level DOM nodes', () => {
-      const element = new Element(defaultTree, [divOne, divTwo], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [divOne, divTwo],
+        getDefaultRoot(),
+      );
 
       expect(() => element.domNode).toThrow(/multiple HTML elements/);
     });
@@ -174,7 +202,11 @@ describe('Element', () => {
   describe('#prop()', () => {
     it('returns the prop value for the specified key', () => {
       const props = {foo: 'bar'};
-      const element = new Element({...defaultTree, props}, [], defaultRoot);
+      const element = new Element(
+        {...defaultTree, props},
+        [],
+        getDefaultRoot(),
+      );
       expect(element.prop('foo')).toBe(props.foo);
     });
   });
@@ -189,7 +221,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent, type: 'div', instance: div},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.text()).toBe(text);
@@ -199,13 +231,13 @@ describe('Element', () => {
       const childTextOne = 'foo ';
       const childTextTwo = 'bar';
 
-      const elementChild = new Element(defaultTree, [], defaultRoot);
+      const elementChild = new Element(defaultTree, [], getDefaultRoot());
       jest.spyOn(elementChild, 'text').mockImplementation(() => childTextOne);
 
       const element = new Element(
         {...defaultTree, tag: Tag.FunctionComponent, type: DummyComponent},
         [elementChild, childTextTwo],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.text()).toBe(`${childTextOne}${childTextTwo}`);
@@ -215,7 +247,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostPortal, type: DummyComponent},
         ['Hello world'],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.text()).toBe('');
@@ -232,7 +264,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent, type: 'div', instance: div},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.html()).toBe(`<div>${html}</div>`);
@@ -242,13 +274,13 @@ describe('Element', () => {
       const childHtml = 'foo ';
       const childText = 'bar';
 
-      const elementChild = new Element(defaultTree, [], defaultRoot);
+      const elementChild = new Element(defaultTree, [], getDefaultRoot());
       jest.spyOn(elementChild, 'text').mockImplementation(() => childHtml);
 
       const element = new Element(
         {...defaultTree, tag: Tag.FunctionComponent, type: DummyComponent},
         [elementChild, childText],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.text()).toBe(`${childHtml}${childText}`);
@@ -258,7 +290,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostPortal, type: DummyComponent},
         ['Hello world'],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.html()).toBe('');
@@ -270,7 +302,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.HostComponent, type: 'div'},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.is(DummyComponent)).toBe(false);
@@ -280,7 +312,7 @@ describe('Element', () => {
       const element = new Element(
         {...defaultTree, tag: Tag.FunctionComponent, type: DummyComponent},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.is(DummyComponent)).toBe(true);
@@ -289,7 +321,11 @@ describe('Element', () => {
 
   describe('#find()', () => {
     it('finds the first matching DOM node', () => {
-      const element = new Element(defaultTree, [componentOne], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [componentOne],
+        getDefaultRoot(),
+      );
 
       expect(element.find('div')).toBe(divOne);
     });
@@ -298,7 +334,7 @@ describe('Element', () => {
       const element = new Element(
         defaultTree,
         [divOne, componentOne],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.find(DummyComponent)).toBe(componentOne);
@@ -314,7 +350,7 @@ describe('Element', () => {
           instance: document.createElement('div'),
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       const divTwo = new Element(
@@ -326,7 +362,7 @@ describe('Element', () => {
           instance: document.createElement('div'),
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       const span = new Element(
@@ -338,13 +374,13 @@ describe('Element', () => {
           instance: document.createElement('span'),
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       const element = new Element(
         defaultTree,
         [divOne, divTwo, span],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.find('div', {className: divTwo.props.className})).toBe(
@@ -355,20 +391,24 @@ describe('Element', () => {
     });
 
     it('returns null when no match is found', () => {
-      const element = new Element(defaultTree, [], defaultRoot);
+      const element = new Element(defaultTree, [], getDefaultRoot());
       expect(element.find(DummyComponent)).toBeNull();
     });
   });
 
   describe('#findAll()', () => {
     it('finds all matching DOM nodes', () => {
-      const element = new Element(defaultTree, [divOne], defaultRoot);
+      const element = new Element(defaultTree, [divOne], getDefaultRoot());
 
       expect(element.findAll('div')).toStrictEqual([divOne, divTwo]);
     });
 
     it('finds all matching components', () => {
-      const element = new Element(defaultTree, [componentOne], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [componentOne],
+        getDefaultRoot(),
+      );
 
       expect(element.findAll(DummyComponent)).toStrictEqual([
         componentOne,
@@ -386,7 +426,7 @@ describe('Element', () => {
           instance: document.createElement('div'),
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       const divTwo = new Element(
@@ -398,7 +438,7 @@ describe('Element', () => {
           instance: document.createElement('div'),
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       const span = new Element(
@@ -410,13 +450,13 @@ describe('Element', () => {
           instance: document.createElement('span'),
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       const element = new Element(
         defaultTree,
         [divOne, divTwo, span],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(
@@ -429,7 +469,7 @@ describe('Element', () => {
     });
 
     it('returns an empty array when no matches are found', () => {
-      const element = new Element(defaultTree, [], defaultRoot);
+      const element = new Element(defaultTree, [], getDefaultRoot());
       expect(element.findAll(DummyComponent)).toHaveLength(0);
     });
   });
@@ -440,7 +480,11 @@ describe('Element', () => {
         (element: Element<unknown>) => element === divTwo,
       );
 
-      const element = new Element(defaultTree, [componentOne], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [componentOne],
+        getDefaultRoot(),
+      );
 
       expect(element.findWhere(matches)).toBe(divTwo);
       expect(matches).toHaveBeenCalledWith(componentOne);
@@ -449,14 +493,18 @@ describe('Element', () => {
     });
 
     it('returns null when no match is found', () => {
-      const element = new Element(defaultTree, [componentOne], defaultRoot);
+      const element = new Element(
+        defaultTree,
+        [componentOne],
+        getDefaultRoot(),
+      );
       expect(element.findWhere(() => false)).toBeNull();
     });
   });
 
   describe('#findAllWhere()', () => {
     it('finds all matching nodes', () => {
-      const element = new Element(defaultTree, [divOne], defaultRoot);
+      const element = new Element(defaultTree, [divOne], getDefaultRoot());
       expect(
         element.findAllWhere((element) => element.type === componentTwo.type),
       ).toHaveLength(0);
@@ -480,7 +528,7 @@ describe('Element', () => {
       const element = new Element<Props>(
         {...defaultTree, type: TriggerableComponent, props: {}},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(() => element.trigger('onClick')).toThrow(
@@ -493,7 +541,7 @@ describe('Element', () => {
       const element = new Element<Props>(
         {...defaultTree, type: TriggerableComponent, props: {onClick}},
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       const value = 'foobar';
@@ -502,6 +550,7 @@ describe('Element', () => {
     });
 
     it('wraps the call in a act block from the root', () => {
+      const defaultRoot = getDefaultRoot();
       const act = jest.spyOn(defaultRoot, 'act');
       const element = new Element<Props>(
         {
@@ -526,7 +575,7 @@ describe('Element', () => {
           props: {onClick: () => returnValue},
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.trigger('onClick')).toBe(returnValue);
@@ -541,7 +590,7 @@ describe('Element', () => {
           props: {onClick: jest.fn()},
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(() => element.trigger('onClick', partialEvent)).not.toThrow();
@@ -569,7 +618,7 @@ describe('Element', () => {
           props: {actions: []},
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(() => element.triggerKeypath('actions[1]onAction')).toThrow(
@@ -585,7 +634,7 @@ describe('Element', () => {
           props: {actions: []},
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       // @ts-expect-error actions is not valid parameter, because it does not point to a function
@@ -605,7 +654,7 @@ describe('Element', () => {
           props: {actions: [{onAction}]},
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       element.triggerKeypath('actions.0.onAction', value);
@@ -622,7 +671,7 @@ describe('Element', () => {
           props: {actions: [{onAction: () => returnValue}]},
         },
         [],
-        defaultRoot,
+        getDefaultRoot(),
       );
 
       expect(element.triggerKeypath('actions.0.onAction')).toBe(returnValue);

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -6,8 +6,8 @@ import {mount, createMount} from '../mount';
 import {destroyAll} from '../destroy';
 
 describe('mount()', () => {
-  afterEach(() => {
-    destroyAll();
+  afterEach(async () => {
+    await destroyAll();
   });
 
   it('constructs and returns a root element', () => {

--- a/packages/react-testing/src/tests/root.test.tsx
+++ b/packages/react-testing/src/tests/root.test.tsx
@@ -12,9 +12,9 @@ describe('Root', () => {
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     consoleErrorSpy.mockRestore();
-    destroyAll();
+    await destroyAll();
   });
 
   it('works with react 16 style nodes', () => {

--- a/tests/setup/tests.ts
+++ b/tests/setup/tests.ts
@@ -18,6 +18,6 @@ if (typeof window !== 'undefined') {
 }
 
 // eslint-disable-next-line jest/require-top-level-describe
-afterEach(() => {
-  destroyAll();
+afterEach(async () => {
+  await destroyAll();
 });


### PR DESCRIPTION
## Description

With React 18 a hanging promises returned from `act` can prevent other updates from occurring and since that happens on a global scope it will affect subsequent tests within the same test suite. This PR attempts to free up the act queue by resolving any  unfulfilled promises when the root wrapper is destroyed. 

Within our internal tests we typically have `destroyAll` within a `afterEach` which loops through all active wrappers and calls `destroy` on them. The change with this PR is that now `destoryAll` will have to be awaited so that any active promises holding up the `act` can be resolved.

This PR also adds a warning when attempting to call `wrapper.act` on an already destroyed root, this can happen if for example a `graphQL` context is shared between wrappers. Eventually we'd want to clean those up.

Note: this also eliminates the need to have something like
```
await act(async () => {
    await flushPromises();
  });
```
in a `afterEach`
