### PR TITLE
Update `testing-exported-typescript-types.md`

### DIFF
--- a/documentation/testing-exported-typescript-types.md
+++ b/documentation/testing-exported-typescript-types.md
@@ -73,8 +73,8 @@ import {createPerson} from '../src/create';
 // string is not a member of an array, so we should not be able to assign anything to it.
 expectNotAssignable<ArrayElement<string>>('string');
 
-// createPerson expects an input of Person where firstName is a string. We pass a boolean and so will throw an argument error.
-expectError<typeof createPerson>(() => createPerson({firstName: true}));
+// createPerson expects an input of Person where firstName is a string. We pass a boolean, hence the expression will have a type error.
+expectError(createPerson({firstName: true}));
 ```
 
 ## Why not use `yarn type-check`?


### PR DESCRIPTION
Hi, I am maintaining `'tsd-lite'` package, which you are using to test types. Thanks for your trust!

Minor detail: in the upcoming release of `'tsd-lite'` the type argument of `expectError()` matcher will be removed. It wasn’t documented. Actually it did the same job as `expectNotAssignable<T>()`, so I decided to clean up the API.

The type argument is used in one of examples of `testing-exported-typescript-types.md`. In that case it has no effect, since the argument is causing the error, not the retuned value. With the type argument removed, the example becomes easier to read (at least for my eye).

Another detail: I think it is more precise to say that code _has_ a type error, instead of _throws_ a type error. I mean, the compiler _finds_ errors during compilation and reports them. There is no catch / throw action in this case because the code does not execute. Just thinking out loud (;