### PR TITLE
[rfc] [graphql-typescript-definitions] Add configuration option for read-only types, and module imports

### DIFF
--- a/packages/graphql-typescript-definitions/src/print/document/context.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/context.ts
@@ -9,6 +9,7 @@ import {upperCaseFirst} from './utilities';
 
 export interface Options {
   schemaTypesPath: string;
+  schemaTypesImport?: string;
   enumFormat?: EnumFormat;
   exportFormat?: ExportFormat;
   addTypename?: boolean;
@@ -25,7 +26,7 @@ export class FileContext {
     const {
       path,
       importedTypes,
-      options: {schemaTypesPath},
+      options: {schemaTypesPath, schemaTypesImport},
     } = this;
 
     return importedTypes.size > 0
@@ -33,7 +34,7 @@ export class FileContext {
           [...importedTypes].map((type) =>
             t.importSpecifier(t.identifier(type), t.identifier(type)),
           ),
-          t.stringLiteral(importPath(path, schemaTypesPath)),
+          t.stringLiteral(importPath(path, schemaTypesPath, schemaTypesImport)),
         )
       : null;
   }
@@ -107,7 +108,14 @@ export class OperationContext {
   }
 }
 
-function importPath(from: string, to: string) {
+function importPath(from: string, to: string, module?: string) {
+  if (module) {
+    // strip any trailing slashes from the module name/path
+    const normalizedModule = module.replace(/\/+$/, '');
+
+    return normalizedModule;
+  }
+
   const relativePath = relative(dirname(from), to);
   const normalizedPath = relativePath.startsWith('..')
     ? relativePath

--- a/packages/graphql-typescript-definitions/tests/document.test.ts
+++ b/packages/graphql-typescript-definitions/tests/document.test.ts
@@ -134,6 +134,80 @@ describe('printDocument()', () => {
         import { Date } from "${expectedImportPath(filename, schemaTypesPath)}";
       `);
     });
+
+    describe('module import remapping', () => {
+      it('resides in the same directory', () => {
+        const filename = path.resolve('DetailsQuery.graphql');
+        const schema = buildSchema(`
+          scalar Date
+
+          type Query {
+            dateOfBirth: Date
+          }
+        `);
+
+        // module
+        expect(
+          print('query Details { dateOfBirth }', schema, {
+            filename,
+            printOptions: {
+              schemaTypesPath: path.resolve('./'),
+              schemaTypesImport: '@scope/package/types',
+            },
+          }),
+        ).toContain(stripIndent`
+        import { Date } from "@scope/package/types";
+      `);
+      });
+
+      it('points to an absolute directory', () => {
+        const filename = path.resolve('DetailsQuery.graphql');
+        const schema = buildSchema(`
+          scalar Date
+
+          type Query {
+            dateOfBirth: Date
+          }
+        `);
+
+        // module
+        expect(
+          print('query Details { dateOfBirth }', schema, {
+            filename,
+            printOptions: {
+              schemaTypesPath: '/path/to/node_modules/@scope/package/types/',
+              schemaTypesImport: '@scope/package/types/',
+            },
+          }),
+        ).toContain(stripIndent`
+        import { Date } from "@scope/package/types";
+      `);
+      });
+
+      it('points to a relative directory', () => {
+        const filename = path.resolve('DetailsQuery.graphql');
+        const schema = buildSchema(`
+          scalar Date
+
+          type Query {
+            dateOfBirth: Date
+          }
+        `);
+
+        // module
+        expect(
+          print('query Details { dateOfBirth }', schema, {
+            filename,
+            printOptions: {
+              schemaTypesPath: './node_modules/@scope/package/types/',
+              schemaTypesImport: '@scope/package/types',
+            },
+          }),
+        ).toContain(stripIndent`
+        import { Date } from "@scope/package/types";
+      `);
+      });
+    });
   });
 
   describe('enums', () => {


### PR DESCRIPTION
## Description

Hiya 👋

Over at Shop, we have a GraphQL project defined that points to a schema within `node_modules`. It's admittedly a bit of an edge case, but we want to be able to generate the operations and fragments in our project, but rely on the provided schema and types within the NPM module. (It is assumed the types in the NPM module has been generated via `graphql-typescript-definitions`, and are therefore compatible to be consumed in our generated documents).

This PR updates the configuration (with legacy support), so that a project can be configured like:

```javascript
// .graphqlrc.js
module.exports = {
  projects: {
    server: {
      schema: 'node_modules/some_module/src/schema.graphql',
      documents: 'src/**/*.graphql',
      extensions: {
      schemaTypes: {
        path: 'node_modules/some_module/src/types/',
        import: 'some_module/types',
        readOnly: true,
      }
    }
  }
}
```

The previous config option of `schemaTypesPath` has been turned into an object (`schemaTypes`), so we can add more config:

- `path`: equivalent to the old `schemaTypesPath`
- `import`: a fixed-string used in generated `.graphql.d.ts` files
- `readOnly`: to configure whether to write generated types into `schemaTypesPath`. This could maybe use some better naming, as we'll still write `.graphql.d.ts` document files, but not the `.ts` schema type files.

The configuration example above would, for example, take a file at `src/data/SomeQuery.graphql` and generate:

```typescript
import { DocumentNode } from "graphql-typed";
import { TypeA, TypeB, TypeC } from "some_module/types";
...
```

(and, of course, the contents of `node_modules/some_module/src/types/` would not be overwritten).

I'm open to suggestions on more general ways of solving this use case, but I think this approach offers value outside of just our case, i.e. users of Babel's `module-resolver` can alias their imports, so we don't see instances of `import { ... } from '../../../../../../../data/graqhql-types'` - instead it might look like `'import { ... } from 'data/graqhql-types/`.

Fixes (issue #)

