### PR TITLE
Support for async loading in Remix/Esbuild

### DIFF
--- a/.changeset/nine-pants-switch.md
+++ b/.changeset/nine-pants-switch.md
@@ -1,0 +1,6 @@
+---
+'@shopify/react-async': patch
+'@shopify/react-graphql': patch
+---
+
+Remove unnecessary mounted check while setting async loaded state, unnecessary and causes issues in Esbuild/Remix

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@shopify/async": "^4.0.1",
     "@shopify/react-effect": "^5.0.2",
-    "@shopify/react-hooks": "^3.0.2",
     "@shopify/react-hydrate": "^3.0.6",
     "@shopify/react-idle": "^3.0.3",
     "@shopify/react-intersection-observer": "^4.0.2",

--- a/packages/react-async/src/hooks.ts
+++ b/packages/react-async/src/hooks.ts
@@ -1,7 +1,6 @@
 import {useState, useCallback, useContext} from 'react';
 import {Resolver} from '@shopify/async';
 import {useServerEffect} from '@shopify/react-effect';
-import {useMountedRef} from '@shopify/react-hooks';
 import {IfAllOptionalKeys, NoInfer} from '@shopify/useful-types';
 
 import {AsyncAssetContext} from './context/assets';
@@ -70,8 +69,6 @@ export function useAsync<T>(
     immediate || typeof window !== 'undefined' ? resolver.resolved : null,
   );
 
-  const mounted = useMountedRef();
-
   const load = useCallback(async (): Promise<T | Error> => {
     if (value != null) {
       return value;
@@ -80,25 +77,20 @@ export function useAsync<T>(
     try {
       const resolved = await resolver.resolve();
 
-      if (mounted.current) {
-        // It's important to use the function form of setValue here.
-        // Resolved is going to be a function in most cases, since it's
-        // a React component. If you do not set it using the function form,
-        // React treats the component as the function that returns state,
-        // so it sets state with the result of manually calling the component
-        // (so, usually JSX).
-        setValue(() => resolved);
-      }
+      // It's important to use the function form of setValue here.
+      // Resolved is going to be a function in most cases, since it's
+      // a React component. If you do not set it using the function form,
+      // React treats the component as the function that returns state,
+      // so it sets state with the result of manually calling the component
+      // (so, usually JSX).
+      setValue(() => resolved);
 
       return resolved;
     } catch (error) {
-      if (mounted.current) {
-        setValue(error);
-      }
-
+      setValue(error);
       return error;
     }
-  }, [mounted, resolver, value]);
+  }, [resolver, value]);
 
   const {id} = resolver;
 

--- a/packages/react-async/tsconfig.json
+++ b/packages/react-async/tsconfig.json
@@ -13,7 +13,6 @@
   "references": [
     {"path": "../async"},
     {"path": "../react-effect"},
-    {"path": "../react-hooks"},
     {"path": "../react-hydrate"},
     {"path": "../react-idle"},
     {"path": "../react-intersection-observer"},

--- a/packages/react-graphql/package.json
+++ b/packages/react-graphql/package.json
@@ -29,7 +29,6 @@
     "@shopify/async": "^4.0.1",
     "@shopify/react-async": "^5.0.6",
     "@shopify/react-effect": "^5.0.2",
-    "@shopify/react-hooks": "^3.0.2",
     "@shopify/react-idle": "^3.0.3",
     "@shopify/useful-types": "^5.1.1",
     "apollo-cache-inmemory": ">=1.0.0 <2.0.0",

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -1,7 +1,6 @@
 import {useState, useEffect, useCallback} from 'react';
 import {OperationVariables} from 'apollo-client';
 import {DocumentNode} from 'graphql-typed';
-import {useMountedRef} from '@shopify/react-hooks';
 import {useAsyncAsset} from '@shopify/react-async';
 
 import {AsyncDocumentNode} from '../types';
@@ -26,20 +25,16 @@ export default function useGraphQLDocument<
     }
   });
 
-  const mounted = useMountedRef();
-
   const loadDocument = useCallback(async () => {
     if (!isDocumentNode(documentOrAsyncDocument)) {
       try {
         const resolved = await documentOrAsyncDocument.resolver.resolve();
-        if (mounted.current) {
-          setDocument(resolved);
-        }
+        setDocument(resolved);
       } catch (error) {
         throw Error('error loading GraphQL document');
       }
     }
-  }, [documentOrAsyncDocument, mounted]);
+  }, [documentOrAsyncDocument]);
 
   useEffect(() => {
     if (!document) {

--- a/packages/react-graphql/tsconfig.json
+++ b/packages/react-graphql/tsconfig.json
@@ -15,7 +15,6 @@
     {"path": "../async"},
     {"path": "../react-async"},
     {"path": "../react-effect"},
-    {"path": "../react-hooks"},
     {"path": "../react-idle"},
     {"path": "../react-testing"},
     {"path": "../useful-types"},


### PR DESCRIPTION
## Description

Works together with https://github.com/Shopify/quilt/pull/2538

When attempting to lazy load React components and GraphQL documents using Remix/Esbuild, we've found that the `load` callback from the async resolver will often be fired while the `useMountedRef` is returning false. This might indicate an edge case in `useMountedRef`, potentially because of the use of ESM in the browser, or rendering under Strict Mode.

This meant that the callback would be triggered and would resolve the async value, but because the mounted ref was set to false, we would not call the setState and so would never show the loaded value. By removing the mounted check, we get the value setting correctly.

We also believe that this is the right path forward regardless of this loading bug, because of a change introduced in React 18 to [no longer warn ](https://github.com/facebook/react/pull/22114#issuecomment-929191048) in this scenario. Setting state when the component was unmounted would previously emit a warning, with the intent to get developers to cancel their async actions as a cleanup state when unmounting a component. Unfortunately, many async actions don't have an easy option for cancelling so it led many devs to create variants of `isMounted`