### PR TITLE
useSerialized now returns the latest value from the HtmlManager

### DIFF
--- a/.changeset/metal-wombats-speak.md
+++ b/.changeset/metal-wombats-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-html': patch
+---
+
+`useSerialized` now returns the latest value from the `HtmlManager`

--- a/packages/react-html/src/hooks.ts
+++ b/packages/react-html/src/hooks.ts
@@ -4,10 +4,9 @@ import {useServerEffect} from '@shopify/react-effect';
 import {HtmlContext} from './context';
 import type {HtmlManager} from './manager';
 
-export function useDomEffect(
-  perform: (manager: HtmlManager) => () => void,
-  inputs: unknown[] = [],
-) {
+type PerformCallback = (manager: HtmlManager) => (() => void) | void;
+
+export function useDomEffect(perform: PerformCallback, inputs: unknown[] = []) {
   const manager = useContext(HtmlContext);
   const effect = () => perform(manager);
 
@@ -84,7 +83,7 @@ export function useBodyAttributes(
 }
 
 export function useClientDomEffect(
-  perform: (manager: HtmlManager) => () => void,
+  perform: PerformCallback,
   inputs: unknown[] = [],
 ) {
   const manager = useContext(HtmlContext);
@@ -95,9 +94,7 @@ export function useClientDomEffect(
   }, [manager, perform, ...inputs]);
 }
 
-export function useServerDomEffect(
-  perform: (manager: HtmlManager) => () => void,
-) {
+export function useServerDomEffect(perform: PerformCallback) {
   const manager = useContext(HtmlContext);
 
   useServerEffect(() => perform(manager), manager.effect);

--- a/packages/react-html/src/serializer.tsx
+++ b/packages/react-html/src/serializer.tsx
@@ -18,10 +18,7 @@ export function useSerialized<T>(
   id: string,
 ): [T | undefined, React.ComponentType<SerializeProps<T>>] {
   const manager = React.useContext(HtmlContext);
-  const data = React.useMemo(
-    () => manager.getSerialization<T>(id),
-    [id, manager],
-  );
+  const value = manager.getSerialization<T>(id);
 
   const Serialize = React.useMemo(
     () =>
@@ -42,7 +39,7 @@ export function useSerialized<T>(
     [id],
   );
 
-  return [data, Serialize];
+  return [value, Serialize];
 }
 
 export function createSerializer<T>(id: string) {

--- a/packages/react-html/src/tests/serializer.test.tsx
+++ b/packages/react-html/src/tests/serializer.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {extract} from '@shopify/react-effect/server';
+import {createMount} from '@shopify/react-testing';
 
 import {render, Html} from '../server';
 import {useSerialized, HtmlContext, HtmlManager} from '..';
@@ -22,5 +23,37 @@ describe('useSerialized', () => {
     expect(render(<Html manager={manager}>{app}</Html>)).toContain(
       `<script type="text/json" data-serialized-id="foo">"foo_value"</script>`,
     );
+  });
+
+  it('gets the latest serialization value on re-render', () => {
+    const key = 'serialized-key';
+    const defaultValue = 'default-value';
+
+    function MockComponent() {
+      const [value] = useSerialized<string>(key);
+      return <div>{value || defaultValue}</div>;
+    }
+
+    const manager = new HtmlManager();
+
+    const mount = createMount({
+      render: (element) => (
+        <HtmlContext.Provider value={manager}>{element}</HtmlContext.Provider>
+      ),
+    });
+
+    const wrapper = mount(<MockComponent />);
+
+    expect(manager.getSerialization(key)).toBeUndefined();
+    expect(wrapper.text()).toBe(defaultValue);
+
+    const newValue = 'new-value';
+    manager.setSerialization(key, newValue);
+    // forces re-render
+    wrapper.setProps({bar: true});
+
+    expect(manager.getSerialization(key)).toBe(newValue);
+
+    expect(wrapper.text()).toBe(newValue);
   });
 });


### PR DESCRIPTION
## Description

The current memoization of the serialized value inside of the `useSerialized` hook means that calling `setSerialization` will never reach the component unless it completely remounts.

The memoization doesn't look necessary as it's only preventing reading a value from a `Map` instance, which should not be more expensive than the memoization lookup anyway.

Then, removing this memoization ensures that the hook returns the latest value whenever it renders. Note that setting the serialization client-side doesn't trigger any re-render, as expected.

## Reasoning

Inside storybook stories, if we want to update the serialization, it's currently not possible to get the latest values. This change should at least make it possible to have specific stories for different serialization use-cases.
