### PR TITLE
[jest-koa-mocks] Using non-fully qualified URL

### DIFF
--- a/.changeset/wicked-beans-cheer.md
+++ b/.changeset/wicked-beans-cheer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/jest-koa-mocks': minor
+---
+
+Using non-fully qualified URLs

--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -69,8 +69,6 @@ export default function createContext<
     state,
   };
 
-  const protocolFallback = encrypted ? 'https' : 'http';
-
   const req = httpMocks.createRequest({
     url,
     method,
@@ -88,7 +86,7 @@ export default function createContext<
   req.socket = new stream.Duplex() as any;
   Object.defineProperty(req.socket, 'encrypted', {
     writable: false,
-    value: protocolFallback === 'https',
+    value: encrypted,
   });
 
   const res = httpMocks.createResponse();

--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -1,4 +1,3 @@
-import {URL} from 'url';
 import stream from 'stream';
 
 import httpMocks, {RequestMethod} from 'node-mocks-http';
@@ -52,7 +51,7 @@ export default function createContext<
     session,
     requestBody,
     rawBody = '',
-    url = '',
+    url = '/',
     host = 'test.com',
     encrypted = false,
     throw: throwFn = jest.fn(),
@@ -71,16 +70,15 @@ export default function createContext<
   };
 
   const protocolFallback = encrypted ? 'https' : 'http';
-  const urlObject = new URL(url, `${protocolFallback}://${host}`);
 
   const req = httpMocks.createRequest({
-    url: urlObject.toString(),
+    url,
     method,
     statusCode,
     session,
     headers: {
       // Koa determines protocol based on the `Host` header.
-      Host: urlObject.host,
+      Host: host,
       ...headers,
     },
   });
@@ -90,7 +88,7 @@ export default function createContext<
   req.socket = new stream.Duplex() as any;
   Object.defineProperty(req.socket, 'encrypted', {
     writable: false,
-    value: urlObject.protocol === 'https:',
+    value: protocolFallback === 'https',
   });
 
   const res = httpMocks.createResponse();

--- a/packages/jest-koa-mocks/src/create-mock-context/tests/create-mock-context.test.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/tests/create-mock-context.test.ts
@@ -2,16 +2,16 @@ import type {Context} from 'koa';
 
 import createContext from '../create-mock-context';
 
-const STORE_URL = 'http://mystore.com/admin';
+const STORE_URL = '/admin?id=1';
+const STORE_HOST = 'mystore.com';
 
 describe('create-mock-context', () => {
   it('includes custom method and url', () => {
     const method = 'PUT';
-    const url = STORE_URL;
-    const context = createContext({method, url});
+    const context = createContext({method, url: STORE_URL});
 
     expect(context.method).toBe(method);
-    expect(context.url).toBe(url);
+    expect(context.url).toBe(STORE_URL);
   });
 
   it('defaults status to 404', () => {
@@ -59,27 +59,30 @@ describe('create-mock-context', () => {
   });
 
   it('sets url segment aliases', () => {
-    const context = createContext({url: STORE_URL});
+    const context = createContext({
+      url: STORE_URL,
+      host: STORE_HOST,
+    });
 
     const {url, originalUrl, host, origin, path, protocol} = context;
     expect(url).toBe(STORE_URL);
     expect(originalUrl).toBe(STORE_URL);
-    expect(host).toBe('mystore.com');
     expect(path).toBe('/admin');
     expect(protocol).toBe('http');
-    expect(origin).toBe('http://mystore.com');
+    expect(host).toBe(STORE_HOST);
+    expect(origin).toBe(`http://${STORE_HOST}`);
   });
 
   it('defaults url segments when no origin is given', () => {
-    const context = createContext({url: '/foo'});
+    const context = createContext({url: STORE_URL, host: STORE_HOST});
 
     const {url, originalUrl, host, origin, path, protocol} = context;
-    expect(url).toBe('http://test.com/foo');
-    expect(originalUrl).toBe('http://test.com/foo');
-    expect(host).toBe('test.com');
-    expect(path).toBe('/foo');
+    expect(url).toBe(STORE_URL);
+    expect(originalUrl).toBe(STORE_URL);
+    expect(path).toBe('/admin');
+    expect(host).toBe(STORE_HOST);
     expect(protocol).toBe('http');
-    expect(origin).toBe('http://test.com');
+    expect(origin).toBe(`http://${STORE_HOST}`);
   });
 
   it('determines protocol based on `encrypted`', () => {
@@ -89,32 +92,6 @@ describe('create-mock-context', () => {
     });
 
     expect(protocol).toBe('https');
-  });
-
-  it('generates the same url from segments as a full url', () => {
-    const explicitSegments = createContext({
-      url: '/foo/bar',
-      host: 'www.foobarbaz.com',
-      encrypted: true,
-    });
-
-    const fullyQualifiedUrl = createContext({
-      url: 'https://www.foobarbaz.com/foo/bar',
-    });
-
-    expect(explicitSegments.originalUrl).toBe(fullyQualifiedUrl.originalUrl);
-  });
-
-  it('prefers fully qualified url over explicit segments', () => {
-    const expectedUrl = 'https://www.foobarbaz.com/foo/bar';
-
-    const {originalUrl} = createContext({
-      url: 'https://www.foobarbaz.com/foo/bar',
-      host: 'someotherplace.com',
-      encrypted: false,
-    });
-
-    expect(originalUrl).toBe(expectedUrl);
   });
 
   it('includes custom cookies', () => {


### PR DESCRIPTION
## Description

Update `createContext()`  so that `url` options works the same way as it does in Koa, as well as the message URL [defined by Node.js](https://nodejs.org/api/http.html#messageurl), which is not a fully qualified URL.

> Request URL string. This contains only the URL that is present in the actual HTTP request. Take the following request:
>
> ``` 
> GET /status?name=ryan HTTP/1.1
> Accept: text/plain 
> ```
