### PR TITLE
Add ExportFormat.TypedDocumentNode

### DIFF
--- a/.changeset/sharp-bananas-provide.md
+++ b/.changeset/sharp-bananas-provide.md
@@ -1,0 +1,5 @@
+---
+'graphql-typescript-definitions': minor
+---
+
+Add `ExportFormat.TypedDocumentNode` to generates types that only use `@graphql-typed-document-node/core`. This fills in a gap where users want `@graphql-typed-document-node/core` but not `graphql-typed`.

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -205,7 +205,7 @@ As noted above, the configuration of your schema and GraphQL documents is done v
 - `--cwd`: run tool for `.graphqlconfig` located in this directory (default = `process.cwd()`)
 - `--add-typename`: adds a `__typename` field to every object type (default = `true`)
 - `--export-format`: species the shape of values exported from `.graphql` files (default = `document`)
-  - Options: `document` (exports a `graphql-typed` `DocumentNode`), `documentWithTypedDocumentNode` (exports a union of a `graphql-typed` `DocumentNode` and a `@graphql-typed-document-node/core` `TypedDocumentNode` ),`simple` (exports a `graphql-typed` `SimpleDocument`),
+  - Options: `document` (exports a `graphql-typed` `DocumentNode`), `typedDocumentNode` (exports a `@graphql-typed-document-node/core` `TypedDocumentNode`), `documentWithTypedDocumentNode` (exports a union of a `graphql-typed` `DocumentNode` and a `@graphql-typed-document-node/core` `TypedDocumentNode`),`simple` (exports a `graphql-typed` `SimpleDocument`),
 - `--enum-format`: specifies output format for enum types (default = `undefined`)
   - Options: `camel-case`, `pascal-case`, `snake-case`, `screaming-snake-case`
   - `undefined` results in using the unchanged name from the schema (verbatim)

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -52,6 +52,9 @@
   "peerDependenciesMeta": {
     "@graphql-typed-document-node/core": {
       "optional": true
+    },
+    "graphql-typed": {
+      "optional": true
     }
   },
   "files": [

--- a/packages/graphql-typescript-definitions/src/cli.ts
+++ b/packages/graphql-typescript-definitions/src/cli.ts
@@ -39,6 +39,7 @@ const argv = yargs
     describe: 'The format to use for values exported from GraphQL documents',
     choices: [
       ExportFormat.Document,
+      ExportFormat.TypedDocumentNode,
       ExportFormat.DocumentWithTypedDocumentNode,
       ExportFormat.Simple,
     ],

--- a/packages/graphql-typescript-definitions/src/types.ts
+++ b/packages/graphql-typescript-definitions/src/types.ts
@@ -7,6 +7,7 @@ export enum EnumFormat {
 
 export enum ExportFormat {
   Document = 'document',
+  TypedDocumentNode = 'typedDocumentNode',
   DocumentWithTypedDocumentNode = 'documentWithTypedDocumentNode',
   Simple = 'simple',
 }


### PR DESCRIPTION

## Description

Add `TypedDocumentNode` as an export format to allow users to generate types that adhere to only `@graphql-typed-document-node/core`.

Previously users could use `DocumentWithTypedDocumentNode` to generate types that adhered to both `graphql-typed` and
`@graphql-typed-document-node/core`, however there was no way to get just the `@graphql-typed-document-node/core` types.

See #2289, which added `DocumentWithTypedDocumentNode` for more context on why `@graphql-typed-document-node/core` is important
