### PR TITLE
Use act from 'react'

### DIFF
--- a/.changeset/flat-paws-exercise.md
+++ b/.changeset/flat-paws-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-testing': minor
+---
+
+Change act to use from 'react' if it exists, fallback to 'react-dom/test-utils'

--- a/packages/react-testing/src/compat.ts
+++ b/packages/react-testing/src/compat.ts
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
 import type {Root as ReactRoot} from 'react-dom/client';
+import {act as oldAct} from 'react-dom/test-utils';
 
 import type {ReactInstance, Fiber} from './types';
 
@@ -37,6 +38,16 @@ export function createRoot(element: HTMLElement): ReactRoot {
 }
 
 export const isLegacyReact = parseInt(React.version, 10) < 18;
+
+export const act: typeof oldAct = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const {act} = require('react');
+    return act ?? oldAct;
+  } catch {
+    return oldAct;
+  }
+})();
 
 // https://github.com/facebook/react/blob/12adaffef7105e2714f82651ea51936c563fe15c/packages/shared/enqueueTask.js#L13
 let enqueueTaskImpl: any = null;

--- a/packages/react-testing/src/root.tsx
+++ b/packages/react-testing/src/root.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import {flushSync} from 'react-dom';
 import type {Root as ReactRoot} from 'react-dom/client';
-import {act} from 'react-dom/test-utils';
 import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection.js';
 
 import {TestWrapper} from './TestWrapper';
 import {Element} from './element';
-import {createRoot, getInternals, enqueueTask, isLegacyReact} from './compat';
+import {
+  createRoot,
+  getInternals,
+  enqueueTask,
+  isLegacyReact,
+  act,
+} from './compat';
 import type {
   Fiber,
   Node,


### PR DESCRIPTION
## Description

In React 18.3, they have deprecated `act` from `react-dom/test-utils` and instead export it directly from `react`. To help with backwards compatibility, we can use it from `react` if the repo has >18.3.1 and fallback otherwise.