### PR TITLE
Update to TypeScript 5.0

### DIFF
--- a/.changeset/dirty-lemons-knock.md
+++ b/.changeset/dirty-lemons-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-shortcuts': patch
+---
+
+Adjust imports of internal types to adhere to TypeScript's verbatimModuleSyntax format. This does not affect externally presented types.

--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -1,12 +1,21 @@
 {
-  "extends": "@tsconfig/node-lts-strictest-esm/tsconfig.json",
+  "extends": [
+    "@tsconfig/node-lts/tsconfig.json",
+    "@tsconfig/strictest/tsconfig.json"
+  ],
   "compilerOptions": {
+    // @tsconfig/strictest currently sets importsNotUsedAsValues:"error", which
+    // in TS 5.0.2 causes a crash when used in combo with verbatimModuleSyntax
+    // importsNotUsedAsValues can be removed once `@tsconfig/strictest` removes
+    // its usage of importsNotUsedAsValues, or typescript is updated to 5.0.3
+    "importsNotUsedAsValues": "remove",
     // Project and build output
     "composite": true,
     "emitDeclarationOnly": true,
     "declarationMap": true,
     "lib": ["dom", "dom.iterable", "es2022"],
-    "isolatedModules": true,
+    "module": "es2022",
+    "verbatimModuleSyntax": true,
     "jsx": "react",
 
     // Strictness

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@shopify/app-bridge": "^2.0.3",
     "@shopify/eslint-plugin": "^42.0.1",
-    "@tsconfig/node-lts-strictest-esm": "^18.12.1",
+    "@tsconfig/node-lts": "^18.12.1",
+    "@tsconfig/strictest": "^1.0.2",
     "@tsd/typescript": "^4.9.5",
     "@types/babel__core": "^7.1.7",
     "@types/jest": "^29.4.0",
@@ -80,7 +81,7 @@
     "rimraf": "^2.6.2",
     "rollup": "^2.60.1",
     "rollup-plugin-node-externals": "^2.2.0",
-    "typescript": "~4.9.5",
+    "typescript": "~5.0.2",
     "yalc": "^1.0.0-pre.50"
   }
 }

--- a/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
+++ b/packages/react-shortcuts/src/Shortcut/Shortcut.tsx
@@ -1,5 +1,4 @@
-import type Key from '../keys';
-import type {HeldKey} from '../keys';
+import type {Key, HeldKey} from '../keys';
 
 import type {DefaultIgnoredTag} from './hooks';
 import useShortcut from './hooks';

--- a/packages/react-shortcuts/src/Shortcut/hooks.ts
+++ b/packages/react-shortcuts/src/Shortcut/hooks.ts
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import {ShortcutContext} from '../ShortcutProvider';
-import type Key from '../keys';
-import type {HeldKey} from '../keys';
+import type {Key, HeldKey} from '../keys';
 
 const DEFAULT_IGNORED_TAGS = ['INPUT', 'SELECT', 'TEXTAREA'] as const;
 

--- a/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
+++ b/packages/react-shortcuts/src/ShortcutManager/ShortcutManager.tsx
@@ -1,5 +1,4 @@
-import type Key from '../keys';
-import type {HeldKey, ModifierKey} from '../keys';
+import type {Key, HeldKey, ModifierKey} from '../keys';
 import type {DefaultIgnoredTag} from '../Shortcut';
 
 const ON_MATCH_DELAY = 500;

--- a/packages/react-shortcuts/src/index.ts
+++ b/packages/react-shortcuts/src/index.ts
@@ -6,7 +6,7 @@ export type {Props as ProviderProps} from './ShortcutProvider';
 
 export {default as ShortcutManager} from './ShortcutManager';
 export type {
-  default as Key,
+  Key,
   AlphabetKey,
   NumericKey,
   ModifierKey,

--- a/packages/react-shortcuts/src/keys.ts
+++ b/packages/react-shortcuts/src/keys.ts
@@ -1,4 +1,4 @@
-type Key =
+export type Key =
   | AlphabetKey
   | NumericKey
   | SymbolKey
@@ -18,8 +18,6 @@ type Key =
   | DocumentKey
   | ApplicationSelectorKey
   | BrowserControlKey;
-
-export default Key;
 
 export type AlphabetKey =
   | 'a'

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {timer} from '@shopify/jest-dom-mocks';
 
-import type Key from '../keys';
-import type {HeldKey, ModifierKey} from '../keys';
+import type {Key, HeldKey, ModifierKey} from '../keys';
 import type {DefaultIgnoredTag} from '../Shortcut';
 import Shortcut from '../Shortcut';
 import ShortcutProvider from '../ShortcutProvider';

--- a/packages/storybook-a11y-test/.storybook/main.js
+++ b/packages/storybook-a11y-test/.storybook/main.js
@@ -5,6 +5,9 @@ module.exports = {
   features: {
     storyStoreV7: true,
   },
+  typescript: {
+    reactDocgen: false,
+  },
   babel: (config) => {
     return {...config, targets: 'last 3 chrome versions'};
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,10 +2928,15 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@tsconfig/node-lts-strictest-esm@^18.12.1":
+"@tsconfig/node-lts@^18.12.1":
   version "18.12.1"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node-lts-strictest-esm/-/node-lts-strictest-esm-18.12.1.tgz#6525fec53f46ee6061d3b30f831b5624118a9e64"
-  integrity sha512-LvBLmaC6Q/txTddLc11OeMHF9XjJFzlilkETJuvBlUvHy9pPiMsoH3nxWZM1FMSO53zp4mJP6gzOzxKEq0me7Q==
+  resolved "https://registry.yarnpkg.com/@tsconfig/node-lts/-/node-lts-18.12.1.tgz#82aa61a0e6f02dc08199c59c3fb8d4b806e28d3c"
+  integrity sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA==
+
+"@tsconfig/strictest@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/strictest/-/strictest-1.0.2.tgz#aff98cd714dbd1722c9229eed2dcf3fc6fd30fd9"
+  integrity sha512-IRKlC8cnP7zMz1SDBjyIVyPapkEGWLZ6wkF6Z8T+xU80P9sO5uGXlIUvtzjx+7ehPJRWxkB6CeIDwUfyqNtYkQ==
 
 "@tsd/typescript@^4.9.5":
   version "4.9.5"
@@ -13962,10 +13967,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@~5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 ua-parser-js@^0.7.33:
   version "0.7.33"


### PR DESCRIPTION
## Description

Update to typescript 5.0 and turn on `verbatimModuleSyntax`.

Prior work in #2608, moved us towards using `import type` all the time, which was the bulk of the work required to activate `verbatimModuleSyntax`.


TS5.0 comes with the ability to extend from multiple configs. In light of that new behaviour the `@tsconfig/node-lts-strictest-esm` package is going to be deprecated, so move to extending from `@tsconfig/node-lts` and `@tsconfig/strictest` in an array.
