### PR TITLE
Expand tests for errors and allow errorPolicy to be set on useMutation

### DIFF
--- a/.changeset/dry-rivers-obey.md
+++ b/.changeset/dry-rivers-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-graphql': patch
+---
+
+Use errorPolicy when it is passed to useMutation.

--- a/packages/react-graphql/src/hooks/mutation.ts
+++ b/packages/react-graphql/src/hooks/mutation.ts
@@ -19,6 +19,7 @@ export default function useMutation<Data = any, Variables = OperationVariables>(
     update,
     context,
     fetchPolicy,
+    errorPolicy,
   } = options;
 
   const client = useApolloClient(overrideClient);
@@ -40,6 +41,7 @@ export default function useMutation<Data = any, Variables = OperationVariables>(
         update,
         context,
         fetchPolicy,
+        errorPolicy,
         ...perMutationOptions,
       });
     },
@@ -52,6 +54,7 @@ export default function useMutation<Data = any, Variables = OperationVariables>(
       update,
       context,
       fetchPolicy,
+      errorPolicy,
       // eslint-disable-next-line react-hooks/exhaustive-deps
       JSON.stringify(variables),
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import {DocumentNode} from 'graphql-typed';
-import {ApolloClient, NetworkStatus} from 'apollo-client';
+import {ApolloClient, ApolloError, NetworkStatus} from 'apollo-client';
 import {ApolloLink} from 'apollo-link';
 import {InMemoryCache} from 'apollo-cache-inmemory';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
@@ -187,6 +187,7 @@ describe('useQuery', () => {
       expect(renderPropSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           data: undefined,
+          error: expect.any(ApolloError),
         }),
       );
     });


### PR DESCRIPTION
## Description
This PR will now correctly set the `errorPolicy` when it is passed to `useMutation`. I also expanded test coverage of `useMutation` and `useQuery` error states.

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
