### PR TITLE
Update `@tsconfig/strictest` to v2.0.0

### DIFF
--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -4,18 +4,12 @@
     "@tsconfig/strictest/tsconfig.json"
   ],
   "compilerOptions": {
-    // @tsconfig/strictest currently sets importsNotUsedAsValues:"error", which
-    // in TS 5.0.2 causes a crash when used in combo with verbatimModuleSyntax
-    // importsNotUsedAsValues can be removed once `@tsconfig/strictest` removes
-    // its usage of importsNotUsedAsValues, or typescript is updated to 5.0.3
-    "importsNotUsedAsValues": "remove",
     // Project and build output
     "composite": true,
     "emitDeclarationOnly": true,
     "declarationMap": true,
     "lib": ["dom", "dom.iterable", "es2022"],
     "module": "es2022",
-    "verbatimModuleSyntax": true,
     "jsx": "react",
 
     // Strictness

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@shopify/app-bridge": "^2.0.3",
     "@shopify/eslint-plugin": "^42.0.1",
     "@tsconfig/node-lts": "^18.12.1",
-    "@tsconfig/strictest": "^1.0.2",
+    "@tsconfig/strictest": "^2.0.0",
     "@tsd/typescript": "^4.9.5",
     "@types/babel__core": "^7.1.7",
     "@types/jest": "^29.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2933,10 +2933,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node-lts/-/node-lts-18.12.1.tgz#82aa61a0e6f02dc08199c59c3fb8d4b806e28d3c"
   integrity sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA==
 
-"@tsconfig/strictest@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tsconfig/strictest/-/strictest-1.0.2.tgz#aff98cd714dbd1722c9229eed2dcf3fc6fd30fd9"
-  integrity sha512-IRKlC8cnP7zMz1SDBjyIVyPapkEGWLZ6wkF6Z8T+xU80P9sO5uGXlIUvtzjx+7ehPJRWxkB6CeIDwUfyqNtYkQ==
+"@tsconfig/strictest@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/strictest/-/strictest-2.0.0.tgz#9528a6298aa28ecc93b0c4c4e9ea6aac813779b5"
+  integrity sha512-E0dpiZNdwO20c8d3seh7OmjAvDpwoRkTcU6M8cvggzB45Bd45tyTU2XJeA5Wfq+8NzVGhunvqOJ30AjSkywMXA==
 
 "@tsd/typescript@^4.9.5":
   version "4.9.5"


### PR DESCRIPTION
## Description

This version improves typescript v5 support, by enabling `verbatimModuleSyntax` by default and removing setting the deprecated `importsNotUsedAsValues` as that is already implied by verbatimModuleSyntax.
