### PR TITLE
add the Webm mimetype as part of adding Video uploads support for .webm files

### DIFF
--- a/.changeset/curly-suits-guess.md
+++ b/.changeset/curly-suits-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mime-types': minor
+---
+
+Add Webm mimetype

--- a/packages/mime-types/README.md
+++ b/packages/mime-types/README.md
@@ -27,6 +27,7 @@ The types of files currently supported are:
   'application/pdf',
   'video/mp4',
   'video/quicktime',
+  'video/webm',
   'model/gltf-binary',
   'application/x-mpegURL',
   'model/vnd.usdz+zip',

--- a/packages/mime-types/src/get-extension-from-mime-type.ts
+++ b/packages/mime-types/src/get-extension-from-mime-type.ts
@@ -22,6 +22,8 @@ export function getExtensionFromMimeType(mimeType: MimeType) {
       return '.mov';
     case MimeType.Mp4:
       return '.mp4';
+    case MimeType.Webm:
+      return '.webm';
     case MimeType.Pdf:
       return '.pdf';
     case MimeType.Png:

--- a/packages/mime-types/src/get-mime-type-from-filename.ts
+++ b/packages/mime-types/src/get-mime-type-from-filename.ts
@@ -25,6 +25,8 @@ export function getMimeTypeFromFilename(filename: string) {
       return MimeType.Mov;
     case 'mp4':
       return MimeType.Mp4;
+    case 'webm':
+      return MimeType.Webm;
     case 'pdf':
       return MimeType.Pdf;
     case 'png':

--- a/packages/mime-types/src/tests/get-extension-from-mime-type.test.ts
+++ b/packages/mime-types/src/tests/get-extension-from-mime-type.test.ts
@@ -12,6 +12,7 @@ describe('getExtensionFromMimeType', () => {
   assertExtensionForMimeType('.m3u8', MimeType.Hls);
   assertExtensionForMimeType('.mov', MimeType.Mov);
   assertExtensionForMimeType('.mp4', MimeType.Mp4);
+  assertExtensionForMimeType('.webm', MimeType.Webm);
   assertExtensionForMimeType('.pdf', MimeType.Pdf);
   assertExtensionForMimeType('.png', MimeType.Png);
   assertExtensionForMimeType('.txt', MimeType.Text);

--- a/packages/mime-types/src/tests/get-mime-type-from-filename.test.ts
+++ b/packages/mime-types/src/tests/get-mime-type-from-filename.test.ts
@@ -14,6 +14,7 @@ describe('getMimeTypeFromFilename', () => {
     [MimeType.Json, 'object.json'],
     [MimeType.Mov, 'collection.mov'],
     [MimeType.Mp4, 'movie.mp4'],
+    [MimeType.Webm, 'video.webm'],
     [MimeType.Pdf, 'document.pdf'],
     [MimeType.Png, 'image.png'],
     [MimeType.Text, 'text.txt'],

--- a/packages/mime-types/src/types.ts
+++ b/packages/mime-types/src/types.ts
@@ -9,6 +9,7 @@ export enum MimeType {
   Json = 'application/json',
   Mov = 'video/quicktime',
   Mp4 = 'video/mp4',
+  Webm = 'video/webm',
   Pdf = 'application/pdf',
   Png = 'image/png',
   Text = 'text/plain',


### PR DESCRIPTION


## Description

This PR adds the `video/webm` mimetype as a step in our push to expand support for common/newer video file types.
Part of [Shopify issue 371670](https://github.com/Shopify/shopify/issues/371670)