### PR TITLE
Name Ruby-CI step

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   ruby-tests:
     runs-on: ubuntu-latest
-
+    name: 'Test (Ruby ${{ matrix.ruby-version }})'
     strategy:
       matrix:
-        ruby-version: ['3.1.2']
+        ruby-version: ['3.1']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Buildkite requires ruby-tests (3.1) in order for deployment, this PR names the ruby-ci step and allows it to match the shipit file. 

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
