### PR TITLE
Ignore negative start values for lifecycle events

### DIFF
--- a/.changeset/popular-pumas-marry.md
+++ b/.changeset/popular-pumas-marry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/performance': patch
+---
+
+Ignore invalid negative values for lifecycle metrics like Time to First Byte

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -280,6 +280,11 @@ export class Performance {
       return;
     }
 
+    // In some cases the value reported is negative. Ignore these cases:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1429422#c12
+    // https://github.com/GoogleChrome/web-vitals/issues/137
+    if (event.start < 0) return;
+
     this.event(event);
     this.lifecycleEvents.push(event);
 


### PR DESCRIPTION
## Description

Some browsers such as Firefox have the potential to send negative time-to-first-byte values because of a bug in the browser: https://bugzilla.mozilla.org/show_bug.cgi?id=1429422#c12

This is causing the aggregations that we perform on our performance data to be skewed because we're getting nonsensical values, it doesn't make sense for us to be recording negative values for lifecycle events because they can't go backwards in time.

This change will drop those values, rather than report them. We'd rather drop them than clamp them to zero because zero also isn't a relevant indicator here.
