### PR TITLE
Move babel config into a root level babel.config.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,34 @@
+/** @type {import('@babel/core').TransformOptions} */
+module.exports = function (api) {
+  const envName = api.env();
+
+  return {
+    targets: getTargetsForEnv(envName),
+    presets: [['@shopify/babel-preset', {typescript: true, react: true}]],
+    overrides: [
+      // Disable useBuiltins and corejs for the polyfills package
+      {
+        test: 'packages/polyfills',
+        presets: [
+          [
+            '@shopify/babel-preset',
+            {typescript: true, react: true, useBuiltIns: false, corejs: false},
+          ],
+        ],
+      },
+      // Target current node for loom files
+      {
+        test: ['config/loom/**/*.ts', '**/loom.config.ts'],
+        targets: 'current node',
+      },
+    ],
+  };
+};
+
+function getTargetsForEnv(envName) {
+  if (envName == 'test') {
+    return 'current node';
+  }
+
+  return {};
+}

--- a/config/loom/index.ts
+++ b/config/loom/index.ts
@@ -7,11 +7,7 @@ import {rollupConfig} from './plugin-rollup-config';
 import {writeBinaries} from './plugin-write-binaries';
 import {writeEntrypoints} from './plugin-write-entrypoints';
 
-export function quiltPackage({isIsomorphic = true, polyfill = true} = {}) {
-  // The babel preset polyfills by default, if we don't want polyfilling to
-  // occur we need to turn some options off
-  const polyfillOptions = polyfill ? {} : {useBuiltIns: false, corejs: false};
-
+export function quiltPackage({isIsomorphic = true} = {}) {
   const targets = isIsomorphic
     ? 'extends @shopify/browserslist-config, node 14.17.0'
     : 'node 14.17.0';
@@ -21,16 +17,6 @@ export function quiltPackage({isIsomorphic = true, polyfill = true} = {}) {
     rollupBuild(),
     rollupConfig({
       targets,
-      babelConfig: {
-        presets: [
-          [
-            '@shopify/babel-preset',
-            {typescript: true, react: true, ...polyfillOptions},
-          ],
-        ],
-        // Disable loading content from babel.config.js
-        configFile: false,
-      },
       commonjs: true,
       esmodules: true,
       esnext: true,

--- a/config/loom/plugin-rollup-config.ts
+++ b/config/loom/plugin-rollup-config.ts
@@ -8,11 +8,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import externals from 'rollup-plugin-node-externals';
 
-// Babel config that is provided by the hook is the same set of options as
-// defined on https://babeljs.io/docs/en/options, except the include and exclude
-// options may not be present
-interface BabelConfig extends Omit<TransformOptions, 'include' | 'exclude'> {}
-
 declare module '@shopify/loom' {
   interface BuildPackageTargetOptions {
     rollupEsnext?: boolean;
@@ -21,7 +16,6 @@ declare module '@shopify/loom' {
 
 interface RollupConfigOptions {
   targets: string;
-  babelConfig: BabelConfig;
   commonjs: boolean;
   esmodules: boolean;
   esnext: boolean;
@@ -87,8 +81,6 @@ export function rollupConfig(options: RollupConfigOptions) {
           });
 
           configuration.rollupPlugins?.hook(async (plugins) => {
-            const babelConfig = options.babelConfig;
-
             const babelTargets = isEsnextBuild
               ? ['last 1 chrome versions']
               : [options.targets];
@@ -107,7 +99,7 @@ export function rollupConfig(options: RollupConfigOptions) {
               }),
               commonjs(),
               babel({
-                ...babelConfig,
+                rootMode: 'upward',
                 // Options specific to @rollup/plugin-babel, these can not be
                 // present on the `babelConfig` object
                 extensions: ['.js', '.jsx', '.ts', '.tsx'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,28 +29,6 @@ const moduleNameMapper = {
 };
 
 const configOverrides = {
-  polyfills: {
-    transform: {
-      '^.+\\.(m?js|tsx?)$': [
-        `babel-jest`,
-        {
-          presets: [
-            [
-              '@shopify/babel-preset',
-              {
-                typescript: true,
-                react: true,
-                useBuiltIns: false,
-                corejs: false,
-              },
-            ],
-          ],
-          targets: 'current node',
-          envName: 'test',
-        },
-      ],
-    },
-  },
   'storybook-a11y-test': {
     testEnvironment: 'node',
   },
@@ -74,11 +52,7 @@ function project(packageName, overrideOptions = {}) {
     transform: {
       '^.+\\.(m?js|tsx?)$': [
         `babel-jest`,
-        {
-          presets: [['@shopify/babel-preset', {typescript: true, react: true}]],
-          targets: 'current node',
-          envName: 'test',
-        },
+        {rootMode: 'upward', targets: 'current node', envName: 'test'},
       ],
     },
     testEnvironment: 'jsdom',

--- a/packages/polyfills/loom.config.ts
+++ b/packages/polyfills/loom.config.ts
@@ -54,5 +54,5 @@ export default createPackage((pkg) => {
     root: './src/mutation-observer.node.ts',
   });
 
-  pkg.use(quiltPackage({polyfill: false}));
+  pkg.use(quiltPackage());
 });


### PR DESCRIPTION
## Description

Removes repeating babel config in loom config and jest config - there's now a single source of truth.


### To test

Compare build output to previous builds:

- Check out the main branch of quilt in your `~/projects/quilt` directory and run `yarn`, `yarn clean && yarn build` to produce a clean build
- Check out this branch of quilt in your `~/src/github.com/Shopify/quilt` directory and run `yarn`, `yarn clean && yarn build` to produce a clean build
- Run ` for PACKAGENAME in $(ls -1 packages); diff -ru ~/projects/quilt/packages/$PACKAGENAME/build packages/$PACKAGENAME/build -x '*.tsbuildinfo' -x '*.d.ts.map'` to compare the build folder output and note that it is identical
