### PR TITLE
Deliberatly cause a NetworkError if we see a misconfigured fixture

### DIFF
--- a/.changeset/three-weeks-vanish.md
+++ b/.changeset/three-weeks-vanish.md
@@ -1,0 +1,5 @@
+---
+'@shopify/graphql-testing': minor
+---
+
+Deliberatly cause a `NetworkError` with a useful error message if we see a fixture that is a function that returns a function. This can happen if you do `createGraphQL({MyQuery: () => fillGraphQL(MyQuery)})` because fillGraphQL returns a function. Apollo 2 already returns a `NetworkError` if you do this but as it happens later on, the error message was much less helpful.

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -32,7 +32,7 @@ export class MockLink extends ApolloLink {
 
       let result: ExecutionResult | Error;
 
-      if (response == null) {
+      if (response == null || typeof response === 'function') {
         let message = `Can’t perform GraphQL operation '${operationName}' because no valid mocks were found`;
 
         if (typeof mock === 'object') {
@@ -44,7 +44,10 @@ export class MockLink extends ApolloLink {
             hasOperations &&
             operationNames.every((name) => name === name.toLowerCase());
 
-          if (looksLikeDataNotFixtures) {
+          if (typeof response === 'function') {
+            message +=
+              ' (it looks like you tried to provide a function that returned a function, but the mock should be either an object or a function that retuns an object)';
+          } else if (looksLikeDataNotFixtures) {
             message += ` (it looks like you tried to provide data directly to the mock GraphQL client. You need to provide your fixture on the key that matches its operation name. To fix this, change your code to read 'mockGraphQLClient({${operationName}: yourFixture})'`;
           } else if (hasOperations) {
             const operationList = Object.keys(mock).join(', ');

--- a/packages/graphql-testing/src/links/tests/mocks.test.ts
+++ b/packages/graphql-testing/src/links/tests/mocks.test.ts
@@ -38,7 +38,7 @@ describe('MockLink', () => {
     );
   });
 
-  it('returns an error message when the mock looks like a fixture', async () => {
+  it('returns an error when the mock looks like a fixture', async () => {
     const link = new MockLink({name: 'Spike'});
     const {error} = await executeOnce(link, petQuery);
 
@@ -49,7 +49,7 @@ describe('MockLink', () => {
     );
   });
 
-  it('returns an error message when there are no matching mocks', async () => {
+  it('returns an error when there are no matching mocks', async () => {
     const link = new MockLink({LostPets: {}, PetsForSale: {}});
     const {error} = await executeOnce(link, petQuery);
 
@@ -60,7 +60,7 @@ describe('MockLink', () => {
     );
   });
 
-  it('returns an error message when no fixture is returned from a mock', async () => {
+  it('returns an error when no fixture is returned from a mock', async () => {
     const link = new MockLink(() => null as unknown as MockGraphQLResponse);
 
     const {error} = await executeOnce(link, petQuery);
@@ -72,7 +72,20 @@ describe('MockLink', () => {
     );
   });
 
-  it('returns a GraphQLError when there is a GraphQLError matching an operation', async () => {
+  it('returns an error when the fixture returns a function', async () => {
+    const data = {pets: [{name: 'Spike'}]};
+    const link = new MockLink({Pet: () => () => data});
+
+    const {error} = await executeOnce(link, petQuery);
+
+    expect(error).toMatchObject(
+      new Error(
+        "Can’t perform GraphQL operation 'Pet' because no valid mocks were found (it looks like you tried to provide a function that returned a function, but the mock should be either an object or a function that retuns an object)",
+      ),
+    );
+  });
+
+  it('returns a result containing a GraphQLError when there is a GraphQLError matching an operation', async () => {
     const error = new GraphQLError(
       'error message',
       undefined,
@@ -88,7 +101,7 @@ describe('MockLink', () => {
     expect(result).toMatchObject({errors: [error]});
   });
 
-  it('returns a GraphQLError with the message from an Error matching an operation', async () => {
+  it('returns a result containing a GraphQLError with the message from an Error matching an operation', async () => {
     const error = new Error('error message');
     const link = new MockLink({
       Pet: error,


### PR DESCRIPTION
## Description

If you misconfigure a fixture so that the fixture is a function that returns a function we now throw a NetworkError with a helpful error message.  This can happen if you try to do `createGraphQL({MyQuery: () => fillGraphQL(MyQuery)})` because fillGraphQL returns a function.

Currently in Apollo 2 this already results in a NetworkError, but as it happens later on, it doesn't highlight the users's error when configuring the fixture. In Apollo 3 this does not result in a NetworkError and thus leads to obtuse test failures.

As a user has misconfigured the fixture I think a NetworkError is the correct response.


