### PR TITLE
remove graphql-mini-transforms warnings in rollup

### DIFF
--- a/packages/graphql-mini-transforms/src/rollup.ts
+++ b/packages/graphql-mini-transforms/src/rollup.ts
@@ -33,9 +33,7 @@ export function graphql({simple = false}: {simple?: boolean} = {}): Plugin {
 
       const exported = simple ? toSimpleDocument(document) : document;
 
-      return `export default JSON.parse(${JSON.stringify(
-        JSON.stringify(exported),
-      )})`;
+      return {code: `export default ${JSON.stringify(exported)}`, map: null };
     },
   };
 }


### PR DESCRIPTION
also remove double-encoding of JSON, which is likely net negative for performance in small objects
