### PR TITLE
Update jest matchers with result

### DIFF
--- a/.changeset/thirty-points-beg.md
+++ b/.changeset/thirty-points-beg.md
@@ -1,0 +1,6 @@
+---
+'@shopify/graphql-testing': minor
+'@shopify/react-testing': minor
+---
+
+Adds jest.Result as a possible type for props

--- a/packages/graphql-testing/src/matchers/index.ts
+++ b/packages/graphql-testing/src/matchers/index.ts
@@ -5,10 +5,19 @@ import {toHavePerformedGraphQLOperation} from './operations';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
+    interface Result {
+      pass: boolean;
+      message(): string;
+    }
+
+    type PartialResult<T> = {
+      [P in keyof T]?: T[P] | Result;
+    };
+
     interface Matchers<R, T = {}> {
       toHavePerformedGraphQLOperation<Variables>(
         document: GraphQLOperation<any, Variables, any>,
-        variables?: Partial<Variables>,
+        variables?: PartialResult<Variables>,
       ): void;
     }
   }

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -15,17 +15,25 @@ type PropsFromNode<T> = T extends Node<infer U> ? U : never;
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
+    interface Result {
+      pass: boolean;
+      message(): string;
+    }
+
+    type PartialResult<T> = {
+      [P in keyof T]?: T[P] | Result;
+    };
     interface Matchers<R, T = {}> {
-      toHaveReactProps(props: Partial<PropsFromNode<T>>): void;
+      toHaveReactProps(props: PartialResult<PropsFromNode<T>>): void;
       toHaveReactDataProps(data: {[key: string]: string}): void;
       toContainReactComponent<Type extends string | ComponentType<any>>(
         type: Type,
-        props?: Partial<PropsFor<Type>>,
+        props?: PartialResult<PropsFor<Type>>,
       ): void;
       toContainReactComponentTimes<Type extends string | ComponentType<any>>(
         type: Type,
         times: number,
-        props?: Partial<PropsFor<Type>>,
+        props?: PartialResult<PropsFor<Type>>,
       ): void;
       toProvideReactContext<Type>(
         context: ReactContext<Type>,


### PR DESCRIPTION
## Description
`jest-extended` updated their types recently to return a `jest.Result` instead of `any`. This PR updates the props matcher to apply `jest.Result` as a possible type to props.

See https://github.com/keeganwitt/jest-extended/blob/d97afc9e2de80f6487dfa91e82fe8af6d40899f6/types/index.d.ts#L435

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
