### PR TITLE
Implement support for redirectDuration event

### DIFF
--- a/.changeset/six-dots-sneeze.md
+++ b/.changeset/six-dots-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@shopify/koa-performance': minor
+'@shopify/performance': minor
+---
+
+Introduce a RedirectDuration metric to get more specific server latency timings. This information will be sent via TTFB metadata. No changes need to be made on the consumer.

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -194,7 +194,7 @@ export function clientPerformanceMetrics({
           );
         }
       }
-      console.log(metrics);
+
       const distributions = metrics.map(({name, value, tags}) => {
         if (development) {
           statsLogger.log(`Skipping sending metric in dev ${name}: ${value}`);

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -105,6 +105,16 @@ export function clientPerformanceMetrics({
       statsLogger.log(`Adding event tags: ${JSON.stringify(tags)}`);
 
       for (const event of events) {
+        if (
+          event.type === EventType.TimeToFirstByte &&
+          event.metadata?.redirectDuration
+        ) {
+          metrics.push({
+            name: EventType.RedirectDuration,
+            value: Math.round(event.metadata.redirectDuration),
+            tags,
+          });
+        }
         const value =
           event.type === EventType.FirstInputDelay
             ? event.duration
@@ -184,7 +194,7 @@ export function clientPerformanceMetrics({
           );
         }
       }
-
+      console.log(metrics);
       const distributions = metrics.map(({name, value, tags}) => {
         if (development) {
           statsLogger.log(`Skipping sending metric in dev ${name}: ${value}`);

--- a/packages/performance/src/types.ts
+++ b/packages/performance/src/types.ts
@@ -11,6 +11,7 @@ export enum EventType {
   GraphQL = 'graphql',
   ScriptDownload = 'script',
   StyleDownload = 'style',
+  RedirectDuration = 'redirect_duration',
 }
 
 interface BasicEvent {
@@ -21,7 +22,9 @@ interface BasicEvent {
 
 export interface TimeToFirstByteEvent extends BasicEvent {
   type: EventType.TimeToFirstByte;
-  metadata?: undefined;
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 export interface TimeToFirstPaintEvent extends BasicEvent {


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/checkout-web/issues/12911

To give additional context, [here](https://github.com/Shopify/checkout-web/pull/13696) is the accompanying change in checkout-web

### Why
There is a redirect from the cart controller that introduces meaningful latency (~500 ms) into checkout-web performance. As part of the [checkout performance metrics](https://vault.shopify.io/gsd/projects/30415) project we want to measure this redirect in order to get feedback as performance projects ship. 

### How
The main change I made is to make TimeToFirstByte support metadata and introduce an additional event called RedirectDuration. While looping through the events, if ttfb has been sent with the relevant metadata, add an additional metric RedirectDuration. 

### Tophat
I used yalc and dev to tophat my koa-performance changes with checkout-one-web-stats. I created a document for my teammates outlining the steps, linking it [here](https://docs.google.com/document/d/1CJmR4r1xOKDZBadK7tSCghBKbezhjSHHB7PxKxasZMs/edit) in case it makes it more convenient for you folks. 

After you've linked the updated package to checkout-one-web-stats, ping it with Insomnia, you should see the below in the server output:
<img width="1122" alt="Screen Shot 2022-09-08 at 11 03 49 AM" src="https://user-images.githubusercontent.com/90475164/189194422-9bdcb879-f105-4004-9b0e-2d63e5cc0be0.png">

