### PR TITLE
[Admin FED Infra] Reduce console logs spam in quilt test runs

### DIFF
--- a/packages/logger/src/formatters/tests/ConsoleFormatter.test.ts
+++ b/packages/logger/src/formatters/tests/ConsoleFormatter.test.ts
@@ -2,6 +2,22 @@ import {ConsoleFormatter} from '../ConsoleFormatter';
 import {LogLevel} from '../..';
 
 describe('ConsoleFormatter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
   it('logs Critical entries to console.error', () => {
     const formatter = new ConsoleFormatter();
     const errorSpy = jest.spyOn(console, 'error');

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -43,15 +43,19 @@ function Loading() {
 }
 
 describe('createAsyncComponent()', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     requestIdleCallback.mock();
     intersectionObserver.mock();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   });
 
   afterEach(() => {
     requestIdleCallback.cancelIdleCallbacks();
     requestIdleCallback.restore();
     intersectionObserver.restore();
+    consoleErrorSpy.mockRestore();
   });
 
   describe('rendering', () => {

--- a/packages/react-async/src/tests/provider.test.tsx
+++ b/packages/react-async/src/tests/provider.test.tsx
@@ -9,12 +9,16 @@ import {AssetTiming} from '../types';
 import {getUsedAssets, createResolvablePromise} from './utilities';
 
 describe('createAsyncContext()', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     requestIdleCallback.mock();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   });
 
   afterEach(() => {
     requestIdleCallback.restore();
+    consoleErrorSpy.mockRestore();
   });
 
   describe('<Provider />', () => {

--- a/packages/react-bugsnag/src/tests/Bugsnag.test.tsx
+++ b/packages/react-bugsnag/src/tests/Bugsnag.test.tsx
@@ -5,6 +5,16 @@ import {ErrorLoggerContext} from '../context';
 import {Bugsnag} from '../Bugsnag';
 
 describe('react-bugsnag', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
   it('renders an <ErrorLoggerContext /> with the given client', () => {
     const client = fakeBugsnag();
     const component = mount(<Bugsnag client={client} />);

--- a/packages/react-csrf/src/tests/hooks.test.tsx
+++ b/packages/react-csrf/src/tests/hooks.test.tsx
@@ -6,6 +6,16 @@ import {CsrfTokenContext} from '../context';
 import {useCsrfToken} from '../hooks';
 
 describe('<CsrfProvider />', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   function CsrfToken() {
     const csrfToken = useCsrfToken();
     return <div id="csrfToken">{csrfToken}</div>;

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -9,6 +9,15 @@ import FormState, {arrayUtils} from '../..';
 import {FieldDescriptor, FieldDescriptors} from '../../types';
 
 describe('<FormState.List />', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
   it('passes form state into child function for each index of the given array', () => {
     const renderPropSpy = jest.fn(
       (_: FieldDescriptors<{title: string}>) => null,

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -18,6 +18,7 @@ describe('<FormState.List />', () => {
   afterEach(() => {
     consoleErrorSpy.mockRestore();
   });
+
   it('passes form state into child function for each index of the given array', () => {
     const renderPropSpy = jest.fn(
       (_: FieldDescriptors<{title: string}>) => null,

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -8,6 +8,16 @@ import {lastCallArgs} from '../../tests/utilities';
 import FormState from '../..';
 
 describe('<Nested />', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   it('passes field state into child function', () => {
     const renderPropSpy = jest.fn(() => null);
 

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -9,6 +9,16 @@ import {lastCallArgs} from './utilities';
 import {Input, InputField} from './components';
 
 describe('<FormState />', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   it('passes form state into child function', () => {
     const renderPropSpy = jest.fn(() => null);
 

--- a/packages/react-form/src/hooks/list/tests/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/baselist.test.tsx
@@ -16,6 +16,16 @@ import {
 } from './utils';
 
 describe('useBaseList', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   function TestList(config: FieldListConfig<Variant>) {
     const {fields, dirty, reset} = useBaseList<Variant>(config);
 

--- a/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
@@ -8,6 +8,16 @@ import {FieldListConfig} from '../baselist';
 import {Variant, randomVariants, clickEvent, TextField} from './utils';
 
 describe('useDynamicList', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   describe('add and remove fields', () => {
     const factory = () => {
       return {price: '', optionName: '', optionValue: ''};

--- a/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
@@ -41,6 +41,8 @@ const {createCsrfLink} = jest.requireMock('../csrf-link');
 const ApolloClient = jest.requireMock('apollo-client').default;
 
 describe('<GraphQLUniversalProvider />', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     isServer.mockClear();
     isServer.mockImplementation(() => true);
@@ -48,6 +50,12 @@ describe('<GraphQLUniversalProvider />', () => {
     ApolloClient.mockClear();
     createRequestIdLink.mockClear();
     createCsrfLink.mockClear();
+
+    consoleErrorSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('renders an ApolloProvider with a client created by the factory', () => {

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -47,15 +47,19 @@ function Children() {
 }
 
 describe('createAsyncQueryComponent()', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     requestIdleCallback.mock();
     intersectionObserver.mock();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   });
 
   afterEach(() => {
     requestIdleCallback.cancelIdleCallbacks();
     requestIdleCallback.restore();
     intersectionObserver.restore();
+    consoleErrorSpy.mockRestore();
   });
 
   it('renders the children with a noop loading result while the query is loading', () => {

--- a/packages/react-html/src/server/components/tests/Html.test.tsx
+++ b/packages/react-html/src/server/components/tests/Html.test.tsx
@@ -19,6 +19,16 @@ jest.mock(
 );
 
 describe('<Html />', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   const mockProps = {children: <div />};
 
   it('hides the body contents in development', () => {

--- a/packages/react-import-remote/src/tests/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/tests/ImportRemote.test.tsx
@@ -29,15 +29,19 @@ jest.mock('../load', () => jest.fn());
 const load: jest.Mock = jest.requireMock('../load');
 
 describe('<ImportRemote />', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     requestIdleCallback.mock();
     intersectionObserver.mock();
     load.mockClear();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   });
 
   afterEach(() => {
     requestIdleCallback.restore();
     intersectionObserver.restore();
+    consoleErrorSpy.mockRestore();
   });
 
   const mockProps: Props = {

--- a/packages/react-network/src/tests/NetworkUniversalProvider.test.tsx
+++ b/packages/react-network/src/tests/NetworkUniversalProvider.test.tsx
@@ -34,6 +34,16 @@ function TestApp({headers = []}: {headers: string[]}) {
 }
 
 describe('NetworkUniversalProvider', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
   it('renders a NetworkUniversalContext', () => {
     const headers = {
       'x-some-header-1': 'header-value-1',

--- a/packages/react-router/src/components/Router/tests/Router.test.tsx
+++ b/packages/react-router/src/components/Router/tests/Router.test.tsx
@@ -17,6 +17,9 @@ describe('Router', () => {
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    isClient.mockClear();
+    isClient.mockImplementation(() => true);
+
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
   });
@@ -24,11 +27,6 @@ describe('Router', () => {
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
-  });
-
-  beforeEach(() => {
-    isClient.mockClear();
-    isClient.mockImplementation(() => true);
   });
 
   it('renders children', () => {

--- a/packages/react-router/src/components/Router/tests/Router.test.tsx
+++ b/packages/react-router/src/components/Router/tests/Router.test.tsx
@@ -13,6 +13,19 @@ const {isClient} = jest.requireMock('../utilities') as {
 };
 
 describe('Router', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
   beforeEach(() => {
     isClient.mockClear();
     isClient.mockImplementation(() => true);

--- a/packages/react-server/src/render/tests/render.test.tsx
+++ b/packages/react-server/src/render/tests/render.test.tsx
@@ -23,9 +23,16 @@ jest.mock('@shopify/sewing-kit-koa', () => ({
 }));
 
 describe('createRender', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
   beforeEach(() => {
     mockAssetsScripts.mockClear();
     mockAssetsStyles.mockClear();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
   });
 
   it('response contains "My cool app"', async () => {

--- a/packages/react-server/src/server/tests/server.test.tsx
+++ b/packages/react-server/src/server/tests/server.test.tsx
@@ -18,6 +18,16 @@ jest.mock('@shopify/sewing-kit-koa', () => ({
 }));
 
 describe('createServer()', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
   afterAll(unsaddle);
 
   it('configurable as koa proxy', async () => {

--- a/packages/react-testing/src/tests/root.test.tsx
+++ b/packages/react-testing/src/tests/root.test.tsx
@@ -6,7 +6,14 @@ import {Tag} from '../types';
 import {destroyAll} from '../destroy';
 
 describe('Root', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
   afterEach(() => {
+    consoleErrorSpy.mockRestore();
     destroyAll();
   });
 

--- a/packages/storybook-a11y-test/tests/index.test.ts
+++ b/packages/storybook-a11y-test/tests/index.test.ts
@@ -9,6 +9,16 @@ const buildDir = path.join(__dirname, './fixtures/storybook');
 jest.setTimeout(180000);
 
 describe('can test a story', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
   beforeAll(() => {
     return new Promise((resolve, reject) => {
       const icuDataPath = path.dirname(require.resolve('full-icu'));

--- a/packages/web-worker/src/tests/e2e.test.ts
+++ b/packages/web-worker/src/tests/e2e.test.ts
@@ -19,6 +19,16 @@ const secondWorkerFile = 'src/worker2.js';
 jest.setTimeout(28_000);
 
 describe('web-worker', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
   it('creates a worker factory that can produce workers that act like the original module', async () => {
     const greetingPrefix = 'Hello ';
     const greetingTarget = 'world';


### PR DESCRIPTION
## Description

Fixes #2157 

Compare how many logs there were [here](https://github.com/Shopify/quilt/runs/7505068849?check_suite_focus=true), over 1700 lines of extra console logs of noise, down to the 200 pass lines we need [here](https://github.com/Shopify/quilt/runs/7521561071?check_suite_focus=true). 

Amazing issue logged by @BPScott 🙌 
