### PR TITLE
Added types to triggerKeyPath

### DIFF
--- a/.changeset/honest-bikes-worry.md
+++ b/.changeset/honest-bikes-worry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': minor
+---
+
+Fully typed triggerKeypath method

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -15,6 +15,10 @@ import {
   DeepPartialArguments,
   PropsFor,
   DebugOptions,
+  TriggerKeypathParams,
+  TriggerKeypathReturn,
+  KeyPathFunction,
+  ExtractKeypath,
 } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -201,16 +205,19 @@ export class Root<Props> implements Node<Props> {
   trigger<K extends FunctionKeys<Props>>(
     prop: K,
     ...args: DeepPartialArguments<Props[K]>
-  ): ReturnType<
-    NonNullable<
-      Props[K] extends ((...args: any[]) => any) | undefined ? Props[K] : never
-    >
-  > {
+  ): NonNullable<Props[K]> extends (...args: any[]) => any
+    ? ReturnType<NonNullable<Props[K]>>
+    : never {
     return this.withRoot((root) => root.trigger(prop, ...(args as any)));
   }
 
-  triggerKeypath<T = unknown>(keypath: string, ...args: unknown[]) {
-    return this.withRoot((root) => root.triggerKeypath<T>(keypath, ...args));
+  triggerKeypath<
+    Path extends string,
+    ExtractedFunction extends KeyPathFunction = ExtractKeypath<Props, Path>,
+  >(
+    ...args: TriggerKeypathParams<Props, Path, ExtractedFunction>
+  ): TriggerKeypathReturn<Props, Path, ExtractedFunction> {
+    return this.withRoot((root) => root.triggerKeypath(...args));
   }
 
   mount() {

--- a/packages/react-testing/src/tests/element.test.tsx
+++ b/packages/react-testing/src/tests/element.test.tsx
@@ -588,6 +588,7 @@ describe('Element', () => {
         defaultRoot,
       );
 
+      // @ts-expect-error actions is not valid parameter, because it does not point to a function
       expect(() => element.triggerKeypath('actions')).toThrow(
         /Value at keypath 'actions' is not a function/,
       );


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

This PR makes the `triggerKeypath` method on `root` and `element` fully typed when `Props` are not `unknown`. Does this using typescript string literal types which were introduced in typescript 4.1.

As a result of this change, prettier also needed to be updated as the existing version was unable to parse string literal types. If preferred I can split that up into it's own PR. 

I've ran the typecheck with these new types for `web` and it only resulted in ~5~ 14 type errors, all of which appeared to be legitimate. 

type checking performance is a concern as this is a pretty complex type. I ran type-checking with `--force` and `--diagnostics` and both branches and here are the results after I addressed the failing types: 

Main: 
[typecheck-web-main.txt](https://github.com/Shopify/quilt/files/9183022/typecheck-web-main.txt)

With `triggerKeypath` typed:
[typecheck-with-triggerKeypath.txt](https://github.com/Shopify/quilt/files/9183028/typecheck-with-triggerKeypath.txt)


# Details

The overall goal is given a keypath string determine if it can lead to a function type. The keypath is a `.` separated string with each part representing a property that is to be looked up on the `Props` type. 

The first step is to split the keypath into a list of strings  but before that the keypath needs to be normalized as it can take many forms such as `propetry.0.anotherProp` or `property[0]anotherProp` or `property[0].anotherProp` etc, This is done in `type NormalizeKeypath`. Once normalized as a `.` separated value we use `type Split` to turn it into a list of property strings. 

The list of properties along with the `Props` is then used in `type ExtractProperty` to recursively iterate through each property on the `Props` and nested objects.  If the property does not exist on the object we short circuit with a `never` type.  Properties on array types are always assumed to be there as it cannot be determined if they will be defined or not at compile time. Once the final type is resolved form the `Props` and list of properties, we change the parameters on `triggerKeyPath` to be `never` if the property was not resolved to a function which is what creates the type error. Special exceptions are made for when the `Props` is `unknown` or when the path is a generic `string` type and not a string literal in which case we effectively turn off type checking and revert to the previous type behaviour. 

The final piece is dealing with unions  to ensure that a union type can still pass as a valid key path without the developer having to manually narrow the type or do casting. For example a keypath of `property.onAction` should be valid on:

```typescript
{
   property: {
     onAction: Function
   } | {
      foo: 'bar
   }
}
```

The idea here is that if the keypath can potentially lead to a valid function it should pass the types. This is achieved by stripping out any non-object types from each iteration of `type ExtractProperty` as well as merging object types into a single type using `type Merge<T>`