### PR TITLE
Improve `useToggle` hooks to also provide tuple format

### DIFF
--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -242,24 +242,40 @@ function Score({value}) {
 
 ### `useToggle()`
 
-This hook provides an object that contains a boolean state value and a set of memoised callbacks to toggle it, force it to true, and force it to false. It accepts one argument that is the initial value of the state. This is useful for toggling the active state of modals and popovers.
+This hook provides an object and a tuple that contains a boolean state value and a set of memoised callbacks to toggle it, force it to true, and force it to false. It accepts one argument that is the initial value of the state. This is useful for toggling the active state of modals and popovers.
 
 ```tsx
 function MyComponent() {
+  const [isActive, setIsActiveTrue, setIsActiveFalse, toggleIsActive] =
+    useToggle(false);
+  const activeText = isActive ? 'true' : 'false';
+
+  return (
+    <>
+      <p>Value: {activeText}</p>
+      <button onClick={setIsActiveTrue}>Set isActive state to true</button>
+      <button onClick={setIsActiveFalse}>Set isActive state to false</button>
+      <button onClick={toggleIsActive}>Toggle isActive state</button>
+    </>
+  );
+}
+
+// Or
+function MyComponent() {
   const {
     value: isActive,
-    toggle: toggleIsActive,
     setTrue: setIsActiveTrue,
     setFalse: setIsActiveFalse,
+    toggle: toggleIsActive,
   } = useToggle(false);
   const activeText = isActive ? 'true' : 'false';
 
   return (
     <>
       <p>Value: {activeText}</p>
-      <button onClick={toggleIsActive}>Toggle isActive state</button>
       <button onClick={setIsActiveTrue}>Set isActive state to true</button>
       <button onClick={setIsActiveFalse}>Set isActive state to false</button>
+      <button onClick={toggleIsActive}>Toggle isActive state</button>
     </>
   );
 }

--- a/packages/react-hooks/src/hooks/tests/toggle.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/toggle.test.tsx
@@ -1,62 +1,93 @@
+/* eslint-disable jest/no-standalone-expect */
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {useToggle} from '../toggle';
 
 describe('useToggle', () => {
-  function MockComponent({initialValueIsTrue = false}) {
-    const {value, toggle, setTrue, setFalse} = useToggle(initialValueIsTrue);
+  function MockComponentObject({initialValueIsTrue = false}) {
+    const {value, setTrue, setFalse, toggle} = useToggle(initialValueIsTrue);
 
     const activeText = value ? 'true' : 'false';
 
     return (
       <>
         <p>Value: {activeText}</p>
-        <button type="button" id="toggle" onClick={toggle} />
         <button type="button" id="forceTrue" onClick={setTrue} />
         <button type="button" id="forceFalse" onClick={setFalse} />
+        <button type="button" id="toggle" onClick={toggle} />
       </>
     );
   }
 
-  it('starts with an initial value', () => {
-    const wrapperInitallyFalse = mount(<MockComponent />);
+  function MockComponentTuple({initialValueIsTrue = false}) {
+    const [value, setTrue, setFalse, toggle] = useToggle(initialValueIsTrue);
+
+    const activeText = value ? 'true' : 'false';
+
+    return (
+      <>
+        <p>Value: {activeText}</p>
+        <button type="button" id="forceTrue" onClick={setTrue} />
+        <button type="button" id="forceFalse" onClick={setFalse} />
+        <button type="button" id="toggle" onClick={toggle} />
+      </>
+    );
+  }
+
+  const tEach = it.each`
+    Component              | format
+    ${MockComponentObject} | ${'Object Return Format'}
+    ${MockComponentTuple}  | ${'Tuple Return Format'}
+  `;
+
+  tEach('$format - starts with an initial value', ({Component}) => {
+    const wrapperInitallyFalse = mount(<Component />);
     expect(wrapperInitallyFalse).toContainReactText('Value: false');
 
-    const wrapperInitallyTrue = mount(<MockComponent initialValueIsTrue />);
+    const wrapperInitallyTrue = mount(<Component initialValueIsTrue />);
     expect(wrapperInitallyTrue).toContainReactText('Value: true');
   });
 
-  it('toggles the value when the toggle callback is triggered', () => {
-    const wrapper = mount(<MockComponent />);
-    expect(wrapper).toContainReactText('Value: false');
+  tEach(
+    '$format - toggles the value when the toggle callback is triggered',
+    ({Component}) => {
+      const wrapper = mount(<Component />);
+      expect(wrapper).toContainReactText('Value: false');
 
-    wrapper.find('button', {id: 'toggle'})!.trigger('onClick');
-    expect(wrapper).toContainReactText('Value: true');
+      wrapper.find('button', {id: 'toggle'})!.trigger('onClick');
+      expect(wrapper).toContainReactText('Value: true');
 
-    wrapper.find('button', {id: 'toggle'})!.trigger('onClick');
-    expect(wrapper).toContainReactText('Value: false');
-  });
+      wrapper.find('button', {id: 'toggle'})!.trigger('onClick');
+      expect(wrapper).toContainReactText('Value: false');
+    },
+  );
 
-  it('forces the value to true when the forceTrue callback is triggered', () => {
-    const wrapper = mount(<MockComponent />);
-    expect(wrapper).toContainReactText('Value: false');
+  tEach(
+    '$format - forces the value to true when the forceTrue callback is triggered',
+    ({Component}) => {
+      const wrapper = mount(<Component />);
+      expect(wrapper).toContainReactText('Value: false');
 
-    wrapper.find('button', {id: 'forceTrue'})!.trigger('onClick');
-    expect(wrapper).toContainReactText('Value: true');
+      wrapper.find('button', {id: 'forceTrue'})!.trigger('onClick');
+      expect(wrapper).toContainReactText('Value: true');
 
-    wrapper.find('button', {id: 'forceTrue'})!.trigger('onClick');
-    expect(wrapper).toContainReactText('Value: true');
-  });
+      wrapper.find('button', {id: 'forceTrue'})!.trigger('onClick');
+      expect(wrapper).toContainReactText('Value: true');
+    },
+  );
 
-  it('forces the value to false when the forceFalse callback is triggered', () => {
-    const wrapper = mount(<MockComponent initialValueIsTrue />);
-    expect(wrapper).toContainReactText('Value: true');
+  tEach(
+    '$format - forces the value to false when the forceFalse callback is triggered',
+    ({Component}) => {
+      const wrapper = mount(<Component initialValueIsTrue />);
+      expect(wrapper).toContainReactText('Value: true');
 
-    wrapper.find('button', {id: 'forceFalse'})!.trigger('onClick');
-    expect(wrapper).toContainReactText('Value: false');
+      wrapper.find('button', {id: 'forceFalse'})!.trigger('onClick');
+      expect(wrapper).toContainReactText('Value: false');
 
-    wrapper.find('button', {id: 'forceFalse'})!.trigger('onClick');
-    expect(wrapper).toContainReactText('Value: false');
-  });
+      wrapper.find('button', {id: 'forceFalse'})!.trigger('onClick');
+      expect(wrapper).toContainReactText('Value: false');
+    },
+  );
 });

--- a/packages/react-hooks/src/hooks/toggle.ts
+++ b/packages/react-hooks/src/hooks/toggle.ts
@@ -1,16 +1,31 @@
 import {useState, useCallback} from 'react';
 
+type ToggleReturn = {
+  value: boolean;
+  setTrue: () => void;
+  setFalse: () => void;
+  toggle: () => void;
+} & [boolean, () => void, () => void, () => void];
+
 /**
  * Returns a stateful value, and a set of memoized functions to toggle it,
- * set it to true and set it to false
+ * set it to true and set it to false.
+ *
+ * @param {boolean} initialState initial value state.
+ * @return [value, setTrue, setFalse, toggle] or {value, setTrue, setFalse, toggle}.
  */
 export function useToggle(initialState: boolean) {
   const [value, setState] = useState(initialState);
 
-  return {
-    value,
-    toggle: useCallback(() => setState((state) => !state), []),
-    setTrue: useCallback(() => setState(true), []),
-    setFalse: useCallback(() => setState(false), []),
-  };
+  const setTrue = useCallback(() => setState(true), []);
+  const setFalse = useCallback(() => setState(false), []);
+  const toggle = useCallback(() => setState((state) => !state), []);
+
+  const ret = [value, setTrue, setFalse, toggle] as ToggleReturn;
+  ret.value = value;
+  ret.setTrue = setTrue;
+  ret.setFalse = setFalse;
+  ret.toggle = toggle;
+
+  return ret;
 }


### PR DESCRIPTION
## Description
In all places across `shopify/web`, we rename fields when using object destructuring for the `useToggle` return, which makes it verbose and not much readable.
This PR aims to tackle the problem above by also providing a tuple format. So we can either destructure as an array or object.
```tsx
const [isOpened, hideModal, showModal, toggleModal] = useToggle(false);

// Or
const {
    value: isOpened,
    setTrue: hideModal,
    setFalse: showModal,
    toggle: toggleModal,
  } = useToggle(false);
```

I decided to place `toggle` function at the last position because it seems to be less used than `setTrue` and `setFalse`.

Since we're supporting both formats, there is no breaking changes.