### PR TITLE
Remove $ from terminal example codeblocks

### DIFF
--- a/packages/address-mocks/README.md
+++ b/packages/address-mocks/README.md
@@ -10,7 +10,7 @@ Address mocks for `@shopify/address`.
 ## Installation
 
 ```bash
-$ yarn add @shopify/address-mocks
+yarn add @shopify/address-mocks
 ```
 
 ## Testing

--- a/packages/address/README.md
+++ b/packages/address/README.md
@@ -10,7 +10,7 @@ Address utilities for formatting addresses.
 ## Installation
 
 ```bash
-$ yarn add @shopify/address
+yarn add @shopify/address
 ```
 
 ## API Reference

--- a/packages/admin-graphql-api-utilities/README.md
+++ b/packages/admin-graphql-api-utilities/README.md
@@ -9,7 +9,7 @@ A set of utilities to use when consuming Shopify’s admin GraphQL API.
 ## Installation
 
 ```bash
-$ yarn add @shopify/admin-graphql-api-utilities
+yarn add @shopify/admin-graphql-api-utilities
 ```
 
 ## API Reference

--- a/packages/ast-utilities/README.md
+++ b/packages/ast-utilities/README.md
@@ -9,7 +9,7 @@ Utilities for working with Abstract Syntax Trees (ASTs).
 ## Installation
 
 ```bash
-$ yarn add @shopify/ast-utilities
+yarn add @shopify/ast-utilities
 ```
 
 ## Usage

--- a/packages/async/README.md
+++ b/packages/async/README.md
@@ -9,7 +9,7 @@ Primitives for loading parts of an application asynchronously.
 ## Installation
 
 ```bash
-$ yarn add @shopify/async
+yarn add @shopify/async
 ```
 
 ## Usage

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -11,7 +11,7 @@ A package providing a simple wrapper around [`ua-parser-js`](https://www.npmjs.c
 ## Installation
 
 ```bash
-$ yarn add @shopify/browser
+yarn add @shopify/browser
 ```
 
 ## You probably don't need this

--- a/packages/csrf-token-fetcher/README.md
+++ b/packages/csrf-token-fetcher/README.md
@@ -9,7 +9,7 @@ JavaScript utility function to fetch the CSRF token required to make requests to
 ## Installation
 
 ```bash
-$ yarn add @shopify/csrf-token-fetcher
+yarn add @shopify/csrf-token-fetcher
 ```
 
 ## API Reference

--- a/packages/css-utilities/README.md
+++ b/packages/css-utilities/README.md
@@ -9,7 +9,7 @@ A set of CSS styling-related utilities.
 ## Installation
 
 ```bash
-$ yarn add @shopify/css-utilities
+yarn add @shopify/css-utilities
 ```
 
 Both `classNames` and `variationName` are helper functions that are use to generate class names.

--- a/packages/dates/README.md
+++ b/packages/dates/README.md
@@ -9,7 +9,7 @@ Lightweight date operations library.
 ## Installation
 
 ```bash
-$ yarn add @shopify/dates
+yarn add @shopify/dates
 ```
 
 ## Usage

--- a/packages/decorators/README.md
+++ b/packages/decorators/README.md
@@ -9,7 +9,7 @@ A set of decorators to aid your JavaScript journey.
 ## Installation
 
 ```bash
-$ yarn add @shopify/decorators
+yarn add @shopify/decorators
 ```
 
 ## Usage

--- a/packages/function-enhancers/README.md
+++ b/packages/function-enhancers/README.md
@@ -9,7 +9,7 @@ A set of helpers to enhance functions.
 ## Installation
 
 ```bash
-$ yarn add @shopify/function-enhancers
+yarn add @shopify/function-enhancers
 ```
 
 ## Usage

--- a/packages/graphql-config-utilities/README.md
+++ b/packages/graphql-config-utilities/README.md
@@ -9,7 +9,7 @@ Common utilities for graphql-config.
 ## Installation
 
 ```bash
-$ yarn add graphql-config-utilities
+yarn add graphql-config-utilities
 ```
 
 ## Usage

--- a/packages/graphql-fixtures/README.md
+++ b/packages/graphql-fixtures/README.md
@@ -9,7 +9,7 @@ Utilities for generating fixture objects from GraphQL documents.
 ## Installation
 
 ```bash
-$ yarn add graphql-fixtures
+yarn add graphql-fixtures
 ```
 
 ## Usage

--- a/packages/graphql-mini-transforms/README.md
+++ b/packages/graphql-mini-transforms/README.md
@@ -9,7 +9,7 @@ Transformers for importing .graphql files in various build tools.
 ## Installation
 
 ```bash
-$ yarn add graphql-mini-transforms
+yarn add graphql-mini-transforms
 ```
 
 ## Usage

--- a/packages/graphql-persisted/README.md
+++ b/packages/graphql-persisted/README.md
@@ -9,7 +9,7 @@ Apollo and Koa integrations for [persisted GraphQL queries](https://blog.apollog
 ## Installation
 
 ```bash
-$ yarn add @shopify/graphql-persisted
+yarn add @shopify/graphql-persisted
 ```
 
 ## Usage

--- a/packages/graphql-testing/README.md
+++ b/packages/graphql-testing/README.md
@@ -12,7 +12,7 @@ This package provides utilities to help in the following testing scenarios:
 ## Installation
 
 ```bash
-$ yarn add @shopify/graphql-testing
+yarn add @shopify/graphql-testing
 ```
 
 ## Usage

--- a/packages/graphql-tool-utilities/README.md
+++ b/packages/graphql-tool-utilities/README.md
@@ -9,7 +9,7 @@ Common utilities for GraphQL developer tools.
 ## Installation
 
 ```bash
-$ yarn add graphql-tool-utilities
+yarn add graphql-tool-utilities
 ```
 
 ## Usage

--- a/packages/graphql-typed/README.md
+++ b/packages/graphql-typed/README.md
@@ -9,7 +9,7 @@ A more strongly typed version of GraphQL's DocumentNode.
 ## Installation
 
 ```bash
-$ yarn add graphql-typed
+yarn add graphql-typed
 ```
 
 ## Usage

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -9,7 +9,7 @@ Generate TypeScript definition files from .graphql documents.
 ## Installation
 
 ```bash
-$ yarn add graphql-typescript-definitions
+yarn add graphql-typescript-definitions
 ```
 
 ## Usage

--- a/packages/graphql-validate-fixtures/README.md
+++ b/packages/graphql-validate-fixtures/README.md
@@ -9,7 +9,7 @@ Validates JSON fixtures for GraphQL responses against the associated operations 
 ## Installation
 
 ```bash
-$ yarn add graphql-validate-fixtures
+yarn add graphql-validate-fixtures
 ```
 
 ## Usage

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -9,7 +9,7 @@ Generic i18n-related utilities.
 ## Installation
 
 ```bash
-$ yarn add @shopify/i18n
+yarn add @shopify/i18n
 ```
 
 ## Usage

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -9,7 +9,7 @@ Jest mocking utilities for working with the DOM.
 ## Installation
 
 ```bash
-$ yarn add @shopify/jest-dom-mocks
+yarn add @shopify/jest-dom-mocks
 ```
 
 ## Setup

--- a/packages/jest-koa-mocks/README.md
+++ b/packages/jest-koa-mocks/README.md
@@ -9,7 +9,7 @@ Utilities to easily stub Koa context and cookies. The utilities are designed to 
 ## Installation
 
 ```bash
-$ yarn add @shopify/jest-koa-mocks
+yarn add @shopify/jest-koa-mocks
 ```
 
 ## Usage

--- a/packages/koa-liveness-ping/README.md
+++ b/packages/koa-liveness-ping/README.md
@@ -12,7 +12,7 @@ A liveness ping is a URL at which your application will respond with a `200` whe
 ## Installation
 
 ```bash
-$ yarn add @shopify/koa-liveness-ping
+yarn add @shopify/koa-liveness-ping
 ```
 
 ## Usage

--- a/packages/koa-metrics/README.md
+++ b/packages/koa-metrics/README.md
@@ -9,7 +9,7 @@ Opinionated performance metric tracking for Koa, implemented with DogStatsD.
 ## Installation
 
 ```bash
-$ yarn add @shopify/koa-metrics
+yarn add @shopify/koa-metrics
 ```
 
 ## Usage

--- a/packages/koa-performance/README.md
+++ b/packages/koa-performance/README.md
@@ -27,7 +27,7 @@ Best used with [`@shopify/performance`](https://www.npmjs.com/package/@shopify/p
 First we will need to install the npm package.
 
 ```bash
-$ yarn add @shopify/koa-performance
+yarn add @shopify/koa-performance
 ```
 
 ### Add the middleware

--- a/packages/koa-shopify-graphql-proxy/README.md
+++ b/packages/koa-shopify-graphql-proxy/README.md
@@ -9,7 +9,7 @@ A wrapper around `koa-better-http-proxy` which allows easy proxying of GraphQL r
 ## Installation
 
 ```bash
-$ yarn add @shopify/koa-shopify-graphql-proxy
+yarn add @shopify/koa-shopify-graphql-proxy
 ```
 
 ## Usage

--- a/packages/koa-shopify-webhooks/README.md
+++ b/packages/koa-shopify-webhooks/README.md
@@ -9,7 +9,7 @@ Register and receive webhooks from Shopify with ease. This package was created p
 ## Installation
 
 ```bash
-$ yarn add @shopify/koa-shopify-webhooks
+yarn add @shopify/koa-shopify-webhooks
 ```
 
 ## API
@@ -182,7 +182,7 @@ app.use(router.routes());
 Make sure to install a fetch polyfill, since internally we use it to make HTTP requests.
 
 In your terminal
-`$ yarn add isomorphic-fetch`
+`yarn add isomorphic-fetch`
 
 In your app
 `import 'isomorphic-fetch'`

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -10,7 +10,7 @@ Opinionated logger for production-scale applications.
 ## Installation
 
 ```bash
-$ yarn add @shopify/logger
+yarn add @shopify/logger
 ```
 
 ## Usage

--- a/packages/mime-types/README.md
+++ b/packages/mime-types/README.md
@@ -9,7 +9,7 @@ MIME type consistency.
 ## Installation
 
 ```bash
-$ yarn add @shopify/mime-types
+yarn add @shopify/mime-types
 ```
 
 ## Usage

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -9,7 +9,7 @@ Common values related to dealing with the network.
 ## Installation
 
 ```bash
-$ yarn add @shopify/network
+yarn add @shopify/network
 ```
 
 ## Usage

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -9,7 +9,7 @@ Primitives for collecting browser performance metrics.
 ## Installation
 
 ```bash
-$ yarn add @shopify/performance
+yarn add @shopify/performance
 ```
 
 ## Usage

--- a/packages/polyfills/README.md
+++ b/packages/polyfills/README.md
@@ -19,7 +19,7 @@ The following polyfills are currently provided:
 ## Installation
 
 ```bash
-$ yarn add @shopify/polyfills
+yarn add @shopify/polyfills
 ```
 
 ## Usage

--- a/packages/predicates/README.md
+++ b/packages/predicates/README.md
@@ -9,7 +9,7 @@ A set of common JavaScript predicates. The functions in this library either take
 ## Installation
 
 ```bash
-$ yarn add @shopify/predicates
+yarn add @shopify/predicates
 ```
 
 ## API

--- a/packages/react-app-bridge-universal-provider/README.md
+++ b/packages/react-app-bridge-universal-provider/README.md
@@ -9,7 +9,7 @@ A self-serializing/deserializing [`app-bridge-react`](https://github.com/Shopify
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-app-bridge-universal-provider
+yarn add @shopify/react-app-bridge-universal-provider
 ```
 
 ## Usage

--- a/packages/react-async/README.md
+++ b/packages/react-async/README.md
@@ -9,7 +9,7 @@ Tools for creating powerful, asynchronously-loaded React components.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-async
+yarn add @shopify/react-async
 ```
 
 ## Usage

--- a/packages/react-bugsnag/README.md
+++ b/packages/react-bugsnag/README.md
@@ -9,7 +9,7 @@ An opinionated wrapper for Bugsnag's React plugin with smart defaults and suppor
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-bugsnag
+yarn add @shopify/react-bugsnag
 ```
 
 ## QuickStart

--- a/packages/react-compose/README.md
+++ b/packages/react-compose/README.md
@@ -9,7 +9,7 @@ Cleanly compose multiple component enhancers together with minimal fuss.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-compose
+yarn add @shopify/react-compose
 ```
 
 ## Usage

--- a/packages/react-cookie/README.md
+++ b/packages/react-cookie/README.md
@@ -9,7 +9,7 @@ Cookies in React for the server and client.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-cookie
+yarn add @shopify/react-cookie
 ```
 
 ## Usage

--- a/packages/react-csrf-universal-provider/README.md
+++ b/packages/react-csrf-universal-provider/README.md
@@ -9,7 +9,7 @@ A self-serializing/deserializing CSRF token provider that works for isomorphic a
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-csrf-universal-provider
+yarn add @shopify/react-csrf-universal-provider
 ```
 
 ## Usage

--- a/packages/react-csrf/README.md
+++ b/packages/react-csrf/README.md
@@ -9,7 +9,7 @@ Share CSRF tokens throughout a React application.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-csrf
+yarn add @shopify/react-csrf
 ```
 
 ## Usage

--- a/packages/react-effect/README.md
+++ b/packages/react-effect/README.md
@@ -9,7 +9,7 @@ This package contains a component and set of utilities for performing multiple e
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-effect
+yarn add @shopify/react-effect
 ```
 
 ## Usage

--- a/packages/react-form-state/README.md
+++ b/packages/react-form-state/README.md
@@ -11,7 +11,7 @@ This library is now superseded by [@shopify/react-form](https://github.com/Shopi
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-form-state
+yarn add @shopify/react-form-state
 ```
 
 ## Usage

--- a/packages/react-form/README.md
+++ b/packages/react-form/README.md
@@ -39,7 +39,7 @@ Manage React forms tersely and safely-typed with no magic using React hooks. Bui
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-form
+yarn add @shopify/react-form
 ```
 
 ## Usage

--- a/packages/react-google-analytics/README.md
+++ b/packages/react-google-analytics/README.md
@@ -9,7 +9,7 @@ Allows React apps to easily embed Google Analytics scripts.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-google-analytics
+yarn add @shopify/react-google-analytics
 ```
 
 ## Usage

--- a/packages/react-graphql-universal-provider/README.md
+++ b/packages/react-graphql-universal-provider/README.md
@@ -9,7 +9,7 @@ A self-serializing/deserializing GraphQL provider that works for isomorphic appl
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-graphql-universal-provider
+yarn add @shopify/react-graphql-universal-provider
 ```
 
 ## Self serializers

--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -9,7 +9,7 @@ Tools for consuming GraphQL in a fun and type-safe way.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-graphql
+yarn add @shopify/react-graphql
 ```
 
 ## Usage

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -9,7 +9,7 @@ A collection of primitive React hooks.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-hooks
+yarn add @shopify/react-hooks
 ```
 
 ## List of hooks

--- a/packages/react-html/README.md
+++ b/packages/react-html/README.md
@@ -8,7 +8,7 @@ A collection of utilities for constructing an HTML document.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-html
+yarn add @shopify/react-html
 ```
 
 ## Usage

--- a/packages/react-hydrate/README.md
+++ b/packages/react-hydrate/README.md
@@ -9,7 +9,7 @@ Utilities for hydrating server-rendered React apps.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-hydrate
+yarn add @shopify/react-hydrate
 ```
 
 ## Usage

--- a/packages/react-i18n-universal-provider/README.md
+++ b/packages/react-i18n-universal-provider/README.md
@@ -9,7 +9,7 @@ A self-serializing/deserializing i18n provider that works for isomorphic applica
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-i18n-universal-provider
+yarn add @shopify/react-i18n-universal-provider
 ```
 
 ## Usage
@@ -65,14 +65,14 @@ Duplicate and/or unmet versions of `react-i18n`
 Deduplicating dependencies for react-i18n-universal-provider and react-i18n.
 
 ```bash
-$ npx yarn-deduplicate --packages @shopify/react-i18n yarn.lock
+npx yarn-deduplicate --packages @shopify/react-i18n yarn.lock
 npx yarn-deduplicate --packages @shopify/react-html yarn.lock
 npx yarn-deduplicate --packages @shopify/react-effect yarn.lock
 # deduplicate other dependencies of @shopify/react-i18n
 ```
 
 ```bash
-$ yarn why @shopify/react-i18n # ensure no duplicate / unmet dependencies
+yarn why @shopify/react-i18n # ensure no duplicate / unmet dependencies
 yarn list  # ensure no duplicate / unmet dependencies
 yarn install
 ```

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -9,7 +9,7 @@ i18n utilities for React handling translations, formatting, and more.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-i18n
+yarn add @shopify/react-i18n
 ```
 
 ## Usage

--- a/packages/react-i18n/babel-plugin.md
+++ b/packages/react-i18n/babel-plugin.md
@@ -5,7 +5,7 @@ This package includes a plugin for Babel that auto-fills `useI18n`'s or `withI18
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-i18n
+yarn add @shopify/react-i18n
 ```
 
 ## Usage

--- a/packages/react-idle/README.md
+++ b/packages/react-idle/README.md
@@ -9,7 +9,7 @@ Utilities for working with [idle callbacks](https://developer.mozilla.org/en-US/
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-idle
+yarn add @shopify/react-idle
 ```
 
 ## Usage

--- a/packages/react-import-remote/README.md
+++ b/packages/react-import-remote/README.md
@@ -9,7 +9,7 @@ Asynchronous script loading for React.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-import-remote
+yarn add @shopify/react-import-remote
 ```
 
 ## Usage

--- a/packages/react-intersection-observer/README.md
+++ b/packages/react-intersection-observer/README.md
@@ -9,7 +9,7 @@ A React wrapper around the [Intersection Observer API](https://developer.mozilla
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-intersection-observer
+yarn add @shopify/react-intersection-observer
 ```
 
 ## Usage

--- a/packages/react-network/README.md
+++ b/packages/react-network/README.md
@@ -9,7 +9,7 @@ A collection of components that allow you to set common HTTP headers from within
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-network
+yarn add @shopify/react-network
 ```
 
 ## Usage

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -28,7 +28,7 @@ Primitives to measure your React application's performance using `@shopify/perfo
 First we will need to install the npm package.
 
 ```bash
-$ yarn add @shopify/react-performance
+yarn add @shopify/react-performance
 ```
 
 ### Track some stats

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -9,7 +9,7 @@ A universal router for React, wrapping `react-router-dom`'s `BrowserRouter` and 
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-router
+yarn add @shopify/react-router
 ```
 
 ## Usage

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -18,7 +18,7 @@ A simple library for React server-side rendering using [`@shopify/react-html`](h
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-server
+yarn add @shopify/react-server
 ```
 
 ## Rails Usage

--- a/packages/react-shortcuts/README.md
+++ b/packages/react-shortcuts/README.md
@@ -9,7 +9,7 @@ Declarative and performant library for matching shortcut combinations in React a
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-shortcuts
+yarn add @shopify/react-shortcuts
 ```
 
 ## Usage

--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -31,7 +31,7 @@ A library for testing React components according to Shopify conventions.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-testing
+yarn add @shopify/react-testing
 ```
 
 ## Usage

--- a/packages/react-tracking-pixel/README.md
+++ b/packages/react-tracking-pixel/README.md
@@ -9,7 +9,7 @@ Allows React apps to easily embed tracking pixel iframes.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-tracking-pixel
+yarn add @shopify/react-tracking-pixel
 ```
 
 ## Usage

--- a/packages/react-universal-provider/README.md
+++ b/packages/react-universal-provider/README.md
@@ -15,7 +15,7 @@ Factory function and utilities to create self-serializing/deserializing provider
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-universal-provider
+yarn add @shopify/react-universal-provider
 ```
 
 ## What is a Universal Provider ?

--- a/packages/react-web-worker/README.md
+++ b/packages/react-web-worker/README.md
@@ -9,7 +9,7 @@ A hook for using web workers in React applications.
 ## Installation
 
 ```bash
-$ yarn add @shopify/react-web-worker
+yarn add @shopify/react-web-worker
 ```
 
 ## Usage

--- a/packages/semaphore/README.md
+++ b/packages/semaphore/README.md
@@ -17,7 +17,7 @@ A real-life anology is parking spots at a parking lot. If the parking lot has a 
 ## Installation
 
 ```bash
-$ yarn add @shopify/semaphore
+yarn add @shopify/semaphore
 ```
 
 ## Usage

--- a/packages/sewing-kit-koa/README.md
+++ b/packages/sewing-kit-koa/README.md
@@ -9,7 +9,7 @@ Easily access [sewing-kit](https://github.com/Shopify/sewing-kit) assets from a 
 ## Installation
 
 ```bash
-$ yarn add @shopify/sewing-kit-koa
+yarn add @shopify/sewing-kit-koa
 ```
 
 ## Usage

--- a/packages/statsd/README.md
+++ b/packages/statsd/README.md
@@ -9,7 +9,7 @@ An opinionated StatsD client for Shopify Node.js servers and other StatsD utilit
 ## Installation
 
 ```bash
-$ yarn add @shopify/statsd
+yarn add @shopify/statsd
 ```
 
 ## Usage

--- a/packages/storybook-a11y-test/README.md
+++ b/packages/storybook-a11y-test/README.md
@@ -9,7 +9,7 @@ Test [Storybook](https://storybook.js.org/) stories with [axe®](https://github.
 Add this package to your project’s development dependencies.
 
 ```bash
-$ yarn add @shopify/storybook-a11y-test --dev
+yarn add @shopify/storybook-a11y-test --dev
 ```
 
 This assumes you’ve installed and set up the [Storybook accessibility addon](https://www.npmjs.com/package/@storybook/addon-a11y).

--- a/packages/useful-types/README.md
+++ b/packages/useful-types/README.md
@@ -9,7 +9,7 @@ A few handy TypeScript types.
 ## Installation
 
 ```bash
-$ yarn add @shopify/useful-types
+yarn add @shopify/useful-types
 ```
 
 ## Usage

--- a/packages/web-worker/README.md
+++ b/packages/web-worker/README.md
@@ -9,7 +9,7 @@ Tools for making [web workers](https://developer.mozilla.org/en-US/docs/Web/API/
 ## Installation
 
 ```bash
-$ yarn add @shopify/web-worker
+yarn add @shopify/web-worker
 ```
 
 ## Usage

--- a/packages/with-env/README.md
+++ b/packages/with-env/README.md
@@ -9,13 +9,13 @@ A utility for executing code under a specific `NODE_ENV`.
 ## Installation
 
 ```bash
-$ yarn add @shopify/with-env
+yarn add @shopify/with-env
 ```
 
 Or, if you just need this for `test`s:
 
 ```bash
-$ yarn add --dev @shopify/with-env
+yarn add --dev @shopify/with-env
 ```
 
 ## Example Usage

--- a/templates/README.hbs.md
+++ b/templates/README.hbs.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-$ yarn add @shopify/{{name}}
+yarn add @shopify/{{name}}
 ```
 
 ## Usage


### PR DESCRIPTION
## Description

Remove `$` prefix in terminal example codeblocks to improve copy+pasting.

Supersedes and closes #2474