### PR TITLE
Import faker from the locale-specific file

### DIFF
--- a/.changeset/dry-buckets-juggle.md
+++ b/.changeset/dry-buckets-juggle.md
@@ -1,0 +1,5 @@
+---
+'graphql-fixtures': patch
+---
+
+Import from faker from `faker-js/faker/locale/en` to avoid the overhead of loading non-english locales

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,17 @@ module.exports = {
     '@typescript-eslint/await-thenable': 'off',
     'import/no-extraneous-dependencies': 'error',
     'import/consistent-type-specifier-style': 'error',
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@faker-js/faker',
+            message: "Please use '@faker-js/faker/locale/en' instead",
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     {

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import type {
   GraphQLSchema,
   GraphQLType,

--- a/packages/graphql-fixtures/src/tests/fill.test.ts
+++ b/packages/graphql-fixtures/src/tests/fill.test.ts
@@ -2,7 +2,7 @@
 import {buildSchema} from 'graphql';
 import type {DocumentNode} from 'graphql-typed';
 import {parse} from 'graphql-typed';
-import {faker as originalFaker} from '@faker-js/faker';
+import {faker as originalFaker} from '@faker-js/faker/locale/en';
 
 import type {Options} from '../fill';
 import {createFillers, list, faker} from '../fill';

--- a/packages/graphql-fixtures/src/utilities.ts
+++ b/packages/graphql-fixtures/src/utilities.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 
 export function chooseNull() {
   return faker.datatype.boolean();

--- a/packages/graphql-persisted/src/tests/apollo.test.ts
+++ b/packages/graphql-persisted/src/tests/apollo.test.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {ApolloLink, gql} from '@apollo/client';
 
 import {createPersistedLink} from '../apollo';

--- a/packages/graphql-persisted/src/tests/koa-middleware.test.ts
+++ b/packages/graphql-persisted/src/tests/koa-middleware.test.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {Header} from '@shopify/network';
 import {createMockContext} from '@shopify/jest-koa-mocks';
 import {setAssets} from '@shopify/sewing-kit-koa';

--- a/packages/react-app-bridge-universal-provider/src/tests/AppBridgeUniversalProvider.test.tsx
+++ b/packages/react-app-bridge-universal-provider/src/tests/AppBridgeUniversalProvider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {Provider as AppBridgeProvider} from '@shopify/app-bridge-react';
 import {extract} from '@shopify/react-effect/server';
 import {mount} from '@shopify/react-testing';

--- a/packages/react-async/src/context/tests/assets.test.ts
+++ b/packages/react-async/src/context/tests/assets.test.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {AssetTiming} from '../../types';
 import {AsyncAssetManager} from '../assets';

--- a/packages/react-async/src/tests/component.test.tsx
+++ b/packages/react-async/src/tests/component.test.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 import React, {Component} from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {DeferTiming} from '@shopify/async';
 import {createMount} from '@shopify/react-testing';
 import {

--- a/packages/react-async/src/tests/provider.test.tsx
+++ b/packages/react-async/src/tests/provider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 import {requestIdleCallback} from '@shopify/jest-dom-mocks';
 

--- a/packages/react-csrf-universal-provider/src/tests/CsrfUniversalProvider.test.tsx
+++ b/packages/react-csrf-universal-provider/src/tests/CsrfUniversalProvider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {extract} from '@shopify/react-effect/server';
 import {CsrfTokenContext} from '@shopify/react-csrf';
 import {mount} from '@shopify/react-testing';

--- a/packages/react-csrf/src/tests/hooks.test.tsx
+++ b/packages/react-csrf/src/tests/hooks.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import {CsrfTokenContext} from '../context';

--- a/packages/react-form-state/src/components/tests/List.test.tsx
+++ b/packages/react-form-state/src/components/tests/List.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 // eslint-disable-next-line @shopify/strict-component-boundaries

--- a/packages/react-form-state/src/components/tests/Nested.test.tsx
+++ b/packages/react-form-state/src/components/tests/Nested.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 // eslint-disable-next-line @shopify/strict-component-boundaries

--- a/packages/react-form-state/src/tests/FormState.test.tsx
+++ b/packages/react-form-state/src/tests/FormState.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import {validateList} from '../validators';

--- a/packages/react-form-state/src/tests/array-utilities.test.tsx
+++ b/packages/react-form-state/src/tests/array-utilities.test.tsx
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {push, replace, remove} from '../utilities';
 

--- a/packages/react-form-state/src/tests/validators.test.tsx
+++ b/packages/react-form-state/src/tests/validators.test.tsx
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {
   validate,

--- a/packages/react-form/src/hooks/field/tests/field.test.tsx
+++ b/packages/react-form/src/hooks/field/tests/field.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import type {FieldConfig} from '../field';

--- a/packages/react-form/src/hooks/list/tests/baselist.test.tsx
+++ b/packages/react-form/src/hooks/list/tests/baselist.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 
 import type {FieldListConfig} from '../baselist';

--- a/packages/react-form/src/hooks/list/tests/utils.tsx
+++ b/packages/react-form/src/hooks/list/tests/utils.tsx
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import React from 'react';
 
 export interface Variant {

--- a/packages/react-form/src/hooks/tests/utilities/index.ts
+++ b/packages/react-form/src/hooks/tests/utilities/index.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import type {Root} from '@shopify/react-testing';
 
 import type {SimpleProduct} from './components';

--- a/packages/react-form/src/validation/tests/validator.test.ts
+++ b/packages/react-form/src/validation/tests/validator.test.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {validator} from '..';
 

--- a/packages/react-graphql/src/async/tests/component.test.tsx
+++ b/packages/react-graphql/src/async/tests/component.test.tsx
@@ -1,6 +1,6 @@
 import type {ReactElement} from 'react';
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {ApolloClient, ApolloLink, InMemoryCache, gql} from '@apollo/client';
 import {getUsedAssets as baseGetUsedAssets} from '@shopify/react-async/testing';
 import {createMount} from '@shopify/react-testing';

--- a/packages/react-hydrate/src/tests/e2e.test.tsx
+++ b/packages/react-hydrate/src/tests/e2e.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {createMount} from '@shopify/react-testing';
 
 import {Hydrator} from '../Hydrator';

--- a/packages/react-i18n-universal-provider/src/tests/I18nUniversalProvider.test.tsx
+++ b/packages/react-i18n-universal-provider/src/tests/I18nUniversalProvider.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import {allLocales, faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {extract} from '@shopify/react-effect/server';
 import {createMount} from '@shopify/react-testing';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';
 import {I18nContext, I18nManager} from '@shopify/react-i18n';
 
 import {I18nUniversalProvider} from '../I18nUniversalProvider';
+
+const allLocales = ['en', 'fr', 'de', 'es', 'pt_BR'];
 
 const mount = createMount<{htmlManager?: HtmlManager}>({
   render: (element, _, {htmlManager = new HtmlManager()}) => (
@@ -15,7 +17,7 @@ const mount = createMount<{htmlManager?: HtmlManager}>({
 
 describe('<I18nUniversalProvider />', () => {
   it('renders an I18nContext and creates an I18nManager using the given data', () => {
-    const locale = faker.helpers.objectKey(allLocales);
+    const locale = faker.helpers.arrayElement(allLocales);
     const currency = faker.finance.currencyCode();
     const country = faker.location.country();
     const timezone = faker.lorem.word();
@@ -45,7 +47,7 @@ describe('<I18nUniversalProvider />', () => {
 
   it('serializes i18n details and reuses them', async () => {
     const htmlManager = new HtmlManager();
-    const locale = faker.helpers.objectKey(allLocales);
+    const locale = faker.helpers.arrayElement(allLocales);
     const currency = faker.finance.currencyCode();
     const country = faker.location.country();
     const timezone = faker.lorem.word();
@@ -83,7 +85,7 @@ describe('<I18nUniversalProvider />', () => {
 
   it('overrides serialized data with defined overrides', async () => {
     const htmlManager = new HtmlManager();
-    const locale = faker.helpers.objectKey(allLocales);
+    const locale = faker.helpers.arrayElement(allLocales);
     const currency = faker.finance.currencyCode();
     const country = faker.location.country();
     const timezone = faker.lorem.word();
@@ -105,7 +107,7 @@ describe('<I18nUniversalProvider />', () => {
     );
 
     const overrideDetails = {
-      locale: faker.helpers.objectKey(allLocales),
+      locale: faker.helpers.arrayElement(allLocales),
       currency: undefined,
       country: faker.location.country(),
       timezone: undefined,

--- a/packages/react-i18n-universal-provider/src/tests/utilities.test.ts
+++ b/packages/react-i18n-universal-provider/src/tests/utilities.test.ts
@@ -1,11 +1,13 @@
-import {allLocales, faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {combinedI18nDetails} from '../utilities';
+
+const allLocales = ['en', 'fr', 'de', 'es', 'pt_BR'];
 
 describe('combinedI18nDetails()', () => {
   it('merges two details objects together', () => {
     const details = {
-      locale: faker.helpers.objectKey(allLocales),
+      locale: faker.helpers.arrayElement(allLocales),
       country: faker.location.country(),
     };
     const overrides = {
@@ -20,7 +22,7 @@ describe('combinedI18nDetails()', () => {
   });
 
   it('overrides fields with defined overrides', () => {
-    const locale = faker.helpers.objectKey(allLocales);
+    const locale = faker.helpers.arrayElement(allLocales);
     const country = faker.location.country();
     const currency = faker.finance.currencyCode();
     const details = {
@@ -44,8 +46,11 @@ describe('combinedI18nDetails()', () => {
 
   describe('locale', () => {
     it('returns a details object with a locale field', () => {
-      const locale = faker.helpers.objectKey(allLocales);
-      const fallbackLocale = faker.helpers.objectKey(allLocales);
+      const [locale, fallbackLocale] = faker.helpers.arrayElements(
+        allLocales,
+        2,
+      );
+
       const details = {locale};
       const overrides = {locale: undefined, fallbackLocale};
 
@@ -56,8 +61,10 @@ describe('combinedI18nDetails()', () => {
     });
 
     it('favours an override locale if one is specified', () => {
-      const locale = faker.helpers.objectKey(allLocales);
-      const overrideLocale = faker.helpers.objectKey(allLocales);
+      const [locale, overrideLocale] = faker.helpers.arrayElements(
+        allLocales,
+        2,
+      );
       const details = {locale};
       const overrides = {locale: overrideLocale};
 
@@ -68,7 +75,7 @@ describe('combinedI18nDetails()', () => {
     });
 
     it('returns a details object with a fallback locale field if one is specified', () => {
-      const fallbackLocale = faker.helpers.objectKey(allLocales);
+      const fallbackLocale = faker.helpers.arrayElement(allLocales);
       const details = {};
       const overrides = {fallbackLocale};
 

--- a/packages/react-performance/src/tests/PerformanceReport.test.tsx
+++ b/packages/react-performance/src/tests/PerformanceReport.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {mount} from '@shopify/react-testing';
 import {fetch, timer, connection} from '@shopify/jest-dom-mocks';
 import {Method, Header} from '@shopify/network';

--- a/packages/react-performance/src/tests/utilities.ts
+++ b/packages/react-performance/src/tests/utilities.ts
@@ -1,4 +1,4 @@
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import type {Performance, LifecycleEvent} from '@shopify/performance';
 import {Navigation, NavigationResult, EventType} from '@shopify/performance';
 

--- a/packages/react-testing/src/tests/mount.test.tsx
+++ b/packages/react-testing/src/tests/mount.test.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 
 import {Root} from '../root';
 import {mount, createMount} from '../mount';

--- a/packages/react-universal-provider/src/tests/create-universal-provider.test.tsx
+++ b/packages/react-universal-provider/src/tests/create-universal-provider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {faker} from '@faker-js/faker';
+import {faker} from '@faker-js/faker/locale/en';
 import {extract} from '@shopify/react-effect/server';
 import {HtmlManager, HtmlContext} from '@shopify/react-html';
 import {mount} from '@shopify/react-testing';


### PR DESCRIPTION
## Description

#2655 updated faker to v8. It also changed our imports of faker from `@faker-js/faker/locale/en` to `@faker-js/faker`.

However the reason why we imported from `@faker-js/faker/locale/en` instead of the base - because the root loads all locales which is about 6 times the size of just the english locale - [has not been addressed](https://fakerjs.dev/guide/localization.html#individual-localized-packages). 

Thus we should still continue to import faker from the locale-specific import as its root import still results in you loading all locales instead of english only.


This PR reverts the changes to our faker import paths - so we go back to importing from `@faker-js/faker/locale/en`

### Changeset notes

This PR touches files in many packages however all of them except for the `graphql-fixtures` are code that is only used within tests. Thus the only package with user-facing changes is `graphql-fixtures`, so that's the only package in the changeset.
