### PR TITLE
Move web-worker tests to the E2E block to reduce contention

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -57,11 +57,11 @@ jobs:
           yarn ci:lint-docs
 
       - name: Unit tests
-        run: yarn test "^(?:(?!(address|react-server)).)*$"
+        run: yarn test "^(?:(?!(address|react-server|web-worker)).)*$"
         env:
           REACT_VERSION: ${{ matrix.react-version}}
 
       - name: E2E tests
-        run: yarn test --debug "(address|react-server)"
+        run: yarn test --debug "(address|react-server|web-worker)"
         env:
           REACT_VERSION: ${{ matrix.react-version}}


### PR DESCRIPTION
web-worker tests intermittently fail on CI. My hunch is that running them in parallel with other tests means therte's a bit to much contention and puppeteer doesn't quite react in time. I'm hoping that moving them to the e2e block shall result in less contention, and thus they're more likely to pass
