### PR TITLE
Removing onCompleted and onError from the useQuery types

### DIFF
--- a/.changeset/breezy-dolphins-exercise.md
+++ b/.changeset/breezy-dolphins-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-graphql': patch
+---
+
+Remove `onCompleted` and `onError` from the types on `useQuery`'s options as they are not implemented

--- a/packages/react-graphql/src/hooks/types.ts
+++ b/packages/react-graphql/src/hooks/types.ts
@@ -13,7 +13,12 @@ import type {VariableOptions} from '../types';
 
 export type QueryHookOptions<Data = any, Variables = OperationVariables> = Omit<
   QueryComponentOptions<Data, Variables>,
-  'query' | 'partialRefetch' | 'children' | 'variables'
+  | 'query'
+  | 'partialRefetch'
+  | 'children'
+  | 'variables'
+  | 'onCompleted'
+  | 'onError'
 > &
   VariableOptions<Variables> & {
     skip?: boolean;


### PR DESCRIPTION
## Description
Our custom implementation of `useQuery` and `<Query />` doesn't support `onCompleted` and `onError`.

This PR update the types to reflect the difference between our API and Apollo API.