### PR TITLE
Improve error handling of missing GraphQL mocks

### DIFF
--- a/.changeset/orange-walls-cross.md
+++ b/.changeset/orange-walls-cross.md
@@ -1,0 +1,7 @@
+---
+'@shopify/graphql-testing': minor
+---
+
+Improve error that is thrown when you test a GraphQL operation that has not been mocked. It now details what mock was absent.
+
+Calling `createGraphQL()` with no argument now results in the operation returning a NetworkError. This makes it consistent with the error that results from `createGraphQL({})`.

--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -1,4 +1,4 @@
-import {ApolloLink, GraphQLRequest} from 'apollo-link';
+import {ApolloLink} from 'apollo-link';
 import {
   InMemoryCache,
   IntrospectionFragmentMatcher,
@@ -32,7 +32,7 @@ export class GraphQL {
   private readonly mockLink: MockLink | null = null;
 
   constructor(
-    mock: GraphQLMock | undefined,
+    mock: GraphQLMock = {},
     {
       unionOrIntersectionTypes = [],
       cacheOptions = {},
@@ -51,7 +51,7 @@ export class GraphQL {
       ...cacheOptions,
     });
 
-    this.mockLink = new MockLink(mock || defaultGraphQLMock);
+    this.mockLink = new MockLink(mock);
     const link = ApolloLink.from([
       ...links,
       new InflightLink({
@@ -108,12 +108,4 @@ export class GraphQL {
     this.operations.push(request.operation);
     this.pendingRequests.delete(request);
   };
-}
-
-function defaultGraphQLMock({operationName}: GraphQLRequest) {
-  return new Error(
-    `Can’t perform GraphQL operation '${
-      operationName || ''
-    }' because no mocks were set.`,
-  );
 }

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -37,24 +37,28 @@ export class MockLink extends ApolloLink {
 
         if (typeof mock === 'object') {
           const operationNames = Object.keys(mock);
+          const hasOperations = operationNames.length > 0;
           // We will provide a more helpful message when it looks like they just provided data,
           // not an object mapping names to fixtures.
-          const looksLikeDataNotFixtures = operationNames.every(
-            (name) => name === name.toLowerCase(),
-          );
+          const looksLikeDataNotFixtures =
+            hasOperations &&
+            operationNames.every((name) => name === name.toLowerCase());
 
-          message += looksLikeDataNotFixtures
-            ? ` (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({${operationName}: yourFixture}).'`
-            : ` (you provided an object that had mocks only for the following operations: ${Object.keys(
-                mock,
-              ).join(', ')}).`;
+          if (looksLikeDataNotFixtures) {
+            message += ` (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, change your code to read 'mockGraphQLClient({${operationName}: yourFixture})'`;
+          } else if (hasOperations) {
+            const operationList = Object.keys(mock).join(', ');
+            message += ` (you provided an object that had mocks only for the following operations: ${operationList})`;
+          } else {
+            message += ` (you provided an empty object that contained no mocks)`;
+          }
         } else {
           message +=
             ' (you provided a function that did not return a valid mock result)';
         }
 
-        const error = new Error(message);
-        result = error;
+        obs.error(new Error(message));
+        return;
       } else if (response instanceof GraphQLError) {
         result = {
           errors: [response],

--- a/packages/graphql-testing/src/links/tests/mocks.test.ts
+++ b/packages/graphql-testing/src/links/tests/mocks.test.ts
@@ -39,23 +39,23 @@ describe('MockLink', () => {
   });
 
   it('returns an error message when the mock looks like a fixture', async () => {
-    const link = new MockLink({});
-    const {result} = await executeOnce(link, petQuery);
+    const link = new MockLink({name: 'Spike'});
+    const {error} = await executeOnce(link, petQuery);
 
-    expect(result).toMatchObject(
+    expect(error).toMatchObject(
       new Error(
-        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, simply change your code to read 'mockGraphQLClient({Pet: yourFixture}).'",
+        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, change your code to read 'mockGraphQLClient({Pet: yourFixture})'",
       ),
     );
   });
 
   it('returns an error message when there are no matching mocks', async () => {
     const link = new MockLink({LostPets: {}, PetsForSale: {}});
-    const {result} = await executeOnce(link, petQuery);
+    const {error} = await executeOnce(link, petQuery);
 
-    expect(result).toMatchObject(
+    expect(error).toMatchObject(
       new Error(
-        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale).",
+        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided an object that had mocks only for the following operations: LostPets, PetsForSale)",
       ),
     );
   });
@@ -63,9 +63,9 @@ describe('MockLink', () => {
   it('returns an error message when no fixture is returned from a mock', async () => {
     const link = new MockLink(() => null as unknown as MockGraphQLResponse);
 
-    const {result} = await executeOnce(link, petQuery);
+    const {error} = await executeOnce(link, petQuery);
 
-    expect(result).toMatchObject(
+    expect(error).toMatchObject(
       new Error(
         "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided a function that did not return a valid mock result)",
       ),

--- a/packages/graphql-testing/src/tests/e2e.test.tsx
+++ b/packages/graphql-testing/src/tests/e2e.test.tsx
@@ -173,7 +173,7 @@ describe('graphql-testing', () => {
     );
   });
 
-  it('resolves to a GraphQLError when there are no mocks set', async () => {
+  it('resolves to a NetworkError when there are no mocks set', async () => {
     const graphQL = createGraphQL();
 
     const myComponent = mount(
@@ -190,12 +190,10 @@ describe('graphql-testing', () => {
 
     expect(queryResult.error).toStrictEqual(
       new ApolloError({
-        graphQLErrors: [
-          new GraphQLError(
-            "Can’t perform GraphQL operation 'Pet' because no mocks were set.",
-          ),
-        ],
-        networkError: null,
+        graphQLErrors: [],
+        networkError: new Error(
+          "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided an empty object that contained no mocks)",
+        ),
       }),
     );
   });
@@ -220,19 +218,12 @@ describe('graphql-testing', () => {
     expect(graphQL).toHavePerformedGraphQLOperation(petQuery);
     const queryResult = myComponent.find(ApolloResult)!.prop('result');
 
-    // Can't use toStrictEqual(new ApolloError(...)) here because we can't
-    // reproduce the exact error message as it is a giant string
-    expect(queryResult.error).toBeInstanceOf(ApolloError);
-    expect(queryResult.error?.networkError).toBeInstanceOf(Error);
-
-    expect(queryResult.error!).toStrictEqual(
-      expect.objectContaining({
+    expect(queryResult.error).toStrictEqual(
+      new ApolloError({
         graphQLErrors: [],
-        networkError: expect.objectContaining({
-          message: expect.stringMatching(
-            /^Error writing result to store for query/,
-          ),
-        }),
+        networkError: new Error(
+          "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (you provided an object that had mocks only for the following operations: Pets)",
+        ),
       }),
     );
   });


### PR DESCRIPTION
## Description

We had some error handling code in graphql-fixtures that describes what mocks you ommited, but it never got raised correctly. This PR fixes that behaviour, and ensures consistency between Apollo2 and Apollo3 behaviour.

- When you omit a mock for a operation that is required by the test the operation responds with a NetworkError that shows what mocks were omitted
- `createGraphQL()` now responds with a NetworkError, to match the behaviour of `createGraphQL({})`
