### PR TITLE
Disable manifest caching in development

### DIFF
--- a/.changeset/sour-cycles-tickle.md
+++ b/.changeset/sour-cycles-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/sewing-kit-koa': minor
+---
+
+Allow consumers to disable manifest caching (useful in development).

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -12,6 +12,7 @@ interface Options {
   assetPrefix: string;
   userAgent?: string;
   manifestPath?: string;
+  caching?: boolean;
 }
 
 interface AssetSelector {
@@ -37,10 +38,10 @@ export default class Assets {
   private manifests: Manifests;
   private resolvedManifestEntry?: Manifest;
 
-  constructor({assetPrefix, userAgent, manifestPath}: Options) {
+  constructor({assetPrefix, userAgent, manifestPath, caching = true}: Options) {
     this.assetPrefix = assetPrefix;
     this.userAgent = userAgent;
-    this.manifests = new Manifests(manifestPath);
+    this.manifests = new Manifests(manifestPath, caching);
   }
 
   async scripts(options: AssetOptions = {}) {

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -17,6 +17,7 @@ export interface Options {
   assetPrefix?: string;
   serveAssets?: boolean;
   manifestPath?: string;
+  caching?: boolean;
 }
 
 const ASSETS = Symbol('assets');
@@ -33,12 +34,14 @@ export default function middleware({
   serveAssets = false,
   assetPrefix = defaultAssetPrefix(serveAssets),
   manifestPath,
+  caching = true,
 }: Options = {}): Middleware {
   async function sewingKitMiddleware(ctx: Context, next: () => Promise<any>) {
     const assets = new Assets({
       assetPrefix,
       userAgent: ctx.get(Header.UserAgent),
       manifestPath,
+      caching,
     });
 
     setAssets(ctx, assets);

--- a/packages/sewing-kit-koa/src/tests/manifests-read.test.ts
+++ b/packages/sewing-kit-koa/src/tests/manifests-read.test.ts
@@ -85,6 +85,17 @@ describe('Manifests read', () => {
     expect(readJson).toHaveBeenCalledTimes(1);
   });
 
+  it('reads manifests multiple times when caching is disabled', async () => {
+    const path = null;
+    const caching = false;
+    const manifests = new Manifests(path, caching);
+
+    await manifests.resolve('Chrome 71');
+    await manifests.resolve('Chrome 73');
+
+    expect(readJson).toHaveBeenCalledTimes(2);
+  });
+
   it('reads manifests from a custom path', async () => {
     const manifestPath = 'path/to/manifest';
     const manifests = new Manifests(manifestPath);

--- a/packages/sewing-kit-koa/src/tests/middleware.test.ts
+++ b/packages/sewing-kit-koa/src/tests/middleware.test.ts
@@ -54,7 +54,16 @@ describe('middleware', () => {
     const context = createMockContext();
     const manifestPath = 'path/to/manifest';
     await middleware({manifestPath})(context, () => Promise.resolve());
-    expect(Manifests).toHaveBeenCalledWith(manifestPath);
+    expect(Manifests).toHaveBeenCalledWith(manifestPath, true);
+  });
+
+  it('disable caching manifest', async () => {
+    const context = createMockContext();
+    const manifestPath = 'path/to/manifest';
+    await middleware({manifestPath, caching: false})(context, () =>
+      Promise.resolve(),
+    );
+    expect(Manifests).toHaveBeenCalledWith(manifestPath, false);
   });
 
   it('calls the next middleware', async () => {


### PR DESCRIPTION
## Description
This PR fixes an issue when sewing-kit only recompiles the client's assets, the manifest is cached on the server and the developer faced a script integrity issue because the new manifest file is not reloaded.

This PR adds a new option to disable the cache. This option should only be used in development.