### PR TITLE
graphql-mini-transforms rollup plugin omit sourcemaps

### DIFF
--- a/.changeset/flat-teachers-thank.md
+++ b/.changeset/flat-teachers-thank.md
@@ -1,0 +1,5 @@
+---
+'graphql-mini-transforms': patch
+---
+
+Update rollup plugin to ignore sourcemaps to prevent build warnings

--- a/packages/graphql-mini-transforms/src/rollup.ts
+++ b/packages/graphql-mini-transforms/src/rollup.ts
@@ -33,12 +33,7 @@ export function graphql({simple = false}: {simple?: boolean} = {}): Plugin {
 
       const exported = simple ? toSimpleDocument(document) : document;
 
-      return {
-        code: `export default JSON.parse(${JSON.stringify(
-          JSON.stringify(exported),
-        )})`,
-        map: {mappings: ''},
-      };
+      return {code: `export default ${JSON.stringify(exported)}`, map: null};
     },
   };
 }

--- a/packages/graphql-mini-transforms/src/rollup.ts
+++ b/packages/graphql-mini-transforms/src/rollup.ts
@@ -33,9 +33,12 @@ export function graphql({simple = false}: {simple?: boolean} = {}): Plugin {
 
       const exported = simple ? toSimpleDocument(document) : document;
 
-      return `export default JSON.parse(${JSON.stringify(
-        JSON.stringify(exported),
-      )})`;
+      return {
+        code: `export default JSON.parse(${JSON.stringify(
+          JSON.stringify(exported),
+        )})`,
+        map: {mappings: ''},
+      };
     },
   };
 }


### PR DESCRIPTION
## Description
There is a warning produced by vite when mappings are not available. This will prevent that warning as sourcemaps are not valuable for this plugin.
Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
