### PR TITLE
[React-testing]: adding custom data prop type for find methods

### DIFF
--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -118,10 +118,10 @@ export type TriggerKeypathReturn<
 export type PropsFor<T extends string | React.ComponentType<any>> =
   T extends string
     ? T extends keyof JSX.IntrinsicElements
-      ? JSX.IntrinsicElements[T]
-      : React.HTMLAttributes<T>
+      ? JSX.IntrinsicElements[T] & CustomDataProps
+      : React.HTMLAttributes<T> & CustomDataProps
     : T extends React.ComponentType<any>
-    ? React.ComponentPropsWithoutRef<T>
+    ? React.ComponentPropsWithoutRef<T> & CustomDataProps
     : never;
 
 export type UnknowablePropsFor<
@@ -251,4 +251,9 @@ export interface DebugOptions {
   allProps?: boolean;
   depth?: number;
   verbosity?: number;
+}
+
+interface CustomDataProps {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  'data-test-id': string;
 }


### PR DESCRIPTION
## Description

In order to be more explicit for testing `find` selections we want to be able to use `data-test-id`.  With currently types under the `PropsFor` typing these custom data attributes are not allowed within find methods.

In the `shop-server` repository we have a current situation:
```javascript
expect(
  wrapper.find(Select, {id: 'minOrderValue'})!
            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
            // @ts-ignore
            // eslint-disable-next-line @typescript-eslint/naming-convention
            .find(TextStyle, {'data-test-id': 'suggestedMinOrderValue'}),
  ).toContainReactText('25.00');
```

The `TextStyle` component in this example is allowed to have `data-*` attributes, but our `find` method in this package doesn't support them. 

This PR adds the custom `data-test-id` prop type as an available option. Unfortunately TypeScript does not support regex matchers, so we cannot add `data-*` as a valid prop type. 
