### PR TITLE
Update currency formatting to support ar-EG and other Arabic locales

### DIFF
--- a/.changeset/six-rice-rhyme.md
+++ b/.changeset/six-rice-rhyme.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/react-i18n': patch
+'@shopify/react-i18n': minor
 ---
 
-Support currency formatting for `ar-EG` and other Arabic locales.
+Improve currency formatting by enforcing latin number formatting and preserving negative sign and directional control characters.

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -216,3 +216,5 @@ export const CurrencyShortFormException = {
   BRL: 'R$',
   HKD: 'HK$',
 } as const;
+
+export const DIRECTION_CONTROL_CHARACTERS = '\\p{Cf}';

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -895,8 +895,9 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'OMR'} | ${'1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${'1 234,56 $ USD'}
       ${'fr-FR'} | ${'CAD'} | ${'1 234,56 $'}
-      ${'ar-EG'} | ${'CAD'} | ${'١٬٢٣٤٫٥٦ $'}
-      ${'ar-EG'} | ${'USD'} | ${'١٬٢٣٤٫٥٦ $ USD'}
+      ${'ar-EG'} | ${'CAD'} | ${'$ 1,234.56'}
+      ${'ar-EG'} | ${'USD'} | ${'$ 1,234.56 USD'}
+      ${'he-IL'} | ${'USD'} | ${'1,234.56 $ USD'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -929,6 +930,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'1 235 ¥ JPY'}
       ${'fr-FR'} | ${'OMR'} | ${'1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${'1 234,56 $ USD'}
+      ${'ar-EG'} | ${'USD'} | ${'$ 1,234.56 USD'}
+      ${'he-IL'} | ${'USD'} | ${'1,234.56 $ USD'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -961,6 +964,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'-1 235 ¥ JPY'}
       ${'fr-FR'} | ${'OMR'} | ${'-1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${'-1 234,56 $ USD'}
+      ${'ar-EG'} | ${'USD'} | ${'\u200E-$ 1,234.56 USD'}
+      ${'he-IL'} | ${'USD'} | ${'\u200E-1,234.56 $ USD'}
     `(
       'formats -1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -992,6 +997,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'1 235'}
       ${'fr-FR'} | ${'OMR'} | ${'1 234,560'}
       ${'fr-FR'} | ${'USD'} | ${'1 234,56'}
+      ${'ar-EG'} | ${'USD'} | ${'1,234.56'}
+      ${'he-IL'} | ${'USD'} | ${'1,234.56'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -1023,6 +1030,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'-1 235'}
       ${'fr-FR'} | ${'OMR'} | ${'-1 234,560'}
       ${'fr-FR'} | ${'USD'} | ${'-1 234,56'}
+      ${'ar-EG'} | ${'USD'} | ${'\u200E-1,234.56'}
+      ${'he-IL'} | ${'USD'} | ${'\u200E-1,234.56'}
     `(
       'formats -1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -1057,6 +1066,7 @@ describe('I18n', () => {
       ${'sv-SE'} | ${'USD'} | ${'1 234,56 $'}
       ${'en-US'} | ${'SGD'} | ${'$1,234.56'}
       ${'fr-FR'} | ${'SGD'} | ${'1 234,56 $'}
+      ${'ar-EG'} | ${'USD'} | ${'$ 1,234.56'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -1085,9 +1095,11 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'-1 235 ¥'}
       ${'fr-FR'} | ${'OMR'} | ${'-1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${'-1 234,56 $'}
-      ${'sv-SE'} | ${'USD'} | ${'-1 234,56 $'}
+      ${'sv-SE'} | ${'USD'} | ${'\u22121 234,56 $'}
       ${'en-US'} | ${'SGD'} | ${'-$1,234.56'}
       ${'fr-FR'} | ${'SGD'} | ${'-1 234,56 $'}
+      ${'ar-EG'} | ${'USD'} | ${'\u200E-$ 1,234.56'}
+      ${'he-IL'} | ${'USD'} | ${'\u200E-1,234.56 $'}
     `(
       'formats -1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -1314,6 +1326,30 @@ describe('I18n', () => {
           });
           expect(i18n.unformatCurrency('123,9999', 'JOD')).toBe('124.000');
           expect(i18n.unformatCurrency('123,4567', 'JOD')).toBe('123.457');
+        });
+      });
+
+      describe('sv-SE locale', () => {
+        it('unformats currency with non-standard negative sign', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'sv-SE',
+          });
+          expect(i18n.unformatCurrency('\u22121 234,56 $', 'USD')).toBe(
+            '-1234.56',
+          );
+        });
+      });
+
+      describe('he-IL locale', () => {
+        it('unformats currency with direction control characters and whitespace before negative sign', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'he-IL',
+          });
+          expect(i18n.unformatCurrency(' \u200E-1,234.56 $ USD', 'USD')).toBe(
+            '-1234.56',
+          );
         });
       });
 

--- a/packages/react-i18n/src/utilities/money.ts
+++ b/packages/react-i18n/src/utilities/money.ts
@@ -1,20 +1,15 @@
+import {DIRECTION_CONTROL_CHARACTERS} from '../constants';
+
 import {memoizedNumberFormatter} from './translate';
 
 export function getCurrencySymbol(
   locale: string,
   options: Intl.NumberFormatOptions,
 ) {
-  const delimiters = ',.٫';
-  const numerals = '0٠';
-  const directionControlCharacters = /[\u200E\u200F]/;
-  const numReg = new RegExp(`[${numerals}][${delimiters}]*[${numerals}]*`);
-
   const currencyStringRaw = formatCurrency(0, locale, options);
-  const currencyString = currencyStringRaw.replace(
-    directionControlCharacters,
-    '',
-  );
-  const matchResult = numReg.exec(currencyString);
+  const controlChars = new RegExp(`[${DIRECTION_CONTROL_CHARACTERS}]*`, 'gu');
+  const currencyString = currencyStringRaw.replace(controlChars, '');
+  const matchResult = /\p{Nd}\p{Po}*\p{Nd}*/gu.exec(currencyString);
   if (!matchResult) {
     throw new Error(
       `Number input in locale ${locale} is currently not supported.`,

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -26,13 +26,28 @@ export function memoizedNumberFormatter(
   locales?: string | string[],
   options?: Intl.NumberFormatOptions,
 ) {
-  const key = numberFormatCacheKey(locales, options);
+  // force a latin locale for number formatting
+  const latnLocales = latinLocales(locales);
+  const key = numberFormatCacheKey(latnLocales, options);
   if (numberFormats.has(key)) {
     return numberFormats.get(key)!;
   }
-  const i = new Intl.NumberFormat(locales, options);
+  const i = new Intl.NumberFormat(latnLocales, options);
   numberFormats.set(key, i);
   return i;
+}
+
+function latinLocales(locales?: string | string[]) {
+  return Array.isArray(locales)
+    ? locales.map((locale) => latinLocale(locale)!)
+    : latinLocale(locales);
+}
+
+function latinLocale(locale?: string) {
+  if (!locale) return locale;
+  return new Intl.Locale(locale, {
+    numberingSystem: 'latn',
+  }).toString();
 }
 
 export const PSEUDOTRANSLATE_OPTIONS: PseudotranslateOptions = {


### PR DESCRIPTION
## Description

Fixes (https://github.com/Shopify/quilt/issues/2497).

Adds currency formatting support for `ar-EG` and other Arabic locales.

In `react-i18n`, `getCurrencySymbol` relies on calling [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) with the value `0`, and uses regular expressions to parse the currency symbol and position.

This is the result when I call Intl.NumberFormat with `ar-EG` vs. `ar`:
```js
console.log(new Intl.NumberFormat('ar-EG', { style: 'currency', currency: 'USD' }).format(number));
// output: "٠٫٠٠ US$"

console.log(new Intl.NumberFormat('ar', { style: 'currency', currency: 'USD' }).format(number));
// output: "US$ 0.00"
```

In Egyptian Arabic, the output is `٠٫٠٠ US$`, which doesn't match the regular expression, which is why it's throwing the exception it is.

This pull request expanded the regular expression to:
- treat `٠` and `0` like numerals
- treat `,`, `.`, and `٫` like delimiters

This will specifically solve the `ar-EG` use case, and any other locale that uses `٠` to represent `0`.