### PR TITLE
Support storybook v7

### DIFF
--- a/.changeset/silver-books-type.md
+++ b/.changeset/silver-books-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/storybook-a11y-test': patch
+---
+
+Add #storybook-root selector to support Storybook v7

--- a/packages/storybook-a11y-test/src/index.ts
+++ b/packages/storybook-a11y-test/src/index.ts
@@ -204,6 +204,7 @@ export class A11yTestRunner {
 
         const results = await new AxePuppeteer(page)
           .include('#root')
+          .include('#storybook-root')
           .configure(config)
           .options(options)
           .analyze();


### PR DESCRIPTION
## Description

The storybook `#root` element was updated to `#storybook-root` for v7: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#change-of-root-html-ids
This is adding the `#storybook-root` selector to the a11y-test runner for this package to continue working after upgrading to Storybook v7.