### PR TITLE
Use transferSize to determine if a resource was cached

### DIFF
--- a/.changeset/kind-bats-try.md
+++ b/.changeset/kind-bats-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/performance': major
+---
+
+cacheEffectiveness uses cache ratio based on cache hit information discerned from transferSize and decodedBodySize properties

--- a/packages/performance/src/navigation.ts
+++ b/packages/performance/src/navigation.ts
@@ -104,7 +104,10 @@ export class Navigation implements NavigationDefinition {
       return undefined;
     }
 
-    return events.filter(({duration}) => duration === 0).length / events.length;
+    return (
+      events.filter(({metadata}) => Boolean(metadata?.cached)).length /
+      events.length
+    );
   }
 
   toJSON({

--- a/packages/performance/src/performance.ts
+++ b/packages/performance/src/performance.ts
@@ -120,6 +120,7 @@ export class Performance {
             metadata: {
               name: entry.name,
               size: entry.encodedBodySize,
+              cached: entry.transferSize === 0 && entry.decodedBodySize > 0,
             },
           },
           {replace: true},

--- a/packages/performance/src/tests/navigation.test.ts
+++ b/packages/performance/src/tests/navigation.test.ts
@@ -159,12 +159,12 @@ describe('Navigation', () => {
       expect(navigation).toHaveProperty('cacheEffectiveness', undefined);
     });
 
-    it('returns a ratio of cached (duration = 0) resources to uncached ones', () => {
+    it('returns a ratio of cached resources to uncached ones', () => {
       const navigation = createNavigation({
         events: [
-          createScriptDownloadEvent({duration: 0, metadata: {size: 1000}}),
-          createScriptDownloadEvent({duration: 0, metadata: {size: 250}}),
-          createStyleDownloadEvent({duration: 100, metadata: {size: 250}}),
+          createScriptDownloadEvent({metadata: {size: 1000, cached: true}}),
+          createScriptDownloadEvent({metadata: {size: 250, cached: true}}),
+          createStyleDownloadEvent({metadata: {size: 250, cached: false}}),
         ],
       });
       expect(navigation).toHaveProperty('cacheEffectiveness', 2 / 3);

--- a/packages/performance/src/types.ts
+++ b/packages/performance/src/types.ts
@@ -65,12 +65,12 @@ export interface LongTaskEvent extends BasicEvent {
 
 export interface ScriptDownloadEvent extends BasicEvent {
   type: EventType.ScriptDownload;
-  metadata: {name: string; size?: number};
+  metadata: {name: string; size?: number; cached?: boolean};
 }
 
 export interface StyleDownloadEvent extends BasicEvent {
   type: EventType.StyleDownload;
-  metadata: {name: string; size?: number};
+  metadata: {name: string; size?: number; cached?: boolean};
 }
 
 export interface GraphQLEvent extends BasicEvent {


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/web/issues/87828

The current cache effectiveness metric relies on a navigation event duration of 0 to flag a resource as being cached. Our metrics in Observe show this metric at <5% which seems much too low. From what I've observed cached assets have short request durations so this metric is inaccurate. 

I've added an explicit property to the navigation event metadata which uses the [transferSize](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize#value) value to determine if the resource was cached by the browser.

> (A transferSize of) 0 if the resource was instantaneously retrieved from a cache.

🎩 

1. `staging4`
2. Open network tab and filter xhr requests with `metrics` keyword
3. Ensure `disable cache` option is not selected
4. Find the navigations object, check script and style resource events, check the metadata cached property is false
5. Reload the page, check that the cached property is true on subsequent loads

<img width="599" alt="Screenshot 2023-03-30 at 2 40 24 PM" src="https://user-images.githubusercontent.com/3865674/228933234-9b5b078f-f333-4206-b21a-6fe0568f59f1.png">

