### PR TITLE
Fix GraphQL type generation in ESM projects

### DIFF
--- a/.changeset/long-donuts-enjoy.md
+++ b/.changeset/long-donuts-enjoy.md
@@ -1,0 +1,5 @@
+---
+'graphql-typescript-definitions': patch
+---
+
+Fix GraphQL type generation in ESM projects

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -10,7 +10,7 @@ import type {
 } from 'graphql';
 import {parse, Source, concatAST} from 'graphql';
 import chalk from 'chalk';
-import {mkdirp, readFile, writeFile} from 'fs-extra';
+import fsExtra from 'fs-extra';
 import type {GraphQLProjectConfig, GraphQLConfig} from 'graphql-config';
 import {loadConfigSync} from 'graphql-config';
 import {
@@ -27,6 +27,8 @@ import {AbstractGraphQLFilesystem} from './filesystem';
 import type {PrintDocumentOptions, PrintSchemaOptions} from './print';
 import {printDocument, generateSchemaTypes} from './print';
 import {EnumFormat, ExportFormat} from './types';
+
+const {mkdirp, readFile, writeFile} = fsExtra;
 
 export type {GraphQLFilesystem};
 export {AbstractGraphQLFilesystem, EnumFormat, ExportFormat};

--- a/packages/graphql-typescript-definitions/src/print/document/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/index.ts
@@ -2,6 +2,7 @@ import * as t from '@babel/types';
 import type {GraphQLObjectType} from 'graphql';
 import type {AST, Fragment, Operation} from 'graphql-tool-utilities';
 import {isTypedVariable, OperationType} from 'graphql-tool-utilities';
+import babelGenerator from '@babel/generator';
 
 import {ExportFormat} from '../../types';
 
@@ -10,8 +11,12 @@ import {FileContext, OperationContext} from './context';
 import {ObjectStack} from './utilities';
 import {tsInterfaceBodyForObjectField, variablesInterface} from './language';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const generate = require('@babel/generator').default;
+// The version of @babel/generator we depend on has a strange build process
+// that doesn’t work consistently in ESM and non-ESM consumers. This hacky bit of
+// code makes sure we get the actual `generate()` function in both runtimes.
+const generate: typeof babelGenerator =
+  (babelGenerator as any as {default: typeof babelGenerator}).default ??
+  babelGenerator;
 
 export interface File {
   path: string;

--- a/packages/graphql-typescript-definitions/src/print/schema/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/schema/index.ts
@@ -1,4 +1,5 @@
 import * as t from '@babel/types';
+import babelGenerator from '@babel/generator';
 import {pascalCase, camelCase, snakeCase} from 'change-case';
 import type {
   GraphQLSchema,
@@ -18,8 +19,12 @@ import {
 import {scalarTypeMap} from '../utilities';
 import {EnumFormat} from '../../types';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const generate = require('@babel/generator').default;
+// The version of @babel/generator we depend on has a strange build process
+// that doesn’t work consistently in ESM and non-ESM consumers. This hacky bit of
+// code makes sure we get the actual `generate()` function in both runtimes.
+const generate: typeof babelGenerator =
+  (babelGenerator as any as {default: typeof babelGenerator}).default ??
+  babelGenerator;
 
 export interface ScalarDefinition {
   name: string;


### PR DESCRIPTION
I was trying to convert our app to use `type: "module"` in its root package.json, and I found that there were a few dependencies in `graphql-typescript-definitions` that were not set up to work in ESM. `fs-extra` doesn’t actually provide named exports, and we were using `require()` to bring in `@babel/generator`, even in the ESM version of the build. This PR fixes both of those issues.
