### PR TITLE
feat(): allow passing FallbackComponent and errorBoundary props to bu…

### DIFF
--- a/.changeset/blue-cows-protect.md
+++ b/.changeset/blue-cows-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-bugsnag': minor
+---
+
+allow passing props to bugsnag error boundary component

--- a/packages/react-bugsnag/package.json
+++ b/packages/react-bugsnag/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@bugsnag/js": "^7.1.1",
-    "@bugsnag/plugin-react": "^7.1.1"
+    "@bugsnag/plugin-react": "^7.18.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0"

--- a/packages/react-bugsnag/src/Bugsnag.tsx
+++ b/packages/react-bugsnag/src/Bugsnag.tsx
@@ -1,5 +1,6 @@
-import React, {useRef, ReactNode} from 'react';
-import {Client, OnErrorCallback} from '@bugsnag/js';
+import React, {useRef, ReactNode, ComponentProps} from 'react';
+import {Client} from '@bugsnag/js';
+import {BugsnagErrorBoundary} from '@bugsnag/plugin-react';
 
 import {ErrorLoggerContext, noopErrorLogger} from './context';
 
@@ -10,20 +11,8 @@ export function NoopBoundary({children}: {children: ReactNode}) {
 export function Bugsnag({
   client,
   children,
-  onError,
-  FallbackComponent,
-}: {
-  client?: Client;
-  children?: React.ReactNode;
-  // Copy-pasted @bugsang/plugin-react because this type is not exported or made otherwise available
-  // through typescript
-  onError?: OnErrorCallback;
-  FallbackComponent?: React.ComponentType<{
-    error: Error;
-    info: React.ErrorInfo;
-    clearError: () => void;
-  }>;
-}) {
+  ...props
+}: ComponentProps<BugsnagErrorBoundary> & {client: Client}) {
   const Boundary = useRef(() => {
     if (client) {
       const reactPlugin = client.getPlugin('react');
@@ -42,9 +31,7 @@ export function Bugsnag({
 
   return (
     <ErrorLoggerContext.Provider value={client || noopErrorLogger}>
-      <Boundary FallbackComponent={FallbackComponent} onError={onError}>
-        {children}
-      </Boundary>
+      <Boundary {...props}>{children}</Boundary>
     </ErrorLoggerContext.Provider>
   );
 }

--- a/packages/react-bugsnag/src/Bugsnag.tsx
+++ b/packages/react-bugsnag/src/Bugsnag.tsx
@@ -1,5 +1,5 @@
 import React, {useRef, ReactNode} from 'react';
-import {Client} from '@bugsnag/js';
+import {Client, OnErrorCallback} from '@bugsnag/js';
 
 import {ErrorLoggerContext, noopErrorLogger} from './context';
 
@@ -10,9 +10,19 @@ export function NoopBoundary({children}: {children: ReactNode}) {
 export function Bugsnag({
   client,
   children,
+  onError,
+  FallbackComponent,
 }: {
   client?: Client;
   children?: React.ReactNode;
+  // Copy-pasted @bugsang/plugin-react because this type is not exported or made otherwise available
+  // through typescript
+  onError?: OnErrorCallback;
+  FallbackComponent?: React.ComponentType<{
+    error: Error;
+    info: React.ErrorInfo;
+    clearError: () => void;
+  }>;
 }) {
   const Boundary = useRef(() => {
     if (client) {
@@ -32,7 +42,9 @@ export function Bugsnag({
 
   return (
     <ErrorLoggerContext.Provider value={client || noopErrorLogger}>
-      <Boundary>{children}</Boundary>
+      <Boundary FallbackComponent={FallbackComponent} onError={onError}>
+        {children}
+      </Boundary>
     </ErrorLoggerContext.Provider>
   );
 }

--- a/packages/react-bugsnag/src/tests/Bugsnag.test.tsx
+++ b/packages/react-bugsnag/src/tests/Bugsnag.test.tsx
@@ -38,6 +38,34 @@ describe('react-bugsnag', () => {
     const component = mount(<Bugsnag client={client} />);
     expect(component).toContainReactComponent(Boundary);
   });
+
+  it('passes bugsnag ErrorBoundary props to <Boundary /> component', () => {
+    const FakeBoundary = ({children}) => <>{children}</>;
+    const client = {
+      ...fakeBugsnag(),
+      getPlugin: () => {
+        return {
+          createErrorBoundary: () => FakeBoundary,
+        };
+      },
+    };
+
+    const FallbackComponent = () => <div />;
+    const onError = jest.fn();
+
+    const component = mount(
+      <Bugsnag
+        client={client}
+        FallbackComponent={FallbackComponent}
+        onError={onError}
+      />,
+    );
+
+    expect(component).toContainReactComponent(FakeBoundary, {
+      FallbackComponent,
+      onError,
+    });
+  });
 });
 
 function fakeBugsnag() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,12 +1277,10 @@
     pump "^3.0.0"
     stack-generator "^2.0.3"
 
-"@bugsnag/plugin-react@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react/-/plugin-react-7.1.1.tgz#6faf74546ee8c553083a027b69eb55b5f2ac3778"
-  integrity sha512-bxz3hZa0Our7OO42sVsHWgzEuw0vdTC2cCVG1vXKQUeFQqgggMizC8yzSbxCGaqyj04Dui/YzlYnAGV3MRoUjQ==
-  dependencies:
-    "@bugsnag/core" "^7.1.1"
+"@bugsnag/plugin-react@^7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react/-/plugin-react-7.18.0.tgz#cce7e0185ba4f7c2ca581138efa3f0f6ad1c5564"
+  integrity sha512-i4FYauv/8G1ZRH4dTegYPzw5+xt76ubt1GCr4wRieD8q5QBKcvHIqaNrnM9yQ/QNmWnz24LeCCDUVdIb5SrhPA==
 
 "@bugsnag/safe-json-stringify@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
…gsnag boudary component

## Description

This PR adds the props available to the generated `<Boundary />` component. See source [types](https://github.com/bugsnag/bugsnag-js/blob/master/packages/plugin-react/types/bugsnag-plugin-react.d.ts#L11-L19)

This would allow a consumer to pass in an `onError` callback or a `FallbackComponent` allowing us to customize error UI without having to reimplement an error boundary.

Example usage

```tsx
function FallbackComponent() {
  return <div>Something went wrong</div>
}

// somewhere else
(
<Bugsnag
  client={client}
  FallbackComponent={FallbackComponent}
  onError={onError}
/>
)
```

Now, if Bugsnag catches an error we can display our custom error screen instead of an ugly webpack error screen (no offense webpack)

Fixes (issue #)
