### PR TITLE
Generic type for StatsDClient to accept restrictions

### DIFF
--- a/.changeset/fresh-bees-attack.md
+++ b/.changeset/fresh-bees-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/statsd': minor
+---
+
+Allow restriction on allowed metric names in StatsDClient

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -31,7 +31,7 @@ export interface MetricOptions {
 
 export type Options = ClientOptions | ChildOptions;
 
-export class StatsDClient {
+export class StatsDClient<Stat extends string = string> {
   protected statsd: StatsD;
   protected logger: Logger = console;
   protected options: ClientOptions;
@@ -77,7 +77,7 @@ export class StatsDClient {
   }
 
   distribution(
-    stat: string | string[],
+    stat: Stat | Stat[],
     value: number,
     tags?: Tags,
     options: MetricOptions = {},
@@ -94,7 +94,7 @@ export class StatsDClient {
   }
 
   timing(
-    stat: string | string[],
+    stat: Stat | Stat[],
     value: number,
     tags?: Tags,
     options: MetricOptions = {},
@@ -111,7 +111,7 @@ export class StatsDClient {
   }
 
   gauge(
-    stat: string | string[],
+    stat: Stat | Stat[],
     value: number,
     tags?: Tags,
     options: MetricOptions = {},
@@ -128,7 +128,7 @@ export class StatsDClient {
   }
 
   increment(
-    stat: string | string[],
+    stat: Stat | Stat[],
     tags?: Tags,
     options: MetricOptions = {},
     value = 1,
@@ -151,7 +151,7 @@ export class StatsDClient {
   }
 
   childClient(options?: Omit<ChildOptions, 'client'>) {
-    return new StatsDClient({client: this, ...options});
+    return new StatsDClient<Stat>({client: this, ...options});
   }
 
   addGlobalTags(globalTags: Tags) {

--- a/packages/statsd/src/client.ts
+++ b/packages/statsd/src/client.ts
@@ -150,8 +150,10 @@ export class StatsDClient<Stat extends string = string> {
     });
   }
 
-  childClient(options?: Omit<ChildOptions, 'client'>) {
-    return new StatsDClient<Stat>({client: this, ...options});
+  childClient<ChildStat extends string = Stat>(
+    options?: Omit<ChildOptions, 'client'>,
+  ) {
+    return new StatsDClient<ChildStat>({client: this, ...options});
   }
 
   addGlobalTags(globalTags: Tags) {


### PR DESCRIPTION

## Description

It is often useful to be able to create a StatsDClient that has a well-defined Stat type parameter that restricts the types of stat that can be emitted. This allows us to create a list of allowed metrics in a single place and ensure that we're not emitting any others.

This preserves the existing behaviour by defaulting to string, but allows the creation of a StatsDClient parameterized with a string union or string enum to restrict to a subset.

For example

```
const client = new StatsDClient<'foo' | 'bar'>(...);

client.increment('foo', 1);  // valid
client.increment('bar', 1);  // valid
client.increment('baz', 1);  // invalid
```

