### PR TITLE
Fix references when using react-testing/jest-dom-mocks internally

### DIFF
--- a/packages/koa-shopify-webhooks/package.json
+++ b/packages/koa-shopify-webhooks/package.json
@@ -32,6 +32,7 @@
     "safe-compare": "^1.1.3"
   },
   "devDependencies": {
+    "@shopify/jest-dom-mocks": "^4.0.1",
     "@types/koa-bodyparser": "*",
     "@types/koa-compose": "*"
   },

--- a/packages/koa-shopify-webhooks/tsconfig.json
+++ b/packages/koa-shopify-webhooks/tsconfig.json
@@ -10,5 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "references": [{"path": "../network"}]
+  "references": [{"path": "../jest-dom-mocks"}, {"path": "../network"}]
 }

--- a/packages/react-bugsnag/package.json
+++ b/packages/react-bugsnag/package.json
@@ -30,6 +30,9 @@
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/react-testing": "^4.2.1"
+  },
   "files": [
     "build/",
     "!build/*.tsbuildinfo",

--- a/packages/react-bugsnag/tsconfig.json
+++ b/packages/react-bugsnag/tsconfig.json
@@ -9,5 +9,6 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ]
+  ],
+  "references": [{"path": "../react-testing"}]
 }

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -29,6 +29,9 @@
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/react-testing": "^4.2.1"
+  },
   "sideEffects": false,
   "files": [
     "build/",

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -10,5 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "references": [{"path": "../useful-types"}]
+  "references": [{"path": "../react-testing"}, {"path": "../useful-types"}]
 }

--- a/packages/react-csrf/package.json
+++ b/packages/react-csrf/package.json
@@ -26,6 +26,9 @@
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/react-testing": "^4.2.1"
+  },
   "files": [
     "build/",
     "!build/*.tsbuildinfo",

--- a/packages/react-csrf/tsconfig.json
+++ b/packages/react-csrf/tsconfig.json
@@ -9,5 +9,6 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ]
+  ],
+  "references": [{"path": "../react-testing"}]
 }

--- a/packages/react-effect/package.json
+++ b/packages/react-effect/package.json
@@ -45,6 +45,9 @@
     "react": ">=16.8.0 <19.0.0",
     "react-dom": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/jest-dom-mocks": "^4.0.1"
+  },
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {

--- a/packages/react-effect/tsconfig.json
+++ b/packages/react-effect/tsconfig.json
@@ -9,5 +9,6 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ]
+  ],
+  "references": [{"path": "../jest-dom-mocks"}]
 }

--- a/packages/react-form-state/package.json
+++ b/packages/react-form-state/package.json
@@ -29,6 +29,9 @@
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/react-testing": "^4.2.1"
+  },
   "sideEffects": false,
   "files": [
     "build/",

--- a/packages/react-form-state/tsconfig.json
+++ b/packages/react-form-state/tsconfig.json
@@ -10,5 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "references": [{"path": "../predicates"}]
+  "references": [{"path": "../react-testing"}, {"path": "../predicates"}]
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -45,6 +45,7 @@
     }
   },
   "devDependencies": {
+    "@shopify/jest-dom-mocks": "^4.0.1",
     "@shopify/react-testing": "^4.2.1"
   }
 }

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -10,5 +10,5 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "references": [{"path": "../react-testing"}]
+  "references": [{"path": "../jest-dom-mocks"}, {"path": "../react-testing"}]
 }

--- a/packages/react-idle/package.json
+++ b/packages/react-idle/package.json
@@ -30,6 +30,10 @@
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/jest-dom-mocks": "^4.0.1",
+    "@shopify/react-testing": "^4.2.1"
+  },
   "files": [
     "build/",
     "!build/*.tsbuildinfo",

--- a/packages/react-idle/tsconfig.json
+++ b/packages/react-idle/tsconfig.json
@@ -10,5 +10,10 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "references": [{"path": "../useful-types"}, {"path": "../async"}]
+  "references": [
+    {"path": "../async"},
+    {"path": "../jest-dom-mocks"},
+    {"path": "../react-testing"},
+    {"path": "../useful-types"}
+  ]
 }

--- a/packages/react-intersection-observer/package.json
+++ b/packages/react-intersection-observer/package.json
@@ -34,6 +34,10 @@
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/jest-dom-mocks": "^4.0.1",
+    "@shopify/react-testing": "^4.2.1"
+  },
   "module": "index.mjs",
   "esnext": "index.esnext",
   "exports": {

--- a/packages/react-intersection-observer/tsconfig.json
+++ b/packages/react-intersection-observer/tsconfig.json
@@ -9,5 +9,6 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ]
+  ],
+  "references": [{"path": "../jest-dom-mocks"}, {"path": "../react-testing"}]
 }

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -30,6 +30,7 @@
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
+    "@shopify/jest-dom-mocks": "^4.0.1",
     "@shopify/network": "^3.2.1"
   },
   "files": [

--- a/packages/react-performance/tsconfig.json
+++ b/packages/react-performance/tsconfig.json
@@ -11,5 +11,9 @@
     "./src/**/*.ts",
     "./src/**/*.tsx"
   ],
-  "references": [{"path": "../network"}, {"path": "../performance"}]
+  "references": [
+    {"path": "../jest-dom-mocks"},
+    {"path": "../network"},
+    {"path": "../performance"}
+  ]
 }

--- a/packages/react-shortcuts/package.json
+++ b/packages/react-shortcuts/package.json
@@ -25,6 +25,10 @@
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"
   },
+  "devDependencies": {
+    "@shopify/jest-dom-mocks": "^4.0.1",
+    "@shopify/react-testing": "^4.2.1"
+  },
   "sideEffects": false,
   "files": [
     "build/",

--- a/packages/react-shortcuts/tsconfig.json
+++ b/packages/react-shortcuts/tsconfig.json
@@ -9,5 +9,6 @@
     "../../config/typescript/*.d.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx"
-  ]
+  ],
+  "references": [{"path": "../jest-dom-mocks"}, {"path": "../react-testing"}]
 }


### PR DESCRIPTION
## Description

Preparation for a typescript update. Future TypeScript versions complain when you use project A in project B, but don't mention project A in project B's tsconfig references key.

This PR adds missing references to `react-testing` and `jest-dom-mocks` to the tsconfig.json files of projects that use those projects but don't currently reference them.

Skipping changelog as this is an internal optimization that has no effect on build output.