### PR TITLE
Fix a submit function type

### DIFF
--- a/.changeset/mighty-candles-film.md
+++ b/.changeset/mighty-candles-film.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-form': patch
+---
+
+fix the type for submit() as it returns a promise and not just void.

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -99,7 +99,7 @@ export interface Form<T extends FieldBag> {
   submitErrors: FormError[];
   validate(): FormError[];
   reset(): void;
-  submit(event?: React.FormEvent): void;
+  submit(event?: React.FormEvent): Promise<void>;
   makeClean(): void;
 }
 


### PR DESCRIPTION
## Description

Contributes to: https://github.com/Shopify/quilt/issues/2303

`submit()` is [an async function](https://github.com/Shopify/quilt/blob/main/packages/react-form/src/hooks/submit.ts#L43) so returns a promise.

This PR updates the type definition for `submit()`.
