### PR TITLE
Revert "expose i18n getShortCurrencySymbol interface"

### DIFF
--- a/.changeset/spotty-buttons-poke.md
+++ b/.changeset/spotty-buttons-poke.md
@@ -1,5 +1,0 @@
----
-'@shopify/react-i18n': minor
----
-
-Expose `getShortCurrencySymbol()` interface for i18n

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -144,7 +144,6 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
   - `DateStyle.DateTime`: Formats date and time separately and uses the translation string `date.humanize.lessThanOneYearAway` to format it according to this [Polaris guideline](https://polaris.shopify.com/foundations/content/grammar-and-mechanics#date), e.g. `Jun 12, 2022 at 10:34 pm`.
 - `weekStartDay()`: returns start day of the week according to the country.
 - `getCurrencySymbol()`: returns the currency symbol according to the currency code and locale.
-- `getShortCurrencySymbol()`: returns the short currency symbol according to the currency code and locale.
 - `formatName()`: formats a name (first name and/or last name) according to the locale. e,g
   - `formatName('John', 'Smith')` will return `John` in Germany and `Smith様` in Japan
   - `formatName('John', 'Smith', {full: true})` will return `John Smith` in Germany and `SmithJohn` in Japan

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -357,25 +357,6 @@ export class I18n {
     return getCurrencySymbol(locale, {currency});
   }
 
-  // Intl.NumberFormat sometimes annotates the "currency symbol" with a country code.
-  // For example, in locale 'fr-FR', 'USD' is given the "symbol" of " $US".
-  // This method strips out the country-code annotation, if there is one.
-  // (So, for 'fr-FR' and 'USD', the return value would be " $").
-  //
-  // For other currencies, e.g. CHF and OMR, the "symbol" is the ISO currency code.
-  // In those cases, we return the full currency code without stripping the country.
-  getShortCurrencySymbol(currencyCode?: string) {
-    const currency = currencyCode || this.defaultCurrency || '';
-    const regionCode = currency.substring(0, 2);
-    const info = this.getCurrencySymbol(currency);
-    const shortSymbol = info.symbol.replace(regionCode, '');
-    const alphabeticCharacters = /[A-Za-zÀ-ÖØ-öø-ÿĀ-ɏḂ-ỳ]/;
-
-    return alphabeticCharacters.exec(shortSymbol)
-      ? info
-      : {symbol: shortSymbol, prefixed: info.prefixed};
-  }
-
   formatName(
     firstName?: string,
     lastName?: string,
@@ -489,6 +470,25 @@ export class I18n {
       maximumFractionDigits: adjustedPrecision,
       ...options,
     }).format(amount);
+  }
+
+  // Intl.NumberFormat sometimes annotates the "currency symbol" with a country code.
+  // For example, in locale 'fr-FR', 'USD' is given the "symbol" of " $US".
+  // This method strips out the country-code annotation, if there is one.
+  // (So, for 'fr-FR' and 'USD', the return value would be " $").
+  //
+  // For other currencies, e.g. CHF and OMR, the "symbol" is the ISO currency code.
+  // In those cases, we return the full currency code without stripping the country.
+  private getShortCurrencySymbol(currencyCode = this.defaultCurrency || '') {
+    const currency = currencyCode || this.defaultCurrency || '';
+    const regionCode = currency.substring(0, 2);
+    const info = this.getCurrencySymbol(currency);
+    const shortSymbol = info.symbol.replace(regionCode, '');
+    const alphabeticCharacters = /[A-Za-zÀ-ÖØ-öø-ÿĀ-ɏḂ-ỳ]/;
+
+    return alphabeticCharacters.exec(shortSymbol)
+      ? info
+      : {symbol: shortSymbol, prefixed: info.prefixed};
   }
 
   private humanizeDate(date: Date, options?: Intl.DateTimeFormatOptions) {

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -2141,7 +2141,8 @@ describe('I18n', () => {
       'returns $shortSymbol for $currency in $locale',
       ({currency, locale, expectedPrefixed, expectedSymbol}) => {
         const i18n = new I18n(defaultTranslations, {locale});
-        const {symbol, prefixed} = i18n.getShortCurrencySymbol(currency);
+        // eslint-disable-next-line dot-notation
+        const {symbol, prefixed} = i18n['getShortCurrencySymbol'](currency);
         expect(prefixed).toStrictEqual(expectedPrefixed);
         expect(sanitizeSpaces(symbol)).toStrictEqual(expectedSymbol);
       },


### PR DESCRIPTION
Reverts Shopify/quilt#2330

This changes the visibility of  `i18n.getShortCurrencySymbol` from public to private. This is not a breaking change as #2330 has not yet been merged.

In #2451 we shall update `getCurrencySymbol` to return the short form - which matches the polaris guidelines - instead of making consumers reach into our internals and extract the short form themselves.