### PR TITLE
Rexport ApolloError from apollo-client

### DIFF
--- a/.changeset/shiny-dingos-repeat.md
+++ b/.changeset/shiny-dingos-repeat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-graphql': minor
+---
+
+Reexport ApolloError from apollo-client

--- a/packages/react-graphql/src/index.ts
+++ b/packages/react-graphql/src/index.ts
@@ -1,4 +1,5 @@
 export {DeferTiming} from '@shopify/async';
+export {ApolloError, NetworkStatus} from 'apollo-client';
 export {Query} from './Query';
 export {Prefetch} from './Prefetch';
 export type {Props as PrefetchProps} from './Prefetch';
@@ -9,7 +10,6 @@ export type {
   GraphQLVariables,
   GraphQLDeepPartial,
   QueryProps,
-  NetworkStatus,
 } from './types';
 
 export {ApolloProvider} from './ApolloProvider';

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -13,7 +13,6 @@ import {
   ApolloError,
   ApolloClient,
   WatchQueryFetchPolicy,
-  NetworkStatus,
 } from 'apollo-client';
 import {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
 import {AsyncComponentType, AsyncHookTarget} from '@shopify/react-async';
@@ -25,7 +24,6 @@ export type {
   GraphQLVariables,
   GraphQLDeepPartial,
   GraphQLOperation,
-  NetworkStatus,
 };
 
 export type VariableOptions<Variables> = IfEmptyObject<


### PR DESCRIPTION
## Description

In web lots of things pull in `ApolloError` from apollo-client, because they want to handle the `error` value from useQuery. Rather than make consumers import in from two separate locations, lets allow them to access ApolloError from from `@shopify/react-graphql`.


Along the way, adjust how NetworkStatus is reexported from apollo-client too.

