### PR TITLE
removeItems method for 'useDynamicList' hook in react-form

### DIFF
--- a/.changeset/twelve-scissors-approve.md
+++ b/.changeset/twelve-scissors-approve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-form': minor
+---
+
+Created a 'removeItems' method for the 'useDynamicList' hook that accepts an array of indices to remove

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -696,6 +696,7 @@ const {
   fields,
   addItem,
   removeItem,
+  removeItems,
   moveItem,
   reset,
   dirty,
@@ -723,6 +724,7 @@ const {
   fields,
   addItem,
   removeItem,
+  removeItems,
   moveItem,
   reset,
   dirty,
@@ -752,10 +754,8 @@ const loadedCards = [
   {id: '123456', cardNumber: '4242 4242 4242 4242', cvv: '000'},
 ];
 
-const {fields, addItem, removeItem, moveItem, reset, dirty} = useDynamicList(
-  loadedCards,
-  emptyCardFactory,
-);
+const {fields, addItem, removeItem, removeItems, moveItem, reset, dirty} =
+  useDynamicList(loadedCards, emptyCardFactory);
 ```
 
 You can also pass a more complex configuration object specifying a validation dictionary like in `useList`.
@@ -791,6 +791,9 @@ Rendering your dynamic list would look like this:
       <hr />
     </div>
   ))}
+  <Button onClick={() => removeItems([0])}>
+    Remove multiple fields by index
+  </Button>
   <Button onClick={() => addItem()}>Add Card</Button>
   <Button disabled={!dirty} onClick={reset}>
     Reset

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -3,6 +3,7 @@ import {FieldDictionary} from '../../types';
 import {
   addFieldItemAction,
   removeFieldItemAction,
+  removeFieldItemsAction,
   moveFieldItemAction,
 } from './hooks';
 import {useBaseList, FieldListConfig} from './baselist';
@@ -11,6 +12,7 @@ export interface DynamicList<Item extends object> {
   fields: FieldDictionary<Item>[];
   addItem(factoryArgument?: any): void;
   removeItem(index: number): void;
+  removeItems(indicesToRemove: number[]): void;
   moveItem(fromIndex: number, toIndex: number): void;
   reset(): void;
   dirty: boolean;
@@ -58,10 +60,15 @@ export function useDynamicList<Item extends object>(
     dispatch(removeFieldItemAction(index));
   }
 
+  function removeItems(indicesToRemove: number[]) {
+    dispatch(removeFieldItemsAction(indicesToRemove));
+  }
+
   return {
     fields,
     addItem,
     removeItem,
+    removeItems,
     moveItem,
     reset,
     dirty,

--- a/packages/react-form/src/hooks/list/hooks/index.ts
+++ b/packages/react-form/src/hooks/list/hooks/index.ts
@@ -9,6 +9,7 @@ export {
   addFieldItemAction,
   moveFieldItemAction,
   removeFieldItemAction,
+  removeFieldItemsAction,
   resetListAction,
 } from './reducer';
 

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -14,6 +14,7 @@ export type ListAction<Item> =
   | AddFieldItemAction<Item>
   | MoveFieldItemAction
   | RemoveFieldItemAction
+  | RemoveFieldItemsAction
   | UpdateErrorAction<Item>
   | UpdateAction<Item, keyof Item>
   | ResetAction<Item, keyof Item>
@@ -42,6 +43,11 @@ interface ResetListAction {
 interface RemoveFieldItemAction {
   type: 'removeFieldItem';
   payload: {indexToRemove: number};
+}
+
+interface RemoveFieldItemsAction {
+  type: 'removeFieldItems';
+  payload: {indicesToRemove: number[]};
 }
 
 interface TargetedPayload<Item, Key extends keyof Item> {
@@ -117,6 +123,15 @@ export function removeFieldItemAction(
   return {
     type: 'removeFieldItem',
     payload: {indexToRemove},
+  };
+}
+
+export function removeFieldItemsAction(
+  indicesToRemove: number[],
+): RemoveFieldItemsAction {
+  return {
+    type: 'removeFieldItems',
+    payload: {indicesToRemove},
   };
 }
 
@@ -217,6 +232,14 @@ function reduceList<Item extends object>(
       return {
         ...state,
         list: newList,
+      };
+    }
+    case 'removeFieldItems': {
+      const indicesToRemove = action?.payload?.indicesToRemove ?? [];
+      const list = state.list.filter((_, i) => !indicesToRemove.includes(i));
+      return {
+        ...state,
+        list,
       };
     }
     case 'updateError': {

--- a/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
@@ -23,7 +23,7 @@ describe('useDynamicList', () => {
       return {price: '', optionName: '', optionValue: ''};
     };
     function DynamicListComponent(config: FieldListConfig<Variant>) {
-      const {fields, addItem, removeItem, moveItem, reset, dirty} =
+      const {fields, addItem, removeItem, removeItems, moveItem, reset, dirty} =
         useDynamicList<Variant>(config, factory);
 
       return (
@@ -56,6 +56,9 @@ describe('useDynamicList', () => {
           </ul>
           <button type="button" onClick={reset}>
             Reset
+          </button>
+          <button type="button" onClick={() => removeItems([0, 1, 2])}>
+            Remove Variants
           </button>
           <p>Dirty: {dirty.toString()}</p>
         </>
@@ -112,6 +115,33 @@ describe('useDynamicList', () => {
         .trigger('onClick', clickEvent());
 
       expect(wrapper).not.toContainReactComponent(TextField);
+    });
+
+    it('can remove multiple fields with removeFields', () => {
+      const variants: Variant[] = [
+        {price: 'A', optionName: 'A', optionValue: 'A'},
+        {price: 'B', optionName: 'B', optionValue: 'B'},
+        {price: 'C', optionName: 'C', optionValue: 'C'},
+        {price: 'D', optionName: 'D', optionValue: 'D'},
+      ];
+
+      const wrapper = mount(<DynamicListComponent list={variants} />);
+      wrapper
+        .find('button', {children: 'Remove Variants'})!
+        .trigger('onClick', clickEvent());
+
+      expect(wrapper.findAll(TextField)).toHaveLength(1);
+      const removedVariants = variants.slice(0, 2);
+      const remainingVariant = variants[3];
+      removedVariants.forEach((variant) => {
+        expect(wrapper).not.toContainReactComponent(TextField, {
+          value: variant.price,
+        });
+      });
+      expect(wrapper).toContainReactComponent(TextField, {
+        name: 'price0',
+        value: remainingVariant.price,
+      });
     });
 
     it('can add field', () => {


### PR DESCRIPTION
## Description

[The current `removeItem` method implements JavaScripts .splice method](https://github.com/Shopify/quilt/blob/main/packages/react-form/src/hooks/list/hooks/reducer.ts#L214), which [mutates the original array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) and is causing unwanted side-effects and [bugs](https://github.com/Shopify/partners/issues/41912) in work that I'm currently doing, [which requires me to remove multiple fields at once](https://github.com/Shopify/partners/blob/master/app/assets/javascripts/sections/PartnerLeads/components/PartnerLeadsForm/PartnerLeadsForm.tsx#L295).

I've created a `removeItems` method that accepts an array of indices to remove and negates the need for `removeItem` to be ran multiple times.  `removeItems` runs in a pure fashion that leaves the source array unchanged and provides an easier DX for developers who need this functionality.

Myself and another dev (cc: @dahukish) have [experienced some issues](https://shopify.slack.com/archives/C02E6ML0GS1/p1661368041736969) working locally on this repo with both spin and dev, and were unable to get prettier working properly.  It seems this CI is having issues with prettier and a `README` file that I've changed, and I'm having difficulties understanding what the formatting issues are.  The internal logic for this work is complete + tested, so it is ready for review, but if someone could assist with my prettier / README issues it would be much appreciated!
