### PR TITLE
Remove last require() in react-testing so we can use it with a modern tests runner

### DIFF
--- a/.changeset/forty-singers-bow.md
+++ b/.changeset/forty-singers-bow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': minor
+---
+
+Remove last require() in react-testing so we can use it with a modern tests runner

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {flushSync} from 'react-dom';
 import type {Root as ReactRoot} from 'react-dom/client';
 import {act} from 'react-dom/test-utils';
-import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
+import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection.js';
 
 import {TestWrapper} from './TestWrapper';
 import {Element} from './element';

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {flushSync} from 'react-dom';
 import type {Root as ReactRoot} from 'react-dom/client';
 import {act} from 'react-dom/test-utils';
+import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
 
 import {TestWrapper} from './TestWrapper';
 import {Element} from './element';
@@ -20,9 +21,6 @@ import {
   KeyPathFunction,
   ExtractKeypath,
 } from './types';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const {findCurrentFiberUsingSlowPath} = require('react-reconciler/reflection');
 
 type ResolveRoot = (element: Element<unknown>) => Element<unknown> | null;
 type Render = (


### PR DESCRIPTION

## Description

Remove last require() in react-testing so we can use it with a modern tests runner that bundle ESM.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
