### PR TITLE
[proposal]: Add sensitivity check to prefetcher

### DIFF
--- a/.changeset/tender-walls-hang.md
+++ b/.changeset/tender-walls-hang.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-async': minor
+---
+
+Add a sensitivity check to the Prefetcher component

--- a/packages/react-async/src/Prefetcher.tsx
+++ b/packages/react-async/src/Prefetcher.tsx
@@ -91,10 +91,8 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
   }
 
   private handleMouseMove = ({clientX, clientY}: MouseEvent) => {
-    if (!this.timeout) {
-      this.iX = clientX;
-      this.iY = clientY;
-    }
+    this.iX = clientX;
+    this.iY = clientY;
   };
 
   private handlePressStart = ({target}: MouseEvent) => {
@@ -185,14 +183,14 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
 
     this.timeoutUrl = url;
     // If the event is a mouse event, record initial mouse position upon entering the element
-    if (event instanceof MouseEvent) {
-      this.compare(url);
-    } else {
-      this.timeout = setTimeout(() => {
-        this.clearTimeout();
+    this.timeout = setTimeout(() => {
+      this.clearTimeout();
+      if (event instanceof MouseEvent) {
+        this.compare(url);
+      } else {
         this.setState({url});
-      }, INTENTION_DELAY_MS);
-    }
+      }
+    }, INTENTION_DELAY_MS);
   };
 
   private clearTimeout() {

--- a/packages/react-async/src/Prefetcher.tsx
+++ b/packages/react-async/src/Prefetcher.tsx
@@ -183,7 +183,7 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
     // If the event is a mouse event, record initial mouse position upon entering the element
     this.timeout = setTimeout(() => {
       this.clearTimeout();
-      if (event instanceof MouseEvent) {
+      if ('clientX' in event && 'clientY' in event) {
         this.compare(url);
       } else {
         this.setState({url});

--- a/packages/react-async/src/Prefetcher.tsx
+++ b/packages/react-async/src/Prefetcher.tsx
@@ -16,7 +16,7 @@ interface NavigatorWithConnection extends Navigator {
 }
 
 export const INTENTION_DELAY_MS = 150;
-export const SENSITIVITY = 10;
+export const SENSITIVITY = 15;
 
 class ConnectedPrefetcher extends React.PureComponent<Props, State> {
   state: State = {};
@@ -111,12 +111,10 @@ class ConnectedPrefetcher extends React.PureComponent<Props, State> {
 
   private compare = (url: URL | undefined) => {
     const {iX, iY} = this;
-    if (this.timeout) {
-      this.clearTimeout();
-    }
+    this.clearTimeout();
     // Calculate the change of the mouse position
     // If it is smaller than the sensitivity, we can assume that the user is intending on visiting the link
-    if (Math.abs(this.fX - iX) + Math.abs(this.fY - iY) < SENSITIVITY) {
+    if (Math.hypot(this.fX - iX, this.fY - iY) < SENSITIVITY) {
       this.setState({url});
     } else {
       this.fX = iX;

--- a/packages/react-async/src/tests/Prefetcher.test.tsx
+++ b/packages/react-async/src/tests/Prefetcher.test.tsx
@@ -41,7 +41,7 @@ describe('<Prefetch />', () => {
     expect(prefetcher).not.toContainReactComponent(MockComponent);
   });
 
-  it('prefetches a component when hovering over an element with a matching href for enough time and mouse movement below 10', () => {
+  it('prefetches a component when hovering over and mousemovement is below sensitivity', () => {
     const manager = createPrefetchManager([
       {render: () => <MockComponent />, path},
     ]);
@@ -57,9 +57,6 @@ describe('<Prefetch />', () => {
     triggerListener(prefetcher, 'mouseover', {
       target: mockEl,
     });
-
-    expect(prefetcher).not.toContainReactComponent(MockComponent);
-
     prefetcher.act(() => {
       triggerListener(
         prefetcher,
@@ -75,7 +72,7 @@ describe('<Prefetch />', () => {
     expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
-  it('does not prefetches a component when hovering over an element with a matching href for enough time and mouse movement above 10', () => {
+  it('does not prefetch a component when hovering over and mousemovement is below sensitivity', () => {
     const manager = createPrefetchManager([
       {render: () => <MockComponent />, path},
     ]);
@@ -87,13 +84,6 @@ describe('<Prefetch />', () => {
         </PrefetchContext.Provider>
       </div>,
     );
-
-    triggerListener(prefetcher, 'mouseover', {
-      target: mockEl,
-    });
-
-    expect(prefetcher).not.toContainReactComponent(MockComponent);
-
     prefetcher.act(() => {
       triggerListener(
         prefetcher,
@@ -101,12 +91,18 @@ describe('<Prefetch />', () => {
         {
           target: mockEl,
         },
-        {clientX: 5, clientY: 5},
+        {clientX: 5, clientY: 4},
       );
       clock.tick(INTENTION_DELAY_MS + 1);
     });
 
+    triggerListener(prefetcher, 'mouseover', {
+      target: mockEl,
+    });
+
     expect(prefetcher).not.toContainReactComponent(MockComponent);
+
+    // expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
   it('prefetches a component when focusing on an element with a matching href for enough time', () => {

--- a/packages/react-async/src/tests/Prefetcher.test.tsx
+++ b/packages/react-async/src/tests/Prefetcher.test.tsx
@@ -101,8 +101,6 @@ describe('<Prefetch />', () => {
     });
 
     expect(prefetcher).not.toContainReactComponent(MockComponent);
-
-    // expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
   it('prefetches a component when focusing on an element with a matching href for enough time', () => {

--- a/packages/react-async/src/tests/Prefetcher.test.tsx
+++ b/packages/react-async/src/tests/Prefetcher.test.tsx
@@ -53,10 +53,14 @@ describe('<Prefetch />', () => {
         </PrefetchContext.Provider>
       </div>,
     );
-
-    triggerListener(prefetcher, 'mouseover', {
-      target: mockEl,
-    });
+    triggerListener(
+      prefetcher,
+      'mouseover',
+      {
+        target: mockEl,
+      },
+      {clientX: 6, clientY: 3},
+    );
     prefetcher.act(() => {
       triggerListener(
         prefetcher,
@@ -64,7 +68,7 @@ describe('<Prefetch />', () => {
         {
           target: mockEl,
         },
-        {clientX: 5, clientY: 4},
+        {clientX: 5, clientY: 2},
       );
       clock.tick(INTENTION_DELAY_MS + 1);
     });
@@ -72,7 +76,7 @@ describe('<Prefetch />', () => {
     expect(prefetcher).toContainReactComponent(MockComponent);
   });
 
-  it('does not prefetch a component when hovering over and mousemovement is below sensitivity', () => {
+  it('does not prefetch a component when hovering over and mousemovement is above sensitivity', () => {
     const manager = createPrefetchManager([
       {render: () => <MockComponent />, path},
     ]);
@@ -84,6 +88,14 @@ describe('<Prefetch />', () => {
         </PrefetchContext.Provider>
       </div>,
     );
+    triggerListener(
+      prefetcher,
+      'mouseover',
+      {
+        target: mockEl,
+      },
+      {clientX: 6, clientY: 3},
+    );
     prefetcher.act(() => {
       triggerListener(
         prefetcher,
@@ -91,13 +103,9 @@ describe('<Prefetch />', () => {
         {
           target: mockEl,
         },
-        {clientX: 5, clientY: 4},
+        {clientX: 10, clientY: 25},
       );
       clock.tick(INTENTION_DELAY_MS + 1);
-    });
-
-    triggerListener(prefetcher, 'mouseover', {
-      target: mockEl,
     });
 
     expect(prefetcher).not.toContainReactComponent(MockComponent);


### PR DESCRIPTION
## Description

Proposing to add a sensitivity check to Prefetcher. This allows us to trigger prefetching with a little more accuracy by ensuring the mouse over is intentional. We can use the change in mouse position to calculate whether or not the user intends to navigate to said url. 

Heavily inspired by: https://github.com/natelindev/react-use-hoverintent/blob/master/src/index.ts

### Demo/Explanation

https://user-images.githubusercontent.com/9765013/220665662-5ae03a51-8cba-4fd0-a6e1-1f60e5c3dc4e.mp4

### 🎩 'ing instructions

[Spin URL](https://admin.web.constellation-6t51.thomas-devisscher.us.spin.dev/store/shop1)

1. Go to admin
2. Hover over sidebar navigation menu items
3. You shouldn't see network requests being fired if you hover over items quickly
4. You should see network requests being fired if you stop on an item for more than 2 seconds


<details><summary>

#### Rolling your own instance ⬇️

</summary>


##### How to work with Quilt packages

Some steps to work with Quilt packages or any other package locally/in your spin instance.

1. Create a constellation which includes the repo Quilt

```ymal
schema: v1
extend: shopify
repos:
  - web
  - argus-server
  - quilt
```

```
spin up constellation.yml
```

2. Open the quilt repo in spin and make your changes to the package
3. Publish the package locally with publish:local script. this puts the package in the yalc store

```
PKG_NAME=react-async yarn publish:local
```

4. Install yalc globally: yarn global add yalc, if yalc command is not found, export the path to global node_modules.

```
export PATH="$(yarn global bin):$PATH"
```

5. `yalc add @shopify/react-async && restart`  will grab the package from the yalc store and add it to your web repo then restart web.

</details>

<details><summary>

#### Slowing things down ⬇️

</summary>

1. Go to `packages/react-async/src/Prefetcher.tsx`
2. Increase the `INTENTION_DELAY_MS` to 2000
3. On line 122 add a console.log('prefetching')
4. On line 123 add a console.log('not prefetching')

Then publish the package, add it into web (Follow rolling your own instance instructions), and navigate to the admin. When hovering over an item, and pausing on it, you should see prefetching in the console after 2 seconds. If you hover over quickly, prefetching shouldn't fire.

</details>

I am available to pair or demo this at anytime! 🍐

### Before this can be implemented
- [x] Test mousemove event and ensure prefetch is triggered/not triggered when threshold is reached/not reached
- [x] Ensure all cases work as expected in web
- [x] Remove console logs/ cruft
- [ ] Discuss configuration, do we need to expose the sensitivity prop to consumers of this package?




