### PR TITLE
react-html/server: inject blocking scripts before external stylesheets

### DIFF
--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -157,10 +157,10 @@ export default function Html({
         {metaMarkup}
         {linkMarkup}
 
+        {blockingScriptsMarkup}
         {stylesheetMarkup}
         {inlineStylesMarkup}
         {headMarkup}
-        {blockingScriptsMarkup}
         {deferredScriptsMarkup}
         {preloadAssetsMarkup}
       </head>


### PR DESCRIPTION
## Description

Placing inline scripts after external stylesheets forces the browser to finish downloading and applying those stylesheets before it can continue parsing (because it needs to have the styles present for JS, and needs to run the JS since that could alter the DOM tree mid-parse via document.write). In the majority of cases (or simply all cases), it is better to inject any synchronous inline scripts _prior_ to external stylesheets to avoid this.

My assumption with this PR is that `blockingScripts` is exclusively (or at least primarily) used for inline scripts. If that is incorrect, it may be worth adding a new option for `inlineScripts` that is injected after `<title>` and the core `<meta>` tags (http-equiv).

Once this is done, we can use it in Admin to avoid the performance hit from our [web-vitals inline polyfill](https://github.com/Shopify/web/blob/14312663a0e17e29caeae54a38fda5213937d4d3/server/router/middleware/render-react-app/middleware/render-response/render-response.tsx#L232-L235).

/cc @atesgoral 