### PR TITLE
Remove unneeded baseUrl tsconfig option

### DIFF
--- a/packages/address-consts/tsconfig.json
+++ b/packages/address-consts/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/address-mocks/tsconfig.json
+++ b/packages/address-mocks/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/address/tsconfig.json
+++ b/packages/address/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/admin-graphql-api-utilities/tsconfig.json
+++ b/packages/admin-graphql-api-utilities/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/async/tsconfig.json
+++ b/packages/async/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/csrf-token-fetcher/tsconfig.json
+++ b/packages/csrf-token-fetcher/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/css-utilities/tsconfig.json
+++ b/packages/css-utilities/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/dates/tsconfig.json
+++ b/packages/dates/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/function-enhancers/tsconfig.json
+++ b/packages/function-enhancers/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/graphql-config-utilities/tsconfig.json
+++ b/packages/graphql-config-utilities/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "outDir": "build/ts",
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.ts",

--- a/packages/graphql-fixtures/tsconfig.json
+++ b/packages/graphql-fixtures/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "outDir": "build/ts",
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.ts",

--- a/packages/graphql-mini-transforms/tsconfig.json
+++ b/packages/graphql-mini-transforms/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "outDir": "build/ts",
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.ts",

--- a/packages/graphql-persisted/tsconfig.json
+++ b/packages/graphql-persisted/tsconfig.json
@@ -2,11 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src",
-    "paths": {
-      "koa": ["node_modules/koa"]
-    }
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/graphql-testing/tsconfig.json
+++ b/packages/graphql-testing/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/graphql-tool-utilities/tsconfig.json
+++ b/packages/graphql-tool-utilities/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "outDir": "build/ts",
+    "rootDir": "src"
   },
   "include": ["../../config/typescript/*.ts", "./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/graphql-typed/tsconfig.json
+++ b/packages/graphql-typed/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "outDir": "build/ts",
+    "rootDir": "src"
   },
   "include": ["../../config/typescript/*.ts", "./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/graphql-typescript-definitions/tsconfig.json
+++ b/packages/graphql-typescript-definitions/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "outDir": "build/ts",
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.ts",

--- a/packages/graphql-validate-fixtures/tsconfig.json
+++ b/packages/graphql-validate-fixtures/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "outDir": "build/ts",
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.ts",

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/jest-dom-mocks/tsconfig.json
+++ b/packages/jest-dom-mocks/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/jest-koa-mocks/tsconfig.json
+++ b/packages/jest-koa-mocks/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/koa-liveness-ping/tsconfig.json
+++ b/packages/koa-liveness-ping/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/koa-metrics/tsconfig.json
+++ b/packages/koa-metrics/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/koa-performance/tsconfig.json
+++ b/packages/koa-performance/tsconfig.json
@@ -3,8 +3,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/koa-shopify-graphql-proxy/tsconfig.json
+++ b/packages/koa-shopify-graphql-proxy/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/koa-shopify-webhooks/tsconfig.json
+++ b/packages/koa-shopify-webhooks/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/mime-types/tsconfig.json
+++ b/packages/mime-types/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/network/tsconfig.json
+++ b/packages/network/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/performance/tsconfig.json
+++ b/packages/performance/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/polyfills/tsconfig.json
+++ b/packages/polyfills/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "build/ts",
     "rootDir": "src",
-    "baseUrl": "src",
     "isolatedModules": false
   },
   "include": [

--- a/packages/predicates/tsconfig.json
+++ b/packages/predicates/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-app-bridge-universal-provider/tsconfig.json
+++ b/packages/react-app-bridge-universal-provider/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-async/tsconfig.json
+++ b/packages/react-async/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-bugsnag/tsconfig.json
+++ b/packages/react-bugsnag/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-cookie/tsconfig.json
+++ b/packages/react-cookie/tsconfig.json
@@ -3,8 +3,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-csrf-universal-provider/tsconfig.json
+++ b/packages/react-csrf-universal-provider/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-csrf/tsconfig.json
+++ b/packages/react-csrf/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-effect/tsconfig.json
+++ b/packages/react-effect/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-form-state/tsconfig.json
+++ b/packages/react-form-state/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-form/tsconfig.json
+++ b/packages/react-form/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-google-analytics/tsconfig.json
+++ b/packages/react-google-analytics/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-graphql-universal-provider/tsconfig.json
+++ b/packages/react-graphql-universal-provider/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-graphql/tsconfig.json
+++ b/packages/react-graphql/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-html/tsconfig.json
+++ b/packages/react-html/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-hydrate/tsconfig.json
+++ b/packages/react-hydrate/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-i18n-universal-provider/tsconfig.json
+++ b/packages/react-i18n-universal-provider/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-idle/tsconfig.json
+++ b/packages/react-idle/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-import-remote/tsconfig.json
+++ b/packages/react-import-remote/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-intersection-observer/tsconfig.json
+++ b/packages/react-intersection-observer/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-network/tsconfig.json
+++ b/packages/react-network/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-performance/tsconfig.json
+++ b/packages/react-performance/tsconfig.json
@@ -3,8 +3,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-server/tsconfig.json
+++ b/packages/react-server/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-shortcuts/tsconfig.json
+++ b/packages/react-shortcuts/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-testing/tsconfig.json
+++ b/packages/react-testing/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-universal-provider/tsconfig.json
+++ b/packages/react-universal-provider/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/react-web-worker/tsconfig.json
+++ b/packages/react-web-worker/tsconfig.json
@@ -3,8 +3,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "references": [

--- a/packages/semaphore/tsconfig.json
+++ b/packages/semaphore/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": ["../../config/typescript/*.d.ts", "./src/**/*.ts"]
 }

--- a/packages/sewing-kit-koa/tsconfig.json
+++ b/packages/sewing-kit-koa/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/statsd/tsconfig.json
+++ b/packages/statsd/tsconfig.json
@@ -3,8 +3,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": [
     "../../config/typescript/*.d.ts",

--- a/packages/storybook-a11y-test/tsconfig.json
+++ b/packages/storybook-a11y-test/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": ["./src/**/*.ts"]
 }

--- a/packages/useful-types/tsconfig.json
+++ b/packages/useful-types/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": ["./src/**/*.ts"]
 }

--- a/packages/web-worker/tsconfig.json
+++ b/packages/web-worker/tsconfig.json
@@ -3,7 +3,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "build/ts",
-    "baseUrl": "src",
     "rootDir": "src"
   },
   "include": [

--- a/packages/with-env/tsconfig.json
+++ b/packages/with-env/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "build/ts",
-    "rootDir": "src",
-    "baseUrl": "src"
+    "rootDir": "src"
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
## Description

- Remove the unneeded `baseUrl` tsconfig options.
- Remove an unneeded path alias in graphql-persisted
- Ensure outDir for all packages is 'build/ts'. There were a few places that used `'./build/ts` , which did the same thing but keeping it all the same is a bit tidier



This produces identical build output so I'm skipping changelogs