### PR TITLE
[statsd] Fixing an issue with the order of prefix concatenation for child client.

### DIFF
--- a/.changeset/curvy-flies-fry.md
+++ b/.changeset/curvy-flies-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/statsd': patch
+---
+
+When using a child client concatenation of prefixes is now ordered as `ParentPrefix.ChildPrefix`, which is a more generally desired behaviour. Previously this was `ChildPrefix.ParentPrefix`.

--- a/packages/statsd/README.md
+++ b/packages/statsd/README.md
@@ -25,6 +25,7 @@ const statsdClient = new StatsDClient({
   host: 'some-statsd-host.com',
   port: '8125',
   prefix: 'AppName',
+  suffix: 'AppSuffix',
   globalTags: {hello: 'world'},
 });
 ```
@@ -89,14 +90,14 @@ statsdClient.close();
 
 Create a child client and add more context to the client.
 The globalTags will be merged.
-The prefix and suffix will be concatenate using the `.` separator.
+The prefix and suffix will be concatenated like in this example.
 
 ```javascript
 statsdClient.childClient({
-  prefix: 'MyPrefix',
-  suffix: 'MySuffix',
+  prefix: 'NewPrefix.',
+  suffix: '.NewSuffix',
   globalTags: {foo: 'bar'},
 });
 ```
 
-In this example the prefix will be `AppName.NewPrefix`, the suffix will be `MySuffix` and the globalTags will be `{hello: 'world', foo: 'bar'}`.
+In this example the prefix will be `NewPrefix.AppName.`, the suffix will be `AppSuffix.NewSuffix` and the globalTags will be `{hello: 'world', foo: 'bar'}`.

--- a/packages/statsd/README.md
+++ b/packages/statsd/README.md
@@ -94,10 +94,10 @@ The prefix and suffix will be concatenated like in this example.
 
 ```javascript
 statsdClient.childClient({
-  prefix: 'NewPrefix.',
+  prefix: '.NewPrefix',
   suffix: '.NewSuffix',
   globalTags: {foo: 'bar'},
 });
 ```
 
-In this example the prefix will be `NewPrefix.AppName.`, the suffix will be `AppSuffix.NewSuffix` and the globalTags will be `{hello: 'world', foo: 'bar'}`.
+In this example the prefix will be `AppName.NewPrefix`, the suffix will be `AppSuffix.NewSuffix` and the globalTags will be `{hello: 'world', foo: 'bar'}`.

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -34,10 +34,19 @@ export class StatsDClient {
 
   constructor(options: Options) {
     if (isChildOptions(options)) {
-      const {client, ...childOptions} = options;
+      const {client, prefix, ...childOptions} = options;
       this.logger = client.logger;
       this.options = {...client.options, ...childOptions};
       this.statsd = client.statsd.childClient(childOptions);
+
+      if (prefix) {
+        // The concatenation of the prefix in the library is the inverse of what we want.
+        // The library concatenates the prefix like that: <ChildPrefix><ParentPrefix>
+        // but in most case we want to concatenate like this: <ParentPrefix><ChildPrefix>
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        this.statsd.prefix = `${this.statsd.prefix}${prefix}`;
+      }
       return;
     }
 

--- a/packages/statsd/src/tests/client.test.ts
+++ b/packages/statsd/src/tests/client.test.ts
@@ -13,7 +13,8 @@ describe('StatsDClient', () => {
   const defaultOptions = {
     host: 'localhost',
     port: 1234,
-    prefix: 'MyModule',
+    prefix: 'MyPrefix',
+    suffix: 'MySuffix',
     globalTags: {
       aaa: 'A',
     },
@@ -376,17 +377,36 @@ describe('StatsDClient', () => {
   describe('childClient', () => {
     it('uses the same StatsD client', () => {
       const options = {
-        prefix: 'ChildClientPrefix',
-        suffix: 'ChildClientSuffix',
+        prefix: '.ChildClientPrefix',
+        suffix: '.ChildClientSuffix',
         globalTags: {new: 'tag'},
       };
+
       const statsDClient = new StatsDClient(defaultOptions);
       const stats = StatsDMock.mock.instances[0];
 
+      let childClient;
+      let parentClient;
+      jest.spyOn(stats, 'childClient').mockImplementationOnce((...options) => {
+        const StatsD = jest.requireActual('hot-shots').StatsD;
+        parentClient = new StatsD(defaultOptions);
+        jest.spyOn(parentClient, 'childClient');
+        childClient = parentClient.childClient(...options);
+        return childClient;
+      });
+
       statsDClient.childClient(options);
 
-      expect(StatsDMock.mock.instances).toHaveLength(1);
-      expect(stats.childClient).toHaveBeenCalledWith(options);
+      expect(parentClient.childClient).toHaveBeenCalledWith({
+        suffix: options.suffix,
+        globalTags: options.globalTags,
+      });
+      expect(childClient.prefix).toBe(
+        `${defaultOptions.prefix}${options.prefix}`,
+      );
+      expect(childClient.suffix).toBe(
+        `${defaultOptions.suffix}${options.suffix}`,
+      );
     });
   });
 });


### PR DESCRIPTION
## Description
The prefix concatenation of `hot-shots` follow this logic for child client:
`<ChildPrefix><ParentPrefix>` and this is not what we want. Usually, consumer will define a base statsD client with the name of the app as prefix and every child will add a branch to this prefix for example: `MyApp.Client.<stat>` 