### PR TITLE
Fix for React Router v6 quirk in @shopify/performance

### DIFF
--- a/.changeset/honest-kangaroos-thank.md
+++ b/.changeset/honest-kangaroos-thank.md
@@ -1,0 +1,5 @@
+---
+'@shopify/performance': patch
+---
+
+Workaround quirk in React Router v6 that causes navigation to end prematurely

--- a/packages/performance/src/utilities.ts
+++ b/packages/performance/src/utilities.ts
@@ -84,7 +84,12 @@ export function withNavigation(
   });
 
   history.replaceState = (...args) => {
-    handlePushOrReplace(args[2]);
+    // React Router v6 introduced special behaviour that replaces state on initialization
+    // It does this only when the current idx state is null, and it sets it to 0
+    // We need to account for this to prevent it from being recorded as a navigation
+    if (!(history.state?.idx == null && args[0]?.idx === 0)) {
+      handlePushOrReplace(args[2]);
+    }
     replaceState.call(history, ...args);
   };
 


### PR DESCRIPTION
## Description

Recently encountered an issue in the Admin when updating from React Router v5 to v6. We were seeing our metrics reporting substantially lower numbers of `navigation_complete` metrics where `full_page_navigation` was set to `true`, and substantially more of them set to `false`.

Our calculation for the `full_page_navigation` tag comes from the `Navigation#isFullPageNavigation` method of the `@shopify/performance` library, which in turn is just checking to see if this was the first `Navigation` object for the top-level `Performance` object.

The issue here was that in React Router v6, they internally use a `replaceState` call on initialization in order to set a piece of state that they can use to track the number of navigations: https://github.com/remix-run/react-router/blob/a5e3ca647d733211599310626366e75b1ee228a7/packages/router/history.ts#L606

Within `@shopify/performance`, we consider any calls to `popstate`, `pushState`, or `replaceState`, to mark the end of the current `Navigation` object and to start the creation of a new one. The idea here is that if you've got a Navigation that's in progress, but the user changes the state by means of something like clicking a redirect link, then we want to start that new Navigation immediately.

This use of replaceState inside React Router is unfortunate, but required by their team in order to keep track of things for their internal usage. `@shopify/performance` seeks to be agnostic of any type of router that's in use, but in this case we need to make an exception to account for this behaviour to avoid triggering additional Navigations and breaking our metrics.

In the future, I'll be writing up an issue that details some additional shortcomings around `@shopify/performance`'s inability to support certain patterns that are in use with ReactRouter/Remix such as fetch-then-render, and how we might evolve this library to account for them.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
