### PR TITLE
Less aggressive escaping of `<script>` content

### DIFF
--- a/.changeset/curvy-owls-brake.md
+++ b/.changeset/curvy-owls-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-html': patch
+---
+
+Less aggressive escaping of script tag content

--- a/packages/react-html/package.json
+++ b/packages/react-html/package.json
@@ -33,8 +33,8 @@
     "@shopify/react-effect": "^5.0.2",
     "@shopify/react-hydrate": "^3.0.6",
     "@types/multistream": "^2.1.1",
-    "multistream": "^2.1.1",
-    "serialize-javascript": "^3.0.0"
+    "jsesc": "^3.0.2",
+    "multistream": "^2.1.1"
   },
   "peerDependencies": {
     "react": ">=16.8.0 <19.0.0",

--- a/packages/react-html/src/server/components/Serialize.tsx
+++ b/packages/react-html/src/server/components/Serialize.tsx
@@ -11,6 +11,7 @@ interface Props {
 export default function Serialize({id, data}: Props) {
   const serialized = jsesc(data, {
     isScriptContext: true,
+    json: true,
   });
 
   return (

--- a/packages/react-html/src/server/components/Serialize.tsx
+++ b/packages/react-html/src/server/components/Serialize.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import serialize from 'serialize-javascript';
+import jsesc from 'jsesc';
 
 import {SERIALIZE_ATTRIBUTE} from '../../utilities';
 
@@ -9,10 +9,14 @@ interface Props {
 }
 
 export default function Serialize({id, data}: Props) {
+  const serialized = jsesc(data, {
+    isScriptContext: true,
+  });
+
   return (
     <script
       type="text/json"
-      dangerouslySetInnerHTML={{__html: serialize(data, {isJSON: true})}}
+      dangerouslySetInnerHTML={{__html: serialized}}
       {...{[SERIALIZE_ATTRIBUTE]: id}}
     />
   );

--- a/packages/react-html/src/server/components/tests/Serialize.test.tsx
+++ b/packages/react-html/src/server/components/tests/Serialize.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import serializeJavaScript from 'serialize-javascript';
 import {mount} from '@shopify/react-testing';
 
 import Serialize from '../Serialize';
@@ -23,14 +22,20 @@ describe('<Serialize />', () => {
   describe('data', () => {
     it('serializes the content as the child contents of the script tag', () => {
       const data = {
-        foo: {bar: {baz: 'window.location = "http://dangerous.com"'}},
+        foo: {
+          bar: {
+            baz: 'window.location = "http://example.com"',
+          },
+        },
+        xss: '</script><script>alert("hax")</script>',
       };
 
       const serialize = mount(<Serialize id={id} data={data} />);
 
       expect(serialize).toContainReactComponent('script', {
         dangerouslySetInnerHTML: {
-          __html: serializeJavaScript(data, {isJSON: true}),
+          __html:
+            '{"foo":{"bar":{"baz":"window.location = \\"http://example.com\\""}},"xss":"<\\/script><script>alert(\\"hax\\")<\\/script>"}',
         },
       });
     });

--- a/packages/react-server/src/server/tests/server.test.tsx
+++ b/packages/react-server/src/server/tests/server.test.tsx
@@ -61,7 +61,7 @@ describe('createServer()', () => {
     const response = await wrapper.fetch('/');
 
     expect(await response.clone().text()).toContain(
-      `<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="referrer" content="never"/></head><body><div id="app"><div>markup</div></div><script type="text/json" data-serialized-id="quilt-data">undefined</script></body></html>`,
+      `<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="referrer" content="never"/></head><body><div id="app"><div>markup</div></div><script type="text/json" data-serialized-id="quilt-data">null</script></body></html>`,
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9813,6 +9813,11 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
@@ -12937,13 +12942,6 @@ sentence-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
-
-serialize-javascript@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
-  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
-  dependencies:
-    randombytes "^2.1.0"
 
 serialize-javascript@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

We escape more than necessary, e.g.:

```
"zoneinfo": "America\u002FNew_York"
```

Use `jsesc` in script context + JSON mode instead of using `serialize-javascript` in JSON mode.