### PR TITLE
Only report finished navigations

### DIFF
--- a/.changeset/forty-crews-fold.md
+++ b/.changeset/forty-crews-fold.md
@@ -1,0 +1,11 @@
+---
+'@shopify/react-performance': major
+---
+
+Default to only sending metrics for "Finished" navigations
+
+usePerformanceReport and PerformanceReport will now default to only sending
+navigations in the performance report that have been completed (ie. have
+rendered a PerformanceMark or usePerformanceMark with Stage.Complete).
+
+This reduces the likelihood of evaluating your metrics incorrectly.

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -296,13 +296,7 @@ import {usePerformanceReport} from '@shopify/react-performance';
 import {ProductPage} from './ProductPage';
 
 function App() {
-  usePerformanceReport('/performance-report', {
-    resultsToReport: [
-      NavigationResult.Finished,
-      NavigationResult.Cancelled,
-      NavigationResult.TimedOut,
-    ],
-  });
+  usePerformanceReport('/performance-report', {finishedNavigationsOnly: false});
   return <ProductPage />;
 }
 ```

--- a/packages/react-performance/README.md
+++ b/packages/react-performance/README.md
@@ -284,6 +284,29 @@ function App() {
 }
 ```
 
+##### Including non-Finished Navigations
+
+By default, `usePerformanceReport` will only report on navigations that were "Finished" (ie. a performance mark with Stage.Complete was rendered). If you want to include Navigations that were "Cancelled" or "Timed Out" you can specify those.
+
+```tsx
+// App.tsx
+import React from 'react';
+import {NavigationResult} from '@shopify/performance';
+import {usePerformanceReport} from '@shopify/react-performance';
+import {ProductPage} from './ProductPage';
+
+function App() {
+  usePerformanceReport('/performance-report', {
+    resultsToReport: [
+      NavigationResult.Finished,
+      NavigationResult.Cancelled,
+      NavigationResult.TimedOut,
+    ],
+  });
+  return <ProductPage />;
+}
+```
+
 ### Components
 
 This library also provides the following component implementations of the above hooks:

--- a/packages/react-performance/src/PerformanceReport.tsx
+++ b/packages/react-performance/src/PerformanceReport.tsx
@@ -1,3 +1,4 @@
+import {NavigationResult} from '@shopify/performance';
 import type {ErrorHandler} from './performance-report';
 import {usePerformanceReport} from './performance-report';
 
@@ -5,10 +6,16 @@ interface Props {
   url: string;
   onError?: ErrorHandler;
   locale?: string;
+  resultsToReport?: NavigationResult[];
 }
 
-export function PerformanceReport({url, onError, locale}: Props) {
-  usePerformanceReport(url, {onError, locale});
+export function PerformanceReport({
+  url,
+  onError,
+  locale,
+  resultsToReport,
+}: Props) {
+  usePerformanceReport(url, {onError, locale, resultsToReport});
 
   return null;
 }

--- a/packages/react-performance/src/PerformanceReport.tsx
+++ b/packages/react-performance/src/PerformanceReport.tsx
@@ -1,4 +1,3 @@
-import {NavigationResult} from '@shopify/performance';
 import type {ErrorHandler} from './performance-report';
 import {usePerformanceReport} from './performance-report';
 
@@ -6,16 +5,16 @@ interface Props {
   url: string;
   onError?: ErrorHandler;
   locale?: string;
-  resultsToReport?: NavigationResult[];
+  finishedNavigationsOnly?: boolean;
 }
 
 export function PerformanceReport({
   url,
   onError,
   locale,
-  resultsToReport,
+  finishedNavigationsOnly,
 }: Props) {
-  usePerformanceReport(url, {onError, locale, resultsToReport});
+  usePerformanceReport(url, {onError, locale, finishedNavigationsOnly});
 
   return null;
 }

--- a/packages/react-performance/src/performance-report.ts
+++ b/packages/react-performance/src/performance-report.ts
@@ -13,7 +13,7 @@ export interface ErrorHandler {
 export interface usePerformanceReportOptions {
   locale?: string;
   onError?: ErrorHandler;
-  resultsToReport?: NavigationResult[];
+  finishedNavigationsOnly?: boolean;
 }
 
 export function usePerformanceReport(
@@ -21,8 +21,7 @@ export function usePerformanceReport(
   {
     locale = undefined,
     onError = noop,
-    // By default, only reports finished navigations to avoid skewing metrics
-    resultsToReport = [NavigationResult.Finished],
+    finishedNavigationsOnly = true,
   }: usePerformanceReportOptions = {},
 ) {
   const navigations = useRef<Navigation[]>([]);
@@ -70,11 +69,17 @@ export function usePerformanceReport(
 
   const onNavigation = useCallback(
     (navigation: Navigation) => {
-      if (!resultsToReport.includes(navigation.result)) return;
+      if (
+        finishedNavigationsOnly &&
+        navigation.result !== NavigationResult.Finished
+      ) {
+        return;
+      }
+
       navigations.current.push(navigation);
       sendReport();
     },
-    [sendReport],
+    [sendReport, finishedNavigationsOnly],
   );
 
   const onLifeCycleEvent = useCallback(

--- a/packages/react-performance/src/performance-report.ts
+++ b/packages/react-performance/src/performance-report.ts
@@ -1,5 +1,6 @@
 import {useRef, useCallback} from 'react';
 import type {Navigation, LifecycleEvent} from '@shopify/performance';
+import {NavigationResult} from '@shopify/performance';
 import {Header, Method} from '@shopify/network';
 
 import {useNavigationListener} from './navigation-listener';
@@ -9,12 +10,20 @@ export interface ErrorHandler {
   (error: any): void;
 }
 
+export interface usePerformanceReportOptions {
+  locale?: string;
+  onError?: ErrorHandler;
+  resultsToReport?: NavigationResult[];
+}
+
 export function usePerformanceReport(
   url: string,
   {
     locale = undefined,
     onError = noop,
-  }: {locale?: string; onError?: ErrorHandler} = {},
+    // By default, only reports finished navigations to avoid skewing metrics
+    resultsToReport = [NavigationResult.Finished],
+  }: usePerformanceReportOptions = {},
 ) {
   const navigations = useRef<Navigation[]>([]);
   const events = useRef<LifecycleEvent[]>([]);
@@ -61,6 +70,7 @@ export function usePerformanceReport(
 
   const onNavigation = useCallback(
     (navigation: Navigation) => {
+      if (!resultsToReport.includes(navigation.result)) return;
       navigations.current.push(navigation);
       sendReport();
     },

--- a/packages/react-performance/src/performance-report.ts
+++ b/packages/react-performance/src/performance-report.ts
@@ -10,7 +10,7 @@ export interface ErrorHandler {
   (error: any): void;
 }
 
-export interface usePerformanceReportOptions {
+export interface UsePerformanceReportOptions {
   locale?: string;
   onError?: ErrorHandler;
   finishedNavigationsOnly?: boolean;
@@ -22,7 +22,7 @@ export function usePerformanceReport(
     locale = undefined,
     onError = noop,
     finishedNavigationsOnly = true,
-  }: usePerformanceReportOptions = {},
+  }: UsePerformanceReportOptions = {},
 ) {
   const navigations = useRef<Navigation[]>([]);
   const events = useRef<LifecycleEvent[]>([]);

--- a/packages/react-performance/src/tests/utilities.ts
+++ b/packages/react-performance/src/tests/utilities.ts
@@ -98,7 +98,7 @@ export function mockNavigation() {
       duration: faker.datatype.number({min: 0, max: 100000}),
       target: faker.internet.url(),
       events: [],
-      result: randomNavigationResult(),
+      result: NavigationResult.Finished,
     },
     {
       index: faker.datatype.number(),


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/quilt/issues/2620
Changes the default behaviour of `usePerformanceReport` to only report on Navigations that have a result=Finished. Cancelled and TimedOut Navigations will no longer be sent meaning that metrics will be more accurate to their true intention of measuring completed navigations.