### PR TITLE
Update publish local script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate": "plop",
     "generate:package": "plop package && yarn plop docs",
     "yalc": "yalc",
-    "publish:local": "yarn build --root packages/$PKG_NAME && yalc publish --push packages/$PKG_NAME",
+    "publish:local": "tsc --build && loom build --root packages/$PKG_NAME && yalc publish --push packages/$PKG_NAME",
     "tophat": "npx nodemon --watch packages/$PKG_NAME --exec 'yarn publish:local' --ignore packages/$PKG_NAME/build --ext ts --ignore '*.d.ts' --ignore '*.test.*'"
   },
   "repository": {


### PR DESCRIPTION
## Description

Updates the `publish:local` script. This allows you to publish to the yalc store and consume the package in another project. Change suggested by @BPScott.