### PR TITLE
Implement number/currency formatting for string inputs

### DIFF
--- a/.changeset/twenty-dodos-lick.md
+++ b/.changeset/twenty-dodos-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-i18n': minor
+---
+
+Implement number/currency formatting for string inputs

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -54,6 +54,7 @@
     "@shopify/react-hooks": "^3.0.2",
     "@shopify/useful-types": "^5.1.1",
     "@types/hoist-non-react-statics": "^3.0.1",
+    "decimal.js-light": "^2.5.1",
     "change-case": "^4.1.2",
     "glob": "^7.1.4",
     "hoist-non-react-statics": "^3.0.1",

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -46,6 +46,7 @@ import {
   getTranslationTree,
   TranslateOptions as RootTranslateOptions,
   memoizedNumberFormatter,
+  memoizedStringNumberFormatter,
   memoizedPluralRules,
   convertFirstSpaceToNonBreakingSpace,
 } from './utilities';
@@ -241,6 +242,30 @@ export class I18n {
     }
 
     return memoizedNumberFormatter(locale, {
+      style: as,
+      maximumFractionDigits: precision,
+      currency,
+      ...options,
+    }).format(amount);
+  }
+
+  formatStringNumber(
+    amount: string,
+    {as, precision, ...options}: NumberFormatOptions = {},
+  ) {
+    const {locale, defaultCurrency: currency} = this;
+
+    if (as === 'currency' && currency == null && options.currency == null) {
+      this.onError(
+        new MissingCurrencyCodeError(
+          `formatNumber(amount, {as: 'currency'}) cannot be called without a currency code.`,
+        ),
+      );
+
+      return '';
+    }
+
+    return memoizedStringNumberFormatter(locale, {
       style: as,
       maximumFractionDigits: precision,
       currency,

--- a/packages/react-i18n/src/index.ts
+++ b/packages/react-i18n/src/index.ts
@@ -12,6 +12,7 @@ export {withI18n} from './decorator';
 export type {WithI18nProps} from './decorator';
 export {
   memoizedNumberFormatter,
+  memoizedStringNumberFormatter,
   translate,
   DEFAULT_FORMAT,
   MUSTACHE_FORMAT,

--- a/packages/react-i18n/src/tests/utilities.test.tsx
+++ b/packages/react-i18n/src/tests/utilities.test.tsx
@@ -9,6 +9,7 @@ import {
   memoizedPluralRules,
   ERB_FORMAT,
   MUSTACHE_FORMAT,
+  memoizedStringNumberFormatter,
 } from '../utilities';
 
 const {pseudotranslate} = jest.requireMock('@shopify/i18n') as {
@@ -166,6 +167,42 @@ describe('memoizedNumberFormatter', () => {
       style: 'decimal',
     });
     expect(numberFormatter).toBeInstanceOf(Intl.NumberFormat);
+    expect(numberFormatter.resolvedOptions()).toMatchObject({style: 'decimal'});
+  });
+});
+
+describe('memoizedStringNumberFormatter', () => {
+  it('returns the same object when passed the same arguments', () => {
+    const numberFormatterA = memoizedStringNumberFormatter(locale);
+
+    const numberFormatterB = memoizedStringNumberFormatter(locale);
+    expect(numberFormatterB).toBe(numberFormatterA);
+  });
+
+  it('returns the same object when passed multiple locales as an array', () => {
+    const locales = ['en-US', 'en-CA'];
+    const numberFormatterA = memoizedStringNumberFormatter(locales);
+
+    const numberFormatterB = memoizedStringNumberFormatter(locales);
+    expect(numberFormatterB).toBe(numberFormatterA);
+  });
+
+  it('returns different object when passed different arguments', () => {
+    const numberFormatterA = memoizedStringNumberFormatter(locale);
+
+    const numberFormatterB = memoizedStringNumberFormatter(locale, {
+      style: 'decimal',
+    });
+    expect(numberFormatterB).not.toBe(numberFormatterA);
+    expect(numberFormatterB.resolvedOptions()).toMatchObject({
+      style: 'decimal',
+    });
+  });
+
+  it('passes options to Intl.NumberFormat constructor', () => {
+    const numberFormatter = memoizedStringNumberFormatter(locale, {
+      style: 'decimal',
+    });
     expect(numberFormatter.resolvedOptions()).toMatchObject({style: 'decimal'});
   });
 });

--- a/packages/react-i18n/src/utilities/index.ts
+++ b/packages/react-i18n/src/utilities/index.ts
@@ -4,9 +4,10 @@ export {
   translate,
   getTranslationTree,
   memoizedNumberFormatter,
+  memoizedStringNumberFormatter,
   memoizedPluralRules,
 } from './translate';
 
-export type {TranslateOptions} from './translate';
+export type {StringNumberFormatter, TranslateOptions} from './translate';
 export {convertFirstSpaceToNonBreakingSpace} from './string';
 export {DEFAULT_FORMAT, ERB_FORMAT, MUSTACHE_FORMAT} from './interpolate';

--- a/packages/react-i18n/src/utilities/money.ts
+++ b/packages/react-i18n/src/utilities/money.ts
@@ -1,6 +1,9 @@
 import {DIRECTION_CONTROL_CHARACTERS} from '../constants';
 
-import {memoizedNumberFormatter} from './translate';
+import {
+  memoizedNumberFormatter,
+  memoizedStringNumberFormatter,
+} from './translate';
 
 export function getCurrencySymbol(
   locale: string,
@@ -32,6 +35,17 @@ export function formatCurrency(
   options: Intl.NumberFormatOptions,
 ) {
   return memoizedNumberFormatter(locale, {
+    style: 'currency',
+    ...options,
+  }).format(amount);
+}
+
+export function formatStringCurrency(
+  amount: string,
+  locale: string,
+  options: Intl.NumberFormatOptions,
+) {
+  return memoizedStringNumberFormatter(locale, {
     style: 'currency',
     ...options,
   }).format(amount);

--- a/packages/react-i18n/src/utilities/tests/money.test.ts
+++ b/packages/react-i18n/src/utilities/tests/money.test.ts
@@ -1,11 +1,15 @@
-import {formatCurrency} from '../money';
+import {formatCurrency, formatStringCurrency} from '../money';
 
 jest.mock('../translate', () => ({
   memoizedNumberFormatter: jest.fn(),
+  memoizedStringNumberFormatter: jest.fn(),
 }));
 
 const memoizedNumberFormatterMock: jest.Mock =
   jest.requireMock('../translate').memoizedNumberFormatter;
+
+const memoizedStringNumberFormatterMock: jest.Mock =
+  jest.requireMock('../translate').memoizedStringNumberFormatter;
 
 describe('formatCurrency()', () => {
   const mockFormat = jest.fn();
@@ -42,6 +46,45 @@ describe('formatCurrency()', () => {
     mockFormat.mockImplementation(() => result);
 
     expect(formatCurrency(amount, 'en', {})).toBe(result);
+    expect(mockFormat).toHaveBeenCalledWith(amount);
+  });
+});
+
+describe('formatStringCurrency()', () => {
+  const mockFormat = jest.fn();
+
+  beforeEach(() => {
+    const mockFormatter = {
+      format: mockFormat,
+    };
+    memoizedStringNumberFormatterMock.mockImplementation(() => mockFormatter);
+    mockFormat.mockImplementation(() => 'test');
+  });
+
+  afterEach(() => {
+    memoizedStringNumberFormatterMock.mockReset();
+    mockFormat.mockReset();
+  });
+
+  it('uses memoizedNumberFormatter to get a memoized formatter with currency style', () => {
+    const locale = 'en';
+    const options = {
+      currency: 'USD',
+    };
+
+    formatStringCurrency('123', locale, options);
+    expect(memoizedStringNumberFormatterMock).toHaveBeenCalledWith(locale, {
+      ...options,
+      style: 'currency',
+    });
+  });
+
+  it('calls format on the memoized formatter', () => {
+    const amount = '123';
+    const result = 'result';
+    mockFormat.mockImplementation(() => result);
+
+    expect(formatStringCurrency(amount, 'en', {})).toBe(result);
     expect(mockFormat).toHaveBeenCalledWith(amount);
   });
 });

--- a/packages/react-i18n/src/utilities/tests/translate.test.tsx
+++ b/packages/react-i18n/src/utilities/tests/translate.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {
   memoizedNumberFormatter,
+  memoizedStringNumberFormatter,
   numberFormatCacheKey,
   translate,
 } from '../translate';
@@ -106,6 +107,118 @@ describe('memoizedNumberFormatter()', () => {
       ({locale, expectedValue, expectedLocale}) => {
         const amount = 1.23;
         const numberFormatter = memoizedNumberFormatter(locale, {
+          style: 'currency',
+          currency: 'USD',
+        });
+        expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+        expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+          expectedValue,
+        );
+      },
+    );
+  });
+});
+
+describe('memoizedStringNumberFormatter()', () => {
+  it.each`
+    locale                             | expectedValue | expectedLocale
+    ${'en-US'}                         | ${'1.23'}     | ${'en-US-u-nu-latn'}
+    ${'fr-CA'}                         | ${'1,23'}     | ${'fr-CA-u-nu-latn'}
+    ${'zh-Hans-hk'}                    | ${'1.23'}     | ${'zh-Hans-HK-u-nu-latn'}
+    ${'ar-EG'}                         | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'ar-EG-u-nu-arab'}               | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'fa-IR'}                         | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+  `(
+    'returns formatted number according to the locale provided with the latin numbering system',
+    ({locale, expectedValue, expectedLocale}) => {
+      const amount = '1.23';
+      const numberFormatter = memoizedStringNumberFormatter(locale, {
+        style: 'decimal',
+      });
+      expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+      expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+        expectedValue,
+      );
+    },
+  );
+
+  it.each`
+    locale                             | expectedValue     | expectedLocale
+    ${'en-US'}                         | ${'$1.23'}        | ${'en-US-u-nu-latn'}
+    ${'fr-CA'}                         | ${'1,23 $ US'}    | ${'fr-CA-u-nu-latn'}
+    ${'zh-Hans-hk'}                    | ${'US$1.23'}      | ${'zh-Hans-HK-u-nu-latn'}
+    ${'ar-EG'}                         | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'ar-EG-u-nu-arab'}               | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+    ${'fa-IR'}                         | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+    ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+  `(
+    'returns formatted currency according to the locale provided with the latin numbering system',
+    ({locale, expectedValue, expectedLocale}) => {
+      const amount = '1.23';
+      const numberFormatter = memoizedStringNumberFormatter(locale, {
+        style: 'currency',
+        currency: 'USD',
+      });
+      expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+      expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+        expectedValue,
+      );
+    },
+  );
+
+  describe('when Intl.Locale throws an error', () => {
+    beforeEach(() => {
+      jest.spyOn(Intl, 'Locale').mockImplementation(() => {
+        throw new Error();
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it.each`
+      locale                             | expectedValue | expectedLocale
+      ${'en-US'}                         | ${'1.23'}     | ${'en-US-u-nu-latn'}
+      ${'fr-CA'}                         | ${'1,23'}     | ${'fr-CA-u-nu-latn'}
+      ${'zh-Hans-hk'}                    | ${'1.23'}     | ${'zh-Hans-HK-u-nu-latn'}
+      ${'ar-EG'}                         | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'ar-EG-u-nu-arab'}               | ${'1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'fa-IR'}                         | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'1.23'}     | ${'fa-IR-u-nu-latn'}
+    `(
+      'returns formatted number according to the locale provided, falling back to appending the latin numbering system',
+      ({locale, expectedValue, expectedLocale}) => {
+        const amount = '1.23';
+        const numberFormatter = memoizedStringNumberFormatter(locale, {
+          style: 'decimal',
+        });
+        expect(numberFormatter.resolvedOptions().locale).toBe(expectedLocale);
+        expect(sanitizeSpaces(numberFormatter.format(amount))).toBe(
+          expectedValue,
+        );
+      },
+    );
+
+    it.each`
+      locale                             | expectedValue     | expectedLocale
+      ${'en-US'}                         | ${'$1.23'}        | ${'en-US-u-nu-latn'}
+      ${'fr-CA'}                         | ${'1,23 $ US'}    | ${'fr-CA-u-nu-latn'}
+      ${'zh-Hans-hk'}                    | ${'US$1.23'}      | ${'zh-Hans-HK-u-nu-latn'}
+      ${'ar-EG'}                         | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'ar-EG-u-nu-arab'}               | ${'US$ 1.23'}     | ${'ar-EG-u-nu-latn'}
+      ${'fa-IR'}                         | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-u-nu-arabext-x-ab-cdefg'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+      ${'fa-IR-x-ab-cdefg-u-nu-arabext'} | ${'\u200E$ 1.23'} | ${'fa-IR-u-nu-latn'}
+    `(
+      'returns formatted currency according to the locale provided, falling back to appending the latin numbering system',
+      ({locale, expectedValue, expectedLocale}) => {
+        const amount = '1.23';
+        const numberFormatter = memoizedStringNumberFormatter(locale, {
           style: 'currency',
           currency: 'USD',
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6303,6 +6303,11 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decimal.js-light@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
+
 decimal.js@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"


### PR DESCRIPTION
## Description

Adds new methods for formatting numbers and currencies using string inputs.

This should help us in the Mobile Admin app and in the web admin UI to use arbitrarily large numbers for pricing.

---
'@shopify/react-i18n': minor
---

Implement number/currency formatting for string inputs

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
