### PR TITLE
Triggerkeypath now fails typecheck on invalid array indices

### DIFF
--- a/.changeset/shy-hornets-refuse.md
+++ b/.changeset/shy-hornets-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': patch
+---
+
+TriggerKeypath now fails typecheck on invalid array indices

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -17,7 +17,9 @@ type Merge<T> = {[K in keyof T]: PickTypeOf<T, K>} & {
   [K in Exclude<AllKeys<T>, keyof T>]?: PickTypeOf<T, K>;
 };
 
-type IsArrayIndex<T extends string> = T extends `${number | string}`
+type IsArrayIndex<T extends string> = `${number}` extends T
+  ? true
+  : string extends T
   ? true
   : T extends `${infer Head}${infer Rest}`
   ? Head extends '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'


### PR DESCRIPTION
## Description

`triggerKeypath` is supposed to fail when accessing an array index with an invalid value (not an integer) ie

```javascript
wrapper.triggerKeypath('secondaryActions[foo].onAction)
```

This never worked due to an incorrect `extends` clause. This PR will no correctly flag the above as a type error.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
