### PR TITLE
[react-testing] fixed react queue emptying for React 17

### DIFF
--- a/.changeset/great-comics-appear.md
+++ b/.changeset/great-comics-appear.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': patch
+---
+
+Fix act queue emptying for React 17

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -5,7 +5,7 @@ import {act} from 'react-dom/test-utils';
 
 import {TestWrapper} from './TestWrapper';
 import {Element} from './element';
-import {createRoot, getInternals} from './compat';
+import {createRoot, getInternals, enqueueTask, isLegacyReact} from './compat';
 import {
   Tag,
   Fiber,
@@ -313,6 +313,11 @@ export class Root<Props> implements Node<Props> {
     this.destroyed = true;
     await mountedPromise;
     this.actCallbacks.forEach((callback) => callback());
+
+    if (isLegacyReact) {
+      // flush macro task for react 17 only
+      await new Promise((resolve) => enqueueTask(resolve));
+    }
   }
 
   setProps(props: Partial<Props>) {

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -15,8 +15,6 @@ import {createPortal} from 'react-dom';
 
 import {mount, createMount} from '../mount';
 
-const itIf = (condition) => (condition ? it : it.skip);
-
 describe('@shopify/react-testing', () => {
   it('does not time out with large trees', () => {
     function RecurseMyself({times}: {times: number}) {
@@ -175,35 +173,28 @@ describe('@shopify/react-testing', () => {
       );
     }
 
-    // eslint-disable-next-line no-process-env
-    itIf(process.env.REACT_VERSION !== '17')(
-      'releases any stale promises when component is destroyed',
-      async () => {
-        const wrapper = mount(<Counter />);
-        wrapper.act(() => new Promise(() => {}));
-        wrapper.act(() => new Promise(() => {}));
-        await wrapper.destroy();
+    it('releases any stale promises when component is destroyed', async () => {
+      const wrapper = mount(<Counter />);
+      wrapper.act(() => new Promise(() => {}));
+      wrapper.act(() => new Promise(() => {}));
+      await wrapper.destroy();
 
-        // React 17 will fail without this await
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      function EffectChangeComponent({children}: {children?: ReactNode}) {
+        const [counter, setCounter] = useState(0);
+        useEffect(() => setCounter(100), []);
 
-        function EffectChangeComponent({children}: {children?: ReactNode}) {
-          const [counter, setCounter] = useState(0);
-          useEffect(() => setCounter(100), []);
+        return (
+          // eslint-disable-next-line @shopify/jsx-prefer-fragment-wrappers
+          <div>
+            <Message>{counter}</Message>
+            {children}
+          </div>
+        );
+      }
+      const newWrapper = mount(<EffectChangeComponent />);
 
-          return (
-            // eslint-disable-next-line @shopify/jsx-prefer-fragment-wrappers
-            <div>
-              <Message>{counter}</Message>
-              {children}
-            </div>
-          );
-        }
-        const newWrapper = mount(<EffectChangeComponent />);
-
-        expect(newWrapper.find(Message)!.html()).toBe('<span>100</span>');
-      },
-    );
+      expect(newWrapper.find(Message)!.html()).toBe('<span>100</span>');
+    });
 
     it('updates element tree when state is changed', () => {
       const wrapper = mount(<Counter />);


### PR DESCRIPTION
## Description

#2352 Introduced automatic act queue emptying when a destroying a root wrapper. It fixed this fully in React 18 but not for older versions of react. This resulted in flaky tests for quilt as well as potentially surprising behaviour for React 17 users upgrading to react-testing@5. 

This PR also adds queue emptying for older version of React.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
