### PR TITLE
`@typescript-eslint` update

### DIFF
--- a/config/loom/index.ts
+++ b/config/loom/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import {existsSync} from 'fs';
 
 import {

--- a/packages/address-consts/src/index.ts
+++ b/packages/address-consts/src/index.ts
@@ -99,7 +99,9 @@ export enum GraphqlOperationName {
   Country = 'country',
 }
 
+/* eslint-disable @typescript-eslint/naming-convention */
 export const HEADERS = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
 };
+/* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/address/src/utilities.ts
+++ b/packages/address/src/utilities.ts
@@ -1,6 +1,7 @@
 import {Address, FieldName, Country, Zone} from '@shopify/address-consts';
 
 export const FIELD_REGEXP = /({\w+})/g;
+/* eslint-disable @typescript-eslint/naming-convention */
 export const FIELDS_MAPPING: {
   [key: string]: FieldName;
 } = {
@@ -15,6 +16,7 @@ export const FIELDS_MAPPING: {
   '{phone}': FieldName.Phone,
   '{company}': FieldName.Company,
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 /*
  * Returns empty string if all replacement fields are empty.

--- a/packages/async/src/babel-plugin.ts
+++ b/packages/async/src/babel-plugin.ts
@@ -1,12 +1,14 @@
 import Types from '@babel/types';
 import {NodePath, Binding} from '@babel/traverse';
 
+/* eslint-disable @typescript-eslint/naming-convention */
 const DEFAULT_PACKAGES_TO_PROCESS = {
   '@shopify/alpaql/async': ['createAsyncQuery'],
   '@shopify/async': ['createResolver'],
   '@shopify/react-async': ['createAsyncContext', 'createAsyncComponent'],
   '@shopify/react-graphql': ['createAsyncQueryComponent', 'createAsyncQuery'],
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export interface Options {
   webpack?: boolean;

--- a/packages/async/src/tests/babel-plugin.test.ts
+++ b/packages/async/src/tests/babel-plugin.test.ts
@@ -280,6 +280,7 @@ describe('asyncBabelPlugin()', () => {
       `);
 
       const packages = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         'async-package': ['createAsync'],
       };
 

--- a/packages/dates/src/deprecated-timezones.ts
+++ b/packages/dates/src/deprecated-timezones.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
 export const deprecatedTimezones: {[key: string]: string} = {
   'America/Indiana': 'America/Indiana/Indianapolis',
   'America/Argentina': 'America/Argentina/Buenos_Aires',

--- a/packages/graphql-typescript-definitions/tests/document.test.ts
+++ b/packages/graphql-typescript-definitions/tests/document.test.ts
@@ -660,6 +660,7 @@ describe('printDocument()', () => {
             schema,
             {
               fragments: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 'PersonFragment.graphql': `
                   fragment PersonFragment on Person {
                     occupation
@@ -695,6 +696,7 @@ describe('printDocument()', () => {
             {
               printOptions: {addTypename: true},
               fragments: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 'NamedFragment.graphql': `
                   fragment NamedFragment on Named {
                     name
@@ -1039,6 +1041,7 @@ describe('printDocument()', () => {
             schema,
             {
               fragments: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 'PersonFragment.graphql': `
                   fragment PersonFragment on Person {
                     occupation
@@ -1074,6 +1077,7 @@ describe('printDocument()', () => {
             {
               printOptions: {addTypename: true},
               fragments: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 'NamedFragment.graphql': `
                   fragment NamedFragment on Named {
                     ...on Person { name, occupation }

--- a/packages/koa-metrics/src/tests/middleware.test.ts
+++ b/packages/koa-metrics/src/tests/middleware.test.ts
@@ -172,9 +172,11 @@ describe('koa-metrics', () => {
       const queuingTime = 100;
 
       const ctx = createMockContext({
+        /* eslint-disable @typescript-eslint/naming-convention */
         headers: {
           'X-Request-Start': `t=${queuingTime}`,
         },
+        /* eslint-enable @typescript-eslint/naming-convention */
       });
 
       await metricsMiddleware(ctx, () => {
@@ -259,9 +261,11 @@ describe('koa-metrics', () => {
         skipInstrumentation: true,
       });
       const ctx = createMockContext({
+        /* eslint-disable @typescript-eslint/naming-convention */
         headers: {
           'X-Request-Start': '100',
         },
+        /* eslint-enable @typescript-eslint/naming-convention */
       });
 
       await metricsMiddleware(ctx, () => {

--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -51,10 +51,12 @@ export default function shopifyGraphQLProxy(proxyOptions: ProxyOptions) {
       parseReqBody: false,
       // Setting request header here, not response. That's why we don't use ctx.set()
       // proxy middleware will grab this request header
+      /* eslint-disable @typescript-eslint/naming-convention */
       headers: {
         'Content-Type': 'application/json',
         'X-Shopify-Access-Token': accessToken,
       },
+      /* eslint-enable @typescript-eslint/naming-convention */
       proxyReqOptDecorator(proxyReqOpts) {
         delete proxyReqOpts.headers.cookie;
         delete proxyReqOpts.headers.Cookie;

--- a/packages/koa-shopify-graphql-proxy/src/tests/proxy.test.ts
+++ b/packages/koa-shopify-graphql-proxy/src/tests/proxy.test.ts
@@ -153,10 +153,12 @@ describe('koa-shopify-graphql-proxy', () => {
     expect(host).toBe(shop);
 
     expect(config).toMatchObject({
+      /* eslint-disable @typescript-eslint/naming-convention */
       headers: {
         'Content-Type': 'application/json',
         'X-Shopify-Access-Token': accessToken,
       },
+      /* eslint-enable @typescript-eslint/naming-convention */
       https: true,
       parseReqBody: false,
     });
@@ -183,10 +185,12 @@ describe('koa-shopify-graphql-proxy', () => {
     expect(host).toBe(shop);
 
     expect(config).toMatchObject({
+      /* eslint-disable @typescript-eslint/naming-convention */
       headers: {
         'Content-Type': 'application/json',
         'X-Shopify-Access-Token': password,
       },
+      /* eslint-enable @typescript-eslint/naming-convention */
       https: true,
       parseReqBody: false,
     });

--- a/packages/polyfills/src/index.ts
+++ b/packages/polyfills/src/index.ts
@@ -4,24 +4,16 @@ export interface PolyfillDescriptor {
   featureTest?: string;
 }
 
+/* eslint-disable @typescript-eslint/naming-convention */
 export const polyfills: {[polyfill: string]: PolyfillDescriptor} = {
-  fetch: {
-    featureTest: 'fetch',
-  },
+  fetch: {featureTest: 'fetch'},
   formdata: {},
-  'idle-callback': {
-    featureTest: 'requestidlecallback',
-  },
-  'intersection-observer': {
-    featureTest: 'intersectionobserver',
-  },
-  intl: {
-    featureTest: 'intl-pluralrules',
-  },
-  'mutation-observer': {
-    featureTest: 'mutationobserver',
-  },
+  'idle-callback': {featureTest: 'requestidlecallback'},
+  'intersection-observer': {featureTest: 'intersectionobserver'},
+  intl: {featureTest: 'intl-pluralrules'},
+  'mutation-observer': {featureTest: 'mutationobserver'},
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export function mappedPolyfillsForEnv(env: 'node' | 'jest' | string[]): {
   [key: string]: string;
@@ -45,6 +37,7 @@ export function mappedPolyfillsForEnv(env: 'node' | 'jest' | string[]): {
       return mappedPolyfills;
     },
     {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       '@shopify/polyfills/base$': `${prefix}/base`,
     },
   );

--- a/packages/react-graphql-universal-provider/src/request-id-link.ts
+++ b/packages/react-graphql-universal-provider/src/request-id-link.ts
@@ -4,6 +4,7 @@ export function createRequestIdLink(requestId: string) {
   return setContext((_, {headers}) => ({
     headers: {
       ...headers,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       'X-Initiated-By-Request-ID': requestId,
     },
   }));

--- a/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
+++ b/packages/react-graphql-universal-provider/src/tests/GraphQLUniversalProvider.test.tsx
@@ -320,6 +320,7 @@ describe('<GraphQLUniversalProvider />', () => {
 
       mount(
         <NetworkContext.Provider
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           value={new NetworkManager({headers: {'X-Request-ID': mockRequestId}})}
         >
           <GraphQLUniversalProvider createClientOptions={() => ({})} />
@@ -344,6 +345,7 @@ describe('<GraphQLUniversalProvider />', () => {
 
       mount(
         <NetworkContext.Provider
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           value={new NetworkManager({headers: {'X-Request-ID': mockRequestId}})}
         >
           <GraphQLUniversalProvider

--- a/packages/react-network/src/tests/NetworkUniversalProvider.test.tsx
+++ b/packages/react-network/src/tests/NetworkUniversalProvider.test.tsx
@@ -45,10 +45,12 @@ describe('NetworkUniversalProvider', () => {
   });
 
   it('renders a NetworkUniversalContext', () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
     const headers = {
       'x-some-header-1': 'header-value-1',
       'x-some-header-2': 'header-value-2',
     };
+    /* eslint-enable @typescript-eslint/naming-convention */
     const wrapper = mount(
       <NetworkContext.Provider value={new NetworkManager({headers})}>
         <NetworkUniversalProvider headers={headerNames(headers)}>
@@ -68,10 +70,12 @@ describe('NetworkUniversalProvider', () => {
   });
 
   it('provides the same network details on both server and client-side renders', async () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
     const headers = {
       'x-some-header-1': 'header-value-1',
       'x-some-header-2': 'header-value-2',
     };
+    /* eslint-enable @typescript-eslint/naming-convention */
     const htmlManager = new HtmlManager();
 
     await extract(<NetworkUniversalProvider headers={headerNames(headers)} />, {
@@ -103,10 +107,12 @@ describe('NetworkUniversalProvider', () => {
 
   describe('errors', () => {
     it('throws an error when NetworkContext.Provider is missing', async () => {
+      /* eslint-disable @typescript-eslint/naming-convention */
       const headers = {
         'x-some-header-1': 'header-value-1',
         'x-some-header-2': 'header-value-2',
       };
+      /* eslint-enable @typescript-eslint/naming-convention */
       const htmlManager = new HtmlManager();
 
       await expect(
@@ -125,10 +131,12 @@ describe('NetworkUniversalProvider', () => {
     });
 
     it('does not throw an error when NetworkUniversalProvider is missing', async () => {
+      /* eslint-disable @typescript-eslint/naming-convention */
       const headers = {
         'x-some-header-1': 'header-value-1',
         'x-some-header-2': 'header-value-2',
       };
+      /* eslint-enable @typescript-eslint/naming-convention */
       const htmlManager = new HtmlManager();
       await extract(<div />, {
         decorate: (element: React.ReactNode) => (

--- a/packages/react-server/src/metrics/tests/metric.test.tsx
+++ b/packages/react-server/src/metrics/tests/metric.test.tsx
@@ -8,6 +8,7 @@ describe('createServer()', () => {
   it('responds with a Server-Timing header', async () => {
     const wrapper = await saddle(metricsMiddleware);
     const response = await wrapper.fetch('/');
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     await expect(response).toHaveHeaders({'server-timing': expect.any(String)});
   });
 });

--- a/packages/react-server/src/render/tests/render.test.tsx
+++ b/packages/react-server/src/render/tests/render.test.tsx
@@ -104,6 +104,7 @@ describe('createRender', () => {
     const myCoolApp = 'My cool app';
     const data = {foo: 'bar'};
     const ctx = createMockContext({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       headers: {'x-quilt-data': JSON.stringify({foo: 'bar'})},
     });
 
@@ -117,6 +118,7 @@ describe('createRender', () => {
 
   it('does not clobber proxies in the context object', async () => {
     const headerValue = 'some-value';
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     const ctx = createMockContext({headers: {'some-header': headerValue}});
 
     const renderFunction = createRender((ctx) => <>{ctx.get('some-header')}</>);

--- a/packages/react-testing/src/tests/root.test.tsx
+++ b/packages/react-testing/src/tests/root.test.tsx
@@ -51,6 +51,7 @@ describe('Root', () => {
         type: 'div',
         tag: Tag.HostComponent,
         props: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           'aria-label': 'Hello',
           onClick: (name: string) => `Nicely done, ${name}!`,
         },

--- a/packages/web-worker/src/babel-plugin.ts
+++ b/packages/web-worker/src/babel-plugin.ts
@@ -2,6 +2,7 @@ import {resolve} from 'path';
 import {runInNewContext} from 'vm';
 
 export const DEFAULT_PACKAGES_TO_PROCESS = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   '@shopify/web-worker': [
     {name: 'createPlainWorkerFactory'},
     {

--- a/packages/web-worker/src/tests/utilities/webpack.ts
+++ b/packages/web-worker/src/tests/utilities/webpack.ts
@@ -24,8 +24,10 @@ export function runWebpack(
         resolve: {
           extensions: ['.esnext', '.js', '.ts', '.tsx', '.json'],
           alias: {
+            /* eslint-disable @typescript-eslint/naming-convention */
             '@shopify/web-worker': srcRoot,
             '@shopify/web-worker/worker': path.join(srcRoot, 'worker'),
+            /* eslint-enable @typescript-eslint/naming-convention */
           },
         },
         resolveLoader: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3728,91 +3728,92 @@
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
 "@typescript-eslint/eslint-plugin@^5.4.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.0.tgz#bb46dd7ce7015c0928b98af1e602118e97df6c70"
-  integrity sha512-fwCMkDimwHVeIOKeBHiZhRUfJXU8n6xW1FL9diDxAyGAFvKcH4csy0v7twivOQdQdA0KC8TDr7GGRd3L4Lv0rQ==
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz#6df092a20e0f9ec748b27f293a12cb39d0c1fe4d"
+  integrity sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.12.0"
-    "@typescript-eslint/type-utils" "5.12.0"
-    "@typescript-eslint/utils" "5.12.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.36.2"
+    "@typescript-eslint/type-utils" "5.36.2"
+    "@typescript-eslint/utils" "5.36.2"
+    debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
+    ignore "^5.2.0"
     regexpp "^3.2.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/experimental-utils@^5.0.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.12.0.tgz#b97c599a281f14a68015c25ee24966cb54ba9fc5"
-  integrity sha512-iFVADWH2CmiDF+E9kFK2r474BO2JILDKw1NVD5ytqHrM3ezsfdu5uo6B+77DH0suM7iUC/yOayHNziuiI9BPbQ==
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.36.2.tgz#66a2b07f69595c55e718bf5a0a70a73413daa8e9"
+  integrity sha512-JtRmWb31KQoxGV6CHz8cI+9ki6cC7ciZepXYpCLxsdAtQlBrRBxh5Qpe/ZHyJFOT9j7gyXE+W0shWzRLPfuAFQ==
   dependencies:
-    "@typescript-eslint/utils" "5.12.0"
+    "@typescript-eslint/utils" "5.36.2"
 
 "@typescript-eslint/parser@^5.4.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.12.0.tgz#0ca669861813df99ce54916f66f524c625ed2434"
-  integrity sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.36.2.tgz#3ddf323d3ac85a25295a55fcb9c7a49ab4680ddd"
+  integrity sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.12.0"
-    "@typescript-eslint/types" "5.12.0"
-    "@typescript-eslint/typescript-estree" "5.12.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.36.2"
+    "@typescript-eslint/types" "5.36.2"
+    "@typescript-eslint/typescript-estree" "5.36.2"
+    debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz#59619e6e5e2b1ce6cb3948b56014d3a24da83f5e"
-  integrity sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==
+"@typescript-eslint/scope-manager@5.36.2":
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz#a75eb588a3879ae659514780831370642505d1cd"
+  integrity sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==
   dependencies:
-    "@typescript-eslint/types" "5.12.0"
-    "@typescript-eslint/visitor-keys" "5.12.0"
+    "@typescript-eslint/types" "5.36.2"
+    "@typescript-eslint/visitor-keys" "5.36.2"
 
-"@typescript-eslint/type-utils@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.12.0.tgz#aaf45765de71c6d9707c66ccff76ec2b9aa31bb6"
-  integrity sha512-9j9rli3zEBV+ae7rlbBOotJcI6zfc6SHFMdKI9M3Nc0sy458LJ79Os+TPWeBBL96J9/e36rdJOfCuyRSgFAA0Q==
+"@typescript-eslint/type-utils@5.36.2":
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz#752373f4babf05e993adf2cd543a763632826391"
+  integrity sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==
   dependencies:
-    "@typescript-eslint/utils" "5.12.0"
-    debug "^4.3.2"
+    "@typescript-eslint/typescript-estree" "5.36.2"
+    "@typescript-eslint/utils" "5.36.2"
+    debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.12.0.tgz#5b4030a28222ee01e851836562c07769eecda0b8"
-  integrity sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==
+"@typescript-eslint/types@5.36.2":
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.36.2.tgz#a5066e500ebcfcee36694186ccc57b955c05faf9"
+  integrity sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==
 
-"@typescript-eslint/typescript-estree@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz#cabf545fd592722f0e2b4104711e63bf89525cd2"
-  integrity sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==
+"@typescript-eslint/typescript-estree@5.36.2":
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz#0c93418b36c53ba0bc34c61fe9405c4d1d8fe560"
+  integrity sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==
   dependencies:
-    "@typescript-eslint/types" "5.12.0"
-    "@typescript-eslint/visitor-keys" "5.12.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
+    "@typescript-eslint/types" "5.36.2"
+    "@typescript-eslint/visitor-keys" "5.36.2"
+    debug "^4.3.4"
+    globby "^11.1.0"
     is-glob "^4.0.3"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.12.0.tgz#92fd3193191621ab863add2f553a7b38b65646af"
-  integrity sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==
+"@typescript-eslint/utils@5.36.2":
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.36.2.tgz#b01a76f0ab244404c7aefc340c5015d5ce6da74c"
+  integrity sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.12.0"
-    "@typescript-eslint/types" "5.12.0"
-    "@typescript-eslint/typescript-estree" "5.12.0"
+    "@typescript-eslint/scope-manager" "5.36.2"
+    "@typescript-eslint/types" "5.36.2"
+    "@typescript-eslint/typescript-estree" "5.36.2"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz#1ac9352ed140b07ba144ebf371b743fdf537ec16"
-  integrity sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==
+"@typescript-eslint/visitor-keys@5.36.2":
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz#2f8f78da0a3bad3320d2ac24965791ac39dace5a"
+  integrity sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==
   dependencies:
-    "@typescript-eslint/types" "5.12.0"
-    eslint-visitor-keys "^3.0.0"
+    "@typescript-eslint/types" "5.36.2"
+    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -6384,6 +6385,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -7191,7 +7199,7 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
+eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
@@ -8171,7 +8179,7 @@ globalthis@^1.0.0:
   dependencies:
     define-properties "^1.1.3"
 
-globby@*, globby@^11.0.0, globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.0.4:
+globby@*, globby@^11.0.0, globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -8723,7 +8731,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.4, ignore@^5.0.5, ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.0.4, ignore@^5.0.5, ignore@^5.1.1, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -13109,10 +13117,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+
+semver@^7.3.2, semver@^7.3.4, semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
## Description

Update `@typescript-eslint/*` packages, in preparation for a typescript version update.

Fix new violations in the naming-convention rule by ignoring cases where we to have object keys  that contain a `-` - notably around when we deal with http headers that use `hypen-case`.

Skipping changesets in this PR because it makes no code changes - its all adding eslint-disable comments.