### PR TITLE
Simpify babel config slightly

### DIFF
--- a/.changeset/fair-dancers-train.md
+++ b/.changeset/fair-dancers-train.md
@@ -1,0 +1,23 @@
+---
+'@shopify/browser': patch
+'@shopify/graphql-persisted': patch
+'@shopify/graphql-testing': patch
+'graphql-typescript-definitions': patch
+'@shopify/jest-dom-mocks': patch
+'@shopify/logger': patch
+'@shopify/performance': patch
+'@shopify/react-async': patch
+'@shopify/react-effect': patch
+'@shopify/react-i18n': patch
+'@shopify/react-network': patch
+'@shopify/react-server': patch
+'@shopify/react-shortcuts': patch
+'@shopify/react-testing': patch
+'@shopify/semaphore': patch
+'@shopify/sewing-kit-koa': patch
+'@shopify/statsd': patch
+'@shopify/storybook-a11y-test': patch
+'@shopify/web-worker': patch
+---
+
+Remove unneeded `void 0` class property initializations

--- a/babel.config.js
+++ b/babel.config.js
@@ -7,24 +7,28 @@ module.exports = function (api) {
     presets: [
       [
         '@babel/preset-env',
-        {bugfixes: true, useBuiltIns: 'entry', corejs: '3.0'},
+        {
+          bugfixes: true,
+          useBuiltIns: 'entry',
+          corejs: '3.0',
+          // Always include these transformations, as we want to maintain
+          // webpack v4 support for esnext builds until the next major release.
+          // These syntaxes are not supported in acorn v6 (used by webpack v4),
+          // so we must transpile them away if we want webpack v4 support
+          // See https://github.com/webpack/webpack/issues/10227
+          include: [
+            '@babel/plugin-proposal-class-properties',
+            '@babel/plugin-proposal-private-methods',
+            '@babel/plugin-proposal-numeric-separator',
+            '@babel/plugin-proposal-nullish-coalescing-operator',
+            '@babel/plugin-proposal-optional-chaining',
+          ],
+        },
       ],
       ['@babel/preset-typescript'],
       ['@babel/preset-react', {development, useBuiltIns: true}],
     ],
-    plugins: [
-      // These plugins are handled by preset-env.
-      // But they aren't yet supported in webpack 4 because of missing support
-      // in acorn v6 (support is in acorn v7, which is used in webpack v5).
-      // So we want to always transpile this synax away
-      // See https://github.com/webpack/webpack/issues/10227
-      // Can be removed once we drop support for webpack v4
-      '@babel/plugin-proposal-class-properties',
-      '@babel/plugin-proposal-private-methods',
-      '@babel/plugin-proposal-numeric-separator',
-      '@babel/plugin-proposal-nullish-coalescing-operator',
-      '@babel/plugin-proposal-optional-chaining',
-    ],
+    plugins: [],
     assumptions: {
       setPublicClassFields: true,
       privateFieldsAsProperties: true,


### PR DESCRIPTION
## Description

This moves preset-env plugins to be included as part of the preset-env pass rather than separately - which is now possible because we've dropped decorator support.

This does produce some slight output changes in production builds - mostly removing cases where class properties were needlessly initialized.


### To test

Compare build output to previous builds:

- Check out the main branch of quilt in your `~/projects/quilt` directory and run `yarn`, `yarn clean && yarn build` to produce a clean build
- Check out this branch of quilt in your `~/src/github.com/Shopify/quilt` directory and run `yarn`, `yarn clean && yarn build` to produce a clean build
- Run `for PACKAGENAME in $(ls -1 packages); diff -ru ~/projects/quilt/packages/$PACKAGENAME packages/$PACKAGENAME -x '*.tsbuildinfo' -x '*.d.ts.map'` to compare the build folder output.
  -  Note that the differences are due to removed initializations to `void 0` for class properties. In the majority of these cases the property was set to be a defined value shortly below the removed line.

