### PR TITLE
Add special performance event handling for time to last byte

### DIFF
--- a/.changeset/pretty-timers-begin.md
+++ b/.changeset/pretty-timers-begin.md
@@ -1,0 +1,6 @@
+---
+'@shopify/koa-performance': minor
+'@shopify/performance': minor
+---
+
+Add special performance event handling for time to last byte

--- a/packages/koa-performance/src/enums.ts
+++ b/packages/koa-performance/src/enums.ts
@@ -1,5 +1,6 @@
 export enum LifecycleMetric {
   TimeToFirstByte = 'time_to_first_byte',
+  TimeToLastByte = 'time_to_last_byte',
   TimeToFirstContentfulPaint = 'time_to_first_contentful_paint',
   TimeToLargestContentfulPaint = 'time_to_largest_contentful_paint',
   TimeToFirstPaint = 'time_to_first_paint',

--- a/packages/koa-performance/src/middleware.ts
+++ b/packages/koa-performance/src/middleware.ts
@@ -254,6 +254,7 @@ function getAnomalousNavigationDurationTag(
 
 const EVENT_METRIC_MAPPING = {
   [EventType.TimeToFirstByte]: LifecycleMetric.TimeToFirstByte,
+  [EventType.TimeToLastByte]: LifecycleMetric.TimeToLastByte,
   [EventType.TimeToFirstContentfulPaint]:
     LifecycleMetric.TimeToFirstContentfulPaint,
   [EventType.TimeToLargestContentfulPaint]:

--- a/packages/performance/src/types.ts
+++ b/packages/performance/src/types.ts
@@ -1,5 +1,6 @@
 export enum EventType {
   TimeToFirstByte = 'ttfb',
+  TimeToLastByte = 'ttlb',
   TimeToFirstPaint = 'ttfp',
   TimeToFirstContentfulPaint = 'ttfcp',
   TimeToLargestContentfulPaint = 'ttlcp',
@@ -23,6 +24,13 @@ interface BasicEvent {
 
 export interface TimeToFirstByteEvent extends BasicEvent {
   type: EventType.TimeToFirstByte;
+  metadata?: {
+    [key: string]: any;
+  };
+}
+
+export interface TimeToLastByteEvent extends BasicEvent {
+  type: EventType.TimeToLastByte;
   metadata?: {
     [key: string]: any;
   };
@@ -89,6 +97,7 @@ export interface CustomEvent extends BasicEvent {
 
 export type LifecycleEvent =
   | TimeToFirstByteEvent
+  | TimeToLastByteEvent
   | TimeToFirstPaintEvent
   | TimeToFirstContentfulPaintEvent
   | TimeToLargestContentfulPaintEvent
@@ -107,6 +116,7 @@ export type Event =
 
 export interface EventMap {
   [EventType.TimeToFirstByte]: TimeToFirstByteEvent;
+  [EventType.TimeToLastByte]: TimeToLastByteEvent;
   [EventType.TimeToFirstPaint]: TimeToFirstPaintEvent;
   [EventType.TimeToFirstContentfulPaint]: TimeToFirstContentfulPaintEvent;
   [EventType.TimeToLargestContentfulPaint]: TimeToLargestContentfulPaintEvent;


### PR DESCRIPTION
## Description

With server-rendering frameworks increasingly favoring streamed HTML responses, knowing the time to *last* byte, in addition to the time to *first* byte, can be a helpful tool in some cases. This PR adds dedicated handling for time to last byte to the performance libraries. My main goal is to use these in checkout, where we are now measuring time to last byte to measure the effectiveness of our own streaming HTML render.
