### PR TITLE
🐛 Add basic lateral inheritance

### DIFF
--- a/.changeset/lovely-dodos-fix.md
+++ b/.changeset/lovely-dodos-fix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-i18n': patch
+---
+
+Add basic support for lateral inheritance (`count` lookups will now fall back to `other` first)

--- a/packages/react-i18n/src/tests/utilities.test.tsx
+++ b/packages/react-i18n/src/tests/utilities.test.tsx
@@ -403,6 +403,13 @@ describe('translate()', () => {
         ).toBe('2 foos');
       });
 
+      it('uses Lateral Inheritance to select the `other` rule if the value for the ideal rule is missing', () => {
+        const dictionary = {foo: {other: '{count} foos'}};
+        expect(
+          translate('foo', {replacements: {count: 1}}, dictionary, locale),
+        ).toBe('1 foos');
+      });
+
       it('handles a count of zero', () => {
         const dictionary = {
           foo: {

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -193,7 +193,7 @@ function translateWithDictionary(
 
     if (typeof count === 'number') {
       const group = memoizedPluralRules(locale).select(count);
-      result = result[group];
+      result = result[group] || result.other;
 
       additionalReplacements[PLURALIZATION_KEY_NAME] =
         memoizedNumberFormatter(locale).format(count);


### PR DESCRIPTION
### What are you trying to accomplish?

Add basic lateral inheritance. i.e., it should fall back to `other` plural key if the typical plural key is missing.

CLDR defines a [Lateral Inheritance](https://www.unicode.org/reports/tr35/tr35.html#Lateral_Inheritance) algorithm for handling cases where the typical plural key is missing. This:

* allows you to handle missing data
  * Slightly grammatically incorrect data is deemed to be a better than falling back to a parent locale
* allows you to reduce duplication in the data (at the expense of a second hash lookup)

(Aside: At present, to mitigate the errors that would otherwise occur, the Translation Platform copies the `other` key to fill in any missing plural keys for a language)

### What approach did you choose and why?

Implemented the basic lateral inheritance step of falling back to the value of the `other` key in cases where the typical plural rule key is missing.

This isn't full support for lateral inheritance as described in the spec, since we don't currently support all of the other lateral inheritance attributes (`case`, `gender`, etc.).

### What should reviewers focus on?

🤷 Straight forward enough.

### The impact of these changes

[Partial] Lateral Inheritance support.

### Checklist
- [ ] I have tophatted this change. 
- [x] This PR is safe to roll back.

### In a gif, how does this PR make you feel?

![it_aint_much_honest_work](https://user-images.githubusercontent.com/1459385/188174796-91511829-5fd7-4e25-b451-8a20066ffdc6.gif)

