### PR TITLE
Detect POS Go as a mobile device

### DIFF
--- a/.changeset/three-beers-sniff.md
+++ b/.changeset/three-beers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@shopify/browser': patch
+---
+
+Detect POS Go devices as mobile devices

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -37,7 +37,10 @@ export class Browser {
   }
 
   get isMobile() {
-    return MOBILE_DEVICE_TYPES.includes(this.ua.getDevice().type);
+    return (
+      MOBILE_DEVICE_TYPES.includes(this.ua.getDevice().type) ||
+      this.isPOSFirstPartyDevice()
+    );
   }
 
   get isDesktop() {
@@ -106,6 +109,13 @@ export class Browser {
     this.userAgent = userAgent;
     this.supported = supported;
     this.ua = new UAParser(userAgent);
+  }
+
+  // POS Go is a first party device that is not detected as a mobile device
+  isPOSFirstPartyDevice() {
+    return (
+      this.ua.getUA().includes('WSC6X') || this.ua.getUA().includes('WTH11')
+    );
   }
 }
 

--- a/packages/browser/src/tests/browser.test.ts
+++ b/packages/browser/src/tests/browser.test.ts
@@ -118,6 +118,13 @@ describe('Browser', () => {
 
       expect(new Browser({userAgent}).isMobile).toBe(false);
     });
+
+    it('returns true when the device is a POS Go device', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; Android 10; WSC6X Build/QKQ1.200816.002) Firefox/69.0';
+
+      expect(new Browser({userAgent}).isMobile).toBe(true);
+    });
   });
 
   describe('isIOS', () => {


### PR DESCRIPTION
## Description

Fixes [this issue in `pos-next-react-native`](https://github.com/Shopify/pos-next-react-native/issues/33275)

POS Go devices are not detected as mobile devices since the `getDevice().type` returns `undefined`. We're adding a method to check the device numbers which are part of the user agents. See parent issue for details.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
