### PR TITLE
jest-dom-mocks: add Storage key function

### DIFF
--- a/.changeset/long-pillows-tickle.md
+++ b/.changeset/long-pillows-tickle.md
@@ -2,4 +2,4 @@
 '@shopify/jest-dom-mocks': minor
 ---
 
-Add keys function to Storage mock plus style length function
+Add `keys` function to Storage mock

--- a/.changeset/long-pillows-tickle.md
+++ b/.changeset/long-pillows-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/jest-dom-mocks': minor
+---
+
+Add keys function to Storage mock plus style length function

--- a/packages/jest-dom-mocks/README.md
+++ b/packages/jest-dom-mocks/README.md
@@ -227,6 +227,8 @@ The storage mocks are a bit different than the other mocks, because they serve p
 - `setItem`
 - `removeItem`
 - `clear`
+- `length`
+- `key`
 
 Each of these are wrapped in a jest spy, which is automatically restored at the end of the test run.
 

--- a/packages/jest-dom-mocks/src/storage.ts
+++ b/packages/jest-dom-mocks/src/storage.ts
@@ -7,6 +7,8 @@ export default class Storage {
 
   clear = jest.fn(this.unmockedClearItem);
 
+  key = jest.fn(this.unmockedKey);
+
   private store: {
     [key: string]: string;
   } = Object.create(null);
@@ -45,5 +47,9 @@ export default class Storage {
 
   private unmockedClearItem() {
     this.store = {};
+  }
+
+  private unmockedKey(index: number) {
+    return Object.keys(this.store)[index];
   }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/athena-flex/pull/5904

Bumping jest-dom-mocks caused all our tests to fail with the below error. Bisected and #2107 causes the issue. We call `.keys` inside a scope that uses `.length`.  Adding `.key` in node_modules manually fixes the issue. This PR adds `.key`, changes style of `.length` to match other functions and updates the Storage mock part of the readme. 

```
FAIL app/App.test.tsx
--
  | ● Test suite failed to run
  |  
  | TypeError: TokenStorage.sessionStorage.key is not a function
  |  
  | 1 \| import {EventEmitter} from 'stream';
  | 2 \|
  | > 3 \| import * as Flex from '@twilio/flex-ui';
  | \| ^
  | 4 \| import type {
  | 5 \|   ActionPayload,
  | 6 \|   ITask,
  |  
  | at Function.clear (node_modules/@twilio/flex-ui/node_modules/twilio-sync/node_modules/twilsock/lib/tokenStorage.js:49:57)
```

No tests currently. Let me know what you'd like to see as it's not a manual mock.