### PR TITLE
Allow merging of mocked queries in GraphQL update

### DIFF
--- a/.changeset/perfect-pigs-heal.md
+++ b/.changeset/perfect-pigs-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/graphql-testing': minor
+---
+
+Added `updateMockWithMerge` to `GraphQLController` to allow a partial update of mocked queries.

--- a/packages/graphql-testing/src/graphql-controller.ts
+++ b/packages/graphql-testing/src/graphql-controller.ts
@@ -4,7 +4,7 @@ import {ApolloClient, ApolloLink, InMemoryCache} from '@apollo/client';
 import {MockLink, InflightLink} from './links';
 import {Operations} from './operations';
 import {operationNameFromFindOptions} from './utilities';
-import type {GraphQLMock, MockRequest, FindOptions} from './types';
+import type {GraphQLMock, MockGraphQLObject, MockRequest, FindOptions} from './types';
 
 export interface Options {
   cacheOptions?: InMemoryCacheConfig;
@@ -54,6 +54,13 @@ export class GraphQL {
       return;
     }
     this.mockLink.updateMock(mock);
+  }
+
+  updateWithMerge(mock: MockGraphQLObject) {
+    if (!this.mockLink) {
+      return;
+    }
+    this.mockLink.updateMockWithMerge(mock);
   }
 
   async resolveAll(options: ResolveAllFindOptions = {}) {

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -3,7 +3,11 @@ import {ApolloLink, Observable} from '@apollo/client';
 import type {ExecutionResult} from 'graphql';
 import {GraphQLError} from 'graphql';
 
-import type {GraphQLMock, MockGraphQLFunction} from '../types';
+import type {
+  GraphQLMock,
+  MockGraphQLFunction,
+  MockGraphQLObject,
+} from '../types';
 
 export class MockLink extends ApolloLink {
   constructor(private mock: GraphQLMock) {
@@ -12,6 +16,15 @@ export class MockLink extends ApolloLink {
 
   updateMock(mock: GraphQLMock) {
     this.mock = mock;
+  }
+
+  updateMockWithMerge(mock: MockGraphQLObject) {
+    if (typeof this.mock === 'function') {
+      throw new Error(
+        "Can't merge a GraphQL function mock with a GraphQL object mock",
+      );
+    }
+    this.mock = {...this.mock, ...mock};
   }
 
   request(operation: Operation): Observable<any> {

--- a/packages/graphql-testing/src/types.ts
+++ b/packages/graphql-testing/src/types.ts
@@ -10,9 +10,12 @@ export type MockGraphQLResponse = Error | object;
 export type MockGraphQLFunction = (
   request: GraphQLRequest,
 ) => MockGraphQLResponse;
-export type GraphQLMock =
-  | {[key: string]: MockGraphQLResponse | MockGraphQLFunction}
-  | MockGraphQLFunction;
+
+export type MockGraphQLObject = {
+  [key: string]: MockGraphQLResponse | MockGraphQLFunction;
+};
+
+export type GraphQLMock = MockGraphQLObject | MockGraphQLFunction;
 
 export interface MockRequest {
   operation: Operation;


### PR DESCRIPTION
## Description

Allows applying partial changes to the mocked graphQL queries provided by the `GraphQLController`. This works similarly to the existing `update` option, but merges the existing mocked queries with the new set. This is useful in two cases that I think are relevant:

* Reduces the amount of code required to update a single query response. We no longer need to pass all of the other queries that are not changing, in order to update the response of a single query. This improves readability of the code by making the intention more clear about what is actually being updated:

```tsx

const wrapper = await mountWithAppContext(<MyComponent />, {
  graphQL: createGraphQL({
    Person: fillGraphQL(PersonQuery, initialPersonData),
    Pet: fillGraphQL(PetQuery, initialPetData),
  })
});

// ...

// Update just the Person query
// Previously, we would need to also supply the Pet query too, or it would be removed if we didn't pass one
wrapper.context.graphQL.updateWithMerge({
  Person: fillGraphQL(PersonQuery, newPersonData),
});


```

* It allows composing the graphQL mocks via extending mounting functions.

```tsx

export const mountWithPersonContext = mountWithAppContext.extend<
  Options,
  Context
>({
  context: ({
    graphQL,
  }) => {
    graphQL.updateWithMerge({
      Person: fillGraphQL(PersonQuery, personQueryData)
    });

    return {
      graphQL,
    };
  },
 // ...
});
```


#### Open questions

Should this be the default behaviour of the `update` function? I don't think many will be relying on the removal of mocks in their tests, which I think would be the only way this would break if this was the default behaviour of `update`.

Another approach might be to expose the mocks to the consumer so that we can reuse them. The result of `createGraphQL` is currently sealed, but it would be useful if we can take an existing helper that gives us a `createGraphQL` and be able to extend it to supply more mocks for other queries, without having to know what was passed in initially.
