### PR TITLE
Release name package

### DIFF
--- a/.changeset/itchy-apes-suffer.md
+++ b/.changeset/itchy-apes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/name': major
+---
+
+Initial release of @shopify/name

--- a/packages/name/package.json
+++ b/packages/name/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/name",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "license": "MIT",
   "description": "Name-related utilities",
   "main": "index.js",


### PR DESCRIPTION
## Description

`@shopify/name` package was introduced in https://github.com/Shopify/quilt/pull/2671/ but because it had an empty changeset, it didn't trigger a `Version Packages` PR, and so it wasn't uploaded to NPM. I think by setting the version back down, and then introducing a changeset to bump it it should take effect.