### PR TITLE
Set loading true from the server side when ssr: false

### DIFF
--- a/.changeset/friendly-cups-tell.md
+++ b/.changeset/friendly-cups-tell.md
@@ -1,0 +1,14 @@
+---
+'@shopify/react-graphql': major
+---
+
+Use loading=true from server-side-rendered queries when ssr is set to false
+
+This is for consistency with the way that Apollo does things and to ensure that
+we avoid hydration mismatch errors when the client will initially render with
+true while the server rendered with false.
+
+Functionally, this means that if you previously relied on loading=false in your
+component code as an indication of server side rendering with an ssr false
+value, you should instead make use of the "called" value to determine whether
+or not it was called (this will still be false).

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -53,11 +53,12 @@ export default function useQuery<
   const variables: Variables = options.variables || ({} as any);
   const client = useApolloClient(overrideClient);
 
-  if (
-    typeof window === 'undefined' &&
-    (skip || fetchPolicy === 'no-cache' || !ssr)
-  ) {
-    return createDefaultResult(client, variables);
+  if (typeof window === 'undefined') {
+    if (skip || fetchPolicy === 'no-cache') {
+      return createDefaultResult(client, variables);
+    } else if (!ssr) {
+      return createDefaultResult(client, variables, undefined, true);
+    }
   }
 
   const query = useGraphQLDocument(queryOrAsyncQuery);
@@ -246,12 +247,13 @@ function createDefaultResult<Variables>(
   client: ApolloClient<unknown>,
   variables: Variables,
   queryObservable?: ObservableQuery,
+  loading = false,
 ): QueryHookResult<any, Variables> {
   return {
     data: undefined,
     error: undefined,
     networkStatus: undefined,
-    loading: false,
+    loading,
     called: false,
     variables: (queryObservable ? queryObservable.variables : variables) as any,
     refetch: queryObservable

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -54,9 +54,9 @@ export default function useQuery<
   const client = useApolloClient(overrideClient);
 
   if (typeof window === 'undefined') {
-    if (skip || fetchPolicy === 'no-cache') {
+    if (skip) {
       return createDefaultResult(client, variables);
-    } else if (!ssr) {
+    } else if (!ssr || fetchPolicy === 'no-cache') {
       return createDefaultResult(client, variables, undefined, true);
     }
   }

--- a/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
@@ -109,10 +109,10 @@ describe('useQuery', () => {
     // no GraphQL queries to resolve.
     expect(afterEachSpy).toHaveBeenCalledTimes(1);
 
-    // Not loading and no data
+    // Loading is still true even though we're not fetching data in order to match the client
     const markup = renderToString(element);
-    expect(markup).not.toContain('loading');
-    expect(markup).toContain('no data');
+    expect(markup).toContain('loading');
+    expect(markup).not.toContain('no data');
   });
 
   it('runs a query when `ssr` option is set to true during SSR', async () => {

--- a/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
@@ -83,10 +83,10 @@ describe('useQuery', () => {
     // no GraphQL queries to resolve.
     expect(afterEachSpy).toHaveBeenCalledTimes(1);
 
-    // Not loading and no data
+    // Loading is still true even though we're not fetching data in order to match the client
     const markup = renderToString(element);
-    expect(markup).not.toContain('loading');
-    expect(markup).toContain('no data');
+    expect(markup).toContain('loading');
+    expect(markup).not.toContain('no data');
   });
 
   it('does not run a query when `ssr` option is set to false during SSR', async () => {


### PR DESCRIPTION
When we perform a server side render and the user has specified ssr:
false, the "default result" that gets returned should have loading set
to true. This is consistent with what Apollo itself does, and is
important for avoiding hydration mismatches.

When the client performs its first render, it will by default be in
loading=true mode because the server skipped executing the query and so
there will be no content to load from the cache. Since many components
will render a different "loading state" when loading=true, its important
that loading=true is also the case on the server render so that the
server will send down the appropriate content instead of trying to
render a data object that does not exist.

This will constitute a major breaking change for `@shopify/react-graphql` because it will flip the logic for SSR loading state and may cause issues for some users that rely on this state's (previously "incorrect" value)
