### PR TITLE
Fix NPM badge for react-testing

### DIFF
--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -2,7 +2,8 @@
 
 [![Build Status](https://github.com/Shopify/quilt/workflows/Node-CI/badge.svg?branch=main)](https://github.com/Shopify/quilt/actions?query=workflow%3ANode-CI)
 [![Build Status](https://github.com/Shopify/quilt/workflows/Ruby-CI/badge.svg?branch=main)](https://github.com/Shopify/quilt/actions?query=workflow%3ARuby-CI)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Freact-testing.svg)](https://badge.fury.io/js/%40shopify%2Freact-testing.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) 
+[![npm version](https://badge.fury.io/js/@shopify%2Freact-testing.svg)](https://badge.fury.io/js/@shopify%2Freact-testing.svg)
 
 A library for testing React components according to Shopify conventions.
 


### PR DESCRIPTION
## Description

The @shopify/react-testing badge is not showing properly.

Before
![image](https://user-images.githubusercontent.com/718868/202236178-dc4cb2c3-5414-473c-bf7a-8b244914d008.png)

After
![image](https://user-images.githubusercontent.com/718868/202236683-66cb9c6b-e5ac-4718-826b-e503ce6bf39a.png)

