### PR TITLE
Look for type tests in all projects and update docs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -113,9 +113,9 @@ module.exports = {
     project('root', {rootDir: 'tests'}),
 
     // Everything else is the `packages/*` folders
-    ...packageMapping.map(({name}) => project(name, configOverrides[name])),
-
-    // tsd type assertions using jest-runner-tsd
-    typesProject('useful-types'),
+    ...packageMapping.flatMap(({name}) => [
+      project(name, configOverrides[name]),
+      typesProject(name, configOverrides[name]),
+    ]),
   ],
 };


### PR DESCRIPTION
## Description

Update type test documentation, and look for type tests in all folders instead of only useful-types, so any new type tests don't need to fiddle with the jest config.
