### PR TITLE
Widen peerdeps in web-worker and graphql-mini-transforms

### DIFF
--- a/.changeset/khaki-owls-train.md
+++ b/.changeset/khaki-owls-train.md
@@ -1,0 +1,5 @@
+---
+'graphql-mini-transforms': patch
+---
+
+Allow rollup ^4.0.0 as a peer dependency

--- a/.changeset/ninety-emus-own.md
+++ b/.changeset/ninety-emus-own.md
@@ -1,0 +1,5 @@
+---
+'@shopify/web-worker': patch
+---
+
+Allow webpack-virtual-modules ^0.6.0 as a peer dependency

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -57,7 +57,7 @@
     "webpack": "^5.38.0"
   },
   "peerDependencies": {
-    "rollup": "^3.0.0",
+    "rollup": "^3.0.0 || ^4.0.0",
     "webpack": "^5.38.0"
   },
   "peerDependenciesMeta": {

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -106,7 +106,7 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0",
     "webpack": "^5.38.0",
-    "webpack-virtual-modules": "^0.4.3 || ^0.5.0"
+    "webpack-virtual-modules": "^0.4.3 || ^0.5.0 || ^0.6.0"
   },
   "peerDependenciesMeta": {
     "@babel/core": {


### PR DESCRIPTION
## Description

Over in checkout-web we're getting peer dependency warnings as we're using rollup v4 and webpack-virtual-modules v0.6.

Fix that by:
- Allowing rollup ^4.0.0 as a peerDep in graphql-mini-transforms
- Allowing webpack-virtual-modules ^0.6.0 as a peerDep in web-worker
