### PR TITLE
Improve currency formatting to better support `ar-EG` and similar locales

### DIFF
--- a/.changeset/six-rice-rhyme.md
+++ b/.changeset/six-rice-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-i18n': minor
+---
+
+Improve currency formatting by enforcing latin number formatting and preserving negative sign and directional control characters.

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -126,9 +126,9 @@ export default withI18n()(NotFound);
 
 The provided `i18n` object exposes many useful methods for internationalizing your apps. You can see the full details in the [`i18n` source file](https://github.com/Shopify/quilt/blob/main/packages/react-i18n/src/i18n.ts), but you will commonly need the following:
 
-- `formatNumber()`: formats a number according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `I18nContext.Provider` component will be used where no custom currency code is passed.
+- `formatNumber()`: formats a number in the latin numbering system according to the locale. You can optionally pass an `as` option to format the number as a currency or percentage; in the case of currency, the `defaultCurrency` supplied to the i18n `I18nContext.Provider` component will be used where no custom currency code is passed.
 - `unformatNumber()`: converts a localized number string to a number string parseable by JavaScript. Example: `123.456,45 => 123456.45`
-- `formatCurrency()`: formats a number as a currency according to the locale. Its behaviour depends on the `form:` option.
+- `formatCurrency()`: formats a number as a currency in the latin numbering system according to the locale. Its behaviour depends on the `form:` option.
   - if `form: 'short'` is given, then a possibly-ambiguous short form is used, consisting of the bare symbol if the currency has a symbol, or the ISO 4217 code if there is no symbol for that currency. Examples: `CHF 1.25`, `€1.25`, `OMR 1.250`, `$1.25`
   - if `form: 'none'` is given, the number will be formatted with currency rules but will not include a currency symbol or ISO code in the string. Examples: `1,234.56`, `1 234,56`
   - if `form: 'explicit'` is given, then the result will be the same as for `short`, but will append the ISO 4217 code if it is not already present

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -216,3 +216,5 @@ export const CurrencyShortFormException = {
   BRL: 'R$',
   HKD: 'HK$',
 } as const;
+
+export const DIRECTION_CONTROL_CHARACTERS = '\\p{Cf}';

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -875,6 +875,44 @@ describe('I18n', () => {
     });
   });
 
+  describe('#formatCurrency() form:auto', () => {
+    it.each`
+      locale     | currency | expected
+      ${'cs-CZ'} | ${'CZK'} | ${'1 234,56 Kč CZK'}
+      ${'de-AT'} | ${'EUR'} | ${'€ 1 234,56 EUR'}
+      ${'de-AT'} | ${'JPY'} | ${'¥ 1 235 JPY'}
+      ${'de-AT'} | ${'OMR'} | ${'OMR 1 234,560'}
+      ${'de-AT'} | ${'USD'} | ${'$ 1 234,56 USD'}
+      ${'de-AT'} | ${'CAD'} | ${'$ 1 234,56'}
+      ${'en-AU'} | ${'AUD'} | ${'$1,234.56 AUD'}
+      ${'en-US'} | ${'EUR'} | ${'€1,234.56 EUR'}
+      ${'en-US'} | ${'JPY'} | ${'¥1,235 JPY'}
+      ${'en-US'} | ${'OMR'} | ${'OMR 1,234.560'}
+      ${'en-US'} | ${'USD'} | ${'$1,234.56 USD'}
+      ${'en-US'} | ${'CAD'} | ${'$1,234.56'}
+      ${'fr-FR'} | ${'EUR'} | ${'1 234,56 € EUR'}
+      ${'fr-FR'} | ${'JPY'} | ${'1 235 ¥ JPY'}
+      ${'fr-FR'} | ${'OMR'} | ${'1 234,560 OMR'}
+      ${'fr-FR'} | ${'USD'} | ${'1 234,56 $ USD'}
+      ${'fr-FR'} | ${'CAD'} | ${'1 234,56 $'}
+      ${'ar-EG'} | ${'CAD'} | ${'$ 1,234.56'}
+      ${'ar-EG'} | ${'USD'} | ${'$ 1,234.56 USD'}
+      ${'he-IL'} | ${'USD'} | ${'1,234.56 $ USD'}
+    `(
+      'formats 1234.56 of $currency in $locale to expected $expected',
+      ({locale, currency, expected}) => {
+        const amount = 1234.56;
+
+        const i18n = new I18n(defaultTranslations, {locale, currency: 'CAD'});
+        const result = i18n.formatCurrency(amount, {
+          form: 'auto',
+          currency,
+        });
+        expect(sanitizeSpaces(result)).toBe(expected);
+      },
+    );
+  });
+
   describe('#formatCurrency() form:explicit', () => {
     it.each`
       locale     | currency | expected
@@ -892,6 +930,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'1 235 ¥ JPY'}
       ${'fr-FR'} | ${'OMR'} | ${'1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${'1 234,56 $ USD'}
+      ${'ar-EG'} | ${'USD'} | ${'$ 1,234.56 USD'}
+      ${'he-IL'} | ${'USD'} | ${'1,234.56 $ USD'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -924,6 +964,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'-1 235 ¥ JPY'}
       ${'fr-FR'} | ${'OMR'} | ${'-1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${'-1 234,56 $ USD'}
+      ${'ar-EG'} | ${'USD'} | ${'\u200E-$ 1,234.56 USD'}
+      ${'he-IL'} | ${'USD'} | ${'\u200E-1,234.56 $ USD'}
     `(
       'formats -1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -955,6 +997,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'1 235'}
       ${'fr-FR'} | ${'OMR'} | ${'1 234,560'}
       ${'fr-FR'} | ${'USD'} | ${'1 234,56'}
+      ${'ar-EG'} | ${'USD'} | ${'1,234.56'}
+      ${'he-IL'} | ${'USD'} | ${'1,234.56'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -986,6 +1030,8 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'-1 235'}
       ${'fr-FR'} | ${'OMR'} | ${'-1 234,560'}
       ${'fr-FR'} | ${'USD'} | ${'-1 234,56'}
+      ${'ar-EG'} | ${'USD'} | ${'\u200E-1,234.56'}
+      ${'he-IL'} | ${'USD'} | ${'\u200E-1,234.56'}
     `(
       'formats -1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -1020,6 +1066,7 @@ describe('I18n', () => {
       ${'sv-SE'} | ${'USD'} | ${'1 234,56 $'}
       ${'en-US'} | ${'SGD'} | ${'$1,234.56'}
       ${'fr-FR'} | ${'SGD'} | ${'1 234,56 $'}
+      ${'ar-EG'} | ${'USD'} | ${'$ 1,234.56'}
     `(
       'formats 1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -1048,9 +1095,11 @@ describe('I18n', () => {
       ${'fr-FR'} | ${'JPY'} | ${'-1 235 ¥'}
       ${'fr-FR'} | ${'OMR'} | ${'-1 234,560 OMR'}
       ${'fr-FR'} | ${'USD'} | ${'-1 234,56 $'}
-      ${'sv-SE'} | ${'USD'} | ${'-1 234,56 $'}
+      ${'sv-SE'} | ${'USD'} | ${'\u22121 234,56 $'}
       ${'en-US'} | ${'SGD'} | ${'-$1,234.56'}
       ${'fr-FR'} | ${'SGD'} | ${'-1 234,56 $'}
+      ${'ar-EG'} | ${'USD'} | ${'\u200E-$ 1,234.56'}
+      ${'he-IL'} | ${'USD'} | ${'\u200E-1,234.56 $'}
     `(
       'formats -1234.56 of $currency in $locale to expected $expected',
       ({locale, currency, expected}) => {
@@ -1277,6 +1326,30 @@ describe('I18n', () => {
           });
           expect(i18n.unformatCurrency('123,9999', 'JOD')).toBe('124.000');
           expect(i18n.unformatCurrency('123,4567', 'JOD')).toBe('123.457');
+        });
+      });
+
+      describe('sv-SE locale', () => {
+        it('unformats currency with non-standard negative sign', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'sv-SE',
+          });
+          expect(i18n.unformatCurrency('\u22121 234,56 $', 'USD')).toBe(
+            '-1234.56',
+          );
+        });
+      });
+
+      describe('he-IL locale', () => {
+        it('unformats currency with direction control characters and whitespace before negative sign', () => {
+          const i18n = new I18n(defaultTranslations, {
+            ...defaultDetails,
+            locale: 'he-IL',
+          });
+          expect(i18n.unformatCurrency(' \u200E-1,234.56 $ USD', 'USD')).toBe(
+            '-1234.56',
+          );
         });
       });
 

--- a/packages/react-i18n/src/utilities/money.ts
+++ b/packages/react-i18n/src/utilities/money.ts
@@ -1,19 +1,15 @@
+import {DIRECTION_CONTROL_CHARACTERS} from '../constants';
+
 import {memoizedNumberFormatter} from './translate';
 
 export function getCurrencySymbol(
   locale: string,
   options: Intl.NumberFormatOptions,
 ) {
-  const delimiters = ',.';
-  const directionControlCharacters = /[\u200E\u200F]/;
-  const numReg = new RegExp(`0[${delimiters}]*0*`);
-
   const currencyStringRaw = formatCurrency(0, locale, options);
-  const currencyString = currencyStringRaw.replace(
-    directionControlCharacters,
-    '',
-  );
-  const matchResult = numReg.exec(currencyString);
+  const controlChars = new RegExp(`[${DIRECTION_CONTROL_CHARACTERS}]*`, 'gu');
+  const currencyString = currencyStringRaw.replace(controlChars, '');
+  const matchResult = /\p{Nd}\p{Po}*\p{Nd}*/gu.exec(currencyString);
   if (!matchResult) {
     throw new Error(
       `Number input in locale ${locale} is currently not supported.`,

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -26,13 +26,28 @@ export function memoizedNumberFormatter(
   locales?: string | string[],
   options?: Intl.NumberFormatOptions,
 ) {
-  const key = numberFormatCacheKey(locales, options);
+  // force a latin locale for number formatting
+  const latnLocales = latinLocales(locales);
+  const key = numberFormatCacheKey(latnLocales, options);
   if (numberFormats.has(key)) {
     return numberFormats.get(key)!;
   }
-  const i = new Intl.NumberFormat(locales, options);
+  const i = new Intl.NumberFormat(latnLocales, options);
   numberFormats.set(key, i);
   return i;
+}
+
+function latinLocales(locales?: string | string[]) {
+  return Array.isArray(locales)
+    ? locales.map((locale) => latinLocale(locale)!)
+    : latinLocale(locales);
+}
+
+function latinLocale(locale?: string) {
+  if (!locale) return locale;
+  return new Intl.Locale(locale, {
+    numberingSystem: 'latn',
+  }).toString();
 }
 
 export const PSEUDOTRANSLATE_OPTIONS: PseudotranslateOptions = {


### PR DESCRIPTION
## Description
PR based on https://github.com/Shopify/quilt/pull/2498.

Fixes (https://github.com/Shopify/quilt/issues/2497).

Improves currency formatting support for `ar-EG` and similar locales.

### Original problem

In `react-i18n`, `getCurrencySymbol` relies on calling [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) with the value `0`, and uses regular expressions to parse the currency symbol and position.

This is the result when I call Intl.NumberFormat with `ar-EG` vs. `ar`:
```js
console.log(new Intl.NumberFormat('ar-EG', { style: 'currency', currency: 'USD' }).format(number));
// output: "٠٫٠٠ US$"

console.log(new Intl.NumberFormat('ar', { style: 'currency', currency: 'USD' }).format(number));
// output: "US$ 0.00"
```

In Egyptian Arabic, the output is `٠٫٠٠ US$`, which doesn't match the regular expression, which is why it's throwing the exception it is.

## Solution

### Force the latin numbering system

For `ar-EG`, `-1234.56` is formatted by [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat) like `؜-١٬٢٣٤٫٥٦ US$`.
When forcing a latin locale, `-1234.56` is instead formatted like `‎-US$ 1,234.56`.

This will provide greater consistency for `i18n.formatNumber()` and `i18n.formatCurrency()`, and it will ensure greater compatibility with `i18n.unformatNumber()` and `i18n.unformatCurrency()`.

### Use Unicode property escapes in number formatting regular expressions

[Unicode property escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) provide a broader and more comprehensive range of characters in specific categories for regular expressions, such as control formatting, punctuation, and dashes.

Using these will provide broader support for number formatting in different locales, and cover more use cases than we might initially anticipate.

### Preserve direction control characters for negative numbers

For locales like `ar-EG` and `he-IL`, Intl.NumberFormat returns direction control characters before the negative sign.
Previously, `formatCurrencyShort()` broke the order of these symbols for these locales.

Now, the order of the control characters and negative sign is preserved.

### Preserve original negative sign when formatting numbers

Previously, `formatCurrencyShort()` would replace negative signs encountered with the standard hyphen symbol ([-](https://www.compart.com/en/unicode/U+002D)), regardless of what Intl.NumberFormat returned for a given locale.

Now, `formatCurrencyShort()` preserves the original negative sign returned by Intl.NumberFormat, resulting in a more accurately localized currency string.

Additionally, `unformatNumber()` and `unformatCurrency()` were updated to scan for multiple kinds of negative signs, so they would be correctly interpreted and unformatted as negative numbers.

## Impact

By forcing latin number formatting, formatted numbers and currencies aren't as deeply localized as they otherwise could be for certain locales. However, the benefit is that the formatted numbers are more compatible with other `react-i18n` methods like `unformatNumber()` and `unformatCurrency()`, which is especially important for web input controls.

By preserving the original negative sign returned by `Intl.NumberFormat` when formatting currency, negative numbers could appear different in different locales. This could have a minor visual UX impact; for example, negative numbers lined up vertically against positive numbers may align differently.