### PR TITLE
:wrench: Update vscode settings following an update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "css.validate": false,
   "scss.validate": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
   "typescript.tsdk": "./node_modules/typescript/lib",


### PR DESCRIPTION
## Description

This file gets auto-updated whenever we open this repo with VS Code as it's [the new value in place of `true` and the old boolean value is now deprecated](https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto).
