### PR TITLE
Enable importsNotUsedAsValues:error and use import type where possible

### DIFF
--- a/.changeset/lucky-adults-remember.md
+++ b/.changeset/lucky-adults-remember.md
@@ -1,0 +1,46 @@
+---
+'@shopify/address': patch
+'@shopify/address-mocks': patch
+'@shopify/async': patch
+'@shopify/dates': patch
+'graphql-config-utilities': patch
+'graphql-fixtures': patch
+'graphql-mini-transforms': patch
+'@shopify/graphql-persisted': patch
+'@shopify/graphql-testing': patch
+'graphql-tool-utilities': patch
+'graphql-typescript-definitions': patch
+'graphql-validate-fixtures': patch
+'@shopify/jest-dom-mocks': patch
+'@shopify/jest-koa-mocks': patch
+'@shopify/koa-liveness-ping': patch
+'@shopify/koa-metrics': patch
+'@shopify/koa-performance': patch
+'@shopify/koa-shopify-graphql-proxy': patch
+'@shopify/koa-shopify-webhooks': patch
+'@shopify/performance': patch
+'@shopify/react-async': patch
+'@shopify/react-bugsnag': patch
+'@shopify/react-compose': patch
+'@shopify/react-cookie': patch
+'@shopify/react-effect': patch
+'@shopify/react-form': patch
+'@shopify/react-form-state': patch
+'@shopify/react-google-analytics': patch
+'@shopify/react-graphql': patch
+'@shopify/react-html': patch
+'@shopify/react-hydrate': patch
+'@shopify/react-i18n': patch
+'@shopify/react-idle': patch
+'@shopify/react-intersection-observer': patch
+'@shopify/react-network': patch
+'@shopify/react-performance': patch
+'@shopify/react-server': patch
+'@shopify/react-shortcuts': patch
+'@shopify/react-testing': patch
+'@shopify/react-web-worker': patch
+'@shopify/sewing-kit-koa': patch
+'@shopify/web-worker': patch
+---
+
+Use `import type` when importing types

--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -20,8 +20,6 @@
     // These values are are not controled by strict mode, though they are
     // enabled in the 'strictest' config that we inherit from.
     // These reach a level of pedanticness we aren't worried about
-    // importsNotUsedAsValues has 50 violations, but they're trivial fixes
-    "importsNotUsedAsValues": "remove",
     "noImplicitOverride": false,
     "noPropertyAccessFromIndexSignature": false,
     "noUncheckedIndexedAccess": false,

--- a/packages/address-mocks/src/fixtures/countries_af.ts
+++ b/packages/address-mocks/src/fixtures/countries_af.ts
@@ -1,4 +1,4 @@
-import {LoadCountriesResponse} from '@shopify/address-consts';
+import type {LoadCountriesResponse} from '@shopify/address-consts';
 
 const data: LoadCountriesResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/countries_en.ts
+++ b/packages/address-mocks/src/fixtures/countries_en.ts
@@ -1,4 +1,4 @@
-import {LoadCountriesResponse} from '@shopify/address-consts';
+import type {LoadCountriesResponse} from '@shopify/address-consts';
 
 const data: LoadCountriesResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/countries_fr.ts
+++ b/packages/address-mocks/src/fixtures/countries_fr.ts
@@ -1,4 +1,4 @@
-import {LoadCountriesResponse} from '@shopify/address-consts';
+import type {LoadCountriesResponse} from '@shopify/address-consts';
 
 const data: LoadCountriesResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/countries_ja.ts
+++ b/packages/address-mocks/src/fixtures/countries_ja.ts
@@ -1,4 +1,4 @@
-import {LoadCountriesResponse} from '@shopify/address-consts';
+import type {LoadCountriesResponse} from '@shopify/address-consts';
 
 const data: LoadCountriesResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/country_ca_af.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_af.ts
@@ -1,4 +1,4 @@
-import {LoadCountryResponse} from '@shopify/address-consts';
+import type {LoadCountryResponse} from '@shopify/address-consts';
 
 const data: LoadCountryResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/country_ca_en.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_en.ts
@@ -1,4 +1,4 @@
-import {LoadCountryResponse} from '@shopify/address-consts';
+import type {LoadCountryResponse} from '@shopify/address-consts';
 
 const data: LoadCountryResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/country_ca_fr.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_fr.ts
@@ -1,4 +1,4 @@
-import {LoadCountryResponse} from '@shopify/address-consts';
+import type {LoadCountryResponse} from '@shopify/address-consts';
 
 const data: LoadCountryResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/country_ca_ja.ts
+++ b/packages/address-mocks/src/fixtures/country_ca_ja.ts
@@ -1,4 +1,4 @@
-import {LoadCountryResponse} from '@shopify/address-consts';
+import type {LoadCountryResponse} from '@shopify/address-consts';
 
 const data: LoadCountryResponse = {
   data: {

--- a/packages/address-mocks/src/fixtures/index.ts
+++ b/packages/address-mocks/src/fixtures/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   LoadCountriesResponse,
   LoadCountryResponse,
 } from '@shopify/address-consts';

--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -1,4 +1,4 @@
-import {Address, FieldName, Country} from '@shopify/address-consts';
+import type {Address, FieldName, Country} from '@shopify/address-consts';
 
 import {formatAddress, buildOrderedFields} from './format';
 import {loadCountry, loadCountries} from './loader';

--- a/packages/address/src/format.ts
+++ b/packages/address/src/format.ts
@@ -1,4 +1,4 @@
-import {Address, Country, FieldName} from '@shopify/address-consts';
+import type {Address, Country, FieldName} from '@shopify/address-consts';
 
 import {FIELDS_MAPPING, FIELD_REGEXP, renderLineTemplate} from './utilities';
 

--- a/packages/address/src/tests/AddressFormatter.test.ts
+++ b/packages/address/src/tests/AddressFormatter.test.ts
@@ -1,5 +1,5 @@
 import {fetch} from '@shopify/jest-dom-mocks';
-import {Address} from '@shopify/address-consts';
+import type {Address} from '@shopify/address-consts';
 import {mockCountryRequests} from '@shopify/address-mocks';
 
 import AddressFormatter from '../AddressFormatter';

--- a/packages/address/src/tests/format.test.ts
+++ b/packages/address/src/tests/format.test.ts
@@ -1,4 +1,4 @@
-import {Address} from '@shopify/address-consts';
+import type {Address} from '@shopify/address-consts';
 import {fixtures} from '@shopify/address-mocks';
 
 import {buildOrderedFields, formatAddress} from '../format';

--- a/packages/address/src/tests/utilities.test.ts
+++ b/packages/address/src/tests/utilities.test.ts
@@ -1,4 +1,4 @@
-import {Address} from '@shopify/address-consts';
+import type {Address} from '@shopify/address-consts';
 import {fixtures} from '@shopify/address-mocks';
 
 import {renderLineTemplate} from '../utilities';

--- a/packages/async/src/babel-plugin.ts
+++ b/packages/async/src/babel-plugin.ts
@@ -1,5 +1,5 @@
-import Types from '@babel/types';
-import {NodePath, Binding} from '@babel/traverse';
+import type Types from '@babel/types';
+import type {NodePath, Binding} from '@babel/traverse';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const DEFAULT_PACKAGES_TO_PROCESS = {

--- a/packages/async/src/resolver.ts
+++ b/packages/async/src/resolver.ts
@@ -1,4 +1,4 @@
-import {Import} from './types';
+import type {Import} from './types';
 
 export interface Resolver<T> {
   readonly id?: string;

--- a/packages/dates/src/get-date-diff.ts
+++ b/packages/dates/src/get-date-diff.ts
@@ -1,4 +1,4 @@
-import {TimeUnit} from './constants';
+import type {TimeUnit} from './constants';
 
 export function getDateDiff(
   resolution: TimeUnit,

--- a/packages/graphql-config-utilities/src/config.ts
+++ b/packages/graphql-config-utilities/src/config.ts
@@ -2,7 +2,7 @@ import {existsSync} from 'fs';
 import {promisify} from 'util';
 import {resolve} from 'path';
 
-import {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
+import type {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
 // we need to use an import/require here because it does not force consumers to
 // enable esModuleInterop in tsconfig.json
 import glob from 'glob';

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -11,8 +11,8 @@ import {
   isScalarType,
   GraphQLScalarType,
 } from 'graphql';
-import {DocumentNode, GraphQLOperation} from 'graphql-typed';
-import {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
+import type {DocumentNode, GraphQLOperation} from 'graphql-typed';
+import type {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
 import {
   compile,
   Field,

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -11,7 +11,7 @@ import {
   SelectionNode,
   Location,
 } from 'graphql';
-import {DocumentNode, SimpleDocument} from 'graphql-typed';
+import type {DocumentNode, SimpleDocument} from 'graphql-typed';
 
 const IMPORT_REGEX = /^#import\s+['"]([^'"]*)['"];?[\s\n]*/gm;
 const DEFAULT_NAME = 'Operation';

--- a/packages/graphql-persisted/src/koa-middleware.ts
+++ b/packages/graphql-persisted/src/koa-middleware.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 import compose from 'koa-compose';
 import bodyparser from 'koa-bodyparser';
 import {getAssets} from '@shopify/sewing-kit-koa';

--- a/packages/graphql-testing/src/factory.ts
+++ b/packages/graphql-testing/src/factory.ts
@@ -1,5 +1,5 @@
 import {GraphQL, Options} from './graphql-controller';
-import {GraphQLMock} from './types';
+import type {GraphQLMock} from './types';
 
 export function createGraphQLFactory(options?: Options) {
   return function createGraphQL(mock?: GraphQLMock) {

--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -8,7 +8,7 @@ import {
 import {MockLink, InflightLink} from './links';
 import {Operations} from './operations';
 import {operationNameFromFindOptions} from './utilities';
-import {GraphQLMock, MockRequest, FindOptions} from './types';
+import type {GraphQLMock, MockRequest, FindOptions} from './types';
 
 export interface Options {
   cacheOptions?: InMemoryCacheConfig;

--- a/packages/graphql-testing/src/links/inflight.ts
+++ b/packages/graphql-testing/src/links/inflight.ts
@@ -6,7 +6,7 @@ import {
   FetchResult,
 } from '@apollo/client';
 
-import {MockRequest} from '../types';
+import type {MockRequest} from '../types';
 
 interface Options {
   onCreated(request: MockRequest): void;

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -1,7 +1,7 @@
 import {ApolloLink, Observable, Operation} from '@apollo/client';
 import {ExecutionResult, GraphQLError} from 'graphql';
 
-import {GraphQLMock, MockGraphQLFunction} from '../types';
+import type {GraphQLMock, MockGraphQLFunction} from '../types';
 
 export class MockLink extends ApolloLink {
   constructor(private mock: GraphQLMock) {

--- a/packages/graphql-testing/src/matchers/index.ts
+++ b/packages/graphql-testing/src/matchers/index.ts
@@ -1,4 +1,4 @@
-import {GraphQLOperation} from 'graphql-typed';
+import type {GraphQLOperation} from 'graphql-typed';
 
 import {toHavePerformedGraphQLOperation} from './operations';
 

--- a/packages/graphql-testing/src/matchers/operations.ts
+++ b/packages/graphql-testing/src/matchers/operations.ts
@@ -3,10 +3,10 @@ import {
   printExpected,
   EXPECTED_COLOR as expectedColor,
 } from 'jest-matcher-utils';
-import {GraphQLOperation, DocumentNode} from 'graphql-typed';
-import {Operation} from '@apollo/client';
+import type {GraphQLOperation, DocumentNode} from 'graphql-typed';
+import type {Operation} from '@apollo/client';
 
-import {GraphQL} from '../graphql-controller';
+import type {GraphQL} from '../graphql-controller';
 import {
   operationNameFromDocument,
   operationTypeFromDocument,

--- a/packages/graphql-testing/src/matchers/utilities.ts
+++ b/packages/graphql-testing/src/matchers/utilities.ts
@@ -6,7 +6,7 @@ import {
   printWithType,
   printReceived,
 } from 'jest-matcher-utils';
-import {Operation} from '@apollo/client';
+import type {Operation} from '@apollo/client';
 
 import {GraphQL} from '../graphql-controller';
 

--- a/packages/graphql-testing/src/operations.ts
+++ b/packages/graphql-testing/src/operations.ts
@@ -1,7 +1,7 @@
-import {Operation} from '@apollo/client';
+import type {Operation} from '@apollo/client';
 
 import {operationNameFromFindOptions} from './utilities';
-import {FindOptions} from './types';
+import type {FindOptions} from './types';
 
 export class Operations {
   private operations: Operation[] = [];

--- a/packages/graphql-testing/src/types.ts
+++ b/packages/graphql-testing/src/types.ts
@@ -1,5 +1,5 @@
-import {DocumentNode} from 'graphql';
-import {GraphQLRequest, Operation} from '@apollo/client';
+import type {DocumentNode} from 'graphql';
+import type {GraphQLRequest, Operation} from '@apollo/client';
 
 export interface FindOptions {
   query?: DocumentNode | {resolver: {resolved?: DocumentNode}};

--- a/packages/graphql-testing/src/utilities.ts
+++ b/packages/graphql-testing/src/utilities.ts
@@ -1,6 +1,6 @@
-import {DocumentNode, OperationDefinitionNode} from 'graphql';
+import type {DocumentNode, OperationDefinitionNode} from 'graphql';
 
-import {FindOptions} from './types';
+import type {FindOptions} from './types';
 
 export function operationNameFromFindOptions({query, mutation}: FindOptions) {
   const passedOptions = [query, mutation].filter(Boolean);

--- a/packages/graphql-tool-utilities/src/ast.ts
+++ b/packages/graphql-tool-utilities/src/ast.ts
@@ -1,4 +1,4 @@
-import {DocumentNode, GraphQLInputType, GraphQLSchema} from 'graphql';
+import type {DocumentNode, GraphQLInputType, GraphQLSchema} from 'graphql';
 import {
   BooleanCondition,
   CompilerOptions,

--- a/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
@@ -1,5 +1,5 @@
 import {FSWatcher, watch} from 'chokidar';
-import {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
+import type {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
 import {
   getGraphQLProjectIncludedFilePaths,
   getGraphQLProjects,

--- a/packages/graphql-typescript-definitions/src/filesystem/graphql-filesystem.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/graphql-filesystem.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from 'events';
 
-import {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
+import type {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
 
 export interface GraphQLFilesystem {
   watch(config: GraphQLConfig): Promise<void>;

--- a/packages/graphql-typescript-definitions/src/print/document/context.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/context.ts
@@ -3,7 +3,7 @@ import {relative, dirname} from 'path';
 import * as t from '@babel/types';
 import {AST, Fragment, isOperation, Operation} from 'graphql-tool-utilities';
 
-import {EnumFormat, ExportFormat} from '../../types';
+import type {EnumFormat, ExportFormat} from '../../types';
 
 import {upperCaseFirst} from './utilities';
 

--- a/packages/graphql-typescript-definitions/src/print/document/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/index.ts
@@ -1,5 +1,5 @@
 import * as t from '@babel/types';
-import {GraphQLObjectType} from 'graphql';
+import type {GraphQLObjectType} from 'graphql';
 import {
   AST,
   Fragment,

--- a/packages/graphql-typescript-definitions/src/print/document/language.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/language.ts
@@ -27,8 +27,8 @@ import {
 
 import {scalarTypeMap} from '../utilities';
 
-import {ObjectStack} from './utilities';
-import {OperationContext} from './context';
+import type {ObjectStack} from './utilities';
+import type {OperationContext} from './context';
 
 export function tsInterfaceBodyForObjectField(
   {fields = []}: PrintableFieldDetails,

--- a/packages/graphql-typescript-definitions/src/print/document/utilities.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/utilities.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   GraphQLCompositeType,
   // We need to bring these in as they are implicitly referenced by
   // GraphQLCompositeType, but TypeScript doesn’t know this when it
@@ -10,7 +10,7 @@ import {
   // @ts-expect-error TS needs this implict reference though we never use it explicitly
   GraphQLUnionType,
 } from 'graphql';
-import {Field} from 'graphql-tool-utilities';
+import type {Field} from 'graphql-tool-utilities';
 
 export class ObjectStack {
   private readonly seenFields = new Set<string>();

--- a/packages/graphql-validate-fixtures/src/validate.ts
+++ b/packages/graphql-validate-fixtures/src/validate.ts
@@ -15,8 +15,8 @@ import {
   isObjectType,
   isScalarType,
 } from 'graphql';
-import {GraphQLProjectConfig} from 'graphql-config';
-import {AST, Field, Operation} from 'graphql-tool-utilities';
+import type {GraphQLProjectConfig} from 'graphql-config';
+import type {AST, Field, Operation} from 'graphql-tool-utilities';
 
 export type KeyPath = string;
 

--- a/packages/jest-dom-mocks/src/request-idle-callback.ts
+++ b/packages/jest-dom-mocks/src/request-idle-callback.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   RequestIdleCallback as IdleCallback,
   WindowWithRequestIdleCallback,
 } from '@shopify/async';

--- a/packages/jest-koa-mocks/src/create-mock-context/tests/create-mock-context.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/tests/create-mock-context.test.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 import createContext from '../create-mock-context';
 

--- a/packages/jest-koa-mocks/src/create-mock-cookies/create-mock-cookies.ts
+++ b/packages/jest-koa-mocks/src/create-mock-cookies/create-mock-cookies.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 export type Cookies = Context['cookies'];
 

--- a/packages/koa-liveness-ping/src/index.ts
+++ b/packages/koa-liveness-ping/src/index.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 export default function ping() {
   return async function pingMiddleware(ctx: Context, next: Function) {

--- a/packages/koa-metrics/src/content.ts
+++ b/packages/koa-metrics/src/content.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 export function getContentLength(ctx: Context): number | null {
   const responseContentLength: string | undefined =

--- a/packages/koa-metrics/src/middleware.ts
+++ b/packages/koa-metrics/src/middleware.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 import {StatsDClient, Logger} from '@shopify/statsd';
 
 import {tagsForRequest, tagsForResponse} from './tags';

--- a/packages/koa-metrics/src/tags.ts
+++ b/packages/koa-metrics/src/tags.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 export enum Tag {
   Path = 'path',

--- a/packages/koa-metrics/src/timing.ts
+++ b/packages/koa-metrics/src/timing.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 export function getQueuingTime(ctx: Context): number | null {
   const requestStartHeader = ctx.request.get('X-Request-Start');

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 import compose from 'koa-compose';
 import bodyParser from 'koa-bodyparser';
 import {StatusCode, Header} from '@shopify/network';
@@ -12,7 +12,7 @@ import {
 import {StatsDClient, Logger} from '@shopify/statsd';
 
 import {LifecycleMetric, NavigationMetric} from './enums';
-import {BrowserConnection} from './types';
+import type {BrowserConnection} from './types';
 
 interface Tags {
   [key: string]: string | number | boolean;

--- a/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
+++ b/packages/koa-shopify-graphql-proxy/src/shopify-graphql-proxy.ts
@@ -1,5 +1,5 @@
 import proxy from 'koa-better-http-proxy';
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 export const PROXY_BASE_PATH = '/graphql';
 export const GRAPHQL_PATH_PREFIX = '/admin/api';

--- a/packages/koa-shopify-webhooks/src/receive.ts
+++ b/packages/koa-shopify-webhooks/src/receive.ts
@@ -4,7 +4,7 @@ import safeCompare from 'safe-compare';
 import bodyParser from 'koa-bodyparser';
 import mount from 'koa-mount';
 import compose from 'koa-compose';
-import {Context, Middleware} from 'koa';
+import type {Context, Middleware} from 'koa';
 import {StatusCode} from '@shopify/network';
 
 import {WebhookHeader, Topic} from './types';

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -1,7 +1,7 @@
 import {onLCP, onFID, onFCP, onTTFB} from 'web-vitals';
 
 import {InflightNavigation} from './inflight';
-import {Navigation} from './navigation';
+import type {Navigation} from './navigation';
 import {
   now,
   withEntriesOfType,

--- a/packages/react-async/src/context/assets.ts
+++ b/packages/react-async/src/context/assets.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import {EffectKind} from '@shopify/react-effect';
+import type {EffectKind} from '@shopify/react-effect';
 
 import {AssetTiming} from '../types';
 

--- a/packages/react-async/src/hooks.ts
+++ b/packages/react-async/src/hooks.ts
@@ -1,11 +1,11 @@
 import {useState, useCallback, useContext} from 'react';
-import {Resolver} from '@shopify/async';
+import type {Resolver} from '@shopify/async';
 import {useServerEffect} from '@shopify/react-effect';
 import {useMountedRef} from '@shopify/react-hooks';
-import {IfAllOptionalKeys, NoInfer} from '@shopify/useful-types';
+import type {IfAllOptionalKeys, NoInfer} from '@shopify/useful-types';
 
 import {AsyncAssetContext} from './context/assets';
-import {AssetTiming, AsyncComponentType} from './types';
+import type {AssetTiming, AsyncComponentType} from './types';
 
 export type Preloadable<PreloadOptions extends object> = Pick<
   AsyncComponentType<any, any, PreloadOptions, any, any>,

--- a/packages/react-async/src/tests/hooks.test.tsx
+++ b/packages/react-async/src/tests/hooks.test.tsx
@@ -1,4 +1,4 @@
-import {AsyncComponentType} from '../types';
+import type {AsyncComponentType} from '../types';
 import {usePreload, usePrefetch, useKeepFresh} from '../hooks';
 
 describe('usePreload()', () => {

--- a/packages/react-async/src/types.ts
+++ b/packages/react-async/src/types.ts
@@ -1,6 +1,6 @@
-import {ReactElement} from 'react';
-import {Resolver} from '@shopify/async';
-import {IfAllOptionalKeys, NoInfer} from '@shopify/useful-types';
+import type {ReactElement} from 'react';
+import type {Resolver} from '@shopify/async';
+import type {IfAllOptionalKeys, NoInfer} from '@shopify/useful-types';
 
 export enum AssetTiming {
   None = 1,

--- a/packages/react-bugsnag/src/Bugsnag.tsx
+++ b/packages/react-bugsnag/src/Bugsnag.tsx
@@ -1,6 +1,6 @@
 import React, {useRef, ReactNode, ComponentProps} from 'react';
-import {Client} from '@bugsnag/js';
-import {BugsnagErrorBoundary} from '@bugsnag/plugin-react';
+import type {Client} from '@bugsnag/js';
+import type {BugsnagErrorBoundary} from '@bugsnag/plugin-react';
 
 import {ErrorLoggerContext, noopErrorLogger} from './context';
 

--- a/packages/react-bugsnag/src/context.ts
+++ b/packages/react-bugsnag/src/context.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {ErrorLogger} from './types';
+import type {ErrorLogger} from './types';
 
 export const noopErrorLogger: ErrorLogger = {
   notify() {},

--- a/packages/react-bugsnag/src/types.ts
+++ b/packages/react-bugsnag/src/types.ts
@@ -1,3 +1,3 @@
-import {Client} from '@bugsnag/js';
+import type {Client} from '@bugsnag/js';
 
 export type ErrorLogger = Pick<Client, 'notify' | 'leaveBreadcrumb'>;

--- a/packages/react-compose/src/index.ts
+++ b/packages/react-compose/src/index.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import type {ComponentType, ComponentClass as ReactComponentClass} from 'react';
 import hoistStatics from 'hoist-non-react-statics';
-import {NonReactStatics} from '@shopify/useful-types';
+import type {NonReactStatics} from '@shopify/useful-types';
 
-export type ReactComponent<P> = React.ComponentType<P>;
-export type ComponentClass = React.ComponentClass<any>;
+export type ReactComponent<P> = ComponentType<P>;
+export type ComponentClass = ReactComponentClass<any>;
 
 export type WrappingFunction = (
   Component: ReactComponent<any>,

--- a/packages/react-cookie/src/BrowserCookieManager.ts
+++ b/packages/react-cookie/src/BrowserCookieManager.ts
@@ -1,6 +1,6 @@
 import cookie from 'cookie';
 
-import {CookieValue, Cookie} from './types';
+import type {CookieValue, Cookie} from './types';
 
 export {CookieContext} from './context';
 

--- a/packages/react-cookie/src/context.ts
+++ b/packages/react-cookie/src/context.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 
-import {CookieManager} from './types';
+import type {CookieManager} from './types';
 
 export const CookieContext = React.createContext<CookieManager | null>(null);

--- a/packages/react-cookie/src/hooks.ts
+++ b/packages/react-cookie/src/hooks.ts
@@ -1,5 +1,5 @@
 import {useContext, useState, useCallback} from 'react';
-import {CookieSerializeOptions} from 'cookie';
+import type {CookieSerializeOptions} from 'cookie';
 
 import {CookieContext} from './context';
 

--- a/packages/react-cookie/src/types.ts
+++ b/packages/react-cookie/src/types.ts
@@ -1,4 +1,4 @@
-import {CookieSerializeOptions} from 'cookie';
+import type {CookieSerializeOptions} from 'cookie';
 
 export type {CookieSerializeOptions};
 

--- a/packages/react-cookie/src/utilities.ts
+++ b/packages/react-cookie/src/utilities.ts
@@ -1,5 +1,5 @@
 import {BrowserCookieManager} from './BrowserCookieManager';
-import {Cookie} from './types';
+import type {Cookie} from './types';
 
 export function clearCookies() {
   const cookies = new BrowserCookieManager();

--- a/packages/react-effect/src/Effect.tsx
+++ b/packages/react-effect/src/Effect.tsx
@@ -1,5 +1,5 @@
 import {useServerEffect} from './hook';
-import {EffectKind} from './types';
+import type {EffectKind} from './types';
 
 interface Props {
   kind?: EffectKind;

--- a/packages/react-effect/src/context.ts
+++ b/packages/react-effect/src/context.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 
-import {EffectManager} from './manager';
+import type {EffectManager} from './manager';
 
 export const EffectContext = React.createContext<EffectManager | null>(null);

--- a/packages/react-effect/src/hook.ts
+++ b/packages/react-effect/src/hook.ts
@@ -1,7 +1,7 @@
 import {useContext} from 'react';
 
 import {EffectContext} from './context';
-import {EffectKind} from './types';
+import type {EffectKind} from './types';
 
 export function useServerEffect(perform: () => any, kind?: EffectKind) {
   const manager = useContext(EffectContext);

--- a/packages/react-effect/src/manager.ts
+++ b/packages/react-effect/src/manager.ts
@@ -1,4 +1,4 @@
-import {EffectKind, Pass} from './types';
+import type {EffectKind, Pass} from './types';
 
 interface Options {
   include?: symbol[] | boolean;

--- a/packages/react-effect/src/server.tsx
+++ b/packages/react-effect/src/server.tsx
@@ -3,7 +3,7 @@ import {renderToStaticMarkup} from 'react-dom/server';
 
 import {EffectContext} from './context';
 import {EffectManager} from './manager';
-import {Pass} from './types';
+import type {Pass} from './types';
 
 export {Effect} from './Effect';
 

--- a/packages/react-effect/src/utilities.ts
+++ b/packages/react-effect/src/utilities.ts
@@ -1,4 +1,4 @@
-import {ComponentType} from 'react';
+import type {ComponentType} from 'react';
 
 export function restrictToServer<T extends ComponentType<any>>(
   Component: T,

--- a/packages/react-form-state/src/FormState.ts
+++ b/packages/react-form-state/src/FormState.ts
@@ -2,7 +2,7 @@
 import React from 'react';
 
 import {mapObject, set, isEqual, flatMap} from './utilities';
-import {
+import type {
   FieldDescriptors,
   FieldState,
   ValueMapper,

--- a/packages/react-form-state/src/components/List.tsx
+++ b/packages/react-form-state/src/components/List.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {FieldDescriptor, FieldDescriptors, ValueMapper} from '../types';
+import type {FieldDescriptor, FieldDescriptors, ValueMapper} from '../types';
 import {mapObject, replace} from '../utilities';
 
 interface Props<Fields> {

--- a/packages/react-form-state/src/components/Nested.tsx
+++ b/packages/react-form-state/src/components/Nested.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {FieldDescriptor, FieldDescriptors, ValueMapper} from '../types';
+import type {FieldDescriptor, FieldDescriptors, ValueMapper} from '../types';
 import {mapObject} from '../utilities';
 
 interface Props<Fields> {

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -6,7 +6,7 @@ import {mount} from '@shopify/react-testing';
 import {Input} from '../../tests/components';
 import {lastCallArgs} from '../../tests/utilities';
 import FormState, {arrayUtils} from '../..';
-import {FieldDescriptor, FieldDescriptors} from '../../types';
+import type {FieldDescriptor, FieldDescriptors} from '../../types';
 
 describe('<FormState.List />', () => {
   let consoleErrorSpy: jest.SpyInstance;

--- a/packages/react-form-state/src/tests/components/InputField.tsx
+++ b/packages/react-form-state/src/tests/components/InputField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {FieldState} from '../../types';
+import type {FieldState} from '../../types';
 
 export interface Props {
   onRender?(): void;

--- a/packages/react-form-state/src/utilities.ts
+++ b/packages/react-form-state/src/utilities.ts
@@ -1,6 +1,6 @@
 import isEqual from 'fast-deep-equal';
 
-import {FieldDescriptor} from './types';
+import type {FieldDescriptor} from './types';
 
 export {isEqual};
 

--- a/packages/react-form-state/src/validators.ts
+++ b/packages/react-form-state/src/validators.ts
@@ -9,7 +9,7 @@ import {
   isPositiveNumericString,
 } from '@shopify/predicates';
 
-import {StringMapper} from './types';
+import type {StringMapper} from './types';
 import {mapObject} from './utilities';
 
 interface Matcher<Input, Fields = any> {

--- a/packages/react-form/src/hooks/dirty.ts
+++ b/packages/react-form/src/hooks/dirty.ts
@@ -1,4 +1,4 @@
-import {FieldBag} from '../types';
+import type {FieldBag} from '../types';
 import {reduceFields} from '../utilities';
 
 export function useDirty(fieldBag: FieldBag) {

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useMemo, ChangeEvent} from 'react';
 import isEqual from 'fast-deep-equal';
 
-import {Validates, Field, DirtyStateComparator} from '../../types';
+import type {Validates, Field, DirtyStateComparator} from '../../types';
 import {normalizeValidation, isChangeEvent} from '../../utilities';
 
 import {

--- a/packages/react-form/src/hooks/field/reducer.ts
+++ b/packages/react-form/src/hooks/field/reducer.ts
@@ -1,6 +1,6 @@
 import {useReducer, Reducer} from 'react';
 
-import {FieldState, ErrorValue, DirtyStateComparator} from '../../types';
+import type {FieldState, ErrorValue, DirtyStateComparator} from '../../types';
 import {defaultDirtyComparator, shallowArrayComparison} from '../../utilities';
 
 export interface ReducerOptions<Value> {

--- a/packages/react-form/src/hooks/field/tests/field.test.tsx
+++ b/packages/react-form/src/hooks/field/tests/field.test.tsx
@@ -9,7 +9,7 @@ import {
   FieldConfig,
   asChoiceList,
 } from '../field';
-import {FieldState} from '../../../types';
+import type {FieldState} from '../../../types';
 import {FieldAction, reduceField, makeFieldReducer} from '../reducer';
 
 describe('useField', () => {

--- a/packages/react-form/src/hooks/form.ts
+++ b/packages/react-form/src/hooks/form.ts
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react';
 import {useLazyRef} from '@shopify/react-hooks';
 
-import {
+import type {
   FieldBag,
   FormInput,
   FormWithDynamicListsInput,

--- a/packages/react-form/src/hooks/list/baselist.ts
+++ b/packages/react-form/src/hooks/list/baselist.ts
@@ -1,7 +1,7 @@
 import {useMemo, useEffect} from 'react';
 import isEqual from 'fast-deep-equal';
 
-import {
+import type {
   ValidationDictionary,
   NormalizedValidationDictionary,
   FieldDictionary,

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -1,4 +1,4 @@
-import {FieldDictionary, FieldStates} from '../../types';
+import type {FieldDictionary, FieldStates} from '../../types';
 
 import {
   addFieldItemAction,

--- a/packages/react-form/src/hooks/list/dynamiclistdirty.ts
+++ b/packages/react-form/src/hooks/list/dynamiclistdirty.ts
@@ -1,4 +1,4 @@
-import {DynamicListBag} from '../../types';
+import type {DynamicListBag} from '../../types';
 
 export function useDynamicListDirty(lists?: DynamicListBag) {
   return lists

--- a/packages/react-form/src/hooks/list/dynamiclistreset.ts
+++ b/packages/react-form/src/hooks/list/dynamiclistreset.ts
@@ -1,7 +1,7 @@
 import {useCallback} from 'react';
 import {useLazyRef} from '@shopify/react-hooks';
 
-import {DynamicListBag} from '../../types';
+import type {DynamicListBag} from '../../types';
 
 export function useDynamicListReset(lists?: DynamicListBag) {
   const listBagRef = useLazyRef(() => lists);

--- a/packages/react-form/src/hooks/list/hooks/handlers.ts
+++ b/packages/react-form/src/hooks/list/hooks/handlers.ts
@@ -1,7 +1,7 @@
 import {ChangeEvent, useMemo} from 'react';
 
 import {mapObject, isChangeEvent} from '../../../utilities';
-import {
+import type {
   FieldDictionary,
   FieldState,
   NormalizedValidationDictionary,

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -1,6 +1,6 @@
 import {useReducer, Reducer} from 'react';
 
-import {FieldStates, ErrorValue} from '../../../types';
+import type {FieldStates, ErrorValue} from '../../../types';
 import {
   reduceField,
   FieldAction,

--- a/packages/react-form/src/hooks/list/list.ts
+++ b/packages/react-form/src/hooks/list/list.ts
@@ -1,4 +1,4 @@
-import {FieldDictionary} from '../../types';
+import type {FieldDictionary} from '../../types';
 
 import {useBaseList, FieldListConfig} from './baselist';
 

--- a/packages/react-form/src/hooks/list/tests/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/baselist.test.tsx
@@ -4,7 +4,7 @@ import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import {useBaseList, FieldListConfig} from '../baselist';
-import {ListValidationContext} from '../../../types';
+import type {ListValidationContext} from '../../../types';
 
 import {
   Variant,

--- a/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {useDynamicList} from '../dynamiclist';
-import {FieldListConfig} from '../baselist';
+import type {FieldListConfig} from '../baselist';
 
 import {Variant, randomVariants, clickEvent, TextField} from './utils';
 

--- a/packages/react-form/src/hooks/list/tests/list.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/list.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {useList} from '../list';
-import {FieldListConfig} from '../baselist';
+import type {FieldListConfig} from '../baselist';
 
 import {randomVariants, TextField, Variant} from './utils';
 

--- a/packages/react-form/src/hooks/list/utils/utils.ts
+++ b/packages/react-form/src/hooks/list/utils/utils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Validator,
   FieldStates,
   ErrorValue,

--- a/packages/react-form/src/hooks/reset.ts
+++ b/packages/react-form/src/hooks/reset.ts
@@ -1,4 +1,4 @@
-import {FieldBag, Field} from '../types';
+import type {FieldBag, Field} from '../types';
 
 import useVisitFields from './visitFields';
 

--- a/packages/react-form/src/hooks/submit.ts
+++ b/packages/react-form/src/hooks/submit.ts
@@ -1,7 +1,7 @@
 import {useState, useCallback} from 'react';
 import {useLazyRef, useMountedRef} from '@shopify/react-hooks';
 
-import {
+import type {
   FormMapping,
   SubmitHandler,
   SubmitResult,

--- a/packages/react-form/src/hooks/tests/utilities/components/FormWithDynamicVariantList.tsx
+++ b/packages/react-form/src/hooks/tests/utilities/components/FormWithDynamicVariantList.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import {SubmitHandler} from '../../../../types';
+import type {SubmitHandler} from '../../../../types';
 import {notEmpty} from '../../../../validation';
 import {useDynamicList, useField, useForm} from '../../..';
 
-import {SimpleProduct, Variant} from './types';
+import type {SimpleProduct, Variant} from './types';
 import {TextField} from './TextField';
 
 export function FormWithDynamicVariantList({

--- a/packages/react-form/src/hooks/tests/utilities/components/ProductForm.tsx
+++ b/packages/react-form/src/hooks/tests/utilities/components/ProductForm.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import {SubmitHandler} from '../../../../types';
+import type {SubmitHandler} from '../../../../types';
 import {positiveNumericString, notEmpty} from '../../../../validation';
 import {useList, useField, useForm} from '../../..';
 
-import {SimpleProduct} from './types';
+import type {SimpleProduct} from './types';
 import {TextField} from './TextField';
 
 export function ProductForm({

--- a/packages/react-form/src/hooks/tests/utilities/index.ts
+++ b/packages/react-form/src/hooks/tests/utilities/index.ts
@@ -1,5 +1,5 @@
 import {faker} from '@faker-js/faker/locale/en';
-import {Root} from '@shopify/react-testing';
+import type {Root} from '@shopify/react-testing';
 
 import {SimpleProduct, TextField} from './components';
 

--- a/packages/react-form/src/hooks/visitFields.ts
+++ b/packages/react-form/src/hooks/visitFields.ts
@@ -1,6 +1,6 @@
 import {useCallback, useRef} from 'react';
 
-import {FieldBag, Field} from '../types';
+import type {FieldBag, Field} from '../types';
 import {reduceFields} from '../utilities';
 
 interface FieldVisitor {

--- a/packages/react-form/src/tests/utilities.test.ts
+++ b/packages/react-form/src/tests/utilities.test.ts
@@ -8,7 +8,7 @@ import {
   fieldsToArray,
   reduceFields,
 } from '../utilities';
-import {Field} from '../types';
+import type {Field} from '../types';
 
 function mockField<T>(params: Partial<Field<T>> | T): Field<T | undefined> {
   const value = typeof params === 'string' ? params : undefined;

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -1,6 +1,6 @@
-import {ChangeEvent} from 'react';
+import type {ChangeEvent} from 'react';
 
-import {DynamicList} from './hooks/list/dynamiclist';
+import type {DynamicList} from './hooks/list/dynamiclist';
 
 export type {DynamicList} from './hooks/list/dynamiclist';
 

--- a/packages/react-form/src/utilities.ts
+++ b/packages/react-form/src/utilities.ts
@@ -1,7 +1,7 @@
-import {ChangeEvent} from 'react';
+import type {ChangeEvent} from 'react';
 import get from 'get-value';
 
-import {
+import type {
   Validates,
   Validator,
   FieldOutput,

--- a/packages/react-google-analytics/src/GaJS.tsx
+++ b/packages/react-google-analytics/src/GaJS.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ImportRemote from '@shopify/react-import-remote';
 
-import {GaJSAnalytics} from './types';
+import type {GaJSAnalytics} from './types';
 import {getRootDomain} from './utilities';
 
 export interface Props {

--- a/packages/react-google-analytics/src/Universal.tsx
+++ b/packages/react-google-analytics/src/Universal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ImportRemote from '@shopify/react-import-remote';
 
-import {UniversalAnalytics} from './types';
+import type {UniversalAnalytics} from './types';
 import {getRootDomain} from './utilities';
 
 export interface Props {

--- a/packages/react-graphql/src/ApolloContext.ts
+++ b/packages/react-graphql/src/ApolloContext.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import {ApolloClient} from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {ApolloClient} from '@apollo/client';
+import type {DocumentNode} from 'graphql-typed';
 
 export interface ApolloContextValue<CacheShape = any> {
   client?: ApolloClient<CacheShape>;

--- a/packages/react-graphql/src/Prefetch.tsx
+++ b/packages/react-graphql/src/Prefetch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {Query} from './Query';
-import {QueryProps} from './types';
+import type {QueryProps} from './types';
 
 export type Props<T> = Pick<
   QueryProps<T>,

--- a/packages/react-graphql/src/Query.tsx
+++ b/packages/react-graphql/src/Query.tsx
@@ -1,6 +1,6 @@
-import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
-import {OperationVariables} from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
+import type {OperationVariables} from '@apollo/client';
+import type {DocumentNode} from 'graphql-typed';
 
 import {useQuery, QueryHookResult, QueryHookOptions} from './hooks';
 

--- a/packages/react-graphql/src/async/component.tsx
+++ b/packages/react-graphql/src/async/component.tsx
@@ -1,7 +1,11 @@
 import {useIdleCallback} from '@shopify/react-idle';
 
 import {useQuery, QueryHookOptions} from '../hooks';
-import {AsyncQueryComponentType, QueryProps, VariableOptions} from '../types';
+import type {
+  AsyncQueryComponentType,
+  QueryProps,
+  VariableOptions,
+} from '../types';
 
 import {Options, createAsyncQuery} from './query';
 

--- a/packages/react-graphql/src/async/query.ts
+++ b/packages/react-graphql/src/async/query.ts
@@ -1,9 +1,9 @@
-import {DocumentNode} from 'graphql-typed';
+import type {DocumentNode} from 'graphql-typed';
 import {createResolver, ResolverOptions} from '@shopify/async';
 import {useAsync, AssetTiming} from '@shopify/react-async';
 
 import {useBackgroundQuery} from '../hooks';
-import {AsyncDocumentNode, QueryProps, VariableOptions} from '../types';
+import type {AsyncDocumentNode, QueryProps, VariableOptions} from '../types';
 
 export interface Options<Data, Variables, DeepPartial>
   extends ResolverOptions<DocumentNode<Data, Variables, DeepPartial>> {}

--- a/packages/react-graphql/src/hooks/apollo-client.tsx
+++ b/packages/react-graphql/src/hooks/apollo-client.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ApolloClient} from '@apollo/client';
+import type {ApolloClient} from '@apollo/client';
 
 import {ApolloContext} from '../ApolloContext';
 

--- a/packages/react-graphql/src/hooks/background-query.ts
+++ b/packages/react-graphql/src/hooks/background-query.ts
@@ -1,6 +1,6 @@
 import {useEffect, useRef, useCallback} from 'react';
-import {DocumentNode} from 'graphql-typed';
-import {WatchQueryOptions} from '@apollo/client';
+import type {DocumentNode} from 'graphql-typed';
+import type {WatchQueryOptions} from '@apollo/client';
 
 import useApolloClient from './apollo-client';
 

--- a/packages/react-graphql/src/hooks/graphql-document.ts
+++ b/packages/react-graphql/src/hooks/graphql-document.ts
@@ -1,10 +1,10 @@
 import {useState, useEffect, useCallback} from 'react';
-import {OperationVariables} from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {OperationVariables} from '@apollo/client';
+import type {DocumentNode} from 'graphql-typed';
 import {useMountedRef} from '@shopify/react-hooks';
 import {useAsyncAsset} from '@shopify/react-async';
 
-import {AsyncDocumentNode} from '../types';
+import type {AsyncDocumentNode} from '../types';
 
 export default function useGraphQLDocument<
   Data extends {} = any,

--- a/packages/react-graphql/src/hooks/mutation.ts
+++ b/packages/react-graphql/src/hooks/mutation.ts
@@ -1,9 +1,9 @@
-import {OperationVariables} from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {OperationVariables} from '@apollo/client';
+import type {DocumentNode} from 'graphql-typed';
 import {useCallback} from 'react';
-import {NoInfer} from '@shopify/useful-types';
+import type {NoInfer} from '@shopify/useful-types';
 
-import {MutationHookOptions, MutationHookResult} from './types';
+import type {MutationHookOptions, MutationHookResult} from './types';
 import useApolloClient from './apollo-client';
 
 export default function useMutation<Data = any, Variables = OperationVariables>(

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -9,13 +9,13 @@ import {
   ObservableQuery,
 } from '@apollo/client';
 import isEqual from 'fast-deep-equal';
-import {DocumentNode} from 'graphql-typed';
+import type {DocumentNode} from 'graphql-typed';
 import {useServerEffect} from '@shopify/react-effect';
-import {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
+import type {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
 
-import {AsyncDocumentNode} from '../types';
+import type {AsyncDocumentNode} from '../types';
 
-import {QueryHookOptions, QueryHookResult} from './types';
+import type {QueryHookOptions, QueryHookResult} from './types';
 import useApolloClient from './apollo-client';
 import useGraphQLDocument from './graphql-document';
 

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ApolloClient,
   MutationOptions as ClientMutationOptions,
   QueryResult,
@@ -6,10 +6,10 @@ import {
   MutationOptions,
   FetchResult,
 } from '@apollo/client';
-import {QueryComponentOptions} from '@apollo/client/react/components';
-import {IfAllNullableKeys} from '@shopify/useful-types';
+import type {QueryComponentOptions} from '@apollo/client/react/components';
+import type {IfAllNullableKeys} from '@shopify/useful-types';
 
-import {VariableOptions} from '../types';
+import type {VariableOptions} from '../types';
 
 export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<
   QueryComponentOptions<Data, Variables>,

--- a/packages/react-graphql/src/types.ts
+++ b/packages/react-graphql/src/types.ts
@@ -1,12 +1,12 @@
-import React from 'react';
-import {
+import type {ReactNode} from 'react';
+import type {
   DocumentNode,
   GraphQLOperation,
   GraphQLData,
   GraphQLVariables,
   GraphQLDeepPartial,
 } from 'graphql-typed';
-import {
+import type {
   QueryResult,
   ErrorPolicy,
   OperationVariables,
@@ -14,10 +14,10 @@ import {
   ApolloClient,
   WatchQueryFetchPolicy,
 } from '@apollo/client';
-import {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
-import {AsyncComponentType, AsyncHookTarget} from '@shopify/react-async';
+import type {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
+import type {AsyncComponentType, AsyncHookTarget} from '@shopify/react-async';
 
-import {QueryHookOptions} from './hooks';
+import type {QueryHookOptions} from './hooks';
 
 export type {
   GraphQLData,
@@ -33,7 +33,7 @@ export type VariableOptions<Variables> = IfEmptyObject<
 >;
 
 export type QueryProps<Data = any, Variables = OperationVariables> = {
-  children: (result: QueryResult<Data, Variables>) => React.ReactNode;
+  children: (result: QueryResult<Data, Variables>) => ReactNode;
   fetchPolicy?: WatchQueryFetchPolicy;
   errorPolicy?: ErrorPolicy;
   notifyOnNetworkStatusChange?: boolean;

--- a/packages/react-html/src/components/HtmlUpdater.tsx
+++ b/packages/react-html/src/components/HtmlUpdater.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {HydrationTracker} from '@shopify/react-hydrate';
 
-import {State} from '../manager';
+import type {State} from '../manager';
 import {useClientDomEffect} from '../hooks';
 import {MANAGED_ATTRIBUTE, removeDuplicate} from '../utilities';
 

--- a/packages/react-html/src/components/InlineStyle.tsx
+++ b/packages/react-html/src/components/InlineStyle.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type {HTMLProps} from 'react';
 
 import {useInlineStyle} from '../hooks';
 
-type Props = React.HTMLProps<HTMLStyleElement>;
+type Props = HTMLProps<HTMLStyleElement>;
 
 export function InlineStyle(props: Props) {
   useInlineStyle(props);

--- a/packages/react-html/src/components/Link.tsx
+++ b/packages/react-html/src/components/Link.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type {HTMLProps} from 'react';
 
 import {useLink} from '../hooks';
 
-type Props = React.HTMLProps<HTMLLinkElement>;
+type Props = HTMLProps<HTMLLinkElement>;
 
 export function Link(props: Props) {
   useLink(props);

--- a/packages/react-html/src/components/Meta.tsx
+++ b/packages/react-html/src/components/Meta.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type {HTMLProps} from 'react';
 
 import {useMeta} from '../hooks';
 
-type Props = React.HTMLProps<HTMLMetaElement>;
+type Props = HTMLProps<HTMLMetaElement>;
 
 export function Meta(props: Props) {
   useMeta(props);

--- a/packages/react-html/src/components/tests/utilities.tsx
+++ b/packages/react-html/src/components/tests/utilities.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 
-import {HtmlManager} from '../../manager';
+import type {HtmlManager} from '../../manager';
 import {HtmlContext} from '../../context';
 
 export function mountWithManager(

--- a/packages/react-html/src/hooks.ts
+++ b/packages/react-html/src/hooks.ts
@@ -2,7 +2,7 @@ import {useEffect, useContext} from 'react';
 import {useServerEffect} from '@shopify/react-effect';
 
 import {HtmlContext} from './context';
-import {HtmlManager} from './manager';
+import type {HtmlManager} from './manager';
 
 export function useDomEffect(
   perform: (manager: HtmlManager) => () => void,

--- a/packages/react-html/src/manager.ts
+++ b/packages/react-html/src/manager.ts
@@ -1,4 +1,4 @@
-import {EffectKind} from '@shopify/react-effect';
+import type {EffectKind} from '@shopify/react-effect';
 
 import {getSerializationsFromDocument} from './utilities';
 

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {renderToString} from 'react-dom/server';
 import {HydrationContext, HydrationManager} from '@shopify/react-hydrate';
 
-import {HtmlManager} from '../../manager';
+import type {HtmlManager} from '../../manager';
 import {HtmlContext} from '../../context';
 import {MANAGED_ATTRIBUTE, removeDuplicate} from '../../utilities';
 

--- a/packages/react-html/src/server/render.ts
+++ b/packages/react-html/src/server/render.ts
@@ -1,4 +1,4 @@
-import {ReactElement} from 'react';
+import type {ReactElement} from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 
 export default function render(tree: ReactElement<unknown>) {

--- a/packages/react-html/src/server/stream.ts
+++ b/packages/react-html/src/server/stream.ts
@@ -1,6 +1,6 @@
 import {Readable} from 'stream';
 
-import {ReactElement} from 'react';
+import type {ReactElement} from 'react';
 import {renderToStaticNodeStream} from 'react-dom/server';
 import multistream from 'multistream';
 

--- a/packages/react-hydrate/src/manager.ts
+++ b/packages/react-hydrate/src/manager.ts
@@ -1,4 +1,4 @@
-import {EffectKind} from '@shopify/react-effect';
+import type {EffectKind} from '@shopify/react-effect';
 
 import {HYDRATION_ATTRIBUTE} from './shared';
 

--- a/packages/react-i18n/src/babel-plugin/babel-templates.ts
+++ b/packages/react-i18n/src/babel-plugin/babel-templates.ts
@@ -1,5 +1,5 @@
-import {TemplateBuilder} from '@babel/template';
-import Types from '@babel/types';
+import type {TemplateBuilder} from '@babel/template';
+import type Types from '@babel/types';
 
 import {
   TRANSLATION_DIRECTORY_NAME,

--- a/packages/react-i18n/src/babel-plugin/index.ts
+++ b/packages/react-i18n/src/babel-plugin/index.ts
@@ -4,9 +4,9 @@ import glob from 'glob';
 import stringHash from 'string-hash';
 import {camelCase} from 'change-case';
 import type {BabelFile} from '@babel/core';
-import {TemplateBuilder} from '@babel/template';
-import Types from '@babel/types';
-import {Node, NodePath} from '@babel/traverse';
+import type {TemplateBuilder} from '@babel/template';
+import type Types from '@babel/types';
+import type {Node, NodePath} from '@babel/traverse';
 
 import {
   fallbackTranslationsImport,

--- a/packages/react-i18n/src/context.ts
+++ b/packages/react-i18n/src/context.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import {I18nManager} from './manager';
-import {I18n} from './i18n';
+import type {I18nManager} from './manager';
+import type {I18n} from './i18n';
 
 export const I18nContext = React.createContext<I18nManager | null>(null);
 export const I18nIdsContext = React.createContext<string[]>([]);

--- a/packages/react-i18n/src/decorator.tsx
+++ b/packages/react-i18n/src/decorator.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
-import {NonReactStatics} from '@shopify/useful-types';
+import type {NonReactStatics} from '@shopify/useful-types';
 
-import {RegisterOptions} from './manager';
+import type {RegisterOptions} from './manager';
 import {useI18n} from './hooks';
-import {I18n} from './i18n';
+import type {I18n} from './i18n';
 
 export interface WithI18nProps {
   i18n: I18n;

--- a/packages/react-i18n/src/errors.ts
+++ b/packages/react-i18n/src/errors.ts
@@ -1,4 +1,4 @@
-import {Replacements} from './types';
+import type {Replacements} from './types';
 
 export class MissingTranslationError extends Error {
   constructor(key: string, locale: string) {

--- a/packages/react-i18n/src/hooks.tsx
+++ b/packages/react-i18n/src/hooks.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useLazyRef} from '@shopify/react-hooks';
 
 import {I18n} from './i18n';
-import {I18nManager, RegisterOptions} from './manager';
+import type {I18nManager, RegisterOptions} from './manager';
 import {I18nContext, I18nIdsContext, I18nParentContext} from './context';
 
 type Result = [I18n, React.ComponentType<{children: React.ReactNode}>];

--- a/packages/react-i18n/src/manager.ts
+++ b/packages/react-i18n/src/manager.ts
@@ -1,4 +1,4 @@
-import {I18nDetails, TranslationDictionary, MaybePromise} from './types';
+import type {I18nDetails, TranslationDictionary, MaybePromise} from './types';
 
 export interface ConnectionState {
   loading: boolean;

--- a/packages/react-i18n/src/types.ts
+++ b/packages/react-i18n/src/types.ts
@@ -1,4 +1,4 @@
-import {I18nError} from './errors';
+import type {I18nError} from './errors';
 
 export enum LanguageDirection {
   Rtl,

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -5,7 +5,7 @@ import {
   PseudotranslateOptions,
 } from '@shopify/i18n';
 
-import {
+import type {
   TranslationDictionary,
   ComplexReplacementDictionary,
   PrimitiveReplacementDictionary,

--- a/packages/react-idle/src/OnIdle.tsx
+++ b/packages/react-idle/src/OnIdle.tsx
@@ -1,5 +1,5 @@
 import {useIdleCallback} from './hooks';
-import {UnsupportedBehavior} from './types';
+import type {UnsupportedBehavior} from './types';
 
 interface Props {
   perform(): void;

--- a/packages/react-intersection-observer/src/IntersectionObserver.tsx
+++ b/packages/react-intersection-observer/src/IntersectionObserver.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {useIntersection, useValueTracking} from './hooks';
-import {UnsupportedBehavior} from './types';
+import type {UnsupportedBehavior} from './types';
 
 interface Props {
   root?: Element | string | null;

--- a/packages/react-network/src/components/Redirect.tsx
+++ b/packages/react-network/src/components/Redirect.tsx
@@ -1,4 +1,4 @@
-import {StatusCode} from '@shopify/network';
+import type {StatusCode} from '@shopify/network';
 
 import {useRedirect} from '../hooks';
 

--- a/packages/react-network/src/components/Status.tsx
+++ b/packages/react-network/src/components/Status.tsx
@@ -1,4 +1,4 @@
-import {StatusCode} from '@shopify/network';
+import type {StatusCode} from '@shopify/network';
 
 import {useStatus} from '../hooks';
 

--- a/packages/react-network/src/context.ts
+++ b/packages/react-network/src/context.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createUniversalProvider} from '@shopify/react-universal-provider';
 
-import {NetworkManager} from './manager';
+import type {NetworkManager} from './manager';
 
 export const NetworkContext = React.createContext<NetworkManager | null>(null);
 

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -4,7 +4,7 @@ import {CspDirective, StatusCode, Header} from '@shopify/network';
 import {useServerEffect} from '@shopify/react-effect';
 
 import {NetworkContext, NetworkUniversalContext} from './context';
-import {NetworkManager} from './manager';
+import type {NetworkManager} from './manager';
 
 const NO_UNIVERSAL_PROVIDER_WARNING =
   'Could not find serialized network context. Ensure that your app is rendering <NetworkUniversalProvider /> above in your tree';

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -1,7 +1,7 @@
-import {IncomingHttpHeaders} from 'http';
+import type {IncomingHttpHeaders} from 'http';
 
 import {StatusCode, CspDirective, Header} from '@shopify/network';
-import {EffectKind} from '@shopify/react-effect';
+import type {EffectKind} from '@shopify/react-effect';
 
 import {ServerCookieManager, Cookie} from './ServerCookieManager';
 

--- a/packages/react-network/src/server.ts
+++ b/packages/react-network/src/server.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 import {NetworkManager, EFFECT_ID} from './manager';
 

--- a/packages/react-performance/src/lifecycle-event-listener.ts
+++ b/packages/react-performance/src/lifecycle-event-listener.ts
@@ -1,4 +1,4 @@
-import {LifecycleEvent} from '@shopify/performance';
+import type {LifecycleEvent} from '@shopify/performance';
 
 import {usePerformanceEffect} from './performance-effect';
 

--- a/packages/react-performance/src/navigation-listener.ts
+++ b/packages/react-performance/src/navigation-listener.ts
@@ -1,4 +1,4 @@
-import {Navigation} from '@shopify/performance';
+import type {Navigation} from '@shopify/performance';
 
 import {usePerformanceEffect} from './performance-effect';
 

--- a/packages/react-performance/src/performance-effect.ts
+++ b/packages/react-performance/src/performance-effect.ts
@@ -1,5 +1,5 @@
 import {useContext, useEffect} from 'react';
-import {Performance} from '@shopify/performance';
+import type {Performance} from '@shopify/performance';
 
 import {PerformanceContext} from './context';
 

--- a/packages/react-performance/src/performance-report.ts
+++ b/packages/react-performance/src/performance-report.ts
@@ -1,5 +1,5 @@
 import {useRef, useCallback} from 'react';
-import {Navigation, LifecycleEvent} from '@shopify/performance';
+import type {Navigation, LifecycleEvent} from '@shopify/performance';
 import {Header, Method} from '@shopify/network';
 
 import {useNavigationListener} from './navigation-listener';

--- a/packages/react-performance/src/tests/utilities.ts
+++ b/packages/react-performance/src/tests/utilities.ts
@@ -7,8 +7,8 @@ import {
   EventType,
 } from '@shopify/performance';
 
-import {NavigationListener} from '../navigation-listener';
-import {LifecycleEventListener} from '../lifecycle-event-listener';
+import type {NavigationListener} from '../navigation-listener';
+import type {LifecycleEventListener} from '../lifecycle-event-listener';
 
 interface TestInterface {
   simulateNavigation(navigation?: Navigation): Navigation;

--- a/packages/react-server/src/logger/logger.ts
+++ b/packages/react-server/src/logger/logger.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-process-env */
-import {Context, Request} from 'koa';
+import type {Context, Request} from 'koa';
 import chalk from 'chalk';
 import {Header} from '@shopify/react-network';
 
-import {KoaNextFunction} from '../types';
+import type {KoaNextFunction} from '../types';
 
 export const LOGGER = Symbol('logger');
 

--- a/packages/react-server/src/metrics/metrics.ts
+++ b/packages/react-server/src/metrics/metrics.ts
@@ -1,7 +1,7 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 import compose from 'koa-compose';
 
-import {KoaNextFunction} from '../types';
+import type {KoaNextFunction} from '../types';
 
 const MILLIS_PER_SECOND = 1000;
 const NANOS_PER_MILLIS = 1e6;

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -2,7 +2,7 @@ import {join} from 'path';
 import {existsSync} from 'fs';
 
 import React from 'react';
-import {Context} from 'koa';
+import type {Context} from 'koa';
 import compose from 'koa-compose';
 import {
   Html,
@@ -33,7 +33,7 @@ import {
 
 import {quiltDataMiddleware} from '../quilt-data';
 import {getLogger} from '../logger';
-import {ValueFromContext} from '../types';
+import type {ValueFromContext} from '../types';
 
 import {fallbackErrorMarkup} from './error';
 

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -1,5 +1,5 @@
 import 'cross-fetch';
-import {Server} from 'http';
+import type {Server} from 'http';
 
 import Koa, {Context} from 'koa';
 import compose from 'koa-compose';

--- a/packages/react-server/src/tests/utilities.ts
+++ b/packages/react-server/src/tests/utilities.ts
@@ -1,10 +1,10 @@
-import {Server} from 'http';
+import type {Server} from 'http';
 
 import fetch from 'cross-fetch';
-import {Context} from 'koa';
+import type {Context} from 'koa';
 import getPort from 'get-port';
 
-import {KoaNextFunction} from '../types';
+import type {KoaNextFunction} from '../types';
 
 export class TestRack {
   private servers: Server[] = [];

--- a/packages/react-server/src/types.ts
+++ b/packages/react-server/src/types.ts
@@ -1,4 +1,4 @@
-import {Context} from 'koa';
+import type {Context} from 'koa';
 
 export interface KoaNextFunction {
   (): Promise<any>;

--- a/packages/react-server/src/webpack-plugin/error/utilities.ts
+++ b/packages/react-server/src/webpack-plugin/error/utilities.ts
@@ -1,4 +1,4 @@
-import {Compiler} from 'webpack';
+import type {Compiler} from 'webpack';
 
 import {noSourceExists, HEADER, Options, Entrypoint} from '../shared';
 

--- a/packages/react-server/src/webpack-plugin/shared.ts
+++ b/packages/react-server/src/webpack-plugin/shared.ts
@@ -1,7 +1,7 @@
 import {existsSync, readdirSync} from 'fs';
 import {resolve, join} from 'path';
 
-import {Compiler} from 'webpack';
+import type {Compiler} from 'webpack';
 
 export interface Options {
   basePath: string;

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,4 +1,5 @@
-import Key, {HeldKey} from '../keys';
+import type Key from '../keys';
+import type {HeldKey} from '../keys';
 
 import useShortcut, {DefaultIgnoredTag} from './hooks';
 

--- a/packages/react-shortcuts/src/Shortcut/hooks.ts
+++ b/packages/react-shortcuts/src/Shortcut/hooks.ts
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import {ShortcutContext} from '../ShortcutProvider';
-import Key, {HeldKey} from '../keys';
+import type Key from '../keys';
+import type {HeldKey} from '../keys';
 
 const DEFAULT_IGNORED_TAGS = ['INPUT', 'SELECT', 'TEXTAREA'] as const;
 

--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -1,5 +1,6 @@
-import Key, {HeldKey, ModifierKey} from '../keys';
-import {DefaultIgnoredTag} from '../Shortcut';
+import type Key from '../keys';
+import type {HeldKey, ModifierKey} from '../keys';
+import type {DefaultIgnoredTag} from '../Shortcut';
 
 const ON_MATCH_DELAY = 500;
 

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {timer} from '@shopify/jest-dom-mocks';
 
-import Key, {HeldKey, ModifierKey} from '../keys';
+import type Key from '../keys';
+import type {HeldKey, ModifierKey} from '../keys';
 import Shortcut, {DefaultIgnoredTag} from '../Shortcut';
 import ShortcutProvider from '../ShortcutProvider';
 

--- a/packages/react-testing/src/compat.ts
+++ b/packages/react-testing/src/compat.ts
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import type {Root as ReactRoot} from 'react-dom/client';
 
-import {ReactInstance, Fiber} from './types';
+import type {ReactInstance, Fiber} from './types';
 
 export function getInternals(instance: ReactInstance): Fiber {
   // In React 17+ _reactInternalFiber was renamed to _reactInternals. As such we need to handle both APIs to maintain support.

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import type {ComponentType} from 'react';
 
 import {nodeName, toReactString} from './toReactString';
 import {
@@ -20,7 +20,7 @@ type Root = import('./root').Root<unknown>;
 
 interface Tree<Props> {
   tag: Tag;
-  type: string | React.ComponentType<any> | null;
+  type: string | ComponentType<any> | null;
   props: Props;
   instance?: any;
 }
@@ -151,13 +151,13 @@ export class Element<Props> implements Node<Props> {
     );
   }
 
-  is<Type extends React.ComponentType<any> | string>(
+  is<Type extends ComponentType<any> | string>(
     type: Type,
   ): this is Element<PropsFor<Type>> {
     return isMatchingType(this.type, type);
   }
 
-  find<Type extends React.ComponentType<any> | string>(
+  find<Type extends ComponentType<any> | string>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Element<PropsFor<Type>> | null {
@@ -168,7 +168,7 @@ export class Element<Props> implements Node<Props> {
     ) || null) as Element<PropsFor<Type>> | null;
   }
 
-  findAll<Type extends React.ComponentType<any> | string>(
+  findAll<Type extends ComponentType<any> | string>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Element<PropsFor<Type>>[] {
@@ -179,16 +179,16 @@ export class Element<Props> implements Node<Props> {
     ) as Element<PropsFor<Type>>[];
   }
 
-  findWhere<Type extends React.ComponentType<any> | string | unknown = unknown>(
+  findWhere<Type extends ComponentType<any> | string | unknown = unknown>(
     predicate: Predicate,
   ): Element<UnknowablePropsFor<Type>> | null {
     return (this.elementDescendants.find((element) => predicate(element)) ||
       null) as Element<UnknowablePropsFor<Type>> | null;
   }
 
-  findAllWhere<
-    Type extends React.ComponentType<any> | string | unknown = unknown,
-  >(predicate: Predicate): Element<UnknowablePropsFor<Type>>[] {
+  findAllWhere<Type extends ComponentType<any> | string | unknown = unknown>(
+    predicate: Predicate,
+  ): Element<UnknowablePropsFor<Type>>[] {
     return this.elementDescendants.filter((element) =>
       predicate(element),
     ) as Element<UnknowablePropsFor<Type>>[];

--- a/packages/react-testing/src/matchers/components.ts
+++ b/packages/react-testing/src/matchers/components.ts
@@ -1,4 +1,4 @@
-import {ComponentType} from 'react';
+import type {ComponentType} from 'react';
 import {
   matcherHint,
   printExpected,
@@ -6,7 +6,7 @@ import {
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
 
-import {Node, PropsFor} from '../types';
+import type {Node, PropsFor} from '../types';
 
 import {
   assertIsNode,

--- a/packages/react-testing/src/matchers/context.ts
+++ b/packages/react-testing/src/matchers/context.ts
@@ -1,4 +1,4 @@
-import {Context} from 'react';
+import type {Context} from 'react';
 import {
   matcherHint,
   printExpected,
@@ -6,7 +6,7 @@ import {
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
 
-import {Node} from '../types';
+import type {Node} from '../types';
 
 import {assertIsNode, diffs, printType} from './utilities';
 

--- a/packages/react-testing/src/matchers/index.ts
+++ b/packages/react-testing/src/matchers/index.ts
@@ -1,6 +1,6 @@
-import {ComponentType, Context as ReactContext} from 'react';
+import type {ComponentType, Context as ReactContext} from 'react';
 
-import {Node, PropsFor} from '../types';
+import type {Node, PropsFor} from '../types';
 
 import {toHaveReactProps, toHaveReactDataProps} from './props';
 import {

--- a/packages/react-testing/src/matchers/props.ts
+++ b/packages/react-testing/src/matchers/props.ts
@@ -5,7 +5,7 @@ import {
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils';
 
-import {Node} from '../types';
+import type {Node} from '../types';
 
 import {assertIsNode, diffPropsForNode} from './utilities';
 

--- a/packages/react-testing/src/matchers/strings.ts
+++ b/packages/react-testing/src/matchers/strings.ts
@@ -6,7 +6,7 @@ import {
   INVERTED_COLOR as invertedColor,
 } from 'jest-matcher-utils';
 
-import {Node} from '../types';
+import type {Node} from '../types';
 
 import {assertIsNode} from './utilities';
 

--- a/packages/react-testing/src/matchers/utilities.ts
+++ b/packages/react-testing/src/matchers/utilities.ts
@@ -10,7 +10,7 @@ import {
 
 import {Root} from '../root';
 import {Element} from '../element';
-import {Node} from '../types';
+import type {Node} from '../types';
 
 export function assertIsNode(
   node: unknown,

--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -1,12 +1,12 @@
-import React from 'react';
-import {IfAllOptionalKeys} from '@shopify/useful-types';
+import type {ReactElement} from 'react';
+import type {IfAllOptionalKeys} from '@shopify/useful-types';
 
 import {Root, Options as RootOptions} from './root';
 import {Element} from './element';
 
 export {Root, Element};
 
-export function mount<Props>(element: React.ReactElement<Props>) {
+export function mount<Props>(element: ReactElement<Props>) {
   return new Root<Props>(element);
 }
 
@@ -52,10 +52,10 @@ export type CustomMountOptions<
   Async extends boolean = false,
 > = {
   render(
-    element: React.ReactElement<any>,
+    element: ReactElement<any>,
     context: Context,
     options: MountOptions,
-  ): React.ReactElement<any>;
+  ): ReactElement<any>;
 } & ContextOption<MountOptions, CreateContext> &
   AfterMountOption<MountOptions, Context, Async> &
   Cleanup<MountOptions, Context>;
@@ -68,8 +68,8 @@ export interface CustomMount<
   <Props>(
     ...args: IfAllOptionalKeys<
       MountOptions,
-      [React.ReactElement<any>, MountOptions?],
-      [React.ReactElement<any>, MountOptions]
+      [ReactElement<any>, MountOptions?],
+      [ReactElement<any>, MountOptions]
     >
   ): CustomMountResult<Props, Context, Async>;
   extend<
@@ -100,7 +100,7 @@ type CustomMountResult<
 
 export class CustomRoot<Props, Context extends object> extends Root<Props> {
   constructor(
-    tree: React.ReactElement<Props>,
+    tree: ReactElement<Props>,
     public readonly context: Context,
     options?: RootOptions,
   ) {
@@ -123,7 +123,7 @@ export function createMount<
   Async
 > {
   function mount<Props>(
-    element: React.ReactElement<Props>,
+    element: ReactElement<Props>,
     options: MountOptions = {} as any,
   ) {
     const context = createContext(options);

--- a/packages/react-testing/src/tests/compat.test.tsx
+++ b/packages/react-testing/src/tests/compat.test.tsx
@@ -1,5 +1,5 @@
 import {getInternals} from '../compat';
-import {ReactInstance} from '../types';
+import type {ReactInstance} from '../types';
 
 describe('compat', () => {
   it('returns the fiber for react-16 style nodes', () => {

--- a/packages/react-testing/src/toReactString.ts
+++ b/packages/react-testing/src/toReactString.ts
@@ -1,6 +1,6 @@
 import {stringify} from 'jest-matcher-utils';
 
-import {DebugOptions, Node} from './types';
+import type {DebugOptions, Node} from './types';
 
 export function toReactString<Props extends {} | unknown>(
   node: Node<Props>,

--- a/packages/react-testing/src/types.ts
+++ b/packages/react-testing/src/types.ts
@@ -1,4 +1,9 @@
-import React from 'react';
+import type {
+  ComponentType,
+  ComponentPropsWithoutRef,
+  HTMLAttributes,
+  LegacyRef,
+} from 'react';
 
 type IsNeverType<T> = [T] extends [never] ? true : false;
 type Rest<T extends any[]> = T extends [any, ...infer Rest] ? Rest : never;
@@ -115,18 +120,17 @@ export type TriggerKeypathReturn<
     : any
   : any;
 
-export type PropsFor<T extends string | React.ComponentType<any>> =
-  T extends string
-    ? T extends keyof JSX.IntrinsicElements
-      ? JSX.IntrinsicElements[T]
-      : React.HTMLAttributes<T>
-    : T extends React.ComponentType<any>
-    ? React.ComponentPropsWithoutRef<T>
-    : never;
+export type PropsFor<T extends string | ComponentType<any>> = T extends string
+  ? T extends keyof JSX.IntrinsicElements
+    ? JSX.IntrinsicElements[T]
+    : HTMLAttributes<T>
+  : T extends ComponentType<any>
+  ? ComponentPropsWithoutRef<T>
+  : never;
 
 export type UnknowablePropsFor<
-  T extends string | React.ComponentType<any> | unknown,
-> = T extends string | React.ComponentType<any> ? PropsFor<T> : unknown;
+  T extends string | ComponentType<any> | unknown,
+> = T extends string | ComponentType<any> ? PropsFor<T> : unknown;
 
 export type FunctionKeys<T> = {
   [K in keyof T]-?: NonNullable<T[K]> extends (...args: any[]) => any
@@ -176,14 +180,14 @@ export enum Tag {
 export interface Fiber {
   tag: Tag;
   key: null | string;
-  elementType: React.ComponentType | string | null;
-  type: React.ComponentType | string | null;
+  elementType: ComponentType | string | null;
+  type: ComponentType | string | null;
   stateNode: any;
   return: Fiber | null;
   child: Fiber | null;
   sibling: Fiber | null;
   index: number;
-  ref: React.LegacyRef<unknown>;
+  ref: LegacyRef<unknown>;
   pendingProps: unknown;
   memoizedProps: unknown;
   memoizedState: unknown;
@@ -201,7 +205,7 @@ export type Predicate = (node: Node<unknown>) => boolean;
 
 export interface Node<Props extends {} | unknown> {
   readonly props: Props;
-  readonly type: string | React.ComponentType<any> | null;
+  readonly type: string | ComponentType<any> | null;
   readonly isDOM: boolean;
   readonly instance: any;
   readonly children: Node<unknown>[];
@@ -215,15 +219,15 @@ export interface Node<Props extends {} | unknown> {
   text(): string;
   html(): string;
 
-  is<Type extends React.ComponentType<any> | string>(
+  is<Type extends ComponentType<any> | string>(
     type: Type,
   ): this is Node<PropsFor<Type>>;
 
-  find<Type extends React.ComponentType<any> | string>(
+  find<Type extends ComponentType<any> | string>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Node<PropsFor<Type>> | null;
-  findAll<Type extends React.ComponentType<any> | string>(
+  findAll<Type extends ComponentType<any> | string>(
     type: Type,
     props?: Partial<PropsFor<Type>>,
   ): Node<PropsFor<Type>>[];

--- a/packages/react-web-worker/src/hooks.ts
+++ b/packages/react-web-worker/src/hooks.ts
@@ -1,7 +1,7 @@
 import {useEffect} from 'react';
 import {terminate} from '@shopify/web-worker';
 import {useLazyRef} from '@shopify/react-hooks';
-import {NoInfer} from '@shopify/useful-types';
+import type {NoInfer} from '@shopify/useful-types';
 
 type WorkerCreator<Options extends any[], ReturnType> = (
   ...args: Options

--- a/packages/sewing-kit-koa/src/assets.ts
+++ b/packages/sewing-kit-koa/src/assets.ts
@@ -3,7 +3,7 @@ import {join} from 'path';
 import {readJson} from 'fs-extra';
 import appRoot from 'app-root-path';
 
-import {Manifest} from './types';
+import type {Manifest} from './types';
 import {Manifests} from './manifests';
 
 export type {Asset} from './types';

--- a/packages/sewing-kit-koa/src/manifests.ts
+++ b/packages/sewing-kit-koa/src/manifests.ts
@@ -5,7 +5,7 @@ import {matchesUA} from 'browserslist-useragent';
 import appRoot from 'app-root-path';
 import {ungzip} from 'node-gzip';
 
-import {ConsolidatedManifest, Manifest} from './types';
+import type {ConsolidatedManifest, Manifest} from './types';
 
 const DEFAULT_MANIFEST_PATH = 'build/client/assets.json';
 

--- a/packages/sewing-kit-koa/src/middleware.ts
+++ b/packages/sewing-kit-koa/src/middleware.ts
@@ -1,6 +1,6 @@
 import {join} from 'path';
 
-import {Context, Middleware} from 'koa';
+import type {Context, Middleware} from 'koa';
 import serve from 'koa-static';
 import compose from 'koa-compose';
 import mount from 'koa-mount';

--- a/packages/sewing-kit-koa/src/tests/test-utilities.ts
+++ b/packages/sewing-kit-koa/src/tests/test-utilities.ts
@@ -1,6 +1,6 @@
 import {basename} from 'path';
 
-import {Asset, AsyncAsset, ConsolidatedManifest, Manifest} from '../types';
+import type {Asset, AsyncAsset, ConsolidatedManifest, Manifest} from '../types';
 
 export function mockAsset(path: string): Asset {
   return {path};

--- a/packages/web-worker/src/messenger/iframe/create-messenger.ts
+++ b/packages/web-worker/src/messenger/iframe/create-messenger.ts
@@ -1,4 +1,4 @@
-import {MessageEndpoint} from '@remote-ui/rpc';
+import type {MessageEndpoint} from '@remote-ui/rpc';
 
 import {IFRAME_RUN_IDENTIFIER} from './constants';
 

--- a/packages/web-worker/src/tests/e2e.test.ts
+++ b/packages/web-worker/src/tests/e2e.test.ts
@@ -5,7 +5,7 @@
 import * as path from 'path';
 
 import {DefinePlugin} from 'webpack';
-import {Page, JSHandle, WebWorker} from 'puppeteer';
+import type {Page, JSHandle, WebWorker} from 'puppeteer';
 
 import {WebWorkerPlugin} from '../webpack-parts';
 

--- a/packages/web-worker/src/tests/utilities/server.ts
+++ b/packages/web-worker/src/tests/utilities/server.ts
@@ -1,5 +1,5 @@
-import {Server} from 'http';
-import {AddressInfo} from 'net';
+import type {Server} from 'http';
+import type {AddressInfo} from 'net';
 import {URL} from 'url';
 
 import Koa, {Middleware, Context} from 'koa';

--- a/packages/web-worker/src/tests/utilities/webpack.ts
+++ b/packages/web-worker/src/tests/utilities/webpack.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 
 import webpack from 'webpack';
 
-import {Context} from './context';
+import type {Context} from './context';
 
 export function runWebpack(
   {workspace, server}: Context,


### PR DESCRIPTION
## Description

Remove our override for the `importsNotUsedAsValues` typescript option, which causes it to use the value from the strictest config - `error`.

Adjust imports of types to use `import type` where required.

