### PR TITLE
Remove the deprecated type attribute from <style> and <script>

### DIFF
--- a/.changeset/real-vans-raise.md
+++ b/.changeset/real-vans-raise.md
@@ -1,0 +1,10 @@
+---
+'@shopify/react-html': major
+'@shopify/react-import-remote': major
+'@shopify/react-server': major
+'@shopify/web-worker': major
+---
+
+Remove the deprecated type attribute from generated HTML for <style> and <script> elements.
+
+Marking this as a breaking change because it may affect consumers expecting these attributes to be present.

--- a/packages/react-html/src/server/components/InlineStyle.tsx
+++ b/packages/react-html/src/server/components/InlineStyle.tsx
@@ -5,5 +5,5 @@ export interface Props extends React.StyleHTMLAttributes<HTMLStyleElement> {
 }
 
 export function InlineStyle(props: Props) {
-  return <style type="text/css" {...props} />;
+  return <style {...props} />;
 }

--- a/packages/react-html/src/server/components/Script.tsx
+++ b/packages/react-html/src/server/components/Script.tsx
@@ -10,7 +10,7 @@ export function Script(props: Props) {
 
   const attributes = {
     ...otherProps,
-    type: !type || isNoModule ? 'text/javascript' : type,
+    type: isNoModule ? 'text/javascript' : type,
     defer: type === 'module' ? undefined : defer,
     noModule: isNoModule ? true : undefined,
   };

--- a/packages/react-html/src/server/components/Stylesheet.tsx
+++ b/packages/react-html/src/server/components/Stylesheet.tsx
@@ -5,5 +5,5 @@ export interface Props extends React.LinkHTMLAttributes<HTMLLinkElement> {
 }
 
 export function Stylesheet(props: Props) {
-  return <link rel="stylesheet" type="text/css" {...props} />;
+  return <link rel="stylesheet" {...props} />;
 }

--- a/packages/react-html/src/server/components/tests/Script.test.tsx
+++ b/packages/react-html/src/server/components/tests/Script.test.tsx
@@ -23,11 +23,11 @@ describe('<Script />', () => {
   });
 
   describe('type', () => {
-    it('defaults to text/javascript', () => {
+    it('omitted by default', () => {
       const script = mount(<Script src="foo.js" />);
 
-      expect(script).toContainReactComponent('script', {
-        type: 'text/javascript',
+      expect(script).not.toContainReactComponent('script', {
+        type: expect.anything(),
       });
       expect(script).not.toContainReactComponent('script', {
         noModule: expect.anything(),

--- a/packages/react-html/src/server/components/tests/Stylesheet.test.tsx
+++ b/packages/react-html/src/server/components/tests/Stylesheet.test.tsx
@@ -15,7 +15,6 @@ describe('<Stylesheet />', () => {
 
     expect(style).toContainReactComponent('link', {
       href: 'foo.css',
-      type: 'text/css',
       rel: 'stylesheet',
       integrity: '00000000',
       crossOrigin: 'anonymous',

--- a/packages/react-import-remote/src/load.ts
+++ b/packages/react-import-remote/src/load.ts
@@ -52,7 +52,6 @@ export function clearCache() {
 
 function scriptTagFor(source: string, nonce: string) {
   const node = document.createElement('script');
-  node.setAttribute('type', 'text/javascript');
   node.setAttribute('src', source);
 
   if (nonce.length > 0) {

--- a/packages/react-server/src/render/tests/render.test.tsx
+++ b/packages/react-server/src/render/tests/render.test.tsx
@@ -79,18 +79,18 @@ describe('createRender', () => {
 
       // Assets from manifest are still present
       expect(bodyResult).toContain(
-        '<script src="main.js" crossorigin="anonymous" type="text/javascript" defer=""></script>',
+        '<script src="main.js" crossorigin="anonymous" defer=""></script>',
       );
       expect(bodyResult).toContain(
-        '<link rel="stylesheet" type="text/css" href="main.css" crossorigin="anonymous"/>',
+        '<link rel="stylesheet" href="main.css" crossorigin="anonymous"/>',
       );
 
       // Additional script/style assets are added
       expect(bodyResult).toContain(
-        '<script src="/extraScript.js" crossorigin="anonymous" type="text/javascript" defer=""></script>',
+        '<script src="/extraScript.js" crossorigin="anonymous" defer=""></script>',
       );
       expect(bodyResult).toContain(
-        '<link rel="stylesheet" type="text/css" href="/extraStyle.css" crossorigin="anonymous"/>',
+        '<link rel="stylesheet" href="/extraStyle.css" crossorigin="anonymous"/>',
       );
 
       // Other props work

--- a/packages/react-server/src/server/tests/server.test.tsx
+++ b/packages/react-server/src/server/tests/server.test.tsx
@@ -86,10 +86,10 @@ describe('createServer()', () => {
     const response = await wrapper.fetch('/');
 
     await expect(response).toHaveBodyText(
-      `<script src="/extraScript.js" crossorigin="anonymous" type="text/javascript" defer="">`,
+      `<script src="/extraScript.js" crossorigin="anonymous" defer="">`,
     );
     await expect(response).toHaveBodyText(
-      `<link rel="stylesheet" type="text/css" href="/extraStyle.css" crossorigin="anonymous"/>`,
+      `<link rel="stylesheet" href="/extraStyle.css" crossorigin="anonymous"/>`,
     );
     await expect(response).toHaveBodyText(
       `<script>let ScriptFromHeadMarkup = 1;</script>`,

--- a/packages/web-worker/src/tests/utilities/server.ts
+++ b/packages/web-worker/src/tests/utilities/server.ts
@@ -70,7 +70,7 @@ export async function createServer({serve: servePath}: {serve: string}) {
     mount('/', (ctx: Context) => {
       ctx.body = `
         <html>
-          <body><script type="text/javascript" src="/assets/main.js"></script></body>
+          <body><script src="/assets/main.js"></script></body>
         </html>
       `;
     }),


### PR DESCRIPTION
## Description

`type="text/css"` is deprecated for `<style>`:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#attr-type

> This attribute should not be provided: if it is, the only permitted values are the empty string or a case-insensitive match for text/css.

`type="text/javascript"` is deprecated for `<script>`:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type

> Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type.

Removing them from HTML generation.
