### PR TITLE
Add a options parameter to all metrics methods with sampleRate

### DIFF
--- a/.changeset/nine-cobras-approve.md
+++ b/.changeset/nine-cobras-approve.md
@@ -1,0 +1,8 @@
+---
+'@shopify/statsd': minor
+---
+
+Introduces an optional parameter to all metrics methods to allow them to accept
+a sampleRate and provide sampling independently of the sampleRate settings
+specified on the client itself. Allows the developer to opt in or out of
+sampling on a metric-by-metric basis.

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -25,6 +25,10 @@ export interface ChildOptions extends HotShotChildOptions {
   snakeCase?: boolean;
 }
 
+export interface MetricOptions {
+  sampleRate?: number;
+}
+
 export type Options = ClientOptions | ChildOptions;
 
 export class StatsDClient {
@@ -72,44 +76,63 @@ export class StatsDClient {
     this.statsd = new StatsD(this.options);
   }
 
-  distribution(stat: string | string[], value: number, tags?: Tags) {
+  distribution(
+    stat: string | string[],
+    value: number,
+    tags?: Tags,
+    options?: MetricOptions,
+  ) {
     return new Promise<void>((resolve) => {
       this.statsd.distribution(
         stat,
         value,
+        options?.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );
     });
   }
 
-  timing(stat: string | string[], value: number, tags?: Tags) {
+  timing(
+    stat: string | string[],
+    value: number,
+    tags?: Tags,
+    options?: MetricOptions,
+  ) {
     return new Promise<void>((resolve) => {
       this.statsd.timing(
         stat,
         value,
+        options?.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );
     });
   }
 
-  gauge(stat: string | string[], value: number, tags?: Tags) {
+  gauge(
+    stat: string | string[],
+    value: number,
+    tags?: Tags,
+    options?: MetricOptions,
+  ) {
     return new Promise<void>((resolve) => {
       this.statsd.gauge(
         stat,
         value,
+        options?.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );
     });
   }
 
-  increment(stat: string | string[], tags?: Tags) {
+  increment(stat: string | string[], tags?: Tags, options?: MetricOptions) {
     return new Promise<void>((resolve) => {
       this.statsd.increment(
         stat,
         1,
+        options?.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -80,13 +80,13 @@ export class StatsDClient {
     stat: string | string[],
     value: number,
     tags?: Tags,
-    options?: MetricOptions,
+    options: MetricOptions = {},
   ) {
     return new Promise<void>((resolve) => {
       this.statsd.distribution(
         stat,
         value,
-        options?.sampleRate,
+        options.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );
@@ -97,13 +97,13 @@ export class StatsDClient {
     stat: string | string[],
     value: number,
     tags?: Tags,
-    options?: MetricOptions,
+    options: MetricOptions = {},
   ) {
     return new Promise<void>((resolve) => {
       this.statsd.timing(
         stat,
         value,
-        options?.sampleRate,
+        options.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );
@@ -114,25 +114,25 @@ export class StatsDClient {
     stat: string | string[],
     value: number,
     tags?: Tags,
-    options?: MetricOptions,
+    options: MetricOptions = {},
   ) {
     return new Promise<void>((resolve) => {
       this.statsd.gauge(
         stat,
         value,
-        options?.sampleRate,
+        options.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );
     });
   }
 
-  increment(stat: string | string[], tags?: Tags, options?: MetricOptions) {
+  increment(stat: string | string[], tags?: Tags, options: MetricOptions = {}) {
     return new Promise<void>((resolve) => {
       this.statsd.increment(
         stat,
         1,
-        options?.sampleRate,
+        options.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),
       );

--- a/packages/statsd/src/tests/client.test.ts
+++ b/packages/statsd/src/tests/client.test.ts
@@ -25,6 +25,7 @@ describe('StatsDClient', () => {
   const tagName = 'fooBar';
   const tagValue = 'camelCasedFooBar';
   const tags = {[tagName]: tagValue};
+  const sampleRate = 0.5;
 
   it('passes all the options to the statsd client', () => {
     const statsDClient = new StatsDClient(defaultOptions);
@@ -40,7 +41,7 @@ describe('StatsDClient', () => {
   describe('distribution', () => {
     it('passes distribution metrics to the statsd client', () => {
       const statsDClient = new StatsDClient(defaultOptions);
-      statsDClient.distribution(stat, value, tags);
+      statsDClient.distribution(stat, value, tags, {sampleRate});
 
       const stats = StatsDMock.mock.instances[0];
       const distributionFn = stats.distribution;
@@ -48,6 +49,7 @@ describe('StatsDClient', () => {
       expect(distributionFn).toHaveBeenCalledWith(
         stat,
         value,
+        sampleRate,
         tags,
         expect.any(Function),
       );
@@ -66,6 +68,7 @@ describe('StatsDClient', () => {
       expect(distributionFn).toHaveBeenCalledWith(
         stat,
         value,
+        undefined,
         {foo_bar: tagValue},
         expect.any(Function),
       );
@@ -78,7 +81,7 @@ describe('StatsDClient', () => {
 
       const error = new Error('Something went wrong!');
       statsDMock.distribution.mockImplementation(
-        (_name, _value, _tags, callback) => {
+        (_name, _value, _sampleRate, _tags, callback) => {
           callback(error);
         },
       );
@@ -97,7 +100,7 @@ describe('StatsDClient', () => {
 
       const error = new Error('Something went wrong!');
       statsDMock.distribution.mockImplementation(
-        (_name, _value, _tags, callback) => {
+        (_name, _value, _sampleRate, _tags, callback) => {
           callback(error);
         },
       );
@@ -110,7 +113,7 @@ describe('StatsDClient', () => {
   describe('timing', () => {
     it('passes timing metrics to the statsd client', () => {
       const statsDClient = new StatsDClient(defaultOptions);
-      statsDClient.timing(stat, value, tags);
+      statsDClient.timing(stat, value, tags, {sampleRate});
 
       const stats = StatsDMock.mock.instances[0];
       const timingFn = stats.timing;
@@ -118,6 +121,7 @@ describe('StatsDClient', () => {
       expect(timingFn).toHaveBeenCalledWith(
         stat,
         value,
+        sampleRate,
         tags,
         expect.any(Function),
       );
@@ -136,6 +140,7 @@ describe('StatsDClient', () => {
       expect(timingFn).toHaveBeenCalledWith(
         stat,
         value,
+        undefined,
         {foo_bar: tagValue},
         expect.any(Function),
       );
@@ -147,9 +152,11 @@ describe('StatsDClient', () => {
       const statsDMock = StatsDMock.mock.instances[0];
 
       const error = new Error('Something went wrong!');
-      statsDMock.timing.mockImplementation((_name, _value, _tags, callback) => {
-        callback(error);
-      });
+      statsDMock.timing.mockImplementation(
+        (_name, _value, _sampleRate, _tags, callback) => {
+          callback(error);
+        },
+      );
 
       statsDClient.timing(stat, value, tags);
       expect(errorHandler).toHaveBeenCalledWith(error);
@@ -164,9 +171,11 @@ describe('StatsDClient', () => {
       const statsDMock = StatsDMock.mock.instances[0];
 
       const error = new Error('Something went wrong!');
-      statsDMock.timing.mockImplementation((_name, _value, _tags, callback) => {
-        callback(error);
-      });
+      statsDMock.timing.mockImplementation(
+        (_name, _value, _sampleRate, _tags, callback) => {
+          callback(error);
+        },
+      );
 
       statsDClient.timing(stat, value, tags);
       expect(logSpy).toHaveBeenCalled();
@@ -176,7 +185,7 @@ describe('StatsDClient', () => {
   describe('gauge', () => {
     it('passes gauge metrics to the statsd client', () => {
       const statsDClient = new StatsDClient(defaultOptions);
-      statsDClient.gauge(stat, value, tags);
+      statsDClient.gauge(stat, value, tags, {sampleRate});
 
       const stats = StatsDMock.mock.instances[0];
       const gaugeFn = stats.gauge;
@@ -184,6 +193,7 @@ describe('StatsDClient', () => {
       expect(gaugeFn).toHaveBeenCalledWith(
         stat,
         value,
+        sampleRate,
         tags,
         expect.any(Function),
       );
@@ -202,6 +212,7 @@ describe('StatsDClient', () => {
       expect(gaugeFn).toHaveBeenCalledWith(
         stat,
         value,
+        undefined,
         {foo_bar: tagValue},
         expect.any(Function),
       );
@@ -213,9 +224,11 @@ describe('StatsDClient', () => {
       const statsDMock = StatsDMock.mock.instances[0];
 
       const error = new Error('Something went wrong!');
-      statsDMock.gauge.mockImplementation((_name, _value, _tags, callback) => {
-        callback(error);
-      });
+      statsDMock.gauge.mockImplementation(
+        (_name, _value, _sampleRate, _tags, callback) => {
+          callback(error);
+        },
+      );
 
       statsDClient.gauge(stat, value, tags);
       expect(errorHandler).toHaveBeenCalledWith(error);
@@ -230,9 +243,11 @@ describe('StatsDClient', () => {
       const statsDMock = StatsDMock.mock.instances[0];
 
       const error = new Error('Something went wrong!');
-      statsDMock.gauge.mockImplementation((_name, _value, _tags, callback) => {
-        callback(error);
-      });
+      statsDMock.gauge.mockImplementation(
+        (_name, _value, _sampleRate, _tags, callback) => {
+          callback(error);
+        },
+      );
 
       statsDClient.gauge(stat, value, tags);
       expect(logSpy).toHaveBeenCalled();
@@ -242,7 +257,7 @@ describe('StatsDClient', () => {
   describe('increment', () => {
     it('passes increment metrics to the statsd client', () => {
       const statsDClient = new StatsDClient(defaultOptions);
-      statsDClient.increment(stat, tags);
+      statsDClient.increment(stat, tags, {sampleRate});
 
       const stats = StatsDMock.mock.instances[0];
       const incrementFn = stats.increment;
@@ -250,6 +265,7 @@ describe('StatsDClient', () => {
       expect(incrementFn).toHaveBeenCalledWith(
         stat,
         1,
+        sampleRate,
         tags,
         expect.any(Function),
       );
@@ -268,6 +284,7 @@ describe('StatsDClient', () => {
       expect(incrementFn).toHaveBeenCalledWith(
         stat,
         1,
+        undefined,
         {foo_bar: tagValue},
         expect.any(Function),
       );
@@ -280,7 +297,7 @@ describe('StatsDClient', () => {
 
       const error = new Error('Something went wrong!');
       statsDMock.increment.mockImplementation(
-        (_name, _value, _tags, callback) => {
+        (_name, _value, _sampleRate, _tags, callback) => {
           callback(error);
         },
       );
@@ -299,7 +316,7 @@ describe('StatsDClient', () => {
 
       const error = new Error('Something went wrong!');
       statsDMock.increment.mockImplementation(
-        (_name, _value, _tags, callback) => {
+        (_name, _value, _sampleRate, _tags, callback) => {
           callback(error);
         },
       );


### PR DESCRIPTION
## Description

Related to https://github.com/Shopify/web/issues/79861

We currently enable sampling at the client level which means that all metrics sent using that client will be sampled. There are only a small subset of metrics that we actually want to be sampled, and it's important that we be able to ensure certain metrics are _not_ sampled because they are sparse and sampling on them results in wildly incorrect values.

This change introduces an option to all of our metrics methods that will proxy to the [underlying implementation](https://github.com/brightcove/hot-shots#statsd-methods) in hot-shots to set a sampleRate on a per-metric basis. By exposing this, we can then turn off sampling at our root level, and instead just apply it to the individual metrics that we care about.

The new parameter has two design considerations:
- Make it the last parameter and make it optional to avoid this being a major breaking change
- Make it an "options" object with a "sampleRate" property rather than just a "sampleRate" parameter to allow future expansion for other APIs that hot-shots exposes (such as callback)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
