### PR TITLE
Provide fallback for Intl.Locale functionality in memoizedNumberFormatter()

### DIFF
--- a/.changeset/old-ligers-matter.md
+++ b/.changeset/old-ligers-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-i18n': patch
+---
+
+Provide fallback for Intl.Locale functionality in memoizedNumberFormatter()

--- a/packages/react-i18n/src/utilities/tests/translate.test.tsx
+++ b/packages/react-i18n/src/utilities/tests/translate.test.tsx
@@ -1,6 +1,122 @@
 import React from 'react';
 
-import {numberFormatCacheKey, translate} from '../translate';
+import {
+  memoizedNumberFormatter,
+  numberFormatCacheKey,
+  translate,
+} from '../translate';
+
+describe('memoizedNumberFormatter()', () => {
+  it.each`
+    locale                             | expectedValue | expectedLocale
+    ${'en-US'}                         | ${'1.23'}     | ${'en-US-u-nu-latn'}
+    ${'fr-CA'}                         | ${'1,23'}     | ${'fr-CA-u-nu-latn'}
+    ${'zh-Hans-hk'}                    | ${'1.23'}     | ${'zh-Hans-HK-u-nu-latn'}
+    ${'ar-EG'}                         | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'ar-EG-u-nu-arab'}               | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'fa-IR'}                         | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+  `(
+    'returns formatted number according to the locale provided with the latin numbering system',
+    ({locale, expectedValue, expectedLocale}) => {
+      const amount = 1.23;
+      const numberFormatter = memoizedNumberFormatter(locale, {
+        style: 'decimal',
+      });
+      expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+      expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+        expectedValue,
+      );
+    },
+  );
+
+  it.each`
+    locale                             | expectedValue     | expectedLocale
+    ${'en-US'}                         | ${'$1.23'}        | ${'en-US-u-nu-latn'}
+    ${'fr-CA'}                         | ${'1,23 $ US'}    | ${'fr-CA-u-nu-latn'}
+    ${'zh-Hans-hk'}                    | ${'US$1.23'}      | ${'zh-Hans-HK-u-nu-latn'}
+    ${'ar-EG'}                         | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'ar-EG-u-nu-arab'}               | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'fa-IR'}                         | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+  `(
+    'returns formatted currency according to the locale provided with the latin numbering system',
+    ({locale, expectedValue, expectedLocale}) => {
+      const amount = 1.23;
+      const numberFormatter = memoizedNumberFormatter(locale, {
+        style: 'currency',
+        currency: 'USD',
+      });
+      expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+      expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+        expectedValue,
+      );
+    },
+  );
+
+  describe('when Intl.Locale throws an error', () => {
+    beforeEach(() => {
+      jest.spyOn(Intl, 'Locale').mockImplementation(() => {
+        throw new Error();
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it.each`
+      locale                             | expectedValue | expectedLocale
+      ${'en-US'}                         | ${'1.23'}     | ${'en-US-u-nu-latn'}
+      ${'fr-CA'}                         | ${'1,23'}     | ${'fr-CA-u-nu-latn'}
+      ${'zh-Hans-hk'}                    | ${'1.23'}     | ${'zh-Hans-HK-u-nu-latn'}
+      ${'ar-EG'}                         | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'ar-EG-u-nu-arab'}               | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'fa-IR'}                         | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+    `(
+      'returns formatted number according to the locale provided, falling back to appending the latin numbering system',
+      ({locale, expectedValue, expectedLocale}) => {
+        const amount = 1.23;
+        const numberFormatter = memoizedNumberFormatter(locale, {
+          style: 'decimal',
+        });
+        expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+        expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+          expectedValue,
+        );
+      },
+    );
+
+    it.each`
+      locale                             | expectedValue     | expectedLocale
+      ${'en-US'}                         | ${'$1.23'}        | ${'en-US-u-nu-latn'}
+      ${'fr-CA'}                         | ${'1,23 $ US'}    | ${'fr-CA-u-nu-latn'}
+      ${'zh-Hans-hk'}                    | ${'US$1.23'}      | ${'zh-Hans-HK-u-nu-latn'}
+      ${'ar-EG'}                         | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'ar-EG-u-nu-arab'}               | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'fa-IR'}                         | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+    `(
+      'returns formatted currency according to the locale provided, falling back to appending the latin numbering system',
+      ({locale, expectedValue, expectedLocale}) => {
+        const amount = 1.23;
+        const numberFormatter = memoizedNumberFormatter(locale, {
+          style: 'currency',
+          currency: 'USD',
+        });
+        expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+        expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+          expectedValue,
+        );
+      },
+    );
+  });
+});
 
 describe('numberFormatCacheKey()', () => {
   const locale = 'en-CA';
@@ -160,3 +276,10 @@ describe('translate()', () => {
     },
   );
 });
+
+function sanitizeSpaces(input) {
+  return input
+    .replace('\xa0', ' ')
+    .replace('\u202f', ' ')
+    .replace('\u00A0', ' ');
+}

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -18,6 +18,8 @@ const MISSING_TRANSLATION = Symbol('Missing translation');
 const CARDINAL_PLURALIZATION_KEY_NAME = 'count';
 const ORDINAL_PLURALIZATION_KEY_NAME = 'ordinal';
 const SEPARATOR = '.';
+const UNICODE_NUMBERING_SYSTEM = '-u-nu-';
+const LATIN = 'latn';
 
 const isString = (value: any): value is string => typeof value === 'string';
 
@@ -45,9 +47,22 @@ function latinLocales(locales?: string | string[]) {
 
 function latinLocale(locale?: string) {
   if (!locale) return locale;
-  return new Intl.Locale(locale, {
-    numberingSystem: 'latn',
-  }).toString();
+  // Intl.Locale was added to iOS in v14. See https://caniuse.com/?search=Intl.Locale
+  // We still support ios 12/13, so we need to check if this works and fallback to the default behaviour if not
+  try {
+    return new Intl.Locale(locale, {
+      numberingSystem: LATIN,
+    }).toString();
+  } catch {
+    const numberingSystemRegex = new RegExp(
+      `(?:-x|${UNICODE_NUMBERING_SYSTEM}).*`,
+      'g',
+    );
+    const latinNumberingSystem = `${UNICODE_NUMBERING_SYSTEM}${LATIN}`;
+    return locale
+      .replace(numberingSystemRegex, '')
+      .concat(latinNumberingSystem);
+  }
 }
 
 export const PSEUDOTRANSLATE_OPTIONS: PseudotranslateOptions = {


### PR DESCRIPTION
## Description

Fixes (https://github.com/Shopify/quilt/issues/2503)

Pull request https://github.com/Shopify/quilt/pull/2501 introduced a change to currency format that relies on [Intl.Locale](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale). 

However, this isn't supported on some browsers, notably iOS Safari before version 14, and we still support versions 12 and 13.

This pull request provides fallback functionality, which will replace or append the unicode latin numbering system (`u-nu-latn`) to the locale string. It also strips any "private use" codes (`-x-***`) from the locale to prevent ordering issues after appending the numbering system. See the MSDN documentation for [the `locales` argument](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) for more info.

### What should reviewers focus on?

Are there any other locale combinations I should test for?

There is a small risk that appending the numbering system to the locale string will also not be compatible with iOS Safari before version 14, but if that is the case, I believe that the behaviour will be to ignore the numbering system extension, rather than throw an exception. This is because the [unicode numbering system extension](https://www.unicode.org/reports/tr35/#Numbering%20System%20Data) is part of the unicode locale data markup language definition.

#### Why don't we just use the fallback and ignore `Intl.Locale` entirely?

The fallback relies on an imperfect regular expression solution that is based on my limited understanding of the very involved [Unicode Locale Data Markup Language](https://www.unicode.org/reports/tr35/). Using `Intl.Locale` to set the numbering system is cleaner and more fool-proof, but based on the unit tests I've written so far, the fallback will work in a pinch.