### PR TITLE
Correct error with export path for jest-simple

### DIFF
--- a/.changeset/violet-mugs-double.md
+++ b/.changeset/violet-mugs-double.md
@@ -1,0 +1,5 @@
+---
+'graphql-mini-transforms': minor
+---
+
+fix export path for jest-simple sub-path

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -84,7 +84,7 @@
     },
     "./jest-simple": {
       "types": "./build/ts/jest-simple.d.ts",
-      "default": "./build/ts/jest-simple.d.ts"
+      "default": "./jest-simple.js"
     },
     "./webpack-loader": {
       "types": "./build/ts/webpack-loader.d.ts",


### PR DESCRIPTION
## Description

Fixes error with the export path for for jest-simple in the graphql-mini-transform package, it's default was set to the type definition output of itself.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
