### PR TITLE
fix: field type on FormError interface to be string

### DIFF
--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -111,7 +111,7 @@ export interface FormWithDynamicLists<
 }
 
 export interface FormError {
-  field?: string[] | null;
+  field?: string | null;
   message: string;
 }
 


### PR DESCRIPTION
## Description

Fixes (issue #2448)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

The field type on the `FormError` interface is currently using `string[] | null`. It should be a string, not an string array.
