### PR TITLE
Fix forceUpdate() for RR6 data routes with loaders

### DIFF
--- a/.changeset/shaggy-carrots-punch.md
+++ b/.changeset/shaggy-carrots-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': patch
+---
+
+Fix forceUpdate via cloneElement to re-render TestWrapper React tree

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@shopify/useful-types": "^5.1.2",
     "jest-matcher-utils": "^26.6.2",
-    "react-reconciler": "^0.28.0"
+    "react-reconciler": "^0.28.0",
+    "react-is": "^18.0.0"
   },
   "files": [
     "build/",

--- a/packages/react-testing/src/TestWrapper.tsx
+++ b/packages/react-testing/src/TestWrapper.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {isPortal} from 'react-is';
 
 interface State<ChildProps> {
   props?: Partial<ChildProps>;
@@ -25,7 +26,9 @@ export class TestWrapper<ChildProps> extends React.Component<
   render() {
     const {props} = this.state;
     const {children, render} = this.props;
-    const rootElement = React.cloneElement(children, props);
+    const rootElement = isPortal(children)
+      ? children
+      : React.cloneElement(children, props);
 
     return render(
       <TestInnerWrapper ref={this.setRef}>{rootElement}</TestInnerWrapper>,

--- a/packages/react-testing/src/TestWrapper.tsx
+++ b/packages/react-testing/src/TestWrapper.tsx
@@ -25,7 +25,7 @@ export class TestWrapper<ChildProps> extends React.Component<
   render() {
     const {props} = this.state;
     const {children, render} = this.props;
-    const rootElement = props ? React.cloneElement(children, props) : children;
+    const rootElement = React.cloneElement(children, props);
 
     return render(
       <TestInnerWrapper ref={this.setRef}>{rootElement}</TestInnerWrapper>,


### PR DESCRIPTION
## Description

React Router data routes don't render in a single pass, so forceUpdate() of a parent component does not force-update matched components. This means that React will bail out of rendering when it hits `rootElement` in `TestWrapper` because it is equal to the previous render.