### PR TITLE
Prepare for typescript 5. Enable consistent type import formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,9 @@ module.exports = {
     '@shopify/jsx-no-hardcoded-content': 'off',
     // reports false positives with React's useRef hook
     'require-atomic-updates': 'off',
+    '@typescript-eslint/consistent-type-imports': 'off',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     '@typescript-eslint/no-unnecessary-type-arguments': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'off',
     '@typescript-eslint/prefer-readonly': 'off',
@@ -35,6 +38,7 @@ module.exports = {
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/await-thenable': 'off',
     'import/no-extraneous-dependencies': 'error',
+    'import/consistent-type-specifier-style': 'error',
     'no-restricted-imports': [
       'error',
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     '@shopify/jsx-no-hardcoded-content': 'off',
     // reports false positives with React's useRef hook
     'require-atomic-updates': 'off',
-    '@typescript-eslint/consistent-type-imports': 'off',
+    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/consistent-type-exports': 'error',
     '@typescript-eslint/no-import-type-side-effects': 'error',
     '@typescript-eslint/no-unnecessary-type-arguments': 'off',

--- a/config/typescript/matchers.d.ts
+++ b/config/typescript/matchers.d.ts
@@ -1,4 +1,4 @@
-import {ComponentType, Context as ReactContext} from 'react';
+import type {ComponentType, Context as ReactContext} from 'react';
 import type {} from 'saddle-up/matchers';
 import type {} from 'saddle-up/koa-matchers';
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "npm-run-all": "^4.1.5",
     "plop": "^2.6.0",
-    "prettier": "~2.7.1",
+    "prettier": "~2.8.6",
     "puppeteer": "^13.2.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/packages/address-mocks/src/index.ts
+++ b/packages/address-mocks/src/index.ts
@@ -1,9 +1,9 @@
-import {
-  GRAPHQL_ENDPOINT,
+import type {
   LoadCountriesResponse,
   LoadCountryResponse,
   ResponseError,
 } from '@shopify/address-consts';
+import {GRAPHQL_ENDPOINT} from '@shopify/address-consts';
 import {fetch} from '@shopify/jest-dom-mocks';
 
 import {fixtures} from './fixtures';

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -1,8 +1,10 @@
-import {
+import type {
   Country,
   LoadCountriesResponse,
   LoadCountryResponse,
   ResponseError,
+} from '@shopify/address-consts';
+import {
   GRAPHQL_ENDPOINT,
   HEADERS,
   GraphqlOperationName,

--- a/packages/address/src/utilities.ts
+++ b/packages/address/src/utilities.ts
@@ -1,4 +1,5 @@
-import {Address, FieldName, Country, Zone} from '@shopify/address-consts';
+import type {Address, Country, Zone} from '@shopify/address-consts';
+import {FieldName} from '@shopify/address-consts';
 
 export const FIELD_REGEXP = /({\w+})/g;
 /* eslint-disable @typescript-eslint/naming-convention */

--- a/packages/async/src/tests/babel-plugin.test.ts
+++ b/packages/async/src/tests/babel-plugin.test.ts
@@ -1,6 +1,7 @@
 import {transformAsync} from '@babel/core';
 
-import asyncBabelPlugin, {Options} from '../babel-plugin';
+import type {Options} from '../babel-plugin';
+import asyncBabelPlugin from '../babel-plugin';
 
 const defaultPackage = 'some-async-package';
 const defaultImport = 'createAsyncComponent';

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -1,24 +1,22 @@
 import {faker} from '@faker-js/faker/locale/en';
-import {
+import type {
   GraphQLSchema,
   GraphQLType,
+  GraphQLObjectType,
+  GraphQLEnumType,
+  GraphQLScalarType,
+} from 'graphql';
+import {
   isNonNullType,
   isEnumType,
   isListType,
   isAbstractType,
-  GraphQLObjectType,
-  GraphQLEnumType,
   isScalarType,
-  GraphQLScalarType,
 } from 'graphql';
 import type {DocumentNode, GraphQLOperation} from 'graphql-typed';
 import type {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
-import {
-  compile,
-  Field,
-  InlineFragment,
-  Operation,
-} from 'graphql-tool-utilities';
+import type {Field, InlineFragment, Operation} from 'graphql-tool-utilities';
+import {compile} from 'graphql-tool-utilities';
 
 import {randomFromArray, chooseNull} from './utilities';
 

--- a/packages/graphql-fixtures/src/tests/fill.test.ts
+++ b/packages/graphql-fixtures/src/tests/fill.test.ts
@@ -1,9 +1,11 @@
 // eslint-disable-next-line @shopify/typescript/prefer-build-client-schema
 import {buildSchema} from 'graphql';
-import {parse, DocumentNode} from 'graphql-typed';
+import type {DocumentNode} from 'graphql-typed';
+import {parse} from 'graphql-typed';
 import {faker as originalFaker} from '@faker-js/faker/locale/en';
 
-import {createFiller, list, Options, faker} from '../fill';
+import type {Options} from '../fill';
+import {createFiller, list, faker} from '../fill';
 
 jest.mock('../utilities', () => {
   const utilities = jest.requireActual('../utilities');

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -1,8 +1,6 @@
 import {createHash} from 'crypto';
 
-import {
-  print,
-  parse,
+import type {
   DocumentNode as UntypedDocumentNode,
   DefinitionNode,
   SelectionSetNode,
@@ -11,6 +9,7 @@ import {
   SelectionNode,
   Location,
 } from 'graphql';
+import {print, parse} from 'graphql';
 import type {DocumentNode, SimpleDocument} from 'graphql-typed';
 
 const IMPORT_REGEX = /^#import\s+['"]([^'"]*)['"];?[\s\n]*/gm;

--- a/packages/graphql-mini-transforms/src/webpack-loader.ts
+++ b/packages/graphql-mini-transforms/src/webpack-loader.ts
@@ -1,7 +1,8 @@
 import {dirname} from 'path';
 
 import type {LoaderContext} from 'webpack';
-import {parse, DocumentNode} from 'graphql';
+import type {DocumentNode} from 'graphql';
+import {parse} from 'graphql';
 
 import {cleanDocument, extractImports, toSimpleDocument} from './document';
 

--- a/packages/graphql-persisted/src/apollo.ts
+++ b/packages/graphql-persisted/src/apollo.ts
@@ -1,10 +1,5 @@
-import {
-  ApolloLink,
-  Operation,
-  NextLink,
-  Observable,
-  FetchResult,
-} from '@apollo/client';
+import type {Operation, NextLink, FetchResult} from '@apollo/client';
+import {ApolloLink, Observable} from '@apollo/client';
 
 import {CacheMissBehavior} from './shared';
 

--- a/packages/graphql-persisted/src/tests/koa-middleware.test.ts
+++ b/packages/graphql-persisted/src/tests/koa-middleware.test.ts
@@ -3,8 +3,8 @@ import {Header} from '@shopify/network';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {setAssets} from '@shopify/sewing-kit-koa';
 
+import type {Cache} from '../koa-middleware';
 import {
-  Cache,
   CacheMissBehavior,
   createPersistedGraphQLMiddleware,
 } from '../koa-middleware';

--- a/packages/graphql-persisted/src/tests/utilities.ts
+++ b/packages/graphql-persisted/src/tests/utilities.ts
@@ -1,12 +1,6 @@
-import {
-  ApolloLink,
-  execute,
-  Operation,
-  Observable,
-  FetchResult,
-  NextLink,
-} from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {Operation, FetchResult, NextLink} from '@apollo/client';
+import {ApolloLink, execute, Observable} from '@apollo/client';
+import type {DocumentNode} from 'graphql-typed';
 
 interface ExecuteOnceOutcome {
   operation: Operation;

--- a/packages/graphql-testing/src/factory.ts
+++ b/packages/graphql-testing/src/factory.ts
@@ -1,4 +1,5 @@
-import {GraphQL, Options} from './graphql-controller';
+import type {Options} from './graphql-controller';
+import {GraphQL} from './graphql-controller';
 import type {GraphQLMock} from './types';
 
 export function createGraphQLFactory(options?: Options) {

--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -1,9 +1,5 @@
-import {
-  ApolloClient,
-  ApolloLink,
-  InMemoryCacheConfig,
-  InMemoryCache,
-} from '@apollo/client';
+import type {InMemoryCacheConfig} from '@apollo/client';
+import {ApolloClient, ApolloLink, InMemoryCache} from '@apollo/client';
 
 import {MockLink, InflightLink} from './links';
 import {Operations} from './operations';

--- a/packages/graphql-testing/src/links/inflight.ts
+++ b/packages/graphql-testing/src/links/inflight.ts
@@ -1,10 +1,5 @@
-import {
-  ApolloLink,
-  Observable,
-  Operation,
-  NextLink,
-  FetchResult,
-} from '@apollo/client';
+import type {Operation, NextLink, FetchResult} from '@apollo/client';
+import {ApolloLink, Observable} from '@apollo/client';
 
 import type {MockRequest} from '../types';
 

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -1,5 +1,7 @@
-import {ApolloLink, Observable, Operation} from '@apollo/client';
-import {ExecutionResult, GraphQLError} from 'graphql';
+import type {Operation} from '@apollo/client';
+import {ApolloLink, Observable} from '@apollo/client';
+import type {ExecutionResult} from 'graphql';
+import {GraphQLError} from 'graphql';
 
 import type {GraphQLMock, MockGraphQLFunction} from '../types';
 

--- a/packages/graphql-testing/src/links/tests/mocks.test.ts
+++ b/packages/graphql-testing/src/links/tests/mocks.test.ts
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {GraphQLError} from 'graphql';
 
-import {MockGraphQLResponse} from '../../types';
+import type {MockGraphQLResponse} from '../../types';
 import {MockLink} from '../mocks';
 
 import {executeOnce} from './utilities';

--- a/packages/graphql-testing/src/links/tests/utilities.ts
+++ b/packages/graphql-testing/src/links/tests/utilities.ts
@@ -1,12 +1,6 @@
-import {
-  ApolloLink,
-  execute,
-  Operation,
-  Observable,
-  FetchResult,
-  NextLink,
-} from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {Operation, FetchResult, NextLink} from '@apollo/client';
+import {ApolloLink, execute, Observable} from '@apollo/client';
+import type {DocumentNode} from 'graphql-typed';
 
 interface ExecuteOnceOutcome {
   operation: Operation;

--- a/packages/graphql-testing/src/tests/e2e.test.tsx
+++ b/packages/graphql-testing/src/tests/e2e.test.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react';
 import {GraphQLError} from 'graphql';
 import {gql} from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {DocumentNode} from 'graphql-typed';
 import {mount} from '@shopify/react-testing';
 import {ApolloProvider, useQuery, ApolloError} from '@shopify/react-graphql';
 

--- a/packages/graphql-tool-utilities/src/ast.ts
+++ b/packages/graphql-tool-utilities/src/ast.ts
@@ -1,14 +1,14 @@
 import type {DocumentNode, GraphQLInputType, GraphQLSchema} from 'graphql';
-import {
+import type {
   BooleanCondition,
   CompilerOptions,
-  compileToLegacyIR as compileToIR,
   LegacyCompilerContext,
   LegacyField,
   LegacyFragment,
   LegacyInlineFragment,
   LegacyOperation,
 } from 'apollo-codegen-core/lib/compiler/legacyIR';
+import {compileToLegacyIR as compileToIR} from 'apollo-codegen-core/lib/compiler/legacyIR';
 
 export enum OperationType {
   Query = 'query',

--- a/packages/graphql-typed/src/index.ts
+++ b/packages/graphql-typed/src/index.ts
@@ -1,9 +1,9 @@
-import {
-  parse as graphQLParse,
+import type {
   DocumentNode as BaseDocumentNode,
   Source,
   ParseOptions,
 } from 'graphql';
+import {parse as graphQLParse} from 'graphql';
 
 export interface GraphQLOperation<Data = {}, Variables = {}, DeepPartial = {}> {
   // We need something to actually use the types, otherwise TypeScript

--- a/packages/graphql-typescript-definitions/src/cli.ts
+++ b/packages/graphql-typescript-definitions/src/cli.ts
@@ -5,7 +5,8 @@ import yargs from 'yargs';
 
 import {EnumFormat, ExportFormat} from './types';
 
-import {Builder, SchemaBuild, DocumentBuild} from '.';
+import type {SchemaBuild, DocumentBuild} from '.';
+import {Builder} from '.';
 
 const argv = yargs
   .usage('Usage: $0 [options]')

--- a/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
+++ b/packages/graphql-typescript-definitions/src/filesystem/default-graphql-filesystem.ts
@@ -1,4 +1,5 @@
-import {FSWatcher, watch} from 'chokidar';
+import type {FSWatcher} from 'chokidar';
+import {watch} from 'chokidar';
 import type {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
 import {
   getGraphQLProjectIncludedFilePaths,

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -1,45 +1,31 @@
 import {EventEmitter} from 'events';
 import {join, resolve} from 'path';
 
-import {
+import type {
   DocumentNode,
   DefinitionNode,
   FragmentDefinitionNode,
   GraphQLSchema,
   OperationDefinitionNode,
-  parse,
-  Source,
-  concatAST,
 } from 'graphql';
+import {parse, Source, concatAST} from 'graphql';
 import chalk from 'chalk';
 import {mkdirp, readFile, writeFile} from 'fs-extra';
-import {
-  loadConfigSync,
-  GraphQLProjectConfig,
-  GraphQLConfig,
-} from 'graphql-config';
+import type {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
+import {loadConfigSync} from 'graphql-config';
 import {
   getGraphQLProjectForSchemaPath,
   getGraphQLProjects,
   getGraphQLSchemaPaths,
   resolvePathRelativeToConfig,
 } from 'graphql-config-utilities';
-import {
-  AST,
-  compile,
-  Fragment,
-  isOperation,
-  Operation,
-} from 'graphql-tool-utilities';
+import type {AST, Fragment, Operation} from 'graphql-tool-utilities';
+import {compile, isOperation} from 'graphql-tool-utilities';
 
 import type {GraphQLFilesystem} from './filesystem';
 import {AbstractGraphQLFilesystem} from './filesystem';
-import {
-  printDocument,
-  generateSchemaTypes,
-  PrintDocumentOptions,
-  PrintSchemaOptions,
-} from './print';
+import type {PrintDocumentOptions, PrintSchemaOptions} from './print';
+import {printDocument, generateSchemaTypes} from './print';
 import {EnumFormat, ExportFormat} from './types';
 
 export type {GraphQLFilesystem};

--- a/packages/graphql-typescript-definitions/src/print/document/context.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/context.ts
@@ -1,7 +1,8 @@
 import {relative, dirname} from 'path';
 
 import * as t from '@babel/types';
-import {AST, Fragment, isOperation, Operation} from 'graphql-tool-utilities';
+import type {AST, Fragment, Operation} from 'graphql-tool-utilities';
+import {isOperation} from 'graphql-tool-utilities';
 
 import type {EnumFormat, ExportFormat} from '../../types';
 

--- a/packages/graphql-typescript-definitions/src/print/document/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/index.ts
@@ -1,16 +1,12 @@
 import * as t from '@babel/types';
 import type {GraphQLObjectType} from 'graphql';
-import {
-  AST,
-  Fragment,
-  isTypedVariable,
-  Operation,
-  OperationType,
-} from 'graphql-tool-utilities';
+import type {AST, Fragment, Operation} from 'graphql-tool-utilities';
+import {isTypedVariable, OperationType} from 'graphql-tool-utilities';
 
 import {ExportFormat} from '../../types';
 
-import {Options, FileContext, OperationContext} from './context';
+import type {Options} from './context';
+import {FileContext, OperationContext} from './context';
 import {ObjectStack} from './utilities';
 import {tsInterfaceBodyForObjectField, variablesInterface} from './language';
 

--- a/packages/graphql-typescript-definitions/src/print/document/language.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/language.ts
@@ -1,4 +1,10 @@
 import * as t from '@babel/types';
+import type {
+  GraphQLInputType,
+  GraphQLType,
+  GraphQLObjectType,
+  GraphQLCompositeType,
+} from 'graphql';
 import {
   GraphQLString,
   isEnumType,
@@ -7,23 +13,19 @@ import {
   isScalarType,
   isListType,
   isAbstractType,
-  GraphQLInputType,
-  GraphQLType,
   GraphQLNonNull,
-  GraphQLObjectType,
   isInputObjectType,
   isInterfaceType,
   isUnionType,
-  GraphQLCompositeType,
 } from 'graphql';
-import {
+import type {
   Field,
   InlineFragment,
-  isTypedVariable,
   PrintableFieldDetails,
   TypedVariable,
   Variable,
 } from 'graphql-tool-utilities';
+import {isTypedVariable} from 'graphql-tool-utilities';
 
 import {scalarTypeMap} from '../utilities';
 

--- a/packages/graphql-typescript-definitions/src/print/schema/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/schema/index.ts
@@ -1,15 +1,17 @@
 import * as t from '@babel/types';
 import {pascalCase, camelCase, snakeCase} from 'change-case';
-import {
+import type {
   GraphQLSchema,
-  isEnumType,
   GraphQLEnumType,
-  isInputType,
   GraphQLScalarType,
-  isScalarType,
   GraphQLInputObjectType,
-  isNonNullType,
   GraphQLInputType,
+} from 'graphql';
+import {
+  isEnumType,
+  isInputType,
+  isScalarType,
+  isNonNullType,
   isListType,
 } from 'graphql';
 

--- a/packages/graphql-typescript-definitions/tests/document.test.ts
+++ b/packages/graphql-typescript-definitions/tests/document.test.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
 
-// eslint-disable-next-line @shopify/typescript/prefer-build-client-schema
-import {buildSchema, parse, GraphQLSchema, Source, concatAST} from 'graphql';
+import type {GraphQLSchema} from 'graphql';
+import {buildSchema, parse, Source, concatAST} from 'graphql';
 import {stripIndent} from 'common-tags';
 import {compile} from 'graphql-tool-utilities';
 
 import {ExportFormat} from '../src/types';
-import {printDocument, Options} from '../src/print/document';
+import type {Options} from '../src/print/document';
+import {printDocument} from '../src/print/document';
 
 describe('printDocument()', () => {
   describe('scalars', () => {

--- a/packages/graphql-typescript-definitions/tests/document.test.ts
+++ b/packages/graphql-typescript-definitions/tests/document.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import type {GraphQLSchema} from 'graphql';
+// eslint-disable-next-line @shopify/typescript/prefer-build-client-schema
 import {buildSchema, parse, Source, concatAST} from 'graphql';
 import {stripIndent} from 'common-tags';
 import {compile} from 'graphql-tool-utilities';

--- a/packages/graphql-validate-fixtures/src/index.ts
+++ b/packages/graphql-validate-fixtures/src/index.ts
@@ -1,22 +1,22 @@
 import {resolve} from 'path';
 
 import {readFile, readJSON} from 'fs-extra';
-import {Source, parse, concatAST, GraphQLSchema} from 'graphql';
-import {loadConfig, GraphQLProjectConfig} from 'graphql-config';
+import type {GraphQLSchema} from 'graphql';
+import {Source, parse, concatAST} from 'graphql';
+import type {GraphQLProjectConfig} from 'graphql-config';
+import {loadConfig} from 'graphql-config';
 import {
   getGraphQLProjectIncludedFilePaths,
   getGraphQLProjects,
 } from 'graphql-config-utilities';
 import {compile} from 'graphql-tool-utilities';
 
+import type {Fixture, Validation, GraphQLProjectAST} from './validate';
 import {
-  Fixture,
-  Validation,
   validateFixture,
   getOperationForFixture,
   MissingOperationError,
   AmbiguousOperationNameError,
-  GraphQLProjectAST,
 } from './validate';
 
 export interface Options {

--- a/packages/graphql-validate-fixtures/src/validate.ts
+++ b/packages/graphql-validate-fixtures/src/validate.ts
@@ -1,14 +1,16 @@
 import {dirname, basename} from 'path';
 
-import {
+import type {
   GraphQLType,
   GraphQLNonNull,
   GraphQLList,
+  GraphQLLeafType,
+} from 'graphql';
+import {
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
   GraphQLBoolean,
-  GraphQLLeafType,
   isEnumType,
   isListType,
   isNonNullType,

--- a/packages/graphql-validate-fixtures/tests/index.test.ts
+++ b/packages/graphql-validate-fixtures/tests/index.test.ts
@@ -4,7 +4,8 @@ import {join} from 'path';
 import * as glob from 'glob';
 
 import {stripFullFilePaths} from '../../../tests/utilities';
-import {evaluateFixtures, Options} from '../src/index';
+import type {Options} from '../src/index';
+import {evaluateFixtures} from '../src/index';
 
 const rootFixtureDirectory = join(__dirname, 'fixtures');
 

--- a/packages/graphql-validate-fixtures/tests/validate.test.ts
+++ b/packages/graphql-validate-fixtures/tests/validate.test.ts
@@ -5,14 +5,11 @@ import {join, resolve} from 'path';
 // eslint-disable-next-line @shopify/typescript/prefer-build-client-schema
 import {buildSchema, parse, concatAST} from 'graphql';
 import {GraphQLProjectConfig, loadConfigSync} from 'graphql-config';
-import {AST, compile} from 'graphql-tool-utilities';
+import type {AST} from 'graphql-tool-utilities';
+import {compile} from 'graphql-tool-utilities';
 
-import {
-  getOperationForFixture,
-  validateFixture,
-  GraphQLProjectAST,
-  Fixture,
-} from '../src/validate';
+import type {GraphQLProjectAST, Fixture} from '../src/validate';
+import {getOperationForFixture, validateFixture} from '../src/validate';
 
 describe('validate', () => {
   describe('validateFixtureAgainstAST()', () => {

--- a/packages/jest-dom-mocks/src/tests/connection.test.ts
+++ b/packages/jest-dom-mocks/src/tests/connection.test.ts
@@ -1,4 +1,5 @@
-import {Connection, NavigatorWithConnection} from '../connection';
+import type {NavigatorWithConnection} from '../connection';
+import {Connection} from '../connection';
 
 describe('Connection', () => {
   describe('mock', () => {

--- a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
+++ b/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts
@@ -1,9 +1,12 @@
 import stream from 'stream';
 
-import httpMocks, {RequestMethod} from 'node-mocks-http';
-import Koa, {Context} from 'koa';
+import type {RequestMethod} from 'node-mocks-http';
+import httpMocks from 'node-mocks-http';
+import type {Context} from 'koa';
+import Koa from 'koa';
 
-import createMockCookies, {MockCookies} from '../create-mock-cookies';
+import type {MockCookies} from '../create-mock-cookies';
+import createMockCookies from '../create-mock-cookies';
 
 export interface Dictionary<T> {
   [key: string]: T;

--- a/packages/koa-metrics/src/middleware.ts
+++ b/packages/koa-metrics/src/middleware.ts
@@ -1,10 +1,12 @@
 import type {Context} from 'koa';
-import {StatsDClient, Logger} from '@shopify/statsd';
+import type {Logger} from '@shopify/statsd';
+import {StatsDClient} from '@shopify/statsd';
 
 import {tagsForRequest, tagsForResponse} from './tags';
 import {getQueuingTime} from './timing';
 import {getContentLength} from './content';
-import {initTimer, Timer} from './timer';
+import type {Timer} from './timer';
+import {initTimer} from './timer';
 
 export enum CustomMetric {
   ContentLength = 'request_content_length',

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -2,14 +2,14 @@ import type {Context} from 'koa';
 import compose from 'koa-compose';
 import bodyParser from 'koa-bodyparser';
 import {StatusCode, Header} from '@shopify/network';
-import {
-  EventType,
-  Navigation,
+import type {
   LifecycleEvent,
   NavigationDefinition,
   NavigationMetadata,
 } from '@shopify/performance';
-import {StatsDClient, Logger} from '@shopify/statsd';
+import {EventType, Navigation} from '@shopify/performance';
+import type {Logger} from '@shopify/statsd';
+import {StatsDClient} from '@shopify/statsd';
 
 import {LifecycleMetric, NavigationMetric} from './enums';
 import type {BrowserConnection} from './types';

--- a/packages/koa-performance/src/tests/middleware.test.ts
+++ b/packages/koa-performance/src/tests/middleware.test.ts
@@ -1,16 +1,15 @@
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {StatusCode, Method, Header} from '@shopify/network';
-import {
+import type {
   LifecycleEvent,
-  EventType,
-  Navigation,
   NavigationDefinition,
-  NavigationResult,
   NavigationMetadata,
 } from '@shopify/performance';
+import {EventType, Navigation, NavigationResult} from '@shopify/performance';
 import withEnv from '@shopify/with-env';
 
-import {clientPerformanceMetrics, Metrics} from '../middleware';
+import type {Metrics} from '../middleware';
+import {clientPerformanceMetrics} from '../middleware';
 
 jest.mock('@shopify/statsd');
 const StatsDClient = jest.requireMock('@shopify/statsd').StatsDClient;

--- a/packages/koa-shopify-webhooks/src/receive.ts
+++ b/packages/koa-shopify-webhooks/src/receive.ts
@@ -7,7 +7,8 @@ import compose from 'koa-compose';
 import type {Context, Middleware} from 'koa';
 import {StatusCode} from '@shopify/network';
 
-import {WebhookHeader, Topic} from './types';
+import type {Topic} from './types';
+import {WebhookHeader} from './types';
 
 interface Options {
   secret: string;

--- a/packages/koa-shopify-webhooks/src/register.ts
+++ b/packages/koa-shopify-webhooks/src/register.ts
@@ -1,6 +1,7 @@
 import {Method, Header} from '@shopify/network';
 
-import {WebhookHeader, Topic} from './types';
+import type {Topic} from './types';
+import {WebhookHeader} from './types';
 
 export type ApiVersion =
   | '2020-10'

--- a/packages/koa-shopify-webhooks/src/tests/register.test.ts
+++ b/packages/koa-shopify-webhooks/src/tests/register.test.ts
@@ -2,7 +2,8 @@ import {Header} from '@shopify/network';
 import {fetch as fetchMock} from '@shopify/jest-dom-mocks';
 
 import {DeliveryMethod} from '../register';
-import {registerWebhook, Options, WebhookHeader} from '..';
+import type {Options} from '..';
+import {registerWebhook, WebhookHeader} from '..';
 
 const successResponse = {
   data: {

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1,4 +1,5 @@
-import {LogEntry, LogLevel, Value, Formatter} from './types';
+import type {LogEntry, Value, Formatter} from './types';
+import {LogLevel} from './types';
 import {ConsoleFormatter} from './formatters';
 
 export interface LoggerOptions {

--- a/packages/logger/src/formatters/ConsoleFormatter.ts
+++ b/packages/logger/src/formatters/ConsoleFormatter.ts
@@ -2,7 +2,8 @@ import chalk from 'chalk';
 import {info, warning, error} from 'log-symbols';
 import prettyMs from 'pretty-ms';
 
-import {LogLevel, FormatEntry, Formatter} from '../types';
+import type {FormatEntry, Formatter} from '../types';
+import {LogLevel} from '../types';
 
 const MAX_LEVEL_LENGTH = [LogLevel.Critical, LogLevel.Info, LogLevel.Warn]
   .map((level) => level.length)

--- a/packages/performance/src/inflight.ts
+++ b/packages/performance/src/inflight.ts
@@ -1,12 +1,11 @@
 import {now} from './utilities';
-import {
+import type {
   Event,
-  NavigationResult,
   NavigationMetadata,
-  EventType,
   ScriptDownloadEvent,
   StyleDownloadEvent,
 } from './types';
+import {NavigationResult, EventType} from './types';
 import {Navigation} from './navigation';
 
 interface NavigationStartOptions {

--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -1,6 +1,5 @@
-import {
+import type {
   Event,
-  EventType,
   NavigationDefinition,
   NavigationResult,
   NavigationMetadata,
@@ -9,6 +8,7 @@ import {
   StyleDownloadEvent,
   EventMap,
 } from './types';
+import {EventType} from './types';
 import {getUniqueRanges} from './utilities';
 
 const LIFECYCLE_EVENTS: LifecycleEvent['type'][] = [

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -12,7 +12,8 @@ import {
   hasGlobal,
   getResourceTypeFromEntry,
 } from './utilities';
-import {Event, EventType, LifecycleEvent} from './types';
+import type {Event, LifecycleEvent} from './types';
+import {EventType} from './types';
 
 const WATCH_RESOURCE_TYPES = ['script', 'css', 'link'];
 

--- a/packages/performance/src/tests/navigation.test.ts
+++ b/packages/performance/src/tests/navigation.test.ts
@@ -1,15 +1,14 @@
 import {Navigation} from '../navigation';
-import {
+import type {
   NavigationDefinition,
   NavigationMetadata,
-  NavigationResult,
   CustomEvent,
   ScriptDownloadEvent,
-  EventType,
   StyleDownloadEvent,
   LifecycleEvent,
   EventMap,
 } from '../types';
+import {NavigationResult, EventType} from '../types';
 
 describe('Navigation', () => {
   it('has a start time', () => {

--- a/packages/react-async/src/PrefetchRoute.tsx
+++ b/packages/react-async/src/PrefetchRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import {PrefetchContext, PrefetchManager} from './context/prefetch';
+import type {PrefetchManager} from './context/prefetch';
+import {PrefetchContext} from './context/prefetch';
 
 interface Props {
   manager: PrefetchManager;

--- a/packages/react-async/src/Prefetcher.tsx
+++ b/packages/react-async/src/Prefetcher.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import {PrefetchContext, PrefetchManager} from './context/prefetch';
+import type {PrefetchManager} from './context/prefetch';
+import {PrefetchContext} from './context/prefetch';
 import {EventListener} from './EventListener';
 
 interface Props {

--- a/packages/react-async/src/component.tsx
+++ b/packages/react-async/src/component.tsx
@@ -1,17 +1,14 @@
-import React, {
-  useEffect,
-  useRef,
-  useCallback,
-  ReactNode,
-  ComponentType,
-} from 'react';
-import {createResolver, ResolverOptions, DeferTiming} from '@shopify/async';
+import type {ReactNode, ComponentType} from 'react';
+import React, {useEffect, useRef, useCallback} from 'react';
+import type {ResolverOptions} from '@shopify/async';
+import {createResolver, DeferTiming} from '@shopify/async';
 import {IntersectionObserver} from '@shopify/react-intersection-observer';
 import {OnIdle, useIdleCallback} from '@shopify/react-idle';
 import {Hydrator, useHydrationManager} from '@shopify/react-hydrate';
 
 import {useAsync} from './hooks';
-import {AssetTiming, AsyncComponentType} from './types';
+import type {AsyncComponentType} from './types';
+import {AssetTiming} from './types';
 
 interface Options<
   Props extends object,

--- a/packages/react-async/src/hooks.ts
+++ b/packages/react-async/src/hooks.ts
@@ -28,7 +28,7 @@ export function usePreload<PreloadOptions extends object>(
     [Preloadable<PreloadOptions>, PreloadOptions?],
     [Preloadable<PreloadOptions>, NoInfer<PreloadOptions>]
   >
-): ReturnType<typeof args[0]['usePreload']> {
+): ReturnType<(typeof args)[0]['usePreload']> {
   const [preloadable, options = {}] = args;
   return (preloadable.usePreload as any)(options);
 }
@@ -39,7 +39,7 @@ export function usePrefetch<PrefetchOptions extends object>(
     [Prefetchable<PrefetchOptions>, PrefetchOptions?],
     [Prefetchable<PrefetchOptions>, NoInfer<PrefetchOptions>]
   >
-): ReturnType<typeof args[0]['usePrefetch']> {
+): ReturnType<(typeof args)[0]['usePrefetch']> {
   const [prefetchable, options = {}] = args;
   return (prefetchable.usePrefetch as any)(options);
 }
@@ -50,7 +50,7 @@ export function useKeepFresh<KeepFreshOptions extends object>(
     [KeepFreshable<KeepFreshOptions>, KeepFreshOptions?],
     [KeepFreshable<KeepFreshOptions>, NoInfer<KeepFreshOptions>]
   >
-): ReturnType<typeof args[0]['useKeepFresh']> {
+): ReturnType<(typeof args)[0]['useKeepFresh']> {
   const [keepFreshable, options = {}] = args;
   return (keepFreshable.useKeepFresh as any)(options);
 }

--- a/packages/react-async/src/provider.tsx
+++ b/packages/react-async/src/provider.tsx
@@ -1,9 +1,12 @@
-import React, {Context, ComponentType, useEffect} from 'react';
-import {createResolver, ResolverOptions} from '@shopify/async';
+import type {Context, ComponentType} from 'react';
+import React, {useEffect} from 'react';
+import type {ResolverOptions} from '@shopify/async';
+import {createResolver} from '@shopify/async';
 import {useIdleCallback} from '@shopify/react-idle';
 
 import {useAsync} from './hooks';
-import {AsyncComponentType, AssetTiming} from './types';
+import type {AsyncComponentType} from './types';
+import {AssetTiming} from './types';
 
 interface Options<Value> extends ResolverOptions<Value> {}
 

--- a/packages/react-async/src/testing.tsx
+++ b/packages/react-async/src/testing.tsx
@@ -1,4 +1,5 @@
-import React, {ReactElement} from 'react';
+import type {ReactElement} from 'react';
+import React from 'react';
 import {extract} from '@shopify/react-effect/server';
 
 import {AsyncAssetManager, AsyncAssetContext} from './context/assets';

--- a/packages/react-async/src/tests/Prefetcher.test.tsx
+++ b/packages/react-async/src/tests/Prefetcher.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {mount, Root} from '@shopify/react-testing';
+import type {Root} from '@shopify/react-testing';
+import {mount} from '@shopify/react-testing';
 import {clock} from '@shopify/jest-dom-mocks';
 
 import {EventListener} from '../EventListener';

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -1,4 +1,5 @@
-import React, {Component, ReactNode} from 'react';
+import type {ReactNode} from 'react';
+import React, {Component} from 'react';
 import {faker} from '@faker-js/faker/locale/en';
 import {DeferTiming} from '@shopify/async';
 import {createMount} from '@shopify/react-testing';

--- a/packages/react-async/src/tests/utilities.tsx
+++ b/packages/react-async/src/tests/utilities.tsx
@@ -1,4 +1,5 @@
-import {PrefetchManager, Registration} from '../context/prefetch';
+import type {Registration} from '../context/prefetch';
+import {PrefetchManager} from '../context/prefetch';
 
 export * from '../testing';
 

--- a/packages/react-bugsnag/src/Bugsnag.tsx
+++ b/packages/react-bugsnag/src/Bugsnag.tsx
@@ -1,4 +1,5 @@
-import React, {useRef, ReactNode, ComponentProps} from 'react';
+import type {ReactNode, ComponentProps} from 'react';
+import React, {useRef} from 'react';
 import type {Client} from '@bugsnag/js';
 import type {BugsnagErrorBoundary} from '@bugsnag/plugin-react';
 

--- a/packages/react-bugsnag/src/client.ts
+++ b/packages/react-bugsnag/src/client.ts
@@ -1,4 +1,5 @@
-import bugsnag, {Config} from '@bugsnag/js';
+import type {Config} from '@bugsnag/js';
+import bugsnag from '@bugsnag/js';
 import BugsnagPluginReact from '@bugsnag/plugin-react';
 
 export type {Client} from '@bugsnag/js';

--- a/packages/react-form-state/src/index.ts
+++ b/packages/react-form-state/src/index.ts
@@ -1,11 +1,6 @@
 import FormState from './FormState';
-import {
-  asChoiceField,
-  ChoiceFieldDescriptor,
-  push,
-  replace,
-  remove,
-} from './utilities';
+import type {ChoiceFieldDescriptor} from './utilities';
+import {asChoiceField, push, replace, remove} from './utilities';
 
 export {asChoiceField};
 export type {ChoiceFieldDescriptor};

--- a/packages/react-form/src/hooks/field/field.ts
+++ b/packages/react-form/src/hooks/field/field.ts
@@ -1,4 +1,5 @@
-import {useCallback, useEffect, useMemo, ChangeEvent} from 'react';
+import type {ChangeEvent} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import isEqual from 'fast-deep-equal';
 
 import type {Validates, Field, DirtyStateComparator} from '../../types';

--- a/packages/react-form/src/hooks/field/reducer.ts
+++ b/packages/react-form/src/hooks/field/reducer.ts
@@ -1,4 +1,5 @@
-import {useReducer, Reducer} from 'react';
+import type {Reducer} from 'react';
+import {useReducer} from 'react';
 
 import type {FieldState, ErrorValue, DirtyStateComparator} from '../../types';
 import {defaultDirtyComparator, shallowArrayComparison} from '../../utilities';

--- a/packages/react-form/src/hooks/field/tests/field.test.tsx
+++ b/packages/react-form/src/hooks/field/tests/field.test.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
-import {
-  asChoiceField,
-  useChoiceField,
-  useField,
-  FieldConfig,
-  asChoiceList,
-} from '../field';
+import type {FieldConfig} from '../field';
+import {asChoiceField, useChoiceField, useField, asChoiceList} from '../field';
 import type {FieldState} from '../../../types';
-import {FieldAction, reduceField, makeFieldReducer} from '../reducer';
+import type {FieldAction} from '../reducer';
+import {reduceField, makeFieldReducer} from '../reducer';
 
 describe('useField', () => {
   function TestField({config}: {config: string | FieldConfig<string>}) {

--- a/packages/react-form/src/hooks/list/baselist.ts
+++ b/packages/react-form/src/hooks/list/baselist.ts
@@ -10,10 +10,10 @@ import type {
 import {mapObject, normalizeValidation} from '../../utilities';
 import {useDirty} from '../dirty';
 
+import type {ListAction} from './hooks';
 import {
   useHandlers,
   useListReducer,
-  ListAction,
   reinitializeAction,
   resetListAction,
 } from './hooks';

--- a/packages/react-form/src/hooks/list/dynamiclist.ts
+++ b/packages/react-form/src/hooks/list/dynamiclist.ts
@@ -7,7 +7,8 @@ import {
   removeFieldItemsAction,
   moveFieldItemAction,
 } from './hooks';
-import {useBaseList, FieldListConfig} from './baselist';
+import type {FieldListConfig} from './baselist';
+import {useBaseList} from './baselist';
 
 export interface DynamicList<Item extends object> {
   fields: FieldDictionary<Item>[];

--- a/packages/react-form/src/hooks/list/hooks/handlers.ts
+++ b/packages/react-form/src/hooks/list/hooks/handlers.ts
@@ -1,4 +1,5 @@
-import {ChangeEvent, useMemo} from 'react';
+import type {ChangeEvent} from 'react';
+import {useMemo} from 'react';
 
 import {mapObject, isChangeEvent} from '../../../utilities';
 import type {
@@ -8,13 +9,12 @@ import type {
 } from '../../../types';
 import {runValidation} from '../utils';
 
+import type {ListState, ListAction} from './index';
 import {
   updateAction,
   updateErrorAction,
   newDefaultAction,
   resetAction,
-  ListState,
-  ListAction,
 } from './index';
 
 export function useHandlers<Item extends object>(

--- a/packages/react-form/src/hooks/list/hooks/reducer.ts
+++ b/packages/react-form/src/hooks/list/hooks/reducer.ts
@@ -1,9 +1,10 @@
-import {useReducer, Reducer} from 'react';
+import type {Reducer} from 'react';
+import {useReducer} from 'react';
 
 import type {FieldStates, ErrorValue} from '../../../types';
+import type {FieldAction} from '../../field';
 import {
   reduceField,
-  FieldAction,
   updateErrorAction as updateFieldError,
   initialFieldState,
 } from '../../field';

--- a/packages/react-form/src/hooks/list/list.ts
+++ b/packages/react-form/src/hooks/list/list.ts
@@ -1,6 +1,7 @@
 import type {FieldDictionary} from '../../types';
 
-import {useBaseList, FieldListConfig} from './baselist';
+import type {FieldListConfig} from './baselist';
+import {useBaseList} from './baselist';
 
 /**
  * A custom hook for utilizing useBaseList. useList uses useBaseList. This hook is responsible for returning just the field objects useBaseList provides.

--- a/packages/react-form/src/hooks/list/tests/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/baselist.test.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
-import {useBaseList, FieldListConfig} from '../baselist';
+import type {FieldListConfig} from '../baselist';
+import {useBaseList} from '../baselist';
 import type {ListValidationContext} from '../../../types';
 
+import type {Variant} from './utils';
 import {
-  Variant,
   randomVariants,
   changeEvent,
   alwaysFail,

--- a/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/dynamiclist.test.tsx
@@ -5,7 +5,8 @@ import {mount} from '@shopify/react-testing';
 import {useDynamicList} from '../dynamiclist';
 import type {FieldListConfig} from '../baselist';
 
-import {Variant, randomVariants, clickEvent, TextField} from './utils';
+import type {Variant} from './utils';
+import {randomVariants, clickEvent, TextField} from './utils';
 
 describe('useDynamicList', () => {
   let consoleErrorSpy: jest.SpyInstance;

--- a/packages/react-form/src/hooks/list/tests/list.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/list.test.tsx
@@ -5,7 +5,8 @@ import {mount} from '@shopify/react-testing';
 import {useList} from '../list';
 import type {FieldListConfig} from '../baselist';
 
-import {randomVariants, TextField, Variant} from './utils';
+import type {Variant} from './utils';
+import {randomVariants, TextField} from './utils';
 
 describe('useList', () => {
   function List(config: FieldListConfig<Variant>) {

--- a/packages/react-form/src/hooks/tests/utilities/index.ts
+++ b/packages/react-form/src/hooks/tests/utilities/index.ts
@@ -1,7 +1,8 @@
 import {faker} from '@faker-js/faker/locale/en';
 import type {Root} from '@shopify/react-testing';
 
-import {SimpleProduct, TextField} from './components';
+import type {SimpleProduct} from './components';
+import {TextField} from './components';
 
 export * from './components';
 

--- a/packages/react-form/src/validation/validators.ts
+++ b/packages/react-form/src/validation/validators.ts
@@ -1,6 +1,7 @@
 import * as predicates from '@shopify/predicates';
 
-import {ErrorContent, validator} from './validator';
+import type {ErrorContent} from './validator';
+import {validator} from './validator';
 
 export function lengthMoreThan(length, error: ErrorContent<string>) {
   return validator(predicates.lengthMoreThan(length))(error);

--- a/packages/react-google-analytics/src/tests/GaJS.test.tsx
+++ b/packages/react-google-analytics/src/tests/GaJS.test.tsx
@@ -2,12 +2,8 @@ import React from 'react';
 import ImportRemote from '@shopify/react-import-remote';
 import {mount} from '@shopify/react-testing';
 
-import GaJS, {
-  Props,
-  SETUP_SCRIPT,
-  setupWithDebugScript,
-  GA_JS_SCRIPT,
-} from '../GaJS';
+import type {Props} from '../GaJS';
+import GaJS, {SETUP_SCRIPT, setupWithDebugScript, GA_JS_SCRIPT} from '../GaJS';
 
 jest.mock('@shopify/react-import-remote', () => () => null);
 

--- a/packages/react-google-analytics/src/tests/Universal.test.tsx
+++ b/packages/react-google-analytics/src/tests/Universal.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import ImportRemote from '@shopify/react-import-remote';
 import {mount} from '@shopify/react-testing';
 
+import type {Props} from '../Universal';
 import Universal, {
-  Props,
   SETUP_SCRIPT,
   UNIVERSAL_GA_SCRIPT,
   UNIVERSAL_GA_DEBUG_SCRIPT,

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -31,10 +31,7 @@ export function GraphQLUniversalProvider<
   const requestID = useRequestHeader('X-Request-ID');
 
   const [client, ssrLink] = useLazyRef<
-    [
-      import('@apollo/client').ApolloClient<any>,
-      ReturnType<typeof createSsrExtractableLink> | undefined,
-    ]
+    [ApolloClient<any>, ReturnType<typeof createSsrExtractableLink> | undefined]
   >(() => {
     const server = isServer();
 

--- a/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
+++ b/packages/react-graphql-universal-provider/src/GraphQLUniversalProvider.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import {
-  ApolloClient,
-  ApolloClientOptions,
-  ApolloLink,
-  InMemoryCache,
-  NormalizedCacheObject,
-} from '@apollo/client';
+import type {ApolloClientOptions, NormalizedCacheObject} from '@apollo/client';
+import {ApolloClient, ApolloLink, InMemoryCache} from '@apollo/client';
 import {useSerialized} from '@shopify/react-html';
 import {ApolloProvider, createSsrExtractableLink} from '@shopify/react-graphql';
 import {useLazyRef} from '@shopify/react-hooks';

--- a/packages/react-graphql/src/ApolloProvider.tsx
+++ b/packages/react-graphql/src/ApolloProvider.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import {
-  ApolloClient,
-  ApolloProvider as OriginalApolloProvider,
-} from '@apollo/client';
+import type {ApolloClient} from '@apollo/client';
+import {ApolloProvider as OriginalApolloProvider} from '@apollo/client';
 
 import {ApolloContext} from './ApolloContext';
 

--- a/packages/react-graphql/src/Query.tsx
+++ b/packages/react-graphql/src/Query.tsx
@@ -2,7 +2,8 @@ import type {IfAllNullableKeys, NoInfer} from '@shopify/useful-types';
 import type {OperationVariables} from '@apollo/client';
 import type {DocumentNode} from 'graphql-typed';
 
-import {useQuery, QueryHookResult, QueryHookOptions} from './hooks';
+import type {QueryHookResult, QueryHookOptions} from './hooks';
+import {useQuery} from './hooks';
 
 interface QueryComponentOptions<Data, Variables> extends QueryHookOptions {
   children: (result: QueryHookResult<Data, Variables>) => JSX.Element | null;

--- a/packages/react-graphql/src/async/component.tsx
+++ b/packages/react-graphql/src/async/component.tsx
@@ -1,13 +1,15 @@
 import {useIdleCallback} from '@shopify/react-idle';
 
-import {useQuery, QueryHookOptions} from '../hooks';
+import type {QueryHookOptions} from '../hooks';
+import {useQuery} from '../hooks';
 import type {
   AsyncQueryComponentType,
   QueryProps,
   VariableOptions,
 } from '../types';
 
-import {Options, createAsyncQuery} from './query';
+import type {Options} from './query';
+import {createAsyncQuery} from './query';
 
 export function createAsyncQueryComponent<
   Data extends {},

--- a/packages/react-graphql/src/async/query.ts
+++ b/packages/react-graphql/src/async/query.ts
@@ -1,5 +1,6 @@
 import type {DocumentNode} from 'graphql-typed';
-import {createResolver, ResolverOptions} from '@shopify/async';
+import type {ResolverOptions} from '@shopify/async';
+import {createResolver} from '@shopify/async';
 import {useAsync, AssetTiming} from '@shopify/react-async';
 
 import {useBackgroundQuery} from '../hooks';

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -1,4 +1,5 @@
-import React, {ReactElement} from 'react';
+import type {ReactElement} from 'react';
+import React from 'react';
 import {faker} from '@faker-js/faker/locale/en';
 import {ApolloClient, ApolloLink, InMemoryCache, gql} from '@apollo/client';
 import {getUsedAssets as baseGetUsedAssets} from '@shopify/react-async/testing';

--- a/packages/react-graphql/src/hooks/background-query.ts
+++ b/packages/react-graphql/src/hooks/background-query.ts
@@ -1,13 +1,11 @@
 import {useEffect, useRef, useCallback} from 'react';
 import type {DocumentNode} from 'graphql-typed';
-import type {WatchQueryOptions} from '@apollo/client';
+import type {ApolloClient, WatchQueryOptions} from '@apollo/client';
 
 import useApolloClient from './apollo-client';
 
 type Subscription = ReturnType<
-  ReturnType<
-    import('@apollo/client').ApolloClient<unknown>['watchQuery']
-  >['subscribe']
+  ReturnType<ApolloClient<unknown>['watchQuery']>['subscribe']
 >;
 
 export function useBackgroundQuery(

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -126,7 +126,7 @@ export default function useQuery<
     }
 
     let subscription:
-      | ReturnType<typeof queryObservable['subscribe']>
+      | ReturnType<(typeof queryObservable)['subscribe']>
       | undefined;
 
     let previousError;

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -1,13 +1,13 @@
 /* eslint react-hooks/rules-of-hooks: off */
 
 import {useEffect, useMemo, useState, useRef} from 'react';
-import {
+import type {
   ApolloClient,
   OperationVariables,
-  ApolloError,
   WatchQueryOptions,
   ObservableQuery,
 } from '@apollo/client';
+import {ApolloError} from '@apollo/client';
 import isEqual from 'fast-deep-equal';
 import type {DocumentNode} from 'graphql-typed';
 import {useServerEffect} from '@shopify/react-effect';

--- a/packages/react-graphql/src/hooks/tests/mutation.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/mutation.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {gql, ErrorPolicy} from '@apollo/client';
+import type {ErrorPolicy} from '@apollo/client';
+import {gql} from '@apollo/client';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 import {GraphQLError} from 'graphql';
 

--- a/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query-ssr.test.tsx
@@ -4,7 +4,8 @@
 
 import React from 'react';
 import {renderToString} from 'react-dom/server';
-import {FetchPolicy, gql} from '@apollo/client';
+import type {FetchPolicy} from '@apollo/client';
+import {gql} from '@apollo/client';
 import {extract} from '@shopify/react-effect/server';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -7,7 +7,7 @@ import {
   gql,
   ApolloError,
 } from '@apollo/client';
-import {DocumentNode} from 'graphql-typed';
+import type {DocumentNode} from 'graphql-typed';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 
 import {createAsyncQueryComponent} from '../../async';

--- a/packages/react-graphql/src/hooks/tests/utilities.tsx
+++ b/packages/react-graphql/src/hooks/tests/utilities.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {createGraphQLFactory, GraphQL} from '@shopify/graphql-testing';
+import type {GraphQL} from '@shopify/graphql-testing';
+import {createGraphQLFactory} from '@shopify/graphql-testing';
 import {createMount} from '@shopify/react-testing';
 
 import {ApolloProvider} from '../../ApolloProvider';

--- a/packages/react-graphql/src/links.ts
+++ b/packages/react-graphql/src/links.ts
@@ -1,4 +1,5 @@
-import {ApolloLink, Operation, NextLink} from '@apollo/client';
+import type {Operation, NextLink} from '@apollo/client';
+import {ApolloLink} from '@apollo/client';
 
 export function createSsrExtractableLink() {
   return new SsrExtractableLink();

--- a/packages/react-graphql/src/tests/link.test.tsx
+++ b/packages/react-graphql/src/tests/link.test.tsx
@@ -3,7 +3,8 @@
  */
 
 import React from 'react';
-import {WatchQueryFetchPolicy, gql} from '@apollo/client';
+import type {WatchQueryFetchPolicy} from '@apollo/client';
+import {gql} from '@apollo/client';
 import {extract} from '@shopify/react-effect/server';
 import {createGraphQLFactory} from '@shopify/graphql-testing';
 

--- a/packages/react-hooks/src/hooks/lazy-ref.ts
+++ b/packages/react-hooks/src/hooks/lazy-ref.ts
@@ -1,4 +1,5 @@
-import {useRef, useState, MutableRefObject} from 'react';
+import type {MutableRefObject} from 'react';
+import {useRef, useState} from 'react';
 
 export function useLazyRef<T>(getValue: () => T): MutableRefObject<T> {
   const [value] = useState<T>(getValue);

--- a/packages/react-html/src/server/components/Html.tsx
+++ b/packages/react-html/src/server/components/Html.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {renderToString} from 'react-dom/server';
-import {HydrationContext, HydrationManager} from '@shopify/react-hydrate';
+import type {HydrationManager} from '@shopify/react-hydrate';
+import {HydrationContext} from '@shopify/react-hydrate';
 
 import type {HtmlManager} from '../../manager';
 import {HtmlContext} from '../../context';

--- a/packages/react-i18n-universal-provider/src/I18nUniversalProvider.tsx
+++ b/packages/react-i18n-universal-provider/src/I18nUniversalProvider.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {useLazyRef} from '@shopify/react-hooks';
 import {useSerialized, useHtmlAttributes} from '@shopify/react-html';
-import {I18nContext, I18nDetails, I18nManager} from '@shopify/react-i18n';
+import type {I18nDetails} from '@shopify/react-i18n';
+import {I18nContext, I18nManager} from '@shopify/react-i18n';
 
 import {combinedI18nDetails} from './utilities';
 

--- a/packages/react-i18n/src/babel-plugin/tests/babel-plugin.test.ts
+++ b/packages/react-i18n/src/babel-plugin/tests/babel-plugin.test.ts
@@ -1,8 +1,10 @@
 import path from 'path';
 
-import {transformAsync, TransformOptions} from '@babel/core';
+import type {TransformOptions} from '@babel/core';
+import {transformAsync} from '@babel/core';
 
-import i18nBabelPlugin, {Options} from '../index';
+import type {Options} from '../index';
+import i18nBabelPlugin from '../index';
 import {TRANSLATION_DIRECTORY_NAME} from '../shared';
 
 jest.mock('string-hash', () => () => {

--- a/packages/react-i18n/src/constants/currency-decimal-places.ts
+++ b/packages/react-i18n/src/constants/currency-decimal-places.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_DECIMAL_PLACES = 2;
 // ISO 4217 2021-10-01 http://www.currency-iso.org/en/home/tables/table-a1.html
-export default new Map([
+export const currencyDecimalPlaces = new Map([
   ['AED', 2],
   ['AFN', 2],
   ['ALL', 2],

--- a/packages/react-i18n/src/constants/index.ts
+++ b/packages/react-i18n/src/constants/index.ts
@@ -185,7 +185,7 @@ export const RTL_LANGUAGES = [
 /* eslint-enable */
 
 export {
-  default as currencyDecimalPlaces,
+  currencyDecimalPlaces,
   DEFAULT_DECIMAL_PLACES,
 } from './currency-decimal-places';
 

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -15,36 +15,33 @@ import {
 import {memoize} from '@shopify/function-enhancers';
 import {languageFromLocale, regionFromLocale} from '@shopify/i18n';
 
-import {
+import type {
   I18nDetails,
   PrimitiveReplacementDictionary,
   ComplexReplacementDictionary,
   TranslationDictionary,
-  LanguageDirection,
 } from './types';
+import {LanguageDirection} from './types';
+import type {Weekday} from './constants';
 import {
   dateStyle,
   DateStyle,
   DEFAULT_WEEK_START_DAY,
   WEEK_START_DAYS,
   RTL_LANGUAGES,
-  Weekday,
   currencyDecimalPlaces,
   DEFAULT_DECIMAL_PLACES,
   DIRECTION_CONTROL_CHARACTERS,
   EASTERN_NAME_ORDER_FORMATTERS,
   CurrencyShortFormException,
 } from './constants';
-import {
-  MissingCurrencyCodeError,
-  MissingCountryError,
-  I18nError,
-} from './errors';
+import type {I18nError} from './errors';
+import {MissingCurrencyCodeError, MissingCountryError} from './errors';
+import type {TranslateOptions as RootTranslateOptions} from './utilities';
 import {
   getCurrencySymbol,
   translate,
   getTranslationTree,
-  TranslateOptions as RootTranslateOptions,
   memoizedNumberFormatter,
   memoizedPluralRules,
   convertFirstSpaceToNonBreakingSpace,

--- a/packages/react-i18n/src/utilities/translate.tsx
+++ b/packages/react-i18n/src/utilities/translate.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import {memoize as memoizeFn} from '@shopify/function-enhancers';
-import {
-  pseudotranslate as pseudotranslateString,
-  PseudotranslateOptions,
-} from '@shopify/i18n';
+import type {PseudotranslateOptions} from '@shopify/i18n';
+import {pseudotranslate as pseudotranslateString} from '@shopify/i18n';
 
 import type {
   TranslationDictionary,

--- a/packages/react-idle/src/hooks.ts
+++ b/packages/react-idle/src/hooks.ts
@@ -1,6 +1,7 @@
 import {useEffect, useRef} from 'react';
 
-import {RequestIdleCallbackHandle, UnsupportedBehavior} from './types';
+import type {RequestIdleCallbackHandle} from './types';
+import {UnsupportedBehavior} from './types';
 
 export function useIdleCallback(
   callback: () => void,

--- a/packages/react-import-remote/src/hooks.ts
+++ b/packages/react-import-remote/src/hooks.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useIntersection} from '@shopify/react-intersection-observer';
-import {DeferTiming, RequestIdleCallbackHandle} from '@shopify/async';
+import type {RequestIdleCallbackHandle} from '@shopify/async';
+import {DeferTiming} from '@shopify/async';
 import {useMountedRef} from '@shopify/react-hooks';
 
 import load from './load';

--- a/packages/react-import-remote/src/tests/ImportRemote.test.tsx
+++ b/packages/react-import-remote/src/tests/ImportRemote.test.tsx
@@ -7,7 +7,8 @@ import {
 } from '@shopify/jest-dom-mocks';
 import {Preconnect} from '@shopify/react-html';
 
-import ImportRemote, {Props} from '../ImportRemote';
+import type {Props} from '../ImportRemote';
+import ImportRemote from '../ImportRemote';
 
 function noop() {}
 

--- a/packages/react-intersection-observer/src/hooks.ts
+++ b/packages/react-intersection-observer/src/hooks.ts
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import {useState, useRef, useEffect, Ref} from 'react';
+import type {Ref} from 'react';
+import {useState, useRef, useEffect} from 'react';
 
 import {isSupported} from './utilities';
 import {UnsupportedBehavior} from './types';

--- a/packages/react-network/src/NetworkUniversalProvider.tsx
+++ b/packages/react-network/src/NetworkUniversalProvider.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import {useLazyRef} from '@shopify/react-hooks';
 
 import {useNetworkManager} from './hooks';
-import {
-  NetworkUniversalProvider as UniversalProvider,
-  NetworkUniversalDetails,
-} from './context';
+import type {NetworkUniversalDetails} from './context';
+import {NetworkUniversalProvider as UniversalProvider} from './context';
 
 interface Props {
   children?: React.ReactNode;

--- a/packages/react-network/src/ServerCookieManager.ts
+++ b/packages/react-network/src/ServerCookieManager.ts
@@ -1,4 +1,5 @@
-import cookie, {CookieSerializeOptions} from 'cookie';
+import type {CookieSerializeOptions} from 'cookie';
+import cookie from 'cookie';
 
 export type CookieValue = {
   value: string;

--- a/packages/react-network/src/components/Sandbox.tsx
+++ b/packages/react-network/src/components/Sandbox.tsx
@@ -1,4 +1,5 @@
-import {CspDirective, CspSandboxAllow} from '@shopify/network';
+import type {CspSandboxAllow} from '@shopify/network';
+import {CspDirective} from '@shopify/network';
 
 import {useCspDirective} from '../hooks';
 

--- a/packages/react-network/src/hooks.ts
+++ b/packages/react-network/src/hooks.ts
@@ -1,6 +1,8 @@
 import {useContext} from 'react';
-import {parse, Language} from 'accept-language-parser';
-import {CspDirective, StatusCode, Header} from '@shopify/network';
+import type {Language} from 'accept-language-parser';
+import {parse} from 'accept-language-parser';
+import type {CspDirective, StatusCode} from '@shopify/network';
+import {Header} from '@shopify/network';
 import {useServerEffect} from '@shopify/react-effect';
 
 import {NetworkContext, NetworkUniversalContext} from './context';

--- a/packages/react-network/src/manager.ts
+++ b/packages/react-network/src/manager.ts
@@ -1,9 +1,11 @@
 import type {IncomingHttpHeaders} from 'http';
 
-import {StatusCode, CspDirective, Header} from '@shopify/network';
+import type {CspDirective} from '@shopify/network';
+import {StatusCode, Header} from '@shopify/network';
 import type {EffectKind} from '@shopify/react-effect';
 
-import {ServerCookieManager, Cookie} from './ServerCookieManager';
+import type {Cookie} from './ServerCookieManager';
+import {ServerCookieManager} from './ServerCookieManager';
 
 export {NetworkContext} from './context';
 

--- a/packages/react-performance/src/LifecycleEventListener.tsx
+++ b/packages/react-performance/src/LifecycleEventListener.tsx
@@ -1,7 +1,5 @@
-import {
-  useLifecycleEventListener,
-  LifecycleEventListener as LifecycleEventListenerType,
-} from './lifecycle-event-listener';
+import type {LifecycleEventListener as LifecycleEventListenerType} from './lifecycle-event-listener';
+import {useLifecycleEventListener} from './lifecycle-event-listener';
 
 export function LifecycleEventListener({
   onEvent,

--- a/packages/react-performance/src/NavigationListener.tsx
+++ b/packages/react-performance/src/NavigationListener.tsx
@@ -1,7 +1,5 @@
-import {
-  useNavigationListener,
-  NavigationListener as NavigationlistenerType,
-} from './navigation-listener';
+import type {NavigationListener as NavigationlistenerType} from './navigation-listener';
+import {useNavigationListener} from './navigation-listener';
 
 export function NavigationListener({
   onNavigation,

--- a/packages/react-performance/src/PerformanceReport.tsx
+++ b/packages/react-performance/src/PerformanceReport.tsx
@@ -1,4 +1,5 @@
-import {usePerformanceReport, ErrorHandler} from './performance-report';
+import type {ErrorHandler} from './performance-report';
+import {usePerformanceReport} from './performance-report';
 
 interface Props {
   url: string;

--- a/packages/react-performance/src/tests/performance-effect.server.test.tsx
+++ b/packages/react-performance/src/tests/performance-effect.server.test.tsx
@@ -5,7 +5,8 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
-import {usePerformanceEffect, PerformanceEffectCallback} from '..';
+import type {PerformanceEffectCallback} from '..';
+import {usePerformanceEffect} from '..';
 
 describe('usePerformanceEffect', () => {
   function TestComponent({callback}: {callback: PerformanceEffectCallback}) {

--- a/packages/react-performance/src/tests/performance-effect.test.tsx
+++ b/packages/react-performance/src/tests/performance-effect.test.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 
-import {
-  usePerformanceEffect,
-  PerformanceEffectCallback,
-  PerformanceContext,
-} from '..';
+import type {PerformanceEffectCallback} from '..';
+import {usePerformanceEffect, PerformanceContext} from '..';
 
 import {mockPerformance} from './utilities';
 

--- a/packages/react-performance/src/tests/utilities.ts
+++ b/packages/react-performance/src/tests/utilities.ts
@@ -1,11 +1,6 @@
 import {faker} from '@faker-js/faker/locale/en';
-import {
-  Navigation,
-  NavigationResult,
-  Performance,
-  LifecycleEvent,
-  EventType,
-} from '@shopify/performance';
+import type {Performance, LifecycleEvent} from '@shopify/performance';
+import {Navigation, NavigationResult, EventType} from '@shopify/performance';
 
 import type {NavigationListener} from '../navigation-listener';
 import type {LifecycleEventListener} from '../lifecycle-event-listener';

--- a/packages/react-server/src/render/render.tsx
+++ b/packages/react-server/src/render/render.tsx
@@ -4,9 +4,9 @@ import {existsSync} from 'fs';
 import React from 'react';
 import type {Context} from 'koa';
 import compose from 'koa-compose';
+import type {HtmlProps} from '@shopify/react-html/server';
 import {
   Html,
-  HtmlProps,
   HtmlManager,
   HtmlContext,
   stream,

--- a/packages/react-server/src/render/tests/render.test.tsx
+++ b/packages/react-server/src/render/tests/render.test.tsx
@@ -6,7 +6,8 @@ import {middleware as sewingKitKoaMiddleware} from '@shopify/sewing-kit-koa';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import withEnv from '@shopify/with-env';
 
-import {createRender, Context} from '../render';
+import type {Context} from '../render';
+import {createRender} from '../render';
 import {mockMiddleware} from '../../tests/utilities';
 
 const mockAssetsScripts = jest.fn(() => Promise.resolve([{path: 'main.js'}]));

--- a/packages/react-server/src/server/server.ts
+++ b/packages/react-server/src/server/server.ts
@@ -1,11 +1,13 @@
 import 'cross-fetch';
 import type {Server} from 'http';
 
-import Koa, {Context} from 'koa';
+import type {Context} from 'koa';
+import Koa from 'koa';
 import compose from 'koa-compose';
 import mount from 'koa-mount';
 
-import {createRender, RenderFunction, RenderOptions} from '../render';
+import type {RenderFunction, RenderOptions} from '../render';
+import {createRender} from '../render';
 import {requestLogger} from '../logger';
 import {metricsMiddleware as metrics} from '../metrics';
 import {ping} from '../ping';

--- a/packages/react-server/src/webpack-plugin/error/utilities.ts
+++ b/packages/react-server/src/webpack-plugin/error/utilities.ts
@@ -1,6 +1,7 @@
 import type {Compiler} from 'webpack';
 
-import {noSourceExists, HEADER, Options, Entrypoint} from '../shared';
+import type {Options} from '../shared';
+import {noSourceExists, HEADER, Entrypoint} from '../shared';
 
 export function errorSSRComponentExists(options: Options, compiler: Compiler) {
   return !noSourceExists(Entrypoint.Error, options, compiler);

--- a/packages/react-server/src/webpack-plugin/tests/webpack-plugin.test.ts
+++ b/packages/react-server/src/webpack-plugin/tests/webpack-plugin.test.ts
@@ -3,9 +3,11 @@ import 'setimmediate';
 import path from 'path';
 
 import memfs from 'memfs';
-import webpack, {Compiler, Stats} from 'webpack';
+import type {Compiler, Stats} from 'webpack';
+import webpack from 'webpack';
 
-import {HEADER, Options, Entrypoint} from '../shared';
+import type {Options} from '../shared';
+import {HEADER, Entrypoint} from '../shared';
 
 import {withWorkspace} from './utilities/workspace';
 

--- a/packages/react-server/src/webpack-plugin/webpack-plugin.ts
+++ b/packages/react-server/src/webpack-plugin/webpack-plugin.ts
@@ -1,9 +1,11 @@
 import {join} from 'path';
 
-import {Compiler, WatchIgnorePlugin} from 'webpack';
+import type {Compiler} from 'webpack';
+import {WatchIgnorePlugin} from 'webpack';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
-import {HEADER, Options, Entrypoint, noSourceExists} from './shared';
+import type {Options} from './shared';
+import {HEADER, Entrypoint, noSourceExists} from './shared';
 import {errorSSRComponentExists, errorClientSource} from './error';
 
 /**

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,7 +1,8 @@
 import type Key from '../keys';
 import type {HeldKey} from '../keys';
 
-import useShortcut, {DefaultIgnoredTag} from './hooks';
+import type {DefaultIgnoredTag} from './hooks';
+import useShortcut from './hooks';
 
 export interface Props {
   ordered: Key[];

--- a/packages/react-shortcuts/src/Shortcut/hooks.ts
+++ b/packages/react-shortcuts/src/Shortcut/hooks.ts
@@ -6,7 +6,7 @@ import type {HeldKey} from '../keys';
 
 const DEFAULT_IGNORED_TAGS = ['INPUT', 'SELECT', 'TEXTAREA'] as const;
 
-export type DefaultIgnoredTag = typeof DEFAULT_IGNORED_TAGS[number];
+export type DefaultIgnoredTag = (typeof DEFAULT_IGNORED_TAGS)[number];
 
 export interface Subscription {
   unsubscribe(): void;

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -4,7 +4,8 @@ import {timer} from '@shopify/jest-dom-mocks';
 
 import type Key from '../keys';
 import type {HeldKey, ModifierKey} from '../keys';
-import Shortcut, {DefaultIgnoredTag} from '../Shortcut';
+import type {DefaultIgnoredTag} from '../Shortcut';
+import Shortcut from '../Shortcut';
 import ShortcutProvider from '../ShortcutProvider';
 
 import ShortcutWithFocus from './ShortcutWithRef';

--- a/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutWithRef.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import Shortcut, {DefaultIgnoredTag} from '../Shortcut';
+import type {DefaultIgnoredTag} from '../Shortcut';
+import Shortcut from '../Shortcut';
 
 interface Props {
   spy: jest.Mock<{}>;

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -16,6 +16,8 @@ import type {
 } from './types';
 import {Tag} from './types';
 
+// dynamic type import to avoid a circular dependency
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 type Root = import('./root').Root<unknown>;
 
 interface Tree<Props> {

--- a/packages/react-testing/src/element.ts
+++ b/packages/react-testing/src/element.ts
@@ -1,8 +1,7 @@
 import type {ComponentType} from 'react';
 
 import {nodeName, toReactString} from './toReactString';
-import {
-  Tag,
+import type {
   Node,
   Predicate,
   FunctionKeys,
@@ -15,6 +14,7 @@ import {
   KeyPathFunction,
   ExtractKeypath,
 } from './types';
+import {Tag} from './types';
 
 type Root = import('./root').Root<unknown>;
 

--- a/packages/react-testing/src/mount.ts
+++ b/packages/react-testing/src/mount.ts
@@ -1,7 +1,8 @@
 import type {ReactElement} from 'react';
 import type {IfAllOptionalKeys} from '@shopify/useful-types';
 
-import {Root, Options as RootOptions} from './root';
+import type {Options as RootOptions} from './root';
+import {Root} from './root';
 import {Element} from './element';
 
 export {Root, Element};

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -7,8 +7,7 @@ import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection.js';
 import {TestWrapper} from './TestWrapper';
 import {Element} from './element';
 import {createRoot, getInternals, enqueueTask, isLegacyReact} from './compat';
-import {
-  Tag,
+import type {
   Fiber,
   Node,
   Predicate,
@@ -21,6 +20,7 @@ import {
   KeyPathFunction,
   ExtractKeypath,
 } from './types';
+import {Tag} from './types';
 
 type ResolveRoot = (element: Element<unknown>) => Element<unknown> | null;
 type Render = (

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -1,15 +1,13 @@
+import type {ReactNode, ComponentType, Ref} from 'react';
 import React, {
   useState,
   useEffect,
   useContext,
   createContext,
-  ReactNode,
   Component,
-  ComponentType,
   memo,
   forwardRef,
   PureComponent,
-  Ref,
 } from 'react';
 import {createPortal} from 'react-dom';
 

--- a/packages/react-web-worker/src/tests/hooks.test.tsx
+++ b/packages/react-web-worker/src/tests/hooks.test.tsx
@@ -1,4 +1,5 @@
-import React, {ReactNode} from 'react';
+import type {ReactNode} from 'react';
+import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {useWorker} from '../index';

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -1,8 +1,8 @@
-import {
-  StatsD,
+import type {
   ClientOptions as HotShotClientOptions,
   ChildClientOptions as HotShotChildOptions,
 } from 'hot-shots';
+import {StatsD} from 'hot-shots';
 import {snakeCase} from 'change-case';
 
 const UNKNOWN = 'Unknown';

--- a/packages/storybook-a11y-test/src/index.ts
+++ b/packages/storybook-a11y-test/src/index.ts
@@ -2,7 +2,8 @@
 import os from 'os';
 import fs from 'fs';
 
-import puppeteer, {Browser, PuppeteerLifeCycleEvent} from 'puppeteer';
+import type {Browser, PuppeteerLifeCycleEvent} from 'puppeteer';
+import puppeteer from 'puppeteer';
 import pMap from 'p-map';
 import chalk from 'chalk';
 import Koa from 'koa';

--- a/packages/storybook-a11y-test/stories/A11yDisabledButton.stories.tsx
+++ b/packages/storybook-a11y-test/stories/A11yDisabledButton.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ComponentStory, ComponentMeta} from '@storybook/react';
+import type {ComponentStory, ComponentMeta} from '@storybook/react';
 
 import {Button} from './Button';
 

--- a/packages/storybook-a11y-test/stories/Button.stories.tsx
+++ b/packages/storybook-a11y-test/stories/Button.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ComponentStory, ComponentMeta} from '@storybook/react';
+import type {ComponentStory, ComponentMeta} from '@storybook/react';
 
 import {Button} from './Button';
 

--- a/packages/useful-types/test-d/types.test-d.ts
+++ b/packages/useful-types/test-d/types.test-d.ts
@@ -5,7 +5,7 @@ import {
   expectNotType,
 } from 'tsd-lite';
 
-import {
+import type {
   ArrayElement,
   DeepPartial,
   IfEmptyObject,

--- a/packages/web-worker/src/create/plain-worker.ts
+++ b/packages/web-worker/src/create/plain-worker.ts
@@ -1,6 +1,7 @@
 import {createWorkerMessenger} from '../messenger';
 
-import {createScriptUrl, FileOrModuleResolver} from './utilities';
+import type {FileOrModuleResolver} from './utilities';
+import {createScriptUrl} from './utilities';
 
 export interface PlainWorkerCreator {
   readonly url?: URL;

--- a/packages/web-worker/src/create/worker.ts
+++ b/packages/web-worker/src/create/worker.ts
@@ -1,13 +1,14 @@
-import {
-  createEndpoint,
+import type {
   Endpoint,
   MessageEndpoint,
   CreateEndpointOptions,
 } from '@remote-ui/rpc';
+import {createEndpoint} from '@remote-ui/rpc';
 
 import {createWorkerMessenger} from '../messenger';
 
-import {createScriptUrl, FileOrModuleResolver} from './utilities';
+import type {FileOrModuleResolver} from './utilities';
+import {createScriptUrl} from './utilities';
 
 export interface CreateWorkerOptions<T> extends CreateEndpointOptions<T> {
   createMessenger?(url: URL): MessageEndpoint;

--- a/packages/web-worker/src/tests/e2e.test.ts
+++ b/packages/web-worker/src/tests/e2e.test.ts
@@ -9,7 +9,8 @@ import type {Page, JSHandle, WebWorker} from 'puppeteer';
 
 import {WebWorkerPlugin} from '../webpack-parts';
 
-import {withContext, Context, runWebpack as runWebpackBase} from './utilities';
+import type {Context} from './utilities';
+import {withContext, runWebpack as runWebpackBase} from './utilities';
 
 const babelPlugin = path.resolve(__dirname, '../babel-plugin.ts');
 const mainFile = 'src/main.js';

--- a/packages/web-worker/src/tests/utilities/browser.ts
+++ b/packages/web-worker/src/tests/utilities/browser.ts
@@ -1,6 +1,7 @@
 import {URL} from 'url';
 
-import puppeteer, {Browser} from 'puppeteer';
+import type {Browser} from 'puppeteer';
+import puppeteer from 'puppeteer';
 
 export class AppBrowser {
   constructor(private readonly browser: Browser, private readonly url: URL) {}

--- a/packages/web-worker/src/tests/utilities/context.ts
+++ b/packages/web-worker/src/tests/utilities/context.ts
@@ -1,6 +1,9 @@
-import {Workspace, createWorkspace} from './workspace';
-import {AppServer, createServer} from './server';
-import {AppBrowser, createBrowser} from './browser';
+import type {Workspace} from './workspace';
+import {createWorkspace} from './workspace';
+import type {AppServer} from './server';
+import {createServer} from './server';
+import type {AppBrowser} from './browser';
+import {createBrowser} from './browser';
 
 export interface Context {
   readonly workspace: Workspace;

--- a/packages/web-worker/src/tests/utilities/server.ts
+++ b/packages/web-worker/src/tests/utilities/server.ts
@@ -2,7 +2,8 @@ import type {Server} from 'http';
 import type {AddressInfo} from 'net';
 import {URL} from 'url';
 
-import Koa, {Middleware, Context} from 'koa';
+import type {Middleware, Context} from 'koa';
+import Koa from 'koa';
 import serve from 'koa-static';
 import mount from 'koa-mount';
 import getPort from 'get-port';

--- a/packages/web-worker/src/tests/utilities/webpack.ts
+++ b/packages/web-worker/src/tests/utilities/webpack.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
 
 import webpack from 'webpack';
+import type {Configuration} from 'webpack';
 
 import type {Context} from './context';
 
 export function runWebpack(
   {workspace, server}: Context,
-  extraConfig: import('webpack').Configuration,
+  extraConfig: Configuration,
 ) {
   return new Promise((resolve, reject) => {
     const srcRoot = path.resolve(__dirname, '../../');

--- a/packages/web-worker/src/webpack-parts/webpack-exports.d.ts
+++ b/packages/web-worker/src/webpack-parts/webpack-exports.d.ts
@@ -1,22 +1,28 @@
 declare module 'webpack/lib/SingleEntryPlugin' {
+  import type {Plugin} from 'webpack';
+
   const SingleEntryPlugin: {
-    new (...args: any[]): import('webpack').Plugin;
+    new (...args: any[]): Plugin;
   };
 
   export default SingleEntryPlugin;
 }
 
 declare module 'webpack/lib/webworker/WebWorkerTemplatePlugin' {
+  import type {Plugin} from 'webpack';
+
   const SingleEntryPlugin: {
-    new (...args: any[]): import('webpack').Plugin;
+    new (...args: any[]): Plugin;
   };
 
   export default SingleEntryPlugin;
 }
 
 declare module 'webpack/lib/web/FetchCompileWasmTemplatePlugin' {
+  import type {Plugin} from 'webpack';
+
   const SingleEntryPlugin: {
-    new (...args: any[]): import('webpack').Plugin;
+    new (...args: any[]): Plugin;
   };
 
   export default SingleEntryPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,6 +1605,18 @@
     ts-node "^9"
     tslib "^2"
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz#a556790523a351b4e47e9d385f47265eaaf9780a"
+  integrity sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.4.0.tgz#3e61c564fcd6b921cb789838631c5ee44df09403"
+  integrity sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==
+
 "@eslint/eslintrc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.1.0.tgz#583d12dbec5d4f22f333f9669f7d0b7c7815b4d3"
@@ -3565,94 +3577,94 @@
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.4.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.51.0.tgz#da3f2819633061ced84bb82c53bba45a6fe9963a"
-  integrity sha512-wcAwhEWm1RgNd7dxD/o+nnLW8oH+6RK1OGnmbmkj/GGoDPV1WWMVP0FXYQBivKHdwM1pwii3bt//RC62EriIUQ==
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz#e4fbb4d6dd8dab3e733485c1a44a02189ae75364"
+  integrity sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.51.0"
-    "@typescript-eslint/type-utils" "5.51.0"
-    "@typescript-eslint/utils" "5.51.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.56.0"
+    "@typescript-eslint/type-utils" "5.56.0"
+    "@typescript-eslint/utils" "5.56.0"
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
     natural-compare-lite "^1.4.0"
-    regexpp "^3.2.0"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/experimental-utils@^5.0.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.51.0.tgz#936124843a9221863f027a08063b737578838bea"
-  integrity sha512-8/3+ZyBENl2aog1/QB3S39ptkZ2oRhDB+sJt15UWXBE3skgwL1C8BN9RjpOyhTejwR2hVrvqEjcYcNY6qtZ7nw==
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.56.0.tgz#2699b5eed7651cc361ac1e6ea2d31a0e51e989a5"
+  integrity sha512-sxWuj0eO5nItmKgZmsBbChVt90EhfkuncDCPbLAVeEJ+SCjXMcZN3AhhNbxed7IeGJ4XwsdL3/FMvD4r+FLqqA==
   dependencies:
-    "@typescript-eslint/utils" "5.51.0"
+    "@typescript-eslint/utils" "5.56.0"
 
 "@typescript-eslint/parser@^5.4.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.51.0.tgz#2d74626652096d966ef107f44b9479f02f51f271"
-  integrity sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.56.0.tgz#42eafb44b639ef1dbd54a3dbe628c446ca753ea6"
+  integrity sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.51.0"
-    "@typescript-eslint/types" "5.51.0"
-    "@typescript-eslint/typescript-estree" "5.51.0"
+    "@typescript-eslint/scope-manager" "5.56.0"
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/typescript-estree" "5.56.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.51.0.tgz#ad3e3c2ecf762d9a4196c0fbfe19b142ac498990"
-  integrity sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==
+"@typescript-eslint/scope-manager@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz#62b4055088903b5254fa20403010e1c16d6ab725"
+  integrity sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==
   dependencies:
-    "@typescript-eslint/types" "5.51.0"
-    "@typescript-eslint/visitor-keys" "5.51.0"
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/visitor-keys" "5.56.0"
 
-"@typescript-eslint/type-utils@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.51.0.tgz#7af48005531700b62a20963501d47dfb27095988"
-  integrity sha512-QHC5KKyfV8sNSyHqfNa0UbTbJ6caB8uhcx2hYcWVvJAZYJRBo5HyyZfzMdRx8nvS+GyMg56fugMzzWnojREuQQ==
+"@typescript-eslint/type-utils@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz#e6f004a072f09c42e263dc50e98c70b41a509685"
+  integrity sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.51.0"
-    "@typescript-eslint/utils" "5.51.0"
+    "@typescript-eslint/typescript-estree" "5.56.0"
+    "@typescript-eslint/utils" "5.56.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.51.0.tgz#e7c1622f46c7eea7e12bbf1edfb496d4dec37c90"
-  integrity sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==
+"@typescript-eslint/types@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.56.0.tgz#b03f0bfd6fa2afff4e67c5795930aff398cbd834"
+  integrity sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==
 
-"@typescript-eslint/typescript-estree@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.51.0.tgz#0ec8170d7247a892c2b21845b06c11eb0718f8de"
-  integrity sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==
+"@typescript-eslint/typescript-estree@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz#48342aa2344649a03321e74cab9ccecb9af086c3"
+  integrity sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==
   dependencies:
-    "@typescript-eslint/types" "5.51.0"
-    "@typescript-eslint/visitor-keys" "5.51.0"
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/visitor-keys" "5.56.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.51.0.tgz#074f4fabd5b12afe9c8aa6fdee881c050f8b4d47"
-  integrity sha512-76qs+5KWcaatmwtwsDJvBk4H76RJQBFe+Gext0EfJdC3Vd2kpY2Pf//OHHzHp84Ciw0/rYoGTDnIAr3uWhhJYw==
+"@typescript-eslint/utils@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.56.0.tgz#db64705409b9a15546053fb4deb2888b37df1f41"
+  integrity sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==
   dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.51.0"
-    "@typescript-eslint/types" "5.51.0"
-    "@typescript-eslint/typescript-estree" "5.51.0"
+    "@typescript-eslint/scope-manager" "5.56.0"
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/typescript-estree" "5.56.0"
     eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz#c0147dd9a36c0de758aaebd5b48cae1ec59eba87"
-  integrity sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==
+"@typescript-eslint/visitor-keys@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz#f19eb297d972417eb13cb69b35b3213e13cc214f"
+  integrity sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==
   dependencies:
-    "@typescript-eslint/types" "5.51.0"
+    "@typescript-eslint/types" "5.56.0"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
@@ -4391,6 +4403,14 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+  dependencies:
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
+
 array-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
@@ -4410,6 +4430,17 @@ array-includes@^3.0.3, array-includes@^3.1.3, array-includes@^3.1.4, array-inclu
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
     get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
+array-includes@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
+  integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
     is-string "^1.0.7"
 
 array-slice@^1.0.0:
@@ -4439,7 +4470,7 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.3, array.prototype.flat@^1.2.5:
+array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz#0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b"
   integrity sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==
@@ -4447,6 +4478,16 @@ array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.3, array.prototype.flat@^
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.flat@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz#ffc6576a7ca3efc2f46a143b9d1dda9b4b3cf5e2"
+  integrity sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
 array.prototype.flatmap@^1.2.1, array.prototype.flatmap@^1.3.0:
@@ -4457,6 +4498,16 @@ array.prototype.flatmap@^1.2.1, array.prototype.flatmap@^1.3.0:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.flatmap@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
+  integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
 array.prototype.map@^1.0.4:
@@ -4564,6 +4615,11 @@ autoprefixer@^9.8.6:
     picocolors "^0.2.1"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 await-to-js@^3.0.0:
   version "3.0.0"
@@ -6169,7 +6225,7 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -6690,6 +6746,46 @@ es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
 
+es-abstract@^1.20.4:
+  version "1.21.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.21.2.tgz#a56b9695322c8a185dc25975aa3b8ec31d0e7eff"
+  integrity sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-set-tostringtag "^2.0.1"
+    es-to-primitive "^1.2.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.2.0"
+    get-symbol-description "^1.0.0"
+    globalthis "^1.0.3"
+    gopd "^1.0.1"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.5"
+    is-array-buffer "^3.0.2"
+    is-callable "^1.2.7"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-typed-array "^1.1.10"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.3"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
+    string.prototype.trim "^1.2.7"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
+    typed-array-length "^1.0.4"
+    unbox-primitive "^1.0.2"
+    which-typed-array "^1.1.9"
+
 es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
@@ -6713,6 +6809,15 @@ es-module-lexer@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+
+es-set-tostringtag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
+  integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
+  dependencies:
+    get-intrinsic "^1.1.3"
+    has "^1.0.3"
+    has-tostringtag "^1.0.0"
 
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
@@ -6787,21 +6892,29 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
-eslint-import-resolver-node@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
-  integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
+eslint-import-resolver-node@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz#83b375187d412324a1963d84fa664377a23eb4d7"
+  integrity sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==
   dependencies:
     debug "^3.2.7"
-    resolve "^1.20.0"
+    is-core-module "^2.11.0"
+    resolve "^1.22.1"
 
-eslint-module-utils@^2.7.1, eslint-module-utils@^2.7.2:
+eslint-module-utils@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
   integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
   dependencies:
     debug "^3.2.7"
     find-up "^2.1.0"
+
+eslint-module-utils@^2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
+  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
+  dependencies:
+    debug "^3.2.7"
 
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
@@ -6820,23 +6933,25 @@ eslint-plugin-eslint-comments@^3.2.0:
     ignore "^5.0.5"
 
 eslint-plugin-import@^2.25.3:
-  version "2.25.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
-  integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==
+  version "2.27.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz#876a6d03f52608a3e5bb439c2550588e51dd6c65"
+  integrity sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==
   dependencies:
-    array-includes "^3.1.4"
-    array.prototype.flat "^1.2.5"
-    debug "^2.6.9"
+    array-includes "^3.1.6"
+    array.prototype.flat "^1.3.1"
+    array.prototype.flatmap "^1.3.1"
+    debug "^3.2.7"
     doctrine "^2.1.0"
-    eslint-import-resolver-node "^0.3.6"
-    eslint-module-utils "^2.7.2"
+    eslint-import-resolver-node "^0.3.7"
+    eslint-module-utils "^2.7.4"
     has "^1.0.3"
-    is-core-module "^2.8.0"
+    is-core-module "^2.11.0"
     is-glob "^4.0.3"
-    minimatch "^3.0.4"
-    object.values "^1.1.5"
-    resolve "^1.20.0"
-    tsconfig-paths "^3.12.0"
+    minimatch "^3.1.2"
+    object.values "^1.1.6"
+    resolve "^1.22.1"
+    semver "^6.3.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-jest-formatting@^3.1.0:
   version "3.1.0"
@@ -7534,6 +7649,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -7800,6 +7922,15 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
+  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
+
 get-port@*, get-port@^5.0.0, get-port@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
@@ -7946,6 +8077,13 @@ globalthis@^1.0.0:
   dependencies:
     define-properties "^1.1.3"
 
+globalthis@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
+  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
+  dependencies:
+    define-properties "^1.1.3"
+
 globby@*, globby@^11.0.0, globby@^11.0.2, globby@^11.0.3, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -7985,6 +8123,13 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -8087,6 +8232,11 @@ has-property-descriptors@^1.0.0:
   integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
   dependencies:
     get-intrinsic "^1.1.1"
+
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
 
 has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
@@ -8597,6 +8747,15 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+internal-slot@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
+  integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
+  dependencies:
+    get-intrinsic "^1.2.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
@@ -8684,6 +8843,15 @@ is-arguments@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
+  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.0"
+    is-typed-array "^1.1.10"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -8725,6 +8893,11 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
+is-callable@^1.1.3, is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -8737,7 +8910,14 @@ is-ci@^3.0.1:
   dependencies:
     ci-info "^3.2.0"
 
-is-core-module@^2.2.0, is-core-module@^2.8.0, is-core-module@^2.8.1:
+is-core-module@^2.11.0, is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.2.0, is-core-module@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
@@ -8992,6 +9172,17 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
   dependencies:
     has-symbols "^1.0.1"
+
+is-typed-array@^1.1.10, is-typed-array@^1.1.9:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 is-unc-path@^1.0.0:
   version "1.0.0"
@@ -9730,7 +9921,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json5@^1.0.1:
+json5@^1.0.1, json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
@@ -10953,6 +11144,11 @@ object-inspect@^1.12.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
+object-inspect@^1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
+  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
+
 object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -10973,6 +11169,16 @@ object.assign@^4.1.0, object.assign@^4.1.2:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.assign@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.defaults@^1.1.0:
@@ -11043,6 +11249,15 @@ object.values@^1.1.0, object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+
+object.values@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
+  integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 objectorarray@^1.0.5:
   version "1.0.5"
@@ -11706,10 +11921,10 @@ prettier-linter-helpers@^1.0.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
-prettier@^2.7.1, prettier@~2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@^2.7.1, prettier@~2.8.6:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.6.tgz#5c174b29befd507f14b83e3c19f83fdc0e974b71"
+  integrity sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==
 
 pretty-error@^2.1.1:
   version "2.1.2"
@@ -12511,6 +12726,15 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.3.tgz#d41016293d4a8586a39ca5d9b5f15cbea1f55e46"
@@ -12648,6 +12872,15 @@ safe-compare@^1.1.3:
   integrity sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==
   dependencies:
     buffer-alloc "^1.2.0"
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -13282,6 +13515,15 @@ string.prototype.padstart@^3.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
+string.prototype.trim@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz#a68352740859f6893f14ce3ef1bb3037f7a90533"
+  integrity sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string.prototype.trimend@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
@@ -13291,6 +13533,15 @@ string.prototype.trimend@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
 
+string.prototype.trimend@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
+  integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string.prototype.trimstart@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
@@ -13299,6 +13550,15 @@ string.prototype.trimstart@^1.0.5:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
+
+string.prototype.trimstart@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
+  integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
@@ -13802,14 +14062,14 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tsconfig-paths@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
-  integrity sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
+tsconfig-paths@^3.14.1:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
+  integrity sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==
   dependencies:
     "@types/json5" "^0.0.29"
-    json5 "^1.0.1"
-    minimist "^1.2.0"
+    json5 "^1.0.2"
+    minimist "^1.2.6"
     strip-bom "^3.0.0"
 
 tsd-lite@^0.6.0:
@@ -13918,6 +14178,15 @@ type-is@^1.6.16, type-is@^1.6.18, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typed-array-length@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
+  integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    is-typed-array "^1.1.9"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -14675,6 +14944,18 @@ which-pm@2.0.0:
   dependencies:
     load-yaml-file "^0.2.0"
     path-exists "^4.0.0"
+
+which-typed-array@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
 
 which@^1.2.14, which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
## Description

Preparation work to make TS5 and `verbatimModuleSyntax` easily adoptable.

- Update `@typescript/eslint/*`, `eslint-plugin-import` and `prettier`
- Enable the `@typescript-eslint/consistent-type-imports`, `@typescript-eslint/consistent-type-exports`, @typescript-eslint/no-import-type-side-effects` and `import/consistent-type-specifier-style` lint rules.

This results in us always using `import type` when dealing with type imports.
