### PR TITLE
Set the correct initial state for the useMedia hook

### DIFF
--- a/.changeset/tall-news-help.md
+++ b/.changeset/tall-news-help.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-hooks': patch
+---
+
+Fixed useMedia to correctly send back the correct initial state of the query match

--- a/packages/react-hooks/src/hooks/media.ts
+++ b/packages/react-hooks/src/hooks/media.ts
@@ -4,7 +4,13 @@ type EffectHook = typeof useEffect | typeof useLayoutEffect;
 
 function createUseMediaFactory(useEffectHook: EffectHook) {
   return (query: string) => {
-    const [match, setMatch] = useState(false);
+    const [match, setMatch] = useState(() => {
+      if (typeof window === 'undefined' || !window.matchMedia) {
+        return false;
+      }
+
+      return window.matchMedia(query).matches;
+    });
 
     useEffectHook(() => {
       if (!window || !window.matchMedia) {


### PR DESCRIPTION
## Description

Fixes #2436

This change updates useMedia to use React's lazy-initialization for useState. Instead of always returning `false` as the initial state, it will do an initial `matchMedia` call (if not on the server). This can help in prevent screen flickering for UIs that use this hook, and will prevent a render cycle as well.
