### PR TITLE
Enable noImplicitReturns:true and allowUnreachableCode:false when type-checking

### DIFF
--- a/.changeset/eighty-bears-leave.md
+++ b/.changeset/eighty-bears-leave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/koa-shopify-graphql-proxy': patch
+---
+
+Remove unneeded return statement after a throw

--- a/.changeset/fair-baboons-destroy.md
+++ b/.changeset/fair-baboons-destroy.md
@@ -1,0 +1,12 @@
+---
+'@shopify/ast-utilities': patch
+'@shopify/koa-performance': patch
+'@shopify/mime-types': patch
+'@shopify/react-form': patch
+'@shopify/react-form-state': patch
+'@shopify/react-google-analytics': patch
+'@shopify/react-hooks': patch
+'@shopify/react-performance': patch
+---
+
+Add explict `return undefined` to functions that had implicit returns

--- a/.changeset/rare-jars-roll.md
+++ b/.changeset/rare-jars-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mime-types': patch
+---
+
+getExtensionFromMimeType should return undefined if you pass in an unknown mime type

--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -22,8 +22,6 @@
     // These reach a level of pedanticness we aren't worried about
     // importsNotUsedAsValues has 50 violations, but they're trivial fixes
     "importsNotUsedAsValues": "remove",
-    // allowUnreachableCode has 3 violations, should be a quick fix
-    "allowUnreachableCode": true,
     "noImplicitOverride": false,
     // noImplicitReturns has 8 violations, should be a quick fix
     "noImplicitReturns": false,

--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -23,8 +23,6 @@
     // importsNotUsedAsValues has 50 violations, but they're trivial fixes
     "importsNotUsedAsValues": "remove",
     "noImplicitOverride": false,
-    // noImplicitReturns has 8 violations, should be a quick fix
-    "noImplicitReturns": false,
     "noPropertyAccessFromIndexSignature": false,
     "noUncheckedIndexedAccess": false,
     "exactOptionalPropertyTypes": false

--- a/packages/ast-utilities/src/javascript/addComponentProps/addComponentProps.ts
+++ b/packages/ast-utilities/src/javascript/addComponentProps/addComponentProps.ts
@@ -32,6 +32,8 @@ export default function addComponentProps(
                   prop.value.name === attr.value.expression.name
                 );
               }
+
+              return false;
             }).length,
           ),
         );

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -210,6 +210,7 @@ export function clientPerformanceMetrics({
       const distributions = metrics.map(({name, value, tags}) => {
         if (development) {
           appLogger.log(`Skipping sending metric in dev ${name}: ${value}`);
+          return undefined;
         } else {
           appLogger.log(`Sending metric ${name}: ${value}`);
           return statsd.distribution(name, value, tags);

--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -48,7 +48,6 @@ export default function shopifyGraphQLProxy(proxyOptions: ProxyOptions) {
 
     if (accessToken == null || shop == null) {
       ctx.throw(403, 'Unauthorized');
-      return;
     }
 
     await proxy(shop, {

--- a/packages/mime-types/src/get-extension-from-mime-type.ts
+++ b/packages/mime-types/src/get-extension-from-mime-type.ts
@@ -41,7 +41,4 @@ export function getExtensionFromMimeType(mimeType: MimeType) {
     case MimeType.Svg:
       return '.svg';
   }
-
-  const nope: never = mimeType;
-  return nope;
 }

--- a/packages/mime-types/src/get-mime-type-from-filename.ts
+++ b/packages/mime-types/src/get-mime-type-from-filename.ts
@@ -44,6 +44,8 @@ export function getMimeTypeFromFilename(filename: string) {
     case 'svg':
       return MimeType.Svg;
   }
+
+  return undefined;
 }
 
 function getFileExtension(filename: string) {
@@ -52,4 +54,6 @@ function getFileExtension(filename: string) {
   if (match) {
     return match[1];
   }
+
+  return undefined;
 }

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -68,6 +68,8 @@ export function validateList<Input extends object, Fields>(
     if (errors.some((error) => error != null)) {
       return errors;
     }
+
+    return undefined;
   };
 }
 

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -134,6 +134,7 @@ export function useField<Value = string>(
       }
 
       dispatch(updateErrorAction(undefined));
+      return undefined;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [state.value, ...dependencies],

--- a/packages/react-form/src/hooks/field/tests/field.test.tsx
+++ b/packages/react-form/src/hooks/field/tests/field.test.tsx
@@ -442,6 +442,7 @@ describe('useField', () => {
           if (someOtherFieldValue === 'radical' && value === 'pants') {
             return 'no radical pants allowed';
           }
+          return undefined;
         },
       };
 

--- a/packages/react-form/src/hooks/list/tests/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/baselist.test.tsx
@@ -214,6 +214,7 @@ describe('useBaseList', () => {
             if (value.length < 1) {
               return 'Price must be specified';
             }
+            return undefined;
           },
         };
 
@@ -383,6 +384,7 @@ describe('useBaseList', () => {
             if (anyDupes) {
               return 'No duplicates allowed';
             }
+            return undefined;
           },
         };
 

--- a/packages/react-form/src/hooks/list/utils/utils.ts
+++ b/packages/react-form/src/hooks/list/utils/utils.ts
@@ -32,4 +32,5 @@ export function runValidation<Value, Record extends object>(
   }
 
   updateError(undefined);
+  return undefined;
 }

--- a/packages/react-google-analytics/src/Universal.tsx
+++ b/packages/react-google-analytics/src/Universal.tsx
@@ -53,7 +53,7 @@ export default function UniversalGoogleAnalytics({
           onError(googleAnalytics);
         }
 
-        return null;
+        return;
       }
 
       googleAnalytics('create', account, 'auto', options);

--- a/packages/react-hooks/src/hooks/interval.ts
+++ b/packages/react-hooks/src/hooks/interval.ts
@@ -26,5 +26,7 @@ export function useInterval(callback: IntervalCallback, delay: IntervalDelay) {
       const id = setInterval(tick, delay);
       return () => clearInterval(id);
     }
+
+    return undefined;
   }, [delay]);
 }

--- a/packages/react-hooks/src/hooks/timeout.ts
+++ b/packages/react-hooks/src/hooks/timeout.ts
@@ -21,5 +21,7 @@ export function useTimeout(callback: IntervalCallback, delay: IntervalDelay) {
       const id = setTimeout(tick, delay);
       return () => clearTimeout(id);
     }
+
+    return undefined;
   }, [delay]);
 }

--- a/packages/react-performance/src/performance-effect.ts
+++ b/packages/react-performance/src/performance-effect.ts
@@ -23,6 +23,8 @@ export function usePerformanceEffect(
     if (cleanup) {
       return cleanup;
     }
+
+    return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [performance, ...dependencies]);
 }


### PR DESCRIPTION
## Description

Simplify our type-checking config, and improve strictness of our codebase by enabling `noImplicitReturns:true` and `allowUnreachableCode:false` in our type-checking config.

- Add explicit `return undefined` statements to functions that contained an implicit return
- Remove unreachable code.