### PR TITLE
:bug: Address React 18 effect bug for useMountedRef

### DIFF
--- a/.changeset/wet-snakes-ring.md
+++ b/.changeset/wet-snakes-ring.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-hooks': patch
+---
+
+Addressed a bug with useMountedRef for React 18 Strict Mode in development where mounted.current would be false after the effect runs for the first time.

--- a/packages/react-hooks/src/hooks/mounted-ref.ts
+++ b/packages/react-hooks/src/hooks/mounted-ref.ts
@@ -6,6 +6,8 @@ export function useMountedRef() {
   const mounted = useRef(true);
 
   useIsomorphicLayoutEffect(() => {
+    mounted.current = true;
+
     return () => {
       mounted.current = false;
     };

--- a/packages/react-hooks/src/hooks/tests/mounted-ref.test.tsx
+++ b/packages/react-hooks/src/hooks/tests/mounted-ref.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {StrictMode, useState, useCallback} from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {useMountedRef} from '../mounted-ref';
@@ -15,6 +15,33 @@ describe('useMountedRef()', () => {
 
     mount(<MockComponent />);
     expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('returns a ref with current value as true when the component is mounted in StrictMode', () => {
+    function MockComponent() {
+      const [count, setCount] = useState(1);
+      const triggerRerender = useCallback(() => setCount((cnt) => cnt + 1), []);
+      const result = useMountedRef().current ? 'isMounted' : 'notMounted';
+
+      return (
+        <>
+          Render {count} | {result}
+          <button type="button" onClick={triggerRerender} />
+        </>
+      );
+    }
+
+    const component = mount(
+      <StrictMode>
+        <MockComponent />
+      </StrictMode>,
+    );
+
+    expect(component).toContainReactText('Render 1 | isMounted');
+    // Update state to trigger a rerender
+    component.find('button')!.trigger('onClick');
+    // Component continues to be mounted after the rerender
+    expect(component).toContainReactText('Render 2 | isMounted');
   });
 
   it('returns a ref with current value as false when the component is un-mounted', async () => {


### PR DESCRIPTION
## Description

Fixes #2500

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

This addresses a bug in React 18 StrictMode environments where effects are run twice on initialization. Previously, the `useMountedRef` bug was initialized via `const mounted = useRef(true)`, but since the effect runs twice in development (including cleanups), the `ref` would be set to `false` and never re-initialized as `true`.

You can read more about the way effects are run in strict mode in the following places:
- [Updates to Strict Mode](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-strict-mode)
- [How to handle the Effect firing twice in development?](https://react.dev/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development)

I'm uncertain where else this bug might be present (via the callbacks being run twice in React 18 w/ Strict Mode), but I do know that this is one instance of it that was causing bugs within `react-form` (see the linked issue that this resolves). I've tested this inside of a 1P app and can provide folks on the team with a demo/spin link for testing if desired.