### PR TITLE
Use rotated token in the hope that CI runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -31,4 +33,4 @@ jobs:
           publish: yarn release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

Use a non-standard token for changesets, in the hope that the created PRs shall have CI steps triggered for them.

See https://github.com/changesets/action/issues/187#issuecomment-1228413850 for changeset info
See https://github.com/Shopify/github-actions-access-provider/pull/215 for PR that adds this new token
