### PR TITLE
admin-graphql-api-utilities: Add `Gid` type

### DIFF
--- a/packages/admin-graphql-api-utilities/README.md
+++ b/packages/admin-graphql-api-utilities/README.md
@@ -56,7 +56,7 @@ parseGidWithParams('gid://shopify/Customer/12345?sessionId=123&foo=bar');
 //   }
 ```
 
-### `function composeGidFactory(namespace: string): Function`
+### `function composeGidFactory<N extends string>(namespace: N): Function`
 
 Create a new `composeGid` with a given namespace instead of the default `shopify` namespace.
 
@@ -71,7 +71,7 @@ composeGid('Product', '123');
 // → 'gid://CustomApp/Product/123'
 ```
 
-### `function composeGid(key: string, id: number | string, params: Record<string, string> = {}): string`
+### `function composeGid<T extends string>(key: T, id: number | string, params: Record<string, string> = {}): Gid<'shopify', T>`
 
 Given a key and id, compose a Gid string.
 

--- a/packages/admin-graphql-api-utilities/src/index.ts
+++ b/packages/admin-graphql-api-utilities/src/index.ts
@@ -1,6 +1,11 @@
 const GID_TYPE_REGEXP = /^gid:\/\/[\w-]+\/([\w-]+)\//;
 const GID_REGEXP = /\/(\w[\w-]*)(?:\?(.*))*$/;
 
+export type Gid<
+  Namespace extends string,
+  Type extends string,
+> = `gid://${Namespace}/${Type}/${number | string}`;
+
 interface ParsedGid {
   id: string;
   params: {[key: string]: string};
@@ -43,21 +48,21 @@ export function parseGidWithParams(gid: string): ParsedGid {
   throw new Error(`Invalid gid: ${gid}`);
 }
 
-export function composeGidFactory(namescape: string) {
-  return function composeGid(
-    key: string,
+export function composeGidFactory<N extends string>(namescape: N) {
+  return function composeGid<T extends string>(
+    key: T,
     id: number | string,
     params: {[key: string]: string} = {},
-  ): string {
+  ): Gid<N, T> {
     const gid = `gid://${namescape}/${key}/${id}`;
     const paramKeys = Object.keys(params);
 
     if (paramKeys.length === 0) {
-      return gid;
+      return gid as Gid<N, T>;
     }
 
     const paramString = new URLSearchParams(params).toString();
-    return `${gid}?${paramString}`;
+    return `${gid}?${paramString}` as Gid<N, T>;
   };
 }
 

--- a/packages/admin-graphql-api-utilities/src/tests/index.test.ts
+++ b/packages/admin-graphql-api-utilities/src/tests/index.test.ts
@@ -1,5 +1,6 @@
 import {v4} from 'uuid';
 
+import type {Gid} from '..';
 import {
   parseGidType,
   parseGid,
@@ -101,28 +102,30 @@ describe('admin-graphql-api-utilities', () => {
     it('returns the composed Gid using key and number id', () => {
       const id = 123;
       const key = 'Section';
-      expect(composeGid(key, id)).toBe(`gid://shopify/${key}/${id}`);
+      const gid: Gid<'shopify', 'Section'> = composeGid(key, id);
+      expect(gid).toBe(`gid://shopify/${key}/${id}`);
     });
 
     it('returns the composed Gid using key and string id', () => {
       const id = '456';
       const key = 'Section';
-      expect(composeGid(key, id)).toBe(`gid://shopify/${key}/${id}`);
+      const gid: Gid<'shopify', 'Section'> = composeGid(key, id);
+      expect(gid).toBe(`gid://shopify/${key}/${id}`);
     });
 
     it('returns the composed Gid using key and uuid', () => {
       const id = v4();
       const key = 'Section';
-      expect(composeGid(key, id)).toBe(`gid://shopify/${key}/${id}`);
+      const gid: Gid<'shopify', 'Section'> = composeGid(key, id);
+      expect(gid).toBe(`gid://shopify/${key}/${id}`);
     });
 
     it('returns the composed Gid with params', () => {
       const id = 'button';
       const key = 'Section';
       const params = {foo: 'bar', hello: 'world'};
-      expect(composeGid(key, id, params)).toBe(
-        `gid://shopify/${key}/${id}?foo=bar&hello=world`,
-      );
+      const gid: Gid<'shopify', 'Section'> = composeGid(key, id, params);
+      expect(gid).toBe(`gid://shopify/${key}/${id}?foo=bar&hello=world`);
     });
   });
 
@@ -131,14 +134,16 @@ describe('admin-graphql-api-utilities', () => {
       const customComposeGid = composeGidFactory('shopify');
       const id = 123;
       const key = 'Section';
-      expect(customComposeGid(key, id)).toBe(`gid://shopify/${key}/${id}`);
+      const gid: Gid<'shopify', 'Section'> = customComposeGid(key, id);
+      expect(gid).toBe(`gid://shopify/${key}/${id}`);
     });
 
     it('returns a function to compose "custom" gid', () => {
       const customComposeGid = composeGidFactory('custom-app');
       const id = 123;
       const key = 'Section';
-      expect(customComposeGid(key, id)).toBe(`gid://custom-app/${key}/${id}`);
+      const gid: Gid<'custom-app', 'Section'> = customComposeGid(key, id);
+      expect(gid).toBe(`gid://custom-app/${key}/${id}`);
     });
 
     it('returns the composed Gid with params', () => {
@@ -146,9 +151,12 @@ describe('admin-graphql-api-utilities', () => {
       const id = 'button';
       const key = 'Section';
       const params = {foo: 'bar', hello: 'world'};
-      expect(customComposeGid(key, id, params)).toBe(
-        `gid://custom-app/${key}/${id}?foo=bar&hello=world`,
+      const gid: Gid<'custom-app', 'Section'> = customComposeGid(
+        key,
+        id,
+        params,
       );
+      expect(gid).toBe(`gid://custom-app/${key}/${id}?foo=bar&hello=world`);
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds a `Gid` type that can be used by consumers of `composeGid` and `composeGidFactory` to provide strongly-typed GID values. This makes it a lot less likely for one GID type to accidentally be used in place of another. For example, with the current API, this is perfectly fine:

```ts
async function getOrder(gid: string) {
 // ...
}

// Oops! This should say 'Order'!
const orderId = composeGid('Orde', 123);

// Runtime Error!
const order = await getOrder(orderId);
```

However, with this change we can easily make this catch the typo as a compile-time error:

```ts
async function getOrder(gid: Gid<'shopify', 'Order'>) {
 // ...
}

// Oops! This should say 'Order'!
const orderId = composeGid('Orde', 123);

// Compile-time Error!
const order = await getOrder(orderId);
```

Additionally, since `Gid` can implicitly cast down to `string`, this change should only affect those who opt into this behavior.

### Possible Additions

1. We could also introduce a Shopify-specific `Gid` type to reduce the amount of typing needed for users using this with the Shopify API:
    ```ts
    type ShopifyGid<T extends string> = Gid<'shopify', T>; 
    ```
2. We could also include type guards like `isGidFactory` and `isGid` to take in a string and check if it's the desired `Gid` type:
    <details>
    <summary>Code Sample</summary>
    
    ```ts
    export function isGidFactory<N extends string>(namespace: N) {
      return function isGid<T extends string = unknown>(
        gid: string,
        key?: T,
      ): gid is Gid<N, T> {
        if (!gid.startsWith(`gid://${namespace}/`)) {
          return false;
        }
    
        try {
          if (key !== undefined && parseGidType(gid) !== key) {
            return false;
          }
    
          parseGid(gid);
        } catch {
          return false;
        }

        return true;
      };
    }
    ```
    
    </details>
