### PR TITLE
feat: support onCompleted callback on useQuery

### DIFF
--- a/.changeset/tricky-walls-exercise.md
+++ b/.changeset/tricky-walls-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-graphql': minor
+---
+
+Add onCompleted callback support for useQuery

--- a/packages/react-graphql/src/hooks/query.ts
+++ b/packages/react-graphql/src/hooks/query.ts
@@ -48,6 +48,7 @@ export default function useQuery<
     notifyOnNetworkStatusChange,
     context,
     ssr = true,
+    onCompleted,
   } = options;
 
   const variables: Variables = options.variables || ({} as any);
@@ -176,6 +177,11 @@ export default function useQuery<
           ) {
             return;
           }
+
+          if (onCompleted && !status.loading && !status.error) {
+            onCompleted(status.data);
+          }
+
           invalidateCurrentResult();
         },
         (error) => {

--- a/packages/react-graphql/src/hooks/tests/query.test.tsx
+++ b/packages/react-graphql/src/hooks/tests/query.test.tsx
@@ -95,7 +95,7 @@ describe('useQuery', () => {
       );
     });
 
-    it('return loading=false, networkStatus and the data once the query resolved', async () => {
+    it('returns loading=false, networkStatus and the data once the query resolved', async () => {
       function MockQuery({children}) {
         const results = useQuery(petQuery);
         return children(results);
@@ -118,6 +118,26 @@ describe('useQuery', () => {
           data: mockData,
         }),
       );
+    });
+
+    it('calls onCompleted function when the query resolved', async () => {
+      const mockedOnCompleted = jest.fn();
+      function MockQuery({children}) {
+        const results = useQuery(petQuery, {
+          onCompleted: mockedOnCompleted,
+        });
+        return children(results);
+      }
+
+      const graphQL = createGraphQL({PetQuery: mockData});
+      const renderPropSpy = jest.fn(() => null);
+
+      await mountWithGraphQL(<MockQuery>{renderPropSpy}</MockQuery>, {
+        graphQL,
+      });
+
+      expect(mockedOnCompleted).toHaveBeenCalledTimes(1);
+      expect(mockedOnCompleted).toHaveBeenCalledWith(mockData);
     });
 
     it('keeps the same data when the variables stay deep-equal', async () => {


### PR DESCRIPTION
## Description

As as now, `useQuery` accepts `onCompleted` option yet does nothing. This PR adds support for that use case

The current situation is that folks need to combine `useLazyQuery` and `useEffect` to achieve similar behaviour which is less than idea IMHO
