### PR TITLE
Improve formatCurrency short form symbol formatting (with exceptions)

### DIFF
--- a/.changeset/quiet-foxes-attend.md
+++ b/.changeset/quiet-foxes-attend.md
@@ -1,0 +1,15 @@
+---
+'@shopify/react-i18n': minor
+---
+
+Update currency symbol formatting to follow Polaris localized currency formatting guidelines. No longer displays a character or ISO code beside the currency symbol, for certain currencies and locales. The following table summarizes the changes, assuming a locale of `en-US`:
+
+| Method                                                        | Previous output                  | New output                      |
+| ------------------------------------------------------------- | -------------------------------- | ------------------------------- |
+| `i18n.formatCurrency(2, {currency: 'AUD', form: 'short'})`    | `A$2.00`                         | `$2.00`                         |
+| `i18n.formatCurrency(2, {currency: 'AUD', form: 'explicit'})` | `A$2.00 AUD`                     | `$2.00 AUD`                     |
+| `i18n.formatCurrency(2, {currency: 'AUD', form: 'auto'})`     | `A$2.00 AUD`                     | `$2.00 AUD`                     |
+| `i18n.formatCurrency(2, {currency: 'SGD', form: 'explicit'})` | `SGD 2.00 SGD`                   | `$2.00 SGD`                     |
+| `i18n.getCurrencySymbol('AUD')`                               | `{symbol: 'A$', prefixed: true}` | `{symbol: '$', prefixed: true}` |
+
+Deprecate usage of`i18n.getCurrencySymbolLocalized(locale, currency)`. Use `i18n.getCurrencySymbol(currency, locale)` instead.

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -211,3 +211,8 @@ export const EASTERN_NAME_ORDER_FORMATTERS = new Map([
       full ? `${lastName}${firstName}` : lastName,
   ],
 ]);
+
+export const CurrencyShortFormException = {
+  BRL: 'R$',
+  HKD: 'HK$',
+} as const;


### PR DESCRIPTION
## Description

Fixes #2304
Part of https://github.com/Shopify/web/issues/70196

- Modifies `i18n.formatCurrency` `short` form to use `narrowSymbol` for `currencyDisplay` instead of the default `symbol`. For old browsers that don't support `narrowSymbol`, it defaults to `symbol`. The changes due to this modification are shown on [this spreadsheet](https://docs.google.com/spreadsheets/d/1NnAp1k-2MoBFNVpCJ9ttZyKQJAJO6C-rgtxR362bojQ/edit#gid=0), which lists all the supported currencies and the "before" and "after" outputs.
- Modifies `i18n.getCurrencySymbol` to return the short form of `i18n.formatCurrency`. It no longer displays a character or ISO code beside the currency symbol.
- Creates exceptions for BRL (Brazilian Real) and HKD (Hong Kong Dollar), which should show the full-length symbol across Shopify (R$ and HK$, respectively).
<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

For auditing purposes, here's the [Spreadsheet](https://docs.google.com/spreadsheets/d/1NnAp1k-2MoBFNVpCJ9ttZyKQJAJO6C-rgtxR362bojQ/edit#gid=0) containing the "before" and "after" states of each supported currency given the modification to the `formatCurrency` `short` form.