### PR TITLE
[react-form] export DynamicList interface

### DIFF
--- a/.changeset/selfish-parents-tan.md
+++ b/.changeset/selfish-parents-tan.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-form': minor
+---
+
+Export DynamicList interface

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -2,6 +2,8 @@ import {ChangeEvent} from 'react';
 
 import {DynamicList} from './hooks/list/dynamiclist';
 
+export type {DynamicList} from './hooks/list/dynamiclist';
+
 export type ErrorValue = string | undefined;
 export type DirtyStateComparator<Value> = (
   defaultValue: Value,


### PR DESCRIPTION
## Description

Export `DynamicList` on `types.ts` so that we can import as:

```tsx
import {DynamicList} from "@shopify/react-form"
```

instead of:

```tsx
import {DynamicList} from '@shopify/react-form/build/ts/hooks/list/dynamiclist';
```
