### PR TITLE
Remove $ for better terminal pasting

### DIFF
--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -9,7 +9,7 @@ Generate TypeScript definition files from .graphql documents.
 ## Installation
 
 ```bash
-$ yarn add graphql-typescript-definitions
+yarn add graphql-typescript-definitions
 ```
 
 ## Usage


### PR DESCRIPTION
## Description
Removing the $ sign on the yarn installation to avoid to remove it when we are copy/pasting into our terminal
