### PR TITLE
Pass the calendar prop to `formatDate`

### DIFF
--- a/.changeset/clever-bees-sing.md
+++ b/.changeset/clever-bees-sing.md
@@ -1,0 +1,5 @@
+---
+'@shopify/dates': patch
+---
+
+Pass the calendar prop to `formatDate`

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -12,9 +12,11 @@ export function memoizedGetDateTimeFormat(
   return i;
 }
 
-const browserFeatureDetectionDate = Intl.DateTimeFormat('en', {
-  hour: 'numeric',
-});
+const browserFeatureDetectionDate = (options: FormatDateOptions) =>
+  Intl.DateTimeFormat('en', {
+    ...options,
+    hour: 'numeric',
+  });
 
 // hourCycle to Intl.DateTimeFormatOptions was added in TS 4.2, so we could
 // remove this, but that would require consumers to update to at least TS 4.2
@@ -29,16 +31,19 @@ interface ResolvedFormatDateOptions extends Intl.ResolvedDateTimeFormatOptions {
   hourCycle?: 'h11' | 'h12' | 'h23' | 'h24';
 }
 
-const resolvedOptions: ResolvedFormatDateOptions | undefined =
-  typeof browserFeatureDetectionDate.resolvedOptions === 'undefined'
+const resolveFormattingOptions: (
+  options: FormatDateOptions,
+) => ResolvedFormatDateOptions | undefined = (options) =>
+  typeof browserFeatureDetectionDate(options).resolvedOptions === 'undefined'
     ? undefined
-    : browserFeatureDetectionDate.resolvedOptions();
+    : browserFeatureDetectionDate(options).resolvedOptions();
 
 export function formatDate(
   date: Date,
   locales: string | string[],
   options: FormatDateOptions = {},
 ) {
+  const resolvedOptions = resolveFormattingOptions(options);
   const hourCycleRequired =
     resolvedOptions != null &&
     options.hour12 === false &&

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -318,11 +318,17 @@ export class I18n {
             ...dateStyle[style],
           });
         default:
-          return this.formatDate(date, {...formatOptions, ...dateStyle[style]});
+          return this.formatDate(date, {
+            ...formatOptions,
+            ...dateStyle[style],
+          });
       }
     }
 
-    return formatDate(date, locale, {...formatOptions, timeZone});
+    return formatDate(date, locale, {
+      ...formatOptions,
+      timeZone,
+    });
   }
 
   ordinal(amount: number) {
@@ -627,7 +633,7 @@ export class I18n {
     date: Date,
     options?: Intl.DateTimeFormatOptions,
   ): string {
-    const {localeMatcher, formatMatcher, timeZone} = options || {};
+    const {localeMatcher, formatMatcher, timeZone, calendar} = options || {};
 
     const hourZone = this.formatDate(date, {
       localeMatcher,
@@ -636,6 +642,7 @@ export class I18n {
       hour12: false,
       timeZoneName: 'short',
       hour: 'numeric',
+      calendar,
     });
 
     const zoneMatchGroup = /\s([\w()+\-:.]+$)/.exec(hourZone);
@@ -654,6 +661,7 @@ export class I18n {
       era,
       timeZone,
       timeZoneName,
+      calendar,
     } = options || {};
 
     const formattedDate = this.formatDate(date, {
@@ -666,14 +674,21 @@ export class I18n {
       era,
       timeZone,
       timeZoneName: timeZoneName === 'short' ? undefined : timeZoneName,
+      calendar,
     });
 
     return formattedDate;
   }
 
   private getTimeFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {
-    const {localeMatcher, formatMatcher, hour12, timeZone, timeZoneName} =
-      options || {};
+    const {
+      localeMatcher,
+      formatMatcher,
+      hour12,
+      timeZone,
+      timeZoneName,
+      calendar,
+    } = options || {};
 
     const formattedTime = this.formatDate(date, {
       localeMatcher,
@@ -683,6 +698,7 @@ export class I18n {
       timeZoneName: timeZoneName === 'short' ? undefined : timeZoneName,
       hour: 'numeric',
       minute: '2-digit',
+      calendar,
     }).toLocaleLowerCase();
 
     const time =
@@ -694,13 +710,15 @@ export class I18n {
   }
 
   private getWeekdayFromDate(date: Date, options?: Intl.DateTimeFormatOptions) {
-    const {localeMatcher, formatMatcher, hour12, timeZone} = options || {};
+    const {localeMatcher, formatMatcher, hour12, timeZone, calendar} =
+      options || {};
     return this.formatDate(date, {
       localeMatcher,
       formatMatcher,
       hour12,
       timeZone,
       weekday: 'long',
+      calendar,
     });
   }
 
@@ -708,7 +726,8 @@ export class I18n {
     date: Date,
     options?: Intl.DateTimeFormatOptions,
   ) {
-    const {localeMatcher, formatMatcher, hour12, timeZone} = options || {};
+    const {localeMatcher, formatMatcher, hour12, timeZone, calendar} =
+      options || {};
     return this.formatDate(date, {
       localeMatcher,
       formatMatcher,
@@ -716,6 +735,7 @@ export class I18n {
       timeZone,
       month: 'short',
       day: 'numeric',
+      calendar,
     });
   }
 


### PR DESCRIPTION
## Description

[FormatJS's Intl.DateTimeFormat](https://formatjs.io/docs/polyfills/intl-datetimeformat/) only supports the Gregorian calendar.  These changes enforce that.

Fixes (or at least it should) crashing issues on React Native for the [mobile repo](https://github.com/Shopify/mobile)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

### Mobile Tophat:

__Setup__:

1. Change an iOS device's region to Thailand
1. Change the device's language to Thai
1. In the mobile repo, run
```
yarn add @shopify/react-i18n@0.0.0-snapshot-20221111164351
```
1. After that successfully completes, run `dev up`
1. Run `dev react-native start --reset-cache`
    * __Note__:  `--reset-cache` may not be needed
1. Run the app (either by building in Xcode or `dev react-native run-ios`

__Test__:

1. Navigate to the online store section of the store tab
    * __Expected behaviour__:  No crashes occur

#### Video of this test:

__Before__:

https://user-images.githubusercontent.com/99921496/201183803-30c175b9-af29-41ac-8087-01ac8bb8fb57.mov

__After__:

https://user-images.githubusercontent.com/99921496/201183933-1b05abf3-14d8-4539-a9b0-a9a36d4532da.mov
