### PR TITLE
Add an optional "absolute" flage to translationKeyExists

### DIFF
--- a/.changeset/strange-windows-drive.md
+++ b/.changeset/strange-windows-drive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-i18n': minor
+---
+
+Add absolute option to I18n#translationKeyExists

--- a/packages/react-i18n/src/i18n.ts
+++ b/packages/react-i18n/src/i18n.ts
@@ -218,9 +218,10 @@ export class I18n {
     }
   }
 
-  translationKeyExists(id: string) {
+  translationKeyExists(id: string, absolute = false) {
     try {
-      getTranslationTree(id, this.translations, this.locale);
+      const result = getTranslationTree(id, this.translations, this.locale);
+      if (absolute) return typeof result === 'string';
       return true;
     } catch (error) {
       return false;

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -2372,6 +2372,38 @@ describe('I18n', () => {
       const result = i18n.translationKeyExists(key);
       expect(result).toBe(false);
     });
+
+    describe('when absolute is true', () => {
+      it('returns true if the key exists and is a string', () => {
+        const mockResult = 'translated string';
+        getTranslationTree.mockReturnValue(mockResult);
+
+        const i18n = new I18n(defaultTranslations, defaultDetails);
+        const result = i18n.translationKeyExists('hello', true);
+
+        expect(result).toBe(true);
+      });
+
+      it('returns false if the key exists and is an object', () => {
+        const mockResult = {hello: 'translated string'};
+        getTranslationTree.mockReturnValue(mockResult);
+
+        const i18n = new I18n(defaultTranslations, defaultDetails);
+        const result = i18n.translationKeyExists('hello', true);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false if the key does not exist', () => {
+        const mockResult = undefined;
+        getTranslationTree.mockReturnValue(mockResult);
+
+        const i18n = new I18n(defaultTranslations, defaultDetails);
+        const result = i18n.translationKeyExists('goodbye', true);
+
+        expect(result).toBe(false);
+      });
+    });
   });
 
   // we only test a few use cases as this method is simply a wrapper for the similarly


### PR DESCRIPTION


## Description

This flag allows us to ask not just that a translation key exists, but also whether it is an "absolute" key, ie. one that can be used by `i18n.translate`.

Currently the method just checks whether a subtree exists with the given key, but that tree is not necessarily a leaf node that would result in a translated string, just a translated set of objects. This flag allows us the ability to safely check that a translation exists before calling translate() to avoid triggering onError.
