### PR TITLE
Allow consumer to manually trigger shortcuts

### DIFF
--- a/.changeset/many-terms-drum.md
+++ b/.changeset/many-terms-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-shortcuts': minor
+---
+
+Allow consumer to trigger shortcut

--- a/packages/react-shortcuts/src/index.ts
+++ b/packages/react-shortcuts/src/index.ts
@@ -1,8 +1,8 @@
 export {default as Shortcut, useShortcut} from './Shortcut';
 export type {Props as ShortcutProps} from './Shortcut';
 
-export {default as ShortcutProvider} from './ShortcutProvider';
 export type {Props as ProviderProps} from './ShortcutProvider';
+export {default as ShortcutProvider, ShortcutContext} from './ShortcutProvider';
 
 export {default as ShortcutManager} from './ShortcutManager';
 export type {

--- a/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
+++ b/packages/react-shortcuts/src/tests/ShortcutManager.test.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, {useContext, useEffect} from 'react';
 import {mount} from '@shopify/react-testing';
 import {timer} from '@shopify/jest-dom-mocks';
 
 import type {Key, HeldKey, ModifierKey} from '../keys';
 import type {DefaultIgnoredTag} from '../Shortcut';
 import Shortcut from '../Shortcut';
-import ShortcutProvider from '../ShortcutProvider';
+import ShortcutProvider, {ShortcutContext} from '../ShortcutProvider';
 
 import ShortcutWithFocus from './ShortcutWithRef';
 
@@ -16,6 +16,60 @@ describe('ShortcutManager', () => {
 
   afterEach(() => {
     timer.restore();
+  });
+
+  it('manually trigger shortcut', () => {
+    const fooSpy = jest.fn();
+
+    const MyComponent = () => {
+      const shortcutManager = useContext(ShortcutContext);
+      useEffect(() => {
+        shortcutManager?.triggerShortcut({ordered: ['k'], held: [['Control']]});
+      }, [shortcutManager]);
+
+      return null;
+    };
+
+    mount(
+      <ShortcutProvider>
+        <Shortcut
+          key="foo"
+          ordered={['k']}
+          held={[['Control']]}
+          onMatch={fooSpy}
+        />
+        <MyComponent />
+      </ShortcutProvider>,
+    );
+
+    expect(fooSpy).toHaveBeenCalled();
+  });
+
+  it('does not manually trigger shortcut when shortcut is not found', () => {
+    const fooSpy = jest.fn();
+
+    const MyComponent = () => {
+      const shortcutManager = useContext(ShortcutContext);
+      useEffect(() => {
+        shortcutManager?.triggerShortcut({ordered: ['k']});
+      }, [shortcutManager]);
+
+      return null;
+    };
+
+    mount(
+      <ShortcutProvider>
+        <Shortcut
+          key="foo"
+          ordered={['k']}
+          held={[['Control']]}
+          onMatch={fooSpy}
+        />
+        <MyComponent />
+      </ShortcutProvider>,
+    );
+
+    expect(fooSpy).not.toHaveBeenCalled();
   });
 
   it('calls the matching shortcut immediately if there are no other similar shortcuts', () => {


### PR DESCRIPTION
## Description
Adding a way to manually trigger shortcuts.

The use case we currently have is Web has a lot of global shortcuts. Those shortcuts can't be triggered from first-party apps. The goal is to implement a way to share the shortcuts between Web and first-party apps and when a shortcut is triggered in the first-party app, we want to manually trigger it in Web.

Example:

- [Online-Store](https://github.com/Shopify/online-store-web/pull/17669)
- [Web](https://github.com/Shopify/web/pull/99679)

This is needed for https://github.com/Shopify/web/pull/101309 to fix the current CMD+K shortcut not working in online store web
