### PR TITLE
allow to override worker public path

### DIFF
--- a/.changeset/tall-cooks-protect.md
+++ b/.changeset/tall-cooks-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/web-worker': minor
+---
+
+Allow to override worker public path

--- a/packages/web-worker/README.md
+++ b/packages/web-worker/README.md
@@ -127,6 +127,7 @@ The `WebWorkerPlugin` helps coordinate a few things during webpack compilation a
 
 - `globalObject`: allows you to customize the [`options.output.globalObject`](https://webpack.js.org/configuration/output/#outputglobalobject) option passed to the child Webpack compiler. By default, this is set to `self`, which works well in workers, but if you have a different global object that must be used, you can pass it here.
 - `plugins`: an array of [webpack plugins](https://webpack.js.org/plugins/) to include in the child compilation of the worker. This library automatically includes a few plugins that will generate output code appropriate for workers.
+- `publicPathGlobalVariable`: a global variable name to be read when prefixing the worker's script path. When this option is set, the loader assumes the global variable will always be defined. By default, this value is `__webpack_public_path__` which is always defined.
 
 #### Tests
 

--- a/packages/web-worker/src/webpack-parts/loader.ts
+++ b/packages/web-worker/src/webpack-parts/loader.ts
@@ -12,6 +12,7 @@ const moduleWrapperCache = new Map<string, string | false>();
 export interface Options {
   name?: string;
   wrapperModule?: string;
+  publicPathGlobalVariable?: string;
 }
 
 export function pitch(this: LoaderContext<Options>, request: string) {
@@ -135,9 +136,13 @@ export function pitch(this: LoaderContext<Options>, request: string) {
         return callback!(finalError);
       }
 
+      const publicPathGlobalVariable =
+        plugin.options.publicPathGlobalVariable ?? '__webpack_public_path__';
       return callback!(
         null,
-        `export default __webpack_public_path__ + ${JSON.stringify(entry)};`,
+        `export default ${publicPathGlobalVariable} + ${JSON.stringify(
+          entry,
+        )};`,
       );
     },
   );

--- a/packages/web-worker/src/webpack-parts/plugin.ts
+++ b/packages/web-worker/src/webpack-parts/plugin.ts
@@ -7,6 +7,7 @@ interface Options {
   globalObject?: string;
   plugins?: ReadonlyArray<WebpackPluginInstance>;
   filename?: string;
+  publicPathGlobalVariable?: string;
 }
 
 export class WebWorkerPlugin implements WebpackPluginInstance {


### PR DESCRIPTION
## Description

Allows to override `__worker_public_path__` with a plugin option. This is needed for using a custom Extension sandbox URL while not changing other URLs in webpack's build ([example](https://github.com/Shopify/checkout-web/pull/32079)).

