### PR TITLE
Fix cyclical import in react-form

### DIFF
--- a/.changeset/new-ladybugs-breathe.md
+++ b/.changeset/new-ladybugs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-form': patch
+---
+
+Fix cyclical import build warning

--- a/packages/react-form/src/hooks/list/hooks/handlers.ts
+++ b/packages/react-form/src/hooks/list/hooks/handlers.ts
@@ -9,13 +9,13 @@ import type {
 } from '../../../types';
 import {runValidation} from '../utils';
 
-import type {ListState, ListAction} from './index';
+import type {ListState, ListAction} from './reducer';
 import {
   updateAction,
   updateErrorAction,
   newDefaultAction,
   resetAction,
-} from './index';
+} from './reducer';
 
 export function useHandlers<Item extends object>(
   state: ListState<Item>,


### PR DESCRIPTION
## Description

Running `yarn build` contained the following warning:

```
packages/react-form: Circular dependency: packages/react-form/src/hooks/list/hooks/index.ts -> packages/react-form/src/hooks/list/hooks/handlers.ts -> packages/react-form/src/hooks/list/hooks/index.ts
```

This PR fixes that cyclical import by avoiding imports from index files
