### PR TITLE
Add signupOnly variable to the query

### DIFF
--- a/.changeset/early-ants-look.md
+++ b/.changeset/early-ants-look.md
@@ -1,0 +1,5 @@
+---
+'@shopify/address': patch
+---
+
+Add `signupOnly` parameter to fetch supported countries for shop creation

--- a/packages/address/src/AddressFormatter.ts
+++ b/packages/address/src/AddressFormatter.ts
@@ -32,13 +32,19 @@ export default class AddressFormatter {
     return loadCountry(this.locale, countryCode, {includeHiddenZones});
   }
 
-  async getCountries({includeHiddenZones = false} = {}): Promise<Country[]> {
+  async getCountries({
+    includeHiddenZones = false,
+    signupOnly = false,
+  } = {}): Promise<Country[]> {
     const cacheKey = this.cacheKey(this.locale, includeHiddenZones);
     const cachedCountries = ORDERED_COUNTRIES_CACHE.get(cacheKey);
 
     if (cachedCountries) return cachedCountries;
 
-    const countries = await loadCountries(this.locale, {includeHiddenZones});
+    const countries = await loadCountries(this.locale, {
+      includeHiddenZones,
+      signupOnly,
+    });
     ORDERED_COUNTRIES_CACHE.set(cacheKey, countries);
 
     return countries;

--- a/packages/address/src/graphqlQuery.ts
+++ b/packages/address/src/graphqlQuery.ts
@@ -1,6 +1,6 @@
 const query = `
-query countries($locale: SupportedLocale!) {
-  countries(locale: $locale) {
+query countries($locale: SupportedLocale!, $signupOnly: Boolean) {
+  countries(locale: $locale, signupOnly: $signupOnly) {
     name
     code
     continent

--- a/packages/address/src/loader.ts
+++ b/packages/address/src/loader.ts
@@ -14,9 +14,12 @@ import query from './graphqlQuery';
 
 export const loadCountries: (
   locale: string,
-  options?: {includeHiddenZones?: boolean},
+  options?: {includeHiddenZones?: boolean; signupOnly?: boolean},
 ) => Promise<Country[]> = memoizeAsync(
-  async (locale: string, {includeHiddenZones = false} = {}) => {
+  async (
+    locale: string,
+    {includeHiddenZones = false, signupOnly = false} = {},
+  ) => {
     const response = await fetch(GRAPHQL_ENDPOINT, {
       method: 'POST',
       headers: HEADERS,
@@ -26,6 +29,7 @@ export const loadCountries: (
         variables: {
           locale: locale.replace(/-/, '_').toUpperCase(),
           includeHiddenZones,
+          signupOnly,
         },
       }),
     });


### PR DESCRIPTION
## Description

Fixes partially: https://github.com/Shopify/mobile/issues/28007

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

When creating a shop, we need a list of supported countries to show to the user. The supported countries for shop creation returns only if we pass `signupOnly` to the countries query.

In this change we're adding the parameter as an opt-in, without any breaking changes.