### PR TITLE
Replace "foundations" with "platform" and remove mention of ATC

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ There are many ways to contribute to Quilt, some of which are:
 - Hacking away on an issue from our [backlog](https://github.com/Shopify/quilt/issues)
 - Improving tests or documentation
 
-Want to contribute, but not sure how? Find us on Slack in `#help-admin-web-foundations`.
+Want to contribute, but not sure how? Find us on Slack in `#help-admin-web-platform`.
 
 ## Development
 
@@ -91,7 +91,7 @@ Another option, if you'd like to break work down into reviewable chunks, is to u
 
 ## Releasing
 
-The release process currently involves some manual steps to complete. Please ping Admin Web Foundations ATC in the `#help-admin-web-foundations` Slack channel when you're ready to merge a new PR into `main`, and we will orchestrate a new release. The repo owner can follow [this guide](../documentation/guides/release-and-deploy.md) to create a release.
+The release process currently involves some manual steps to complete. Please drop a notice in the `#help-admin-web-platform` Slack channel when you're ready to merge a new PR into `main`, and we will orchestrate a new release. The repo owner can follow [this guide](../documentation/guides/release-and-deploy.md) to create a release.
 
 **Note** Version numbers in `package.json` files and `CHANGELOG.md` files should never be altered manually. This will be done via scripts as part of the release process.
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @Shopify/admin-web-foundations
+*       @Shopify/admin-web-platform

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A loosely related set of packages for JavaScript/TypeScript projects at Shopify.
 
 These libraries compose together to help you create performant modern JS apps that you love to develop and test. These packages are developed primarily to be used on top of the stack we like best for our JS apps; Typescript for the flavor, Koa for the server, React for UI, Apollo for data fetching, and Jest for tests. That said, you can mix and match as you like.
 
-⚠️ Over the past few years, this repo has become a dumping ground for a variety of packages unrelated to the core problems Quilt, and it's stewards - the Admin Web Foundation team - aims to solve. Before submitting a pull request, please speak with the Admin Web Foundations team on guidance as to whether a package might belong in Quilt. The Admin Web Foundations team's focus is on the `web` codebase. If you're proposing a package that has not already been widely used in the `web` codebase then it is unlikely that it would be merged into Quilt.
+⚠️ Over the past few years, this repo has become a dumping ground for a variety of packages unrelated to the core problems Quilt, and it's stewards - the Admin Web Foundation team - aims to solve. Before submitting a pull request, please speak with the Admin Web Platform team on guidance as to whether a package might belong in Quilt. The Admin Web Platform team's focus is on the `web` codebase. If you're proposing a package that has not already been widely used in the `web` codebase then it is unlikely that it would be merged into Quilt.
 
 ## Usage
 
@@ -105,7 +105,7 @@ Check out our [Contributing Guide](./.github/CONTRIBUTING.md)
 
 ## Questions?
 
-For Shopifolk, you can reach out to us in Slack in the `#help-admin-web-foundations` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via GitHub issues.
+For Shopifolk, you can reach out to us in Slack in the `#help-admin-web-platform` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via GitHub issues.
 
 ## License
 

--- a/documentation/creating-a-new-package.md
+++ b/documentation/creating-a-new-package.md
@@ -15,7 +15,7 @@ Quilt provides a generator for creating new packages. Simply run `yarn generate:
 
 ### Naming
 
-If you need help with finding a good name for your package, feel free to reach our in `#help-admin-web-foundations` on Slack, or else just pick a relevant name and add a comment to the PR asking for feedback.
+If you need help with finding a good name for your package, feel free to reach our in `#help-admin-web-platform` on Slack, or else just pick a relevant name and add a comment to the PR asking for feedback.
 
 ## Trading in a PR
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -12,7 +12,7 @@ In addition to this documentation, Quilt contributors generally have an in-depth
 - Node.JS
 - Jest
 
-If you're looking to enhance your understanding of these technologies, fell free to reach out in `#help-admin-web-foundations` on Slack.
+If you're looking to enhance your understanding of these technologies, fell free to reach out in `#help-admin-web-platform` on Slack.
 
 ## Tools
 

--- a/templates/ROOT_README.hbs.md
+++ b/templates/ROOT_README.hbs.md
@@ -9,7 +9,7 @@ A loosely related set of packages for JavaScript/TypeScript projects at Shopify.
 
 These libraries compose together to help you create performant modern JS apps that you love to develop and test. These packages are developed primarily to be used on top of the stack we like best for our JS apps; Typescript for the flavor, Koa for the server, React for UI, Apollo for data fetching, and Jest for tests. That said, you can mix and match as you like.
 
-⚠️ Over the past few years, this repo has become a dumping ground for a variety of packages unrelated to the core problems Quilt, and it's stewards - the Admin Web Foundation team - aims to solve. Before submitting a pull request, please speak with the Admin Web Foundations team on guidance as to whether a package might belong in Quilt. The Admin Web Foundations team's focus is on the `web` codebase. If you're proposing a package that has not already been widely used in the `web` codebase then it is unlikely that it would be merged into Quilt.
+⚠️ Over the past few years, this repo has become a dumping ground for a variety of packages unrelated to the core problems Quilt, and it's stewards - the Admin Web Foundation team - aims to solve. Before submitting a pull request, please speak with the Admin Web Platform team on guidance as to whether a package might belong in Quilt. The Admin Web Platform team's focus is on the `web` codebase. If you're proposing a package that has not already been widely used in the `web` codebase then it is unlikely that it would be merged into Quilt.
 
 ## Usage
 
@@ -38,7 +38,7 @@ Check out our [Contributing Guide](./.github/CONTRIBUTING.md)
 
 ## Questions?
 
-For Shopifolk, you can reach out to us in Slack in the `#help-admin-web-foundations` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via GitHub issues.
+For Shopifolk, you can reach out to us in Slack in the `#help-admin-web-platform` channel. For external inquiries, we welcome bug reports, enhancements, and feature requests via GitHub issues.
 
 ## License
 


### PR DESCRIPTION
## Description

The team has been renamed. Update references to it. Remove mention of ATC that no longer exists.