### PR TITLE
[graphql-typescript-definitions] Pass export-format cli option to Builder config

### DIFF
--- a/.changeset/silver-mails-fold.md
+++ b/.changeset/silver-mails-fold.md
@@ -1,0 +1,5 @@
+---
+'graphql-typescript-definitions': patch
+---
+
+Pass export-format CLI option to builder Config allowing cli users to change the type of generated Documents

--- a/packages/graphql-typescript-definitions/src/cli.ts
+++ b/packages/graphql-typescript-definitions/src/cli.ts
@@ -71,6 +71,7 @@ const builder = new Builder({
   addTypename: argv['add-typename'],
   enumFormat: argv['enum-format'],
   customScalars: normalizeCustomScalars(argv['custom-scalars']),
+  exportFormat: argv['export-format'],
 });
 
 function normalizeCustomScalars(customScalarOption: string) {


### PR DESCRIPTION
## Description

The `export-format` cli option was added in https://github.com/Shopify/quilt/commit/1c7dff61b7843627f13578012938f060446d44fc (updated in #2289 and #2559) but never actually passed to the `Builder` config. This means any projects that want to be typed for `@apollo/client` or other libraries using `TypedDocumentNode` can not use the cli for generating their types. This PR adds the value to the CLI Builder.
