### PR TITLE
Updating createAsyncQuery with client override

### DIFF
--- a/.changeset/yellow-pumas-itch.md
+++ b/.changeset/yellow-pumas-itch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-graphql': minor
+---
+
+Updating createAsyncQuery with Apollo client override

--- a/packages/react-graphql/README.md
+++ b/packages/react-graphql/README.md
@@ -227,6 +227,20 @@ const {data, loading} = useQuery(myQuery);
 const prefetch = usePrefetch(myQuery);
 ```
 
+By default, `createAsyncQuery` will use the Apollo client provided by the Apollo context. If you need to use a different client, you can pass it as an option to `createAsyncQuery`.
+
+```tsx
+import {usePrefetch} from '@shopify/react-async';
+import {createAsyncQuery, useQuery} from '@shopify/react-graphql';
+
+const myApolloClient = useMyApolloClient();
+
+const myQuery = createAsyncQuery({
+  load: () => import('./graphql/MyQuery.graphql'),
+  client: myApolloClient,
+});
+```
+
 #### `createAsyncQueryComponent()`
 
 This function uses `createAsyncQuery` with the provided arguments to create an async query, and returns a React component that will run the query when mounted. Like `createAsyncQuery`, the resulting component is strongly type checked, and is fully compatible with the `usePreload`-style hooks from `@shopify/react-async`.
@@ -295,6 +309,8 @@ const MyQuery = createAsyncQueryComponent({
 // when called
 const prefetch = usePrefetch(MyQuery);
 ```
+
+Just like `createAsyncQuery`, `createAsyncQueryComponent` will use the Apollo client provided by the Apollo context by default. If you need to use a different client, you can pass it as an option to `createAsyncQueryComponent`.
 
 ### Components
 

--- a/packages/react-graphql/src/async/query.ts
+++ b/packages/react-graphql/src/async/query.ts
@@ -2,12 +2,15 @@ import type {DocumentNode} from 'graphql-typed';
 import type {ResolverOptions} from '@shopify/async';
 import {createResolver} from '@shopify/async';
 import {useAsync, AssetTiming} from '@shopify/react-async';
+import type {ApolloClient} from '@apollo/client';
 
 import {useBackgroundQuery} from '../hooks';
 import type {AsyncDocumentNode, QueryProps, VariableOptions} from '../types';
 
 export interface Options<Data, Variables, DeepPartial>
-  extends ResolverOptions<DocumentNode<Data, Variables, DeepPartial>> {}
+  extends ResolverOptions<DocumentNode<Data, Variables, DeepPartial>> {
+  client?: ApolloClient<any>;
+}
 
 export function createAsyncQuery<
   Data extends {},
@@ -16,6 +19,7 @@ export function createAsyncQuery<
 >({
   id,
   load,
+  client,
 }: Options<Data, Variables, DeepPartial>): AsyncDocumentNode<
   Data,
   Variables,
@@ -31,14 +35,14 @@ export function createAsyncQuery<
     options: VariableOptions<Variables> & Pick<QueryProps, 'fetchPolicy'>,
   ) {
     const load = usePreload();
-    return useBackgroundQuery(load, options);
+    return useBackgroundQuery(load, options, client);
   }
 
   function useKeepFresh(
     options: VariableOptions<Variables> & Pick<QueryProps, 'pollInterval'>,
   ) {
     const load = usePreload();
-    return useBackgroundQuery(load, {pollInterval: 10_000, ...options});
+    return useBackgroundQuery(load, {pollInterval: 10_000, ...options}, client);
   }
 
   return {

--- a/packages/react-graphql/src/hooks/background-query.ts
+++ b/packages/react-graphql/src/hooks/background-query.ts
@@ -11,8 +11,9 @@ type Subscription = ReturnType<
 export function useBackgroundQuery(
   load: () => Promise<DocumentNode | null | Error>,
   options?: Omit<WatchQueryOptions, 'query'>,
+  overrideClient?: ApolloClient<any>,
 ) {
-  const client = useApolloClient();
+  const client = useApolloClient(overrideClient);
   const lastClient = useRef(client);
   const lastOptions = useRef(options);
   const serializedOptions = JSON.stringify(options);


### PR DESCRIPTION
## Description


Allowing `createAsyncQuery` & `createAsyncQueryComponent` to take an Apollo client override. Ultimate goal is to be able to perform prefetching on a different schema then Shopify in Web.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
