### PR TITLE
[react-graphql] Add warn message when request payload is empty

### DIFF
--- a/.changeset/ten-parrots-prove.md
+++ b/.changeset/ten-parrots-prove.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-graphql': minor
+---
+
+Add warn message when request payload is empty

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -7,6 +7,7 @@ import {
   ApolloError,
   WatchQueryOptions,
   ObservableQuery,
+  NetworkStatus,
 } from 'apollo-client';
 import isEqual from 'fast-deep-equal';
 import {DocumentNode} from 'graphql-typed';
@@ -218,6 +219,15 @@ export default function useQuery<
           : undefined;
     } else if (hasError) {
       data = (queryObservable.getLastResult() || {}).data;
+    } else if (
+      result.data?.constructor === Object &&
+      Object.keys(result.data).length === 0 &&
+      result.networkStatus === NetworkStatus.ready
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The response payload was an empty object. This can happen if all your fields are conditional and they are all omitted',
+      );
     } else if (
       fetchPolicy === 'no-cache' &&
       (!result.data || Object.keys(result.data).length === 0)


### PR DESCRIPTION
## Description

During the [migration of Apollo 2 to Apollo 3 in Web](https://vault.shopify.io/gsd/projects/24323) the team discovered that when a request payload is empty the data response will be different between v2 and v3. On Apollo v2 `data` is returned as an empty object, whereas on v3 it returns as `undefined`, which may cause problems on the consumer if they rely on the value of `data` to be an object after the network request is resolved e.g. `data === undefined` => loading state.

From our exploration we determined that the main reason why a request would be empty is when using the `@include` directive (see [more here](https://www.apollographql.com/docs/apollo-server/schema/directives/#default-directives)). If the argument passed to it is false, and no other field is being requested, the request payload will be just an empty object. For example:

```graphql
query PetQuery($includePets: Boolean! = true) {
  pets @include(if: $includePets) {
    name
  }
}
```

This PR adds a warning message for those cases in order to allow Web to determine early on what unit tests have this issue at the moment so we can address them. This bit of code can be removed once the Apollo 3 migration is complete since `data` being `undefined` will be the expected behaviour for it going forward.