### PR TITLE
[`@shopify/graphql-testing`] Update configuration to allow `assumeImmutableResults` and `freezeResults` to be set.

### DIFF
--- a/.changeset/polite-roses-learn.md
+++ b/.changeset/polite-roses-learn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/graphql-testing': minor
+---
+
+Allow assumeImmutableResults results to be enabled on the apollo client

--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -1,8 +1,8 @@
 import {ApolloLink, GraphQLRequest} from 'apollo-link';
 import {
-  ApolloReducerConfig,
   InMemoryCache,
   IntrospectionFragmentMatcher,
+  InMemoryCacheConfig,
 } from 'apollo-cache-inmemory';
 import {ApolloClient} from 'apollo-client';
 
@@ -14,8 +14,9 @@ import {GraphQLMock, MockRequest, FindOptions} from './types';
 
 export interface Options {
   unionOrIntersectionTypes?: any[];
-  cacheOptions?: ApolloReducerConfig;
+  cacheOptions?: InMemoryCacheConfig;
   links?: ApolloLink[];
+  assumeImmutableResults?: boolean;
 }
 
 interface Wrapper {
@@ -36,6 +37,7 @@ export class GraphQL {
       unionOrIntersectionTypes = [],
       cacheOptions = {},
       links = [],
+      assumeImmutableResults = false,
     }: Options = {},
   ) {
     const cache = new InMemoryCache({
@@ -60,6 +62,7 @@ export class GraphQL {
     ]);
 
     this.client = new TestingApolloClient({
+      assumeImmutableResults,
       link,
       cache,
     });

--- a/packages/graphql-testing/src/tests/e2e.test.tsx
+++ b/packages/graphql-testing/src/tests/e2e.test.tsx
@@ -81,7 +81,7 @@ describe('graphql-testing', () => {
     expect(myComponent).toContainReactText('Loading');
   });
 
-  it.only('allows assumeImmutableResults and freezeResults to be set', async () => {
+  it('allows assumeImmutableResults and freezeResults to be set', async () => {
     const graphQL = createImmutableGraphQL({
       Pet: {
         pet: {


### PR DESCRIPTION
## Description
This PR allows `assumeImmutableResults` client config and the InMemoryCache `freezeResults` to be set during test configuration.

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
