### PR TITLE
Revert changes to binary info in loom.config files

### DIFF
--- a/.changeset/hungry-cobras-wonder.md
+++ b/.changeset/hungry-cobras-wonder.md
@@ -1,0 +1,5 @@
+---
+'graphql-typescript-definitions': patch
+---
+
+Republish to fix issue with index entrypoint in 3.3.0

--- a/packages/graphql-typescript-definitions/loom.config.ts
+++ b/packages/graphql-typescript-definitions/loom.config.ts
@@ -4,6 +4,6 @@ import {quiltPackage} from '../../config/loom';
 
 export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
-  pkg.entry({root: './src/cli.ts'});
+  pkg.binary({name: 'graphql-typescript-definitions', root: './src/cli.ts'});
   pkg.use(quiltPackage());
 });

--- a/packages/graphql-validate-fixtures/loom.config.ts
+++ b/packages/graphql-validate-fixtures/loom.config.ts
@@ -4,6 +4,6 @@ import {quiltPackage} from '../../config/loom';
 
 export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
-  pkg.entry({root: './src/cli.ts'});
+  pkg.binary({name: 'graphql-validate-fixtures', root: './src/cli.ts'});
   pkg.use(quiltPackage());
 });


### PR DESCRIPTION

## Description

Changes to loom.config files in #2558 messed with the generation of the entrypoint files, leading to publishing `graphql-typescript-definitions` v3.3.0 with an invalid index entrypoint.

This commit reverts the problematic part of the change, ensuring correct generation of the entrypoint.