### PR TITLE
Fix links in graphql package readmes

### DIFF
--- a/packages/graphql-config-utilities/README.md
+++ b/packages/graphql-config-utilities/README.md
@@ -16,18 +16,18 @@ yarn add graphql-config-utilities
 
 ### Configuration
 
-This utility reads schema information from a [`.graphqlconfig`](https://github.com/prisma/graphql-config) file in the project root. The configuration can contain one nameless project or many named projects. The configuration is compatible with the [vscode-graphql extension](https://github.com/prisma/vscode-graphql). This extension provides syntax highlighting and autocomplete suggestions for graphql files.
+This utility reads schema information from a [`graphql-config` config file](https://the-guild.dev/graphql/config/docs/user/usage) in the project root. The configuration can contain one nameless project or many named projects. The configuration is compatible with the [vscode-graphql extension](https://github.com/prisma/vscode-graphql). This extension provides syntax highlighting and autocomplete suggestions for graphql files.
 
-Each project specifies a `schemaPath`, `include`, and `exclude` globs. Glob patterns match paths relative to the location of the configuration file. Omit `exclude` if empty.
+Each project specifies a `schema`, `include`, and `exclude` globs. Glob patterns match paths relative to the location of the configuration file. Omit `exclude` if empty.
 
-See the [official specification documentation](https://github.com/prisma/graphql-config/blob/main/specification.md#use-cases) for more detail and examples.
+See the [official specification documentation](https://the-guild.dev/graphql/config/docs/user/usage) for more detail and examples.
 
 #### Example: single nameless project configuration
 
 ```json
 {
-  "schemaPath": "build/schema.json",
-  "includes": "app/**/*.graphql"
+  "schema": "build/schema/schema.json",
+  "include": "app/**/*.graphql"
 }
 ```
 
@@ -37,21 +37,13 @@ See the [official specification documentation](https://github.com/prisma/graphql
 {
   "projects": {
     "foo": {
-      "schemaPath": "build/schema/foo.json",
-      "includes": "app/foo/**/*.graphql"
+      "schema": "build/schema/foo.json",
+      "include": "app/foo/**/*.graphql"
     },
     "bar": {
-      "schemaPath": "build/schema/bar.json",
-      "includes": "app/bar/**/*.graphql"
+      "schema": "build/schema/bar.json",
+      "include": "app/bar/**/*.graphql"
     }
   }
 }
-```
-
-#### Example: YAML format
-
-```yml
-schemaPath: build/schema.json
-includes:
-  - 'app/**/*.graphql'
 ```

--- a/packages/graphql-persisted/README.md
+++ b/packages/graphql-persisted/README.md
@@ -35,7 +35,7 @@ const client = new ApolloClient({
 
 This function accepts an optional `options` object. The following options are available:
 
-- `idFromOperation?(operation: Operation): string | undefined | null`: calculates the unique ID to use for the persisted query, which will eventually be passed to the server’s `cache#get` method to retrieve the full query body. If omitted, this option will default to pulling the `id` field off of the `operation.query` `DocumentNode`, which works well in combination with documents compiled using [`graphql-mini-transforms`](https://github.com/Shopify/graphql-tools-web/tree/main/packages/graphql-mini-transforms) (used by default in sewing-kit).
+- `idFromOperation?(operation: Operation): string | undefined | null`: calculates the unique ID to use for the persisted query, which will eventually be passed to the server’s `cache#get` method to retrieve the full query body. If omitted, this option will default to pulling the `id` field off of the `operation.query` `DocumentNode`, which works well in combination with documents compiled using [`graphql-mini-transforms`](https://github.com/Shopify/quilt/tree/main/packages/graphql-mini-transforms) (used by default in sewing-kit).
 - `alwaysIncludeQuery: boolean`: always include the GraphQL query in a request, instead of the default behavior where the query is only included if the server does not recognize the persisted query ID. This is useful for debugging, and can avoid extra round trips in an SSR environment.
 
 The behavior of this link when a persisted query is not found for a particular ID depends on the `cacheMissBehavior` passed to your server middleware, which is documented below.

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -86,7 +86,7 @@ On startup this tool performs the following actions:
 
 ### Configuration
 
-This tool reads schema information from a [`.graphqlconfig`](https://github.com/Shopify/graphql-tools-web/tree/main/packages/graphql-tool-utilities#configuration) file in the project root.
+This tool reads schema information from a [`graphql-config` config file](https://the-guild.dev/graphql/config/docs/user/usage) in the project root.
 
 #### Examples
 
@@ -94,8 +94,8 @@ A project configuration with a `schemaTypesPath` override
 
 ```json
 {
-  "schemaPath": "build/schema.json",
-  "includes": ["app/**/*.graphql"],
+  "schema": "build/schema.json",
+  "include": ["app/**/*.graphql"],
   "extensions": {
     "schemaTypesPath": "app/bar/types/graphql"
   }

--- a/packages/graphql-validate-fixtures/README.md
+++ b/packages/graphql-validate-fixtures/README.md
@@ -34,7 +34,7 @@ On startup this tool performs the following actions:
 
 ### Configuration
 
-This tool reads schema information from a [`.graphqlconfig`](https://github.com/Shopify/graphql-tools-web/tree/main/packages/graphql-tool-utilities#configuration) file in the project root.
+This tool reads schema information from a [`graphql-config` config file](https://the-guild.dev/graphql/config/docs/user/usage) in the project root.
 
 ### CLI
 


### PR DESCRIPTION
## Description

There were some links to the long outdated graphql-config-web repo. Replace them with better references.


Skip changelog as this is just readme updates that don't warrant a release