### PR TITLE
 Remove unneeded test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "babel-loader": "^8.0.6",
     "core-js": "^3.14.0",
     "cross-fetch": "^3.0.4",
-    "element-closest": "^3.0.1",
     "eslint": "^8.9.0",
     "fs-extra": "^9.1.0",
     "get-port": "^5.0.0",

--- a/tests/setup/environment.ts
+++ b/tests/setup/environment.ts
@@ -5,7 +5,3 @@ import {TextEncoder, TextDecoder} from 'util';
 // our node-fetch polyfill is old, this isn't supported until whatwg-url is ^10.0.0
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
-
-if (Intl.PluralRules == null) {
-  require('intl-pluralrules');
-}

--- a/tests/setup/tests.ts
+++ b/tests/setup/tests.ts
@@ -1,4 +1,3 @@
-import addClosest from 'element-closest';
 import {toBeObject, toBeOneOf} from 'jest-extended';
 
 import '../matchers';
@@ -8,12 +7,7 @@ import '../../packages/graphql-testing/src/matchers';
 
 import {destroyAll} from '../../packages/react-testing/src/destroy';
 
-// expect.extend(matchers);
 expect.extend({toBeObject, toBeOneOf});
-
-if (typeof window !== 'undefined') {
-  addClosest(window);
-}
 
 // eslint-disable-next-line jest/require-top-level-describe
 afterEach(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6624,11 +6624,6 @@ electron-to-chromium@^1.4.84:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz#abfe376a4d70fa1e1b4b353b95df5d6dfd05da3a"
   integrity sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==
 
-element-closest@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-3.0.1.tgz#0b2000266ae43a800274401dc39486f5e4bfbce2"
-  integrity sha512-Wm8B0in+k6GsSCra8vLVnFIjIrff2T1s2b++jU6VL6mqIteP19THxDXwT5JDrmJPlqT3YifOK9cu28+uRGUdew==
-
 element-resize-detector@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.2.3.tgz#5078d9b99398fe4c589f8c8df94ff99e5d413ff3"


### PR DESCRIPTION
## Description

Removing unneeded things in test setup.

- Element.closest is built into jsdom so no need for the polyfill
- Intl.PluralRules in node supports all languages as of node 13
