### PR TITLE
[react-testing] Fixed a null exception if the inner root component is unmounted by the outer wrapper during an act

### DIFF
--- a/.changeset/witty-paws-chew.md
+++ b/.changeset/witty-paws-chew.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': patch
+---
+
+Fixed a null exception if the inner root component is unmounted by the outer wrapper during an act

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -79,7 +79,7 @@ export class Root<Props> implements Node<Props> {
   private resolveRoot: ResolveRoot;
 
   private get mounted() {
-    return this.wrapper != null;
+    return this.wrapper != null && this.wrapper.rootRef != null;
   }
 
   constructor(
@@ -340,7 +340,7 @@ export class Root<Props> implements Node<Props> {
   private update() {
     if (this.wrapper == null) {
       this.root = null;
-    } else {
+    } else if (this.mounted) {
       const rootFiber = getInternals(this.wrapper.rootRef as any);
       const topElement = fiberToElement(
         findCurrentFiberUsingSlowPath(rootFiber),
@@ -352,7 +352,7 @@ export class Root<Props> implements Node<Props> {
   }
 
   private ensureRoot() {
-    if (this.wrapper == null || this.root == null) {
+    if (!this.mounted || this.root == null) {
       throw new Error(
         'Attempted to operate on a mounted tree, but the component is no longer mounted',
       );

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {faker} from '@faker-js/faker/locale/en';
 
 import {Root} from '../root';
@@ -68,6 +68,35 @@ describe('createMount()', () => {
       context,
       options,
     );
+  });
+
+  it('does not throw if the wrapper is unmounted', () => {
+    let toggleTestMount;
+    let tick = 0;
+    function Wrapper({children}) {
+      const [showChildren, setShowChildren] = useState(true);
+      toggleTestMount = () => setShowChildren((show) => !show);
+      // eslint-disable-next-line jest/no-if
+      return showChildren ? children : null;
+    }
+
+    function TestComponent() {
+      tick += 1;
+
+      return <>{tick}</>;
+    }
+
+    const customMount = createMount({
+      render: (element) => <Wrapper>{element}</Wrapper>,
+    });
+
+    const testComponent = customMount(<TestComponent />);
+
+    expect(() => testComponent.act(toggleTestMount)).not.toThrow();
+
+    // this will remount the TestComponent and it should update as expected
+    testComponent.act(toggleTestMount);
+    expect(testComponent.html()).toBe('2');
   });
 
   it('resolves the returned Root instance to the top level node in the original tree', () => {


### PR DESCRIPTION
## Description

This fixes an edge-case that was introduced in https://github.com/Shopify/quilt/pull/1821

This is a rare occurrence but can happen if somehow the test wrapper unmounts the inner test root during an action. We found this while performing the react router 6 migration on `web`. Since we wrap our inner test root with a `<Route>` component at a given path a navigation within the test to a different route will unmount the component resulting in a cryptic error message:

`TypeError: Cannot use 'in' operator to search for '_reactInternalFiber' in null`

This PR prevents the root from updating when the inner wrapper is unmounted, once/if it is remounted subsequent updates will work as expected. 

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
