### PR TITLE
Bump @faker-js/faker to 7.x

### DIFF
--- a/.changeset/quiet-impalas-retire.md
+++ b/.changeset/quiet-impalas-retire.md
@@ -1,0 +1,5 @@
+---
+'graphql-fixtures': major
+---
+
+Upgraded @faker-js/faker from v6 to v7

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/core": "^7.14.6",
     "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.25.0",
-    "@faker-js/faker": "^6.3.1",
+    "@faker-js/faker": "^7.6.0",
     "@shopify/app-bridge": "^2.0.3",
     "@shopify/babel-preset": "^24.1.4",
     "@shopify/browserslist-config": "^3.0.0",

--- a/packages/graphql-fixtures/README.md
+++ b/packages/graphql-fixtures/README.md
@@ -59,7 +59,7 @@ const data = fill(myQuery, data)({query: myQuery});
 
 #### Using faker
 
-When using `faker` to provide fake data within your filler function, you should use the `faker` instance that is exported by this library in order to avoid data mismatches. Rather than `import faker from '@faker-js/faker'` instead use:
+When using `faker` to provide fake data within your filler function, you should use the `faker` instance that is exported by this library in order to avoid data mismatches. Rather than `import {faker} from '@faker-js/faker'` instead use:
 
 ```ts
 import {createFiller, faker} from 'graphql-fixtures';

--- a/packages/graphql-fixtures/package.json
+++ b/packages/graphql-fixtures/package.json
@@ -24,7 +24,7 @@
     "node": "^14.17.0 || >=16.0.0"
   },
   "dependencies": {
-    "@faker-js/faker": "^6.3.1",
+    "@faker-js/faker": "^7.6.0",
     "@shopify/useful-types": "^5.1.1",
     "graphql": ">=14.5.0 <16.0.0",
     "graphql-tool-utilities": "^3.0.1"

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {
   GraphQLSchema,
   GraphQLType,

--- a/packages/graphql-fixtures/src/tests/fill.test.ts
+++ b/packages/graphql-fixtures/src/tests/fill.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @shopify/typescript/prefer-build-client-schema
 import {buildSchema} from 'graphql';
 import {parse, DocumentNode} from 'graphql-typed';
-import originalFaker from '@faker-js/faker/locale/en';
+import {faker as originalFaker} from '@faker-js/faker/locale/en';
 
 import {createFiller, list, Options, faker} from '../fill';
 

--- a/packages/graphql-fixtures/src/utilities.ts
+++ b/packages/graphql-fixtures/src/utilities.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 
 export function chooseNull() {
   return faker.datatype.boolean();

--- a/packages/graphql-persisted/src/tests/apollo.test.ts
+++ b/packages/graphql-persisted/src/tests/apollo.test.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import gql from 'graphql-tag';
 import {ApolloLink} from 'apollo-link';
 

--- a/packages/graphql-persisted/src/tests/koa-middleware.test.ts
+++ b/packages/graphql-persisted/src/tests/koa-middleware.test.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {Header} from '@shopify/network';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {setAssets} from '@shopify/sewing-kit-koa';

--- a/packages/react-app-bridge-universal-provider/src/tests/AppBridgeUniversalProvider.test.tsx
+++ b/packages/react-app-bridge-universal-provider/src/tests/AppBridgeUniversalProvider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {Provider as AppBridgeProvider} from '@shopify/app-bridge-react';
 import {extract} from '@shopify/react-effect/server';
 import {mount} from '@shopify/react-testing';

--- a/packages/react-async/src/context/tests/assets.test.ts
+++ b/packages/react-async/src/context/tests/assets.test.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {AssetTiming} from '../../types';
 import {AsyncAssetManager} from '../assets';

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -1,5 +1,5 @@
 import React, {Component, ReactNode} from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {DeferTiming} from '@shopify/async';
 import {createMount} from '@shopify/react-testing';
 import {

--- a/packages/react-async/src/tests/provider.test.tsx
+++ b/packages/react-async/src/tests/provider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 import {requestIdleCallback} from '@shopify/jest-dom-mocks';
 

--- a/packages/react-csrf-universal-provider/src/tests/CsrfUniversalProvider.test.tsx
+++ b/packages/react-csrf-universal-provider/src/tests/CsrfUniversalProvider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {extract} from '@shopify/react-effect/server';
 import {CsrfTokenContext} from '@shopify/react-csrf';
 import {mount} from '@shopify/react-testing';

--- a/packages/react-csrf/src/tests/hooks.test.tsx
+++ b/packages/react-csrf/src/tests/hooks.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import {CsrfTokenContext} from '../context';

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 // eslint-disable-next-line @shopify/strict-component-boundaries

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 // eslint-disable-next-line @shopify/strict-component-boundaries

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import {validateList} from '../validators';

--- a/packages/react-form-state/src/tests/array-utilities.test.tsx
+++ b/packages/react-form-state/src/tests/array-utilities.test.tsx
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {push, replace, remove} from '../utilities';
 

--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {
   validate,

--- a/packages/react-form/src/hooks/field/tests/field.test.tsx
+++ b/packages/react-form/src/hooks/field/tests/field.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import {

--- a/packages/react-form/src/hooks/list/tests/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/baselist.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import {useBaseList, FieldListConfig} from '../baselist';

--- a/packages/react-form/src/hooks/list/tests/utils.tsx
+++ b/packages/react-form/src/hooks/list/tests/utils.tsx
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import React from 'react';
 
 export interface Variant {

--- a/packages/react-form/src/hooks/tests/utilities/index.ts
+++ b/packages/react-form/src/hooks/tests/utilities/index.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {Root} from '@shopify/react-testing';
 
 import {SimpleProduct, TextField} from './components';

--- a/packages/react-form/src/validation/tests/validator.test.ts
+++ b/packages/react-form/src/validation/tests/validator.test.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {validator} from '..';
 

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -1,5 +1,5 @@
 import React, {ReactElement} from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import gql from 'graphql-tag';
 import {ApolloClient} from 'apollo-client';
 import {ApolloLink} from 'apollo-link';

--- a/packages/react-hydrate/src/tests/e2e.test.tsx
+++ b/packages/react-hydrate/src/tests/e2e.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {createMount} from '@shopify/react-testing';
 
 import {Hydrator} from '../Hydrator';

--- a/packages/react-i18n-universal-provider/src/tests/I18nUniversalProvider.test.tsx
+++ b/packages/react-i18n-universal-provider/src/tests/I18nUniversalProvider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {extract} from '@shopify/react-effect/server';
 import {createMount} from '@shopify/react-testing';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';

--- a/packages/react-i18n-universal-provider/src/tests/utilities.test.ts
+++ b/packages/react-i18n-universal-provider/src/tests/utilities.test.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {combinedI18nDetails} from '../utilities';
 

--- a/packages/react-performance/src/tests/PerformanceReport.test.tsx
+++ b/packages/react-performance/src/tests/PerformanceReport.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 import {fetch, timer, connection} from '@shopify/jest-dom-mocks';
 import {Method, Header} from '@shopify/network';

--- a/packages/react-performance/src/tests/utilities.ts
+++ b/packages/react-performance/src/tests/utilities.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {
   Navigation,
   NavigationResult,

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {Root} from '../root';
 import {mount, createMount} from '../mount';

--- a/packages/react-universal-provider/src/tests/create-universal-provider.test.tsx
+++ b/packages/react-universal-provider/src/tests/create-universal-provider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import faker from '@faker-js/faker/locale/en';
+import {faker} from '@faker-js/faker/locale/en';
 import {extract} from '@shopify/react-effect/server';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';
 import {mount} from '@shopify/react-testing';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,10 +1637,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@faker-js/faker@^6.3.1":
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.3.1.tgz#1ae963dd40405450a2945408cba553e1afa3e0fb"
-  integrity sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==
+"@faker-js/faker@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
+  integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
 
 "@graphql-tools/batch-execute@8.4.7":
   version "8.4.7"
@@ -14665,8 +14665,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
## Description

:wave: Hello from Shop!

We're migrating over to v7 on Shop, and using `resolutions` + patch to get `graphql-fixtures` compatible with v7 (rationale: Faker is a large import over many files, which has an impact on Jest performance on large suites).

Consumers of `graphql-fixtures` can still `import {faker} from 'graphql-fixtures'` as before, which is (afaik?) the only public change this PR might have introduced (the rest are all within our tests?).

This PR is mostly just a large search/replace to swap out the `default` import for the named `faker` export. Nothing else seems too concerning in the v7 notes - it still supports Node 14, so nothing changes there.

(I'll add a changeset if we want to 🚢, otherwise we can hold off until later)