### PR TITLE
Safely require cleanDocument/toSimpleDocument in graphql-mini-transforms

### DIFF
--- a/.changeset/dirty-ghosts-cheat.md
+++ b/.changeset/dirty-ghosts-cheat.md
@@ -1,0 +1,5 @@
+---
+'graphql-mini-transforms': patch
+---
+
+Prevent bad cache entry for jest and jest-simple transforms referencing stale node_modules paths

--- a/packages/graphql-mini-transforms/src/jest-simple.ts
+++ b/packages/graphql-mini-transforms/src/jest-simple.ts
@@ -21,9 +21,7 @@ const transformer: Transformer = {
 
     const utilityImports = `
         var {print, parse} = require('graphql');
-        var {cleanDocument, toSimpleDocument} = require(${JSON.stringify(
-          `${__dirname}/document.js`,
-        )});
+        var {cleanDocument, toSimpleDocument} = require('graphql-mini-transforms');
       `;
 
     const importSource = imports

--- a/packages/graphql-mini-transforms/src/jest.ts
+++ b/packages/graphql-mini-transforms/src/jest.ts
@@ -21,9 +21,7 @@ const transformer: Transformer = {
 
     const utilityImports = `
       var {print} = require('graphql');
-      var {cleanDocument} = require(${JSON.stringify(
-        `${__dirname}/document.js`,
-      )});
+      var {cleanDocument} = require('graphql-mini-transforms');
     `;
 
     const importSource = imports


### PR DESCRIPTION


## Description

Fixes https://github.com/Shopify/quilt/issues/2759

The "jest" and "jest-simple" transforms for graphql-mini-transforms use __dirname in order to retrieve the absolute path to the relative file "document.js" when loading the cleanDocument and toSimpleDocument utilities.

As a result, when the path to these files changes, such as when the package is updated under a manager like pnpm, the directory path will be different but the cache key will not change, causing it to try and use the Jest cached version of these files

Since both cleanDocument and toSimpleDocument are exported at the top-level, we should just reference the `graphql-mini-transforms` package directly in the require statement.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
