### PR TITLE
Fixing an issue with the web-worker babel-plugin

### DIFF
--- a/.changeset/cold-dryers-refuse.md
+++ b/.changeset/cold-dryers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/web-worker': patch
+---
+
+Fixing an issue with the babel-plugin when user try to import `createWorkerFactory` or `createPlainWorkerFactory` from `@shopify/react-web-worker`

--- a/packages/web-worker/src/babel-plugin.ts
+++ b/packages/web-worker/src/babel-plugin.ts
@@ -10,6 +10,14 @@ export const DEFAULT_PACKAGES_TO_PROCESS = {
       wrapperModule: resolve(__dirname, 'wrappers/expose.js.raw'),
     },
   ] as ProcessableImport[],
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  '@shopify/react-web-worker': [
+    {name: 'createPlainWorkerFactory'},
+    {
+      name: 'createWorkerFactory',
+      wrapperModule: resolve(__dirname, 'wrappers/expose.js.raw'),
+    },
+  ] as ProcessableImport[],
 };
 
 const loader = resolve(__dirname, 'webpack-parts/loader');


### PR DESCRIPTION
## Description
Fixing an issue with the babel-plugin used by `@shopify/web-worker` when importing `createWorkerFactory` or `createPlainWorkerFactory` from `@shopify/react-web-worker`

This code doesn't work without this PR.
```
import {createPlainWorkerFactory, useWorker} from '@shopify/react-web-worker';
const createWorker = createPlainWorkerFactory(
  () => import(/* webpackChunkName: 'worker' */ './worker'),
);
```

The import statement need to be converted into a string by the babel plugin.

This will work
```
import {useWorker} from '@shopify/react-web-worker';
import {createPlainWorkerFactory} from '@shopify/web-worker';
const createWorker = createPlainWorkerFactory(
  () => import(/* webpackChunkName: 'worker' */ './worker'),
);
```

I 🎩 everything in my project.