### PR TITLE
Export Bugsnag's Client type and Config type

### DIFF
--- a/.changeset/warm-cooks-matter.md
+++ b/.changeset/warm-cooks-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-bugsnag': patch
+---
+
+Export Bugsnag's Client type and Config type

--- a/packages/react-bugsnag/src/client.ts
+++ b/packages/react-bugsnag/src/client.ts
@@ -1,6 +1,9 @@
 import bugsnag, {Config} from '@bugsnag/js';
 import BugsnagPluginReact from '@bugsnag/plugin-react';
 
+export type {Client} from '@bugsnag/js';
+export type {Config};
+
 export function createBugsnagClient(options: Config) {
   // We could alternatively use `start` here, the only difference between them is that `start` also sets a property on the Bugsnag global
   return bugsnag.createClient({

--- a/packages/react-bugsnag/src/index.ts
+++ b/packages/react-bugsnag/src/index.ts
@@ -1,4 +1,5 @@
 export type {ErrorLogger} from './types';
+export type {Client, Config} from './client';
 
 export {createBugsnagClient} from './client';
 export {Bugsnag} from './Bugsnag';


### PR DESCRIPTION
## Description

In order to use it in other abstraction, like a specific app's Bugsnag client factory function.

```ts
import {
  Bugsnag,
  createBugsnagClient,
  type Config, // <-- This is missing right now
  type Client as BugsnagClient, // <-- also missing
} from '@shopify/react-bugsnag';

export const makeClient = (config: Partial<Config> = {}) =>
  createBugsnagClient({
    apiKey: BUGSNAG_CLIENT_API_KEY,
    enabledReleaseStages: ['production'],
    ...config
  });
```

We could use `Parameters<typeof createBugsnagClient>[0]`, but it's inconvenient and a little less safe (what if the API changes, now `[0]` might point to another type entirely).

We can also take the client type from `@bugsnag/js` though we'd now have to manage another dependency, or assume it is a nested dependency of this lib.
