### PR TITLE
Feature: 📞 phone number formatter package

### DIFF
--- a/.changeset/sour-elephants-try.md
+++ b/.changeset/sour-elephants-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/phone': major
+---
+
+Phone number formatter initial release

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These libraries compose together to help you create performant modern JS apps th
 
 ## Usage
 
-The Quilt repo is managed as a monorepo that is composed of 70 npm packages and one Ruby gem.
+The Quilt repo is managed as a monorepo that is composed of 71 npm packages and one Ruby gem.
 Each package/gem has its own `README.md` and documentation describing usage.
 
 ### Package Index
@@ -52,6 +52,7 @@ Each package/gem has its own `README.md` and documentation describing usage.
 | [@shopify/name](packages/name) | <a href="https://badge.fury.io/js/%40shopify%2Fname"><img src="https://badge.fury.io/js/%40shopify%2Fname.svg" width="200px" /></a> | Name-related utilities |
 | [@shopify/network](packages/network) | <a href="https://badge.fury.io/js/%40shopify%2Fnetwork"><img src="https://badge.fury.io/js/%40shopify%2Fnetwork.svg" width="200px" /></a> | Common values related to dealing with the network |
 | [@shopify/performance](packages/performance) | <a href="https://badge.fury.io/js/%40shopify%2Fperformance"><img src="https://badge.fury.io/js/%40shopify%2Fperformance.svg" width="200px" /></a> | Primitives for collecting browser performance metrics |
+| [@shopify/phone](packages/phone) | <a href="https://badge.fury.io/js/%40shopify%2Fphone"><img src="https://badge.fury.io/js/%40shopify%2Fphone.svg" width="200px" /></a> | Phone number utilities for formatting phone numbers |
 | [@shopify/polyfills](packages/polyfills) | <a href="https://badge.fury.io/js/%40shopify%2Fpolyfills"><img src="https://badge.fury.io/js/%40shopify%2Fpolyfills.svg" width="200px" /></a> | Blessed polyfills for web platform features |
 | [@shopify/predicates](packages/predicates) | <a href="https://badge.fury.io/js/%40shopify%2Fpredicates"><img src="https://badge.fury.io/js/%40shopify%2Fpredicates.svg" width="200px" /></a> | A set of common JavaScript predicates |
 | [@shopify/react-app-bridge-universal-provider](packages/react-app-bridge-universal-provider) | <a href="https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider"><img src="https://badge.fury.io/js/%40shopify%2Freact-app-bridge-universal-provider.svg" width="200px" /></a> | A self-serializing/deserializing `app-bridge-react` provider that works for isomorphic applications |

--- a/packages/phone/CHANGELOG.md
+++ b/packages/phone/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- `@shopify/phone` package

--- a/packages/phone/CHANGELOG.md
+++ b/packages/phone/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-## Unreleased
-
-### Added
+## 1.0.0
 
 - `@shopify/phone` package

--- a/packages/phone/README.md
+++ b/packages/phone/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/Shopify/quilt/workflows/Node-CI/badge.svg?branch=main)](https://github.com/Shopify/quilt/actions?query=workflow%3ANode-CI)
 [![Build Status](https://github.com/Shopify/quilt/workflows/Ruby-CI/badge.svg?branch=main)](https://github.com/Shopify/quilt/actions?query=workflow%3ARuby-CI)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fphone.svg)](https://badge.fury.io/js/%40shopify%2Fphone.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/phone.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/phone.svg) 
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fphone.svg)](https://badge.fury.io/js/%40shopify%2Fphone.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/phone.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/phone.svg)
 
 Phone number utilities for formatting phone numbers.
 
@@ -12,4 +12,46 @@ Phone number utilities for formatting phone numbers.
 yarn add @shopify/phone
 ```
 
-## Usage
+## PhoneNumberFormatter methods
+
+```ts
+import PhoneNumberFormatter from '@shopify/phone';
+
+// Pass a region code to the constructor
+const phoneFormatter = new PhoneNumberFormatter('US');
+const formatted = phoneFormatter.format(myPhoneNumber);
+```
+
+#### `format(phoneNumber: string): string`
+
+Formats the given phone number
+
+#### `update(regionCode: string): void`
+
+Update formatter regionCode which will format number based on that (eg: 'CA' | 'JP' etc.)
+
+#### `getNormalizedNumber(phoneNumber: string): string`
+
+Returns phone number in E164 format
+
+#### `getNationalNumber(phoneNumber: string): string`
+
+Returns the non-formatted version without the country code
+
+#### `requiresItalianLeadingZero(phoneNumber: string)`
+
+Indicates if the leading zero of a national number should be retained when dialling internationally
+
+#### `updateCountryCode(phoneNumber: string): void`
+
+Updates the country code of the formatter based on the phoneNumber passed
+
+## Exported functions
+
+### `getRegionCodeFromNumber(phoneNumber: string): string`
+
+Returns the region code from the provided phone number
+
+### `getCountryCodeFromNumber(phoneNumber: string): number | undefined`
+
+Returns the country code from the provided phone number

--- a/packages/phone/README.md
+++ b/packages/phone/README.md
@@ -1,0 +1,15 @@
+# `@shopify/phone`
+
+[![Build Status](https://github.com/Shopify/quilt/workflows/Node-CI/badge.svg?branch=main)](https://github.com/Shopify/quilt/actions?query=workflow%3ANode-CI)
+[![Build Status](https://github.com/Shopify/quilt/workflows/Ruby-CI/badge.svg?branch=main)](https://github.com/Shopify/quilt/actions?query=workflow%3ARuby-CI)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fphone.svg)](https://badge.fury.io/js/%40shopify%2Fphone.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/phone.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/phone.svg) 
+
+Phone number utilities for formatting phone numbers.
+
+## Installation
+
+```bash
+yarn add @shopify/phone
+```
+
+## Usage

--- a/packages/phone/package.json
+++ b/packages/phone/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@shopify/phone",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Phone number utilities for formatting phone numbers",
+  "main": "index.js",
+  "types": "./build/ts/index.d.ts",
+  "scripts": {},
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/quilt.git",
+    "directory": "packages/phone"
+  },
+  "bugs": {
+    "url": "https://github.com/Shopify/quilt/issues"
+  },
+  "homepage": "https://github.com/Shopify/quilt/blob/main/packages/phone/README.md",
+  "engines": {
+    "node": "^14.17.0 || >=16.0.0"
+  },
+  "dependencies": {
+    "google-libphonenumber": "^3.2.17"
+  },
+  "devDependencies": {
+    "@types/google-libphonenumber": "^7.4.16"
+  },
+  "files": [
+    "build/",
+    "!build/*.tsbuildinfo",
+    "!build/ts/**/tests/",
+    "index.js",
+    "index.mjs",
+    "index.esnext"
+  ],
+  "module": "index.mjs",
+  "esnext": "index.esnext",
+  "exports": {
+    ".": {
+      "types": "./build/ts/index.d.ts",
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    }
+  }
+}

--- a/packages/phone/rollup.config.mjs
+++ b/packages/phone/rollup.config.mjs
@@ -1,0 +1,6 @@
+import {buildConfig} from '../../config/rollup.mjs';
+
+export default buildConfig(import.meta.url, {
+  entries: ['./src/index.ts'],
+  entrypoints: {index: './src/index.ts'},
+});

--- a/packages/phone/src/PhoneNumberFormatter.ts
+++ b/packages/phone/src/PhoneNumberFormatter.ts
@@ -1,0 +1,173 @@
+import {AsYouTypeFormatter, PhoneNumberFormat} from 'google-libphonenumber';
+
+import {
+  digitOnlyNumber,
+  FORMATTING_CHARACTERS_REGEX,
+  getRegionCodeForNumber,
+  phoneUtil,
+} from './utilities';
+
+const US_COUNTRY_CODE = '1';
+const RUSSIA_COUNTRY_CODE = '7';
+
+export default class PhoneNumberFormatter {
+  formatter: AsYouTypeFormatter;
+  regionCode: string;
+  countryCode: number;
+
+  constructor(regionCode: string) {
+    this.regionCode = regionCode;
+    this.countryCode = getCountryCodeFromRegionCode(regionCode);
+    this.formatter = new AsYouTypeFormatter(this.regionCode);
+  }
+
+  format(phoneNumber: string): string {
+    this.updateCountryCode(phoneNumber);
+    this.formatter.clear();
+    return formatNumber(phoneNumber, this.formatter) || '';
+  }
+
+  /*
+   * Update formatter regionCode which will format number based on that
+   * region code
+   * @regionCode: eg: 'CA' | 'JP' etc.
+   */
+  update(regionCode: string): void {
+    this.countryCode = getCountryCodeFromRegionCode(regionCode);
+    this.regionCode = regionCode;
+    this.formatter = new AsYouTypeFormatter(this.regionCode);
+  }
+
+  // This returns phone number in E164 format.
+  getNormalizedNumber(phoneNumber: string): string {
+    try {
+      const parsedPhoneNumber = phoneUtil().parseAndKeepRawInput(
+        phoneNumber,
+        this.regionCode,
+      );
+      return phoneUtil().format(parsedPhoneNumber, PhoneNumberFormat.E164);
+    } catch (_err) {
+      return phoneNumber;
+    }
+  }
+
+  getNationalNumber(phoneNumber: string): string {
+    const onlyDigitsNumber = digitOnlyNumber(phoneNumber);
+    if (!this.regionCode || onlyDigitsNumber.length < 4) {
+      // phoneUtil() cannot find the national number when the phone number is too short
+      // so we try to guess based on single digit country codes (1 - US, 7 - RU)
+      if (
+        onlyDigitsNumber.startsWith(US_COUNTRY_CODE) ||
+        onlyDigitsNumber.startsWith(RUSSIA_COUNTRY_CODE)
+      ) {
+        return phoneNumber.slice(3);
+      }
+      return '';
+    }
+    try {
+      const nationalNumber = phoneUtil()
+        .parseAndKeepRawInput(phoneNumber, this.regionCode)
+        .getNationalNumber();
+
+      return nationalNumber ? nationalNumber.toString() : '';
+    } catch (_err) {
+      return '';
+    }
+  }
+
+  // Indicates if the leading zero of a national number should be retained when dialling internationally
+  requiresItalianLeadingZero(phoneNumber: string) {
+    try {
+      return Boolean(
+        phoneUtil()
+          .parseAndKeepRawInput(phoneNumber, this.regionCode)
+          .getItalianLeadingZero(),
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  /*
+   * Updates the country code of the formatter based on the phoneNumber passed
+   */
+  private updateCountryCode(phoneNumber: string): void {
+    if (!phoneNumber.includes('+') || digitOnlyNumber(phoneNumber).length < 1) {
+      return;
+    }
+
+    let newRegionCode;
+
+    /* If country code is 1, the region code can be CA or US, so we need to
+     * guess base on the phone number.
+     * This can only be done when phone number is long enough
+     */
+    if (digitOnlyNumber(phoneNumber).length > 4) {
+      newRegionCode = getRegionCodeForNumber(phoneNumber);
+    } else {
+      const newCountryCode = getCountryCodeFromNumber(phoneNumber);
+      if (newCountryCode && this.countryCode !== newCountryCode) {
+        newRegionCode = getRegionCodeForCountryCode(newCountryCode);
+      }
+    }
+
+    if (newRegionCode) {
+      this.update(newRegionCode);
+    }
+  }
+}
+
+function getCountryCodeFromRegionCode(regionCode: string): number {
+  return parseInt(phoneUtil().getCountryCodeForRegion(regionCode), 10);
+}
+
+export function getRegionCodeFromNumber(phoneNumber: string): string {
+  const countryCodeFromNumber = getCountryCodeFromNumber(phoneNumber);
+
+  return (
+    getRegionCodeForNumber(phoneNumber) ||
+    (countryCodeFromNumber &&
+      getRegionCodeForCountryCode(countryCodeFromNumber)) ||
+    getRegionCodeForCountryCode(1)
+  );
+}
+
+export function getCountryCodeFromNumber(
+  phoneNumber: string,
+): number | undefined {
+  /*
+   * we map (1 - US, 7 - RU) when the phone number is too short (this handles the key by key input)
+   */
+  const onlyDigitsNumber = digitOnlyNumber(phoneNumber);
+  if (onlyDigitsNumber.length < 4) {
+    if (onlyDigitsNumber.startsWith(US_COUNTRY_CODE)) {
+      return Number(US_COUNTRY_CODE);
+    }
+    if (onlyDigitsNumber.startsWith(RUSSIA_COUNTRY_CODE)) {
+      return Number(RUSSIA_COUNTRY_CODE);
+    }
+  }
+
+  try {
+    return phoneUtil().parse(phoneNumber).getCountryCode();
+  } catch (_err) {
+    return parseInt(phoneNumber.split(' ')[0].replace('+', ''), 10);
+  }
+}
+
+function getRegionCodeForCountryCode(countryCode: number): string {
+  return phoneUtil().getRegionCodeForCountryCode(countryCode);
+}
+
+function formatNumber(
+  phoneNumber: string,
+  formatter: AsYouTypeFormatter,
+): string | undefined {
+  let newValue;
+
+  for (const char of phoneNumber.replace(FORMATTING_CHARACTERS_REGEX, '')) {
+    newValue = formatter.inputDigit(char);
+  }
+
+  return newValue;
+}

--- a/packages/phone/src/PhoneNumberFormatter.ts
+++ b/packages/phone/src/PhoneNumberFormatter.ts
@@ -118,7 +118,7 @@ export default class PhoneNumberFormatter {
 }
 
 function getCountryCodeFromRegionCode(regionCode: string): number {
-  return parseInt(phoneUtil().getCountryCodeForRegion(regionCode), 10);
+  return phoneUtil().getCountryCodeForRegion(regionCode);
 }
 
 export function getRegionCodeFromNumber(phoneNumber: string): string {

--- a/packages/phone/src/index.ts
+++ b/packages/phone/src/index.ts
@@ -1,0 +1,2 @@
+export {default, getRegionCodeFromNumber} from './PhoneNumberFormatter';
+export * from './utilities';

--- a/packages/phone/src/tests/PhoneNumberFormatter.test.ts
+++ b/packages/phone/src/tests/PhoneNumberFormatter.test.ts
@@ -1,0 +1,176 @@
+import PhoneNumberFormatter, {
+  getRegionCodeFromNumber,
+  getCountryCodeFromNumber,
+} from '../PhoneNumberFormatter';
+
+describe('PhoneNumberFormatter', () => {
+  const subject = new PhoneNumberFormatter('CA');
+
+  describe('#format', () => {
+    let formattedNumber: string;
+
+    describe('without + sign', () => {
+      describe('in Canada', () => {
+        beforeEach(() => {
+          subject.update('CA');
+          formattedNumber = subject.format('5144319512');
+        });
+
+        it('formats the number', () => {
+          expect(formattedNumber).toBe('(514) 431-9512');
+        });
+      });
+
+      describe('in France', () => {
+        beforeEach(() => {
+          subject.update('FR');
+          formattedNumber = subject.format('0607653323');
+        });
+
+        it('formats the number', () => {
+          expect(formattedNumber).toBe('06 07 65 33 23');
+        });
+      });
+
+      describe('in Ivory Coast', () => {
+        beforeEach(() => {
+          subject.update('CI');
+          formattedNumber = subject.format('0708990971');
+        });
+
+        it('formats the number', () => {
+          expect(formattedNumber).toBe('07 08 99 0971');
+        });
+      });
+    });
+
+    describe('with + sign', () => {
+      describe('in Canada', () => {
+        beforeEach(() => {
+          formattedNumber = subject.format('+15144319512');
+        });
+
+        it('formats the number and update region code', () => {
+          expect(formattedNumber).toBe('+1 514-431-9512');
+          expect(subject.countryCode).toBe(1);
+          expect(subject.regionCode).toBe('CA');
+        });
+      });
+
+      describe('in France', () => {
+        beforeEach(() => {
+          formattedNumber = subject.format('+33607653323');
+        });
+
+        it('formats the number and update region code', () => {
+          expect(formattedNumber).toBe('+33 6 07 65 33 23');
+          expect(subject.countryCode).toBe(33);
+          expect(subject.regionCode).toBe('FR');
+        });
+      });
+
+      describe('in Ivory Coast', () => {
+        beforeEach(() => {
+          formattedNumber = subject.format('+2250708990971');
+        });
+
+        it('formats the number and update region code', () => {
+          expect(formattedNumber).toBe('+225 07 08 99 0971');
+          expect(subject.countryCode).toBe(225);
+          expect(subject.regionCode).toBe('CI');
+        });
+      });
+    });
+  });
+
+  describe('#update', () => {
+    describe('when regionCode is passed', () => {
+      beforeEach(() => {
+        subject.update('FR');
+      });
+
+      it('sets the country code associated with the region code', () => {
+        expect(subject.countryCode).toBe(33);
+      });
+    });
+
+    describe('when countryCode is passed', () => {
+      beforeEach(() => {
+        subject.update('FR');
+      });
+
+      it('sets the region code associated with the country code', () => {
+        expect(subject.regionCode).toBe('FR');
+      });
+    });
+  });
+
+  describe('#getNormalizedNumber', () => {
+    let e164Number: string;
+
+    beforeEach(() => {
+      subject.update('CA');
+      e164Number = subject.getNormalizedNumber('(514) 431-9512');
+    });
+
+    it('returns e164 format', () => {
+      expect(e164Number).toBe('+15144319512');
+    });
+  });
+
+  describe('#getNationalNumber', () => {
+    it('returns Canadian national number', () => {
+      expect(subject.getNationalNumber('+15144319512')).toBe('5144319512');
+    });
+
+    it('returns French national number', () => {
+      expect(subject.getNationalNumber('+3365454')).toBe('65454');
+    });
+
+    it('returns an American national number when the input is digit by digit', () => {
+      expect(subject.getNationalNumber('+1 8')).toBe('8');
+    });
+
+    it('returns a Russian national number when the input is digit by digit', () => {
+      expect(subject.getNationalNumber('+7 12')).toBe('12');
+    });
+
+    it('returns ""', () => {
+      expect(subject.getNationalNumber('+33')).toBe('');
+    });
+  });
+
+  describe('#getCountryCodeFromNumber', () => {
+    it('returns US country number', () => {
+      expect(getCountryCodeFromNumber('+1')).toBe(1);
+    });
+
+    it('returns Canadian country number', () => {
+      expect(getCountryCodeFromNumber('+15144319512')).toBe(1);
+    });
+
+    it('returns French country number', () => {
+      expect(getCountryCodeFromNumber('+3365454')).toBe(33);
+    });
+  });
+
+  describe('#requiresItalianLeadingZero', () => {
+    it('returns false for French number', () => {
+      expect(subject.requiresItalianLeadingZero('+33680086523')).toBe(false);
+    });
+
+    it('returns true for Ivory Coast number', () => {
+      expect(subject.requiresItalianLeadingZero('+2250708990971')).toBe(true);
+    });
+
+    it('returns undefined for invalid input', () => {
+      expect(subject.requiresItalianLeadingZero('INVALID')).toBeUndefined();
+    });
+  });
+
+  describe('#incompleteNumber', () => {
+    it('gets region code from incomplete number', () => {
+      expect(getRegionCodeFromNumber('+234')).toBe('NG');
+    });
+  });
+});

--- a/packages/phone/src/tests/utilities.test.ts
+++ b/packages/phone/src/tests/utilities.test.ts
@@ -148,7 +148,7 @@ describe('Utilities', () => {
     it('returns the result of calling isValidNumber on the phoneUtil instance', () => {
       mockPhoneInstance.isValidNumber.mockImplementation(() => true);
 
-      expect(validatePhoneNumber('')).toBeTrue();
+      expect(validatePhoneNumber('')).toBe(true);
     });
 
     it('returns false if there is an error', () => {
@@ -156,7 +156,7 @@ describe('Utilities', () => {
         throw new Error('test');
       });
 
-      expect(validatePhoneNumber('')).toBeFalse();
+      expect(validatePhoneNumber('')).toBe(false);
     });
   });
 });

--- a/packages/phone/src/tests/utilities.test.ts
+++ b/packages/phone/src/tests/utilities.test.ts
@@ -1,0 +1,162 @@
+import {
+  getNewCaretPosition,
+  setCaretPosition,
+  digitOnlyNumber,
+  getCleanNumber,
+  isFormattingChar,
+  getRegionCodeForNumber,
+  phoneUtil,
+  validatePhoneNumber,
+} from '../utilities';
+
+jest.mock('google-libphonenumber', () => ({
+  PhoneNumberUtil: {
+    getInstance: jest.fn(() => ({...mockPhoneInstance})),
+  },
+}));
+
+const mockPhoneInstance = {
+  getRegionCodeForNumber: jest.fn(),
+  isValidNumber: jest.fn(),
+  parseAndKeepRawInput: jest.fn(),
+};
+
+describe('Utilities', () => {
+  beforeEach(() => {
+    mockPhoneInstance.getRegionCodeForNumber.mockReset();
+    mockPhoneInstance.isValidNumber.mockReset();
+    mockPhoneInstance.parseAndKeepRawInput.mockReset();
+
+    mockPhoneInstance.parseAndKeepRawInput.mockImplementation((input) => input);
+  });
+
+  describe('#getNewCaretPosition', () => {
+    it('returns caret position', () => {
+      expect(getNewCaretPosition('foobar', 'foo')).toBe(3);
+    });
+  });
+
+  describe('#setCaretPosition', () => {
+    it('sets caret position', () => {
+      const element = document.createElement('input');
+      element.value = '123456789';
+
+      setCaretPosition(2, element);
+
+      expect(element.selectionStart).toBe(2);
+      expect(element.selectionEnd).toBe(2);
+    });
+  });
+
+  describe('#digitOnlyNumber', () => {
+    it('returns digits only', () => {
+      expect(digitOnlyNumber('+1 (514) 431-9512')).toBe('15144319512');
+    });
+
+    it('strips letters', () => {
+      expect(digitOnlyNumber('+1 (514) 431-9512 ext. 001')).toBe(
+        '15144319512001',
+      );
+    });
+  });
+
+  describe('#isFormattingChar', () => {
+    it('returns false when the character is not a formatting character', () => {
+      expect(isFormattingChar('1')).toBe(false);
+    });
+
+    it('returns true when the character is a formatting character', () => {
+      expect(isFormattingChar('-')).toBe(true);
+      expect(isFormattingChar('(')).toBe(true);
+      expect(isFormattingChar(')')).toBe(true);
+      expect(isFormattingChar(' ')).toBe(true);
+      expect(isFormattingChar('.')).toBe(true);
+    });
+  });
+
+  describe('#getCleanNumber', () => {
+    let cleanNumber: string;
+
+    beforeEach(() => {
+      cleanNumber = getCleanNumber('+1 (514) 431-9512');
+    });
+
+    it('returns the passed number without the formatting characters', () => {
+      expect(cleanNumber).toBe('+15144319512');
+    });
+  });
+
+  describe('#getRegionCodeForNumber', () => {
+    it('calls getRegionCodeForNumber on the phoneUtil instance', () => {
+      const phoneNumber = '+15144319512';
+
+      getRegionCodeForNumber(phoneNumber);
+
+      expect(mockPhoneInstance.getRegionCodeForNumber).toHaveBeenCalledWith(
+        phoneNumber,
+      );
+    });
+
+    it('returns the result of calling getRegionCodeForNumber on the phoneUtil instance', () => {
+      const regionCode = 'CA';
+      mockPhoneInstance.getRegionCodeForNumber.mockImplementation(
+        () => regionCode,
+      );
+
+      expect(getRegionCodeForNumber('')).toBe(regionCode);
+    });
+
+    it('returns empty string if there is an error', () => {
+      mockPhoneInstance.getRegionCodeForNumber.mockImplementation(() => {
+        throw new Error('test');
+      });
+
+      expect(getRegionCodeForNumber('')).toBe('');
+    });
+  });
+
+  describe('#phoneUtil', () => {
+    it('returns the same instance for multiple calls', () => {
+      expect(phoneUtil()).toBe(phoneUtil());
+    });
+  });
+
+  describe('#validatePhoneNumber', () => {
+    it('calls isValidNumber on the phoneUtil instance', () => {
+      const phoneNumber = '+15144319512';
+      const regionCode = 'CA';
+
+      validatePhoneNumber(phoneNumber, regionCode);
+
+      expect(mockPhoneInstance.parseAndKeepRawInput).toHaveBeenCalledWith(
+        phoneNumber,
+        regionCode,
+      );
+      expect(mockPhoneInstance.isValidNumber).toHaveBeenCalledWith(phoneNumber);
+    });
+
+    it('uses getRegionCodeForNumber if no region code is provided', () => {
+      const phoneNumber = '+15144319512';
+
+      validatePhoneNumber(phoneNumber);
+
+      expect(mockPhoneInstance.getRegionCodeForNumber).toHaveBeenCalledWith(
+        phoneNumber,
+      );
+    });
+
+    it('returns the result of calling isValidNumber on the phoneUtil instance', () => {
+      mockPhoneInstance.isValidNumber.mockImplementation(() => true);
+
+      expect(validatePhoneNumber('')).toBeTrue();
+    });
+
+    it('returns false if there is an error', () => {
+      mockPhoneInstance.isValidNumber.mockImplementation(() => {
+        throw new Error('test');
+      });
+
+      expect(validatePhoneNumber('')).toBeFalse();
+    });
+  });
+});

--- a/packages/phone/src/utilities.ts
+++ b/packages/phone/src/utilities.ts
@@ -1,0 +1,83 @@
+import {PhoneNumberUtil, PhoneNumberFormat} from 'google-libphonenumber';
+
+export {PhoneNumberFormat};
+export const FORMATTING_CHARACTERS_REGEX = /[()\-. ]+/g;
+
+let phoneNumberUtil: PhoneNumberUtil;
+
+/*
+ * This is to get the cursor position when adding characters in the middle
+ * of the number.
+ */
+export function getNewCaretPosition(textBeforeCaret: string, fullText: string) {
+  let caretPosition = 0;
+  let textCopy = textBeforeCaret;
+
+  for (const char of fullText) {
+    if (!textCopy && !isFormattingChar(char)) {
+      break;
+    }
+
+    if (char === textCopy[0]) {
+      textCopy = textCopy.substring(1);
+    }
+
+    caretPosition++;
+  }
+
+  return caretPosition;
+}
+
+export function setCaretPosition(position: number, element?: HTMLInputElement) {
+  if (!element) {
+    return;
+  }
+
+  if (typeof element.selectionStart === 'undefined') {
+    element.focus();
+    return;
+  }
+
+  element.focus();
+  element.setSelectionRange(position, position);
+}
+
+export function digitOnlyNumber(phoneNumber: string): string {
+  return phoneNumber.replace(/\D/g, '');
+}
+
+export function isFormattingChar(char: string): boolean {
+  return char.search(FORMATTING_CHARACTERS_REGEX) > -1;
+}
+
+export function getCleanNumber(phoneNumber: string): string {
+  return phoneNumber.replace(FORMATTING_CHARACTERS_REGEX, '');
+}
+
+export function getRegionCodeForNumber(
+  phoneNumber: string,
+): string | undefined {
+  try {
+    const parsedPhoneNumber = phoneUtil().parseAndKeepRawInput(phoneNumber);
+    return phoneUtil().getRegionCodeForNumber(parsedPhoneNumber);
+  } catch (_err) {
+    return '';
+  }
+}
+
+export function phoneUtil(): PhoneNumberUtil {
+  return phoneNumberUtil || (phoneNumberUtil = PhoneNumberUtil.getInstance());
+}
+
+export function validatePhoneNumber(phoneNumber: string, regionCode?: string) {
+  try {
+    return phoneUtil().isValidNumber(
+      phoneUtil().parseAndKeepRawInput(
+        phoneNumber,
+        regionCode || getRegionCodeForNumber(phoneNumber),
+      ),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/phone/tsconfig.json
+++ b/packages/phone/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../config/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./build/ts",
+    "rootDir": "src",
+    "baseUrl": "src"
+  },
+  "include": [
+    "../../config/typescript/*.ts",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/tests/no-new-packages.test.ts
+++ b/tests/no-new-packages.test.ts
@@ -41,6 +41,7 @@ describe('no new packages', () => {
       'name',
       'network',
       'performance',
+      'phone',
       'polyfills',
       'predicates',
       'react-app-bridge-universal-provider',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
     {"path": "./packages/name"},
     {"path": "./packages/network"},
     {"path": "./packages/performance"},
+    {"path": "./packages/phone"},
     {"path": "./packages/polyfills"},
     {"path": "./packages/predicates"},
     {"path": "./packages/react-app-bridge-universal-provider"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3226,6 +3226,11 @@
   dependencies:
     globby "*"
 
+"@types/google-libphonenumber@^7.4.16":
+  version "7.4.30"
+  resolved "https://registry.yarnpkg.com/@types/google-libphonenumber/-/google-libphonenumber-7.4.30.tgz#a47ed8f1f237bd43edbd1c8aff24400b0fd9b2fe"
+  integrity sha512-Td1X1ayRxePEm6/jPHUBs2tT6TzW1lrVB6ZX7ViPGellyzO/0xMNi+wx5nH6jEitjznq276VGIqjK5qAju0XVw==
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -8136,6 +8141,11 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+google-libphonenumber@^3.2.17:
+  version "3.2.34"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.34.tgz#ef29b53be0f9fb517aaa53d26a541150f86ec921"
+  integrity sha512-CLwkp0lZvMywh6dCh0T3Fm8XsfJhLAupc8AECwYkJNQBPW8wQPrv/tV0oFKCs8FMw+pTQyNPZoycgBzYjqtTZQ==
 
 gopd@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description

Adds a new `/phone` package which exports utilities to format phone numbers across Shopify (similar to the `/address` package)

Fixes https://github.com/Shopify/quilt/issues/2749

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
