### PR TITLE
fix(dates-timezone): fallback to UTC-0 when selecting GMT timezone

### DIFF
--- a/.changeset/proud-rocks-pull.md
+++ b/.changeset/proud-rocks-pull.md
@@ -1,0 +1,5 @@
+---
+'@shopify/dates': patch
+---
+
+The code change addresses a issue that occurred when the user selected the 'GMT' timezone. The crash was resolved by adding a fallback to 'UTC' timezone when 'GMT' is selected.

--- a/packages/dates/src/tests/utilities.test.ts
+++ b/packages/dates/src/tests/utilities.test.ts
@@ -36,6 +36,25 @@ describe('formatDate()', () => {
 
     expect(formatDate(date, locale, options)).toBe(expected);
   });
+
+  it('formats with the GMT timezone', () => {
+    const date = new Date('2018-01-01T12:34:56-00:00');
+    const locale = 'en';
+    const timeZone = 'GMT';
+    const options: Intl.DateTimeFormatOptions = {
+      timeZone,
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    };
+
+    const expected = '1/1/2018, 12:34:56 PM';
+
+    expect(formatDate(date, locale, options)).toBe(expected);
+  });
 });
 
 describe('dateTimeFormatCacheKey()', () => {

--- a/packages/dates/src/utilities/formatDate.ts
+++ b/packages/dates/src/utilities/formatDate.ts
@@ -56,6 +56,13 @@ export function formatDate(
       ...options,
       timeZone: 'UTC',
     }).format(adjustedDate);
+    // GMT is not supported so we convert it to UTC-0
+  } else if (options.timeZone != null && options.timeZone === 'GMT') {
+    const adjustedDate = new Date(date.valueOf());
+    return memoizedGetDateTimeFormat(locales, {
+      ...options,
+      timeZone: 'UTC',
+    }).format(adjustedDate);
   }
 
   return memoizedGetDateTimeFormat(locales, options).format(date);


### PR DESCRIPTION
### Description 📝

This pull request addresses an issue where the library was causing apps to crash when the 'GMT' timezone was selected by the user. 

The fix involves a modification in the `formatDate` function. If the selected timezone is 'GMT', the function now creates an adjusted date without changing the original date value and formats the date using the 'UTC' timezone instead of 'GMT'. 

This change ensures that the application doesn't crash when 'GMT' is selected.

The code has been thoroughly tested to ensure that the fix works as expected and doesn't introduce any new issues. 