### PR TITLE
Fix triggerKeyPath when path resolves to a type that is unioned with an empty object type

### DIFF
--- a/.changeset/rotten-boxes-attend.md
+++ b/.changeset/rotten-boxes-attend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': patch
+---
+
+Fix triggerKeyPath when path resolves to a type that is unioned with an empty object type ({})

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -7,8 +7,10 @@ type AllKeys<T> = T extends any ? keyof T : never;
 type PickType<T, K extends AllKeys<T>> = T extends {[k in K]?: any}
   ? T[K]
   : undefined;
-type PickTypeOf<T, K extends PropertyKey> = K extends AllKeys<T>
-  ? PickType<T, K>
+type PickTypeOf<T, K extends PropertyKey> = T extends any
+  ? K extends AllKeys<T>
+    ? PickType<T, K>
+    : never
   : never;
 
 type Merge<T> = {[K in keyof T]: PickTypeOf<T, K>} & {


### PR DESCRIPTION
## Description

This fixes the recent `triggerKeyPath` types to also support the case where the path resolves to a type that is unioned with the empty object type `{}` . For example

```
{primaryAction: {onAction(): void} | {}
```
```
triggerKeyPath('primaryAction.onAction');
```

Which would have previously failed to type-check.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
