### PR TITLE
[StatsD] Support amount input on increment

### DIFF
--- a/.changeset/tender-lemons-film.md
+++ b/.changeset/tender-lemons-film.md
@@ -1,0 +1,5 @@
+---
+'@shopify/statsd': minor
+---
+
+Added support for incrementing metric by specific value

--- a/packages/statsd/README.md
+++ b/packages/statsd/README.md
@@ -77,6 +77,17 @@ statsdClient.increment(
 );
 ```
 
+Increment can also be supplied a value to increment the metric by.
+
+```javascript
+statsdClient.increment(
+  'myCounter',
+  ['navigation', 'complete', 'performance'], // user-defined tags to go with the data,
+  {}, // additional options
+  4, // value to increment by
+);
+```
+
 #### `close`
 
 Close statsd client.

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -127,11 +127,16 @@ export class StatsDClient {
     });
   }
 
-  increment(stat: string | string[], tags?: Tags, options: MetricOptions = {}) {
+  increment(
+    stat: string | string[],
+    tags?: Tags,
+    options: MetricOptions = {},
+    value = 1,
+  ) {
     return new Promise<void>((resolve) => {
       this.statsd.increment(
         stat,
-        1,
+        value,
         options.sampleRate,
         this.normalizeTags(tags),
         this.createCallback(resolve),

--- a/packages/statsd/src/tests/client.test.ts
+++ b/packages/statsd/src/tests/client.test.ts
@@ -290,6 +290,28 @@ describe('StatsDClient', () => {
       );
     });
 
+    it('increment can be passed a value input so that the metric is incremented by a specific amount', () => {
+      const statsDClient = new StatsDClient({
+        ...defaultOptions,
+        snakeCase: true,
+      });
+
+      const amount = 4;
+
+      statsDClient.increment(stat, tags, {}, amount);
+      const stats = StatsDMock.mock.instances[0];
+      const incrementFn = stats.increment;
+
+      expect(incrementFn).toHaveBeenCalledTimes(1);
+      expect(incrementFn).toHaveBeenCalledWith(
+        stat,
+        amount,
+        undefined,
+        {foo_bar: tagValue},
+        expect.any(Function),
+      );
+    });
+
     it('calls errorHandler on the promise when the client returns an error', () => {
       const errorHandler = jest.fn();
       const statsDClient = new StatsDClient({...defaultOptions, errorHandler});


### PR DESCRIPTION
The base StatsD client we use (and also many other clients) support an optional input on `.increment` which increments the metric by the inputted value. This is especially helpful for bulk actions, currently we have to increment in a for loop. I think it's worth exposing this parameter as an optional input.

We've implemented this two different ways (each with pros and cons given the current setup)

### Method 1: Separate `incrementByAmount` method [9f10c4c80f1528fcc4968790a0f71059c0b3edaf]
This keeps things nice and clean input param wise, but can't help but think this action should be more of an overload than a separate method
```ts
incrementByAmount('metric', 5, ['tags'])
```
This is also inline with other similar packages

### Method 2: New optional param in `increment` [35bd84ebdc7525f1a1c90b3c4469abc21822dc84]
This allows for a cleaner interface, but with the downside of needing to also specify the optional `metricOptions` field if you want to specify `value`. Something like this
```ts
increment('metric', ['tags'], {}, 5)
```

Will add in the changelog once we decide on which way we want to go