### PR TITLE
Support webpack-virtual-modules 0.6.x

### DIFF
--- a/.changeset/red-points-suffer.md
+++ b/.changeset/red-points-suffer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/web-worker': patch
+---
+
+Widen peerDependency range for webpack-virtual-modules, to allow for v0.6.x

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -106,7 +106,7 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0",
     "webpack": "^5.38.0",
-    "webpack-virtual-modules": "^0.4.3 || ^0.5.0"
+    "webpack-virtual-modules": "^0.4.3 || ^0.5.0 || ^0.6.0"
   },
   "peerDependenciesMeta": {
     "@babel/core": {


### PR DESCRIPTION
## Description

Widen webpack-virtual-modules dependency range to allow for v0.6.x
