### PR TITLE
Support graphql v16

### DIFF
--- a/.changeset/empty-spiders-sparkle.md
+++ b/.changeset/empty-spiders-sparkle.md
@@ -1,0 +1,11 @@
+---
+'graphql-fixtures': minor
+'graphql-mini-transforms': minor
+'@shopify/graphql-testing': minor
+'graphql-tool-utilities': minor
+'graphql-typed': minor
+'graphql-typescript-definitions': minor
+'graphql-validate-fixtures': minor
+---
+
+Add graphql `^16.0.0` as an allowable graphql dependency version

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "fs-extra": "^9.1.0",
     "get-port": "^5.0.0",
     "glob": "^7.1.6",
-    "graphql": "^15.4.0",
+    "graphql": "^16.8.1",
     "intl-pluralrules": "^0.2.1",
     "jest": "^29.4.2",
     "jest-environment-jsdom": "^29.4.2",

--- a/packages/graphql-fixtures/package.json
+++ b/packages/graphql-fixtures/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@faker-js/faker": "^8.4.0",
     "@shopify/useful-types": "^5.1.2",
-    "graphql": ">=14.5.0 <16.0.0",
+    "graphql": ">=14.5.0 <17.0.0",
     "graphql-tool-utilities": "^3.0.3"
   },
   "peerDependencies": {

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -12,6 +12,7 @@ import {
   isListType,
   isAbstractType,
   isScalarType,
+  isInputObjectType,
 } from 'graphql';
 import type {DocumentNode, GraphQLOperation} from 'graphql-typed';
 import type {IfEmptyObject, IfAllNullableKeys} from '@shopify/useful-types';
@@ -439,6 +440,10 @@ function fillType<Request extends GraphQLRequest<any, any, any> | null>(
 
   if (field.fieldName === '__typename') {
     return parent.name;
+  } else if (isInputObjectType(unwrappedType)) {
+    // We almost certainly won't ever have to deal with an InputObjectType.
+    // This is mostly here to keep typescript happy
+    return unwrappedType.name;
   } else if (isEnumType(unwrappedType) || isScalarType(unwrappedType)) {
     return createValue(
       partial,

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@jest/transform": ">= 27 <29",
     "fs-extra": "^9.1.0",
-    "graphql": ">=14.5.0 <16.0.0",
+    "graphql": ">=14.5.0 <17.0.0",
     "graphql-typed": "^2.0.2"
   },
   "devDependencies": {

--- a/packages/graphql-testing/package.json
+++ b/packages/graphql-testing/package.json
@@ -31,7 +31,7 @@
     "node": "^14.17.0 || >=16.0.0"
   },
   "dependencies": {
-    "graphql": ">=14.5.0 <16.0.0",
+    "graphql": ">=14.5.0 <17.0.0",
     "jest-matcher-utils": "^26.6.2"
   },
   "devDependencies": {

--- a/packages/graphql-testing/src/links/mocks.ts
+++ b/packages/graphql-testing/src/links/mocks.ts
@@ -19,7 +19,7 @@ export class MockLink extends ApolloLink {
       const {mock} = this;
       const {operationName = ''} = operation;
 
-      let response: object | null = null;
+      let response: Error | ExecutionResult['data'] | null = null;
 
       if (typeof mock === 'function') {
         response = mock(operation);

--- a/packages/graphql-testing/src/types.ts
+++ b/packages/graphql-testing/src/types.ts
@@ -1,4 +1,4 @@
-import type {DocumentNode} from 'graphql';
+import type {DocumentNode, ExecutionResult} from 'graphql';
 import type {GraphQLRequest, Operation} from '@apollo/client';
 
 export interface FindOptions {
@@ -6,7 +6,7 @@ export interface FindOptions {
   mutation?: DocumentNode;
 }
 
-export type MockGraphQLResponse = Error | object;
+export type MockGraphQLResponse = Error | ExecutionResult['data'];
 export type MockGraphQLFunction = (
   request: GraphQLRequest,
 ) => MockGraphQLResponse;

--- a/packages/graphql-tool-utilities/package.json
+++ b/packages/graphql-tool-utilities/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "apollo-codegen-core": "^0.40.4",
-    "graphql": ">=14.5.0 <16.0.0"
+    "graphql": ">=14.5.0 <17.0.0"
   },
   "files": [
     "build/",

--- a/packages/graphql-typed/package.json
+++ b/packages/graphql-typed/package.json
@@ -24,7 +24,7 @@
     "node": "^14.17.0 || >=16.0.0"
   },
   "peerDependencies": {
-    "graphql": ">=14.5.0 <16.0.0"
+    "graphql": ">=14.5.0 <17.0.0"
   },
   "files": [
     "build/",

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -34,7 +34,7 @@
     "change-case": "^4.1.1",
     "chokidar": "^3.3.1",
     "fs-extra": "^9.1.0",
-    "graphql": ">=14.5.0 <16.0.0",
+    "graphql": ">=14.5.0 <17.0.0",
     "graphql-config": "^4.3.0",
     "graphql-config-utilities": "^4.1.3",
     "graphql-tool-utilities": "^3.0.3",

--- a/packages/graphql-validate-fixtures/package.json
+++ b/packages/graphql-validate-fixtures/package.json
@@ -28,7 +28,7 @@
     "chalk": "^4.0.0",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.2",
-    "graphql": ">=14.5.0 <16.0.0",
+    "graphql": ">=14.5.0 <17.0.0",
     "graphql-config": "^4.3.0",
     "graphql-config-utilities": "^4.1.3",
     "graphql-tool-utilities": "^3.0.3",

--- a/packages/graphql-validate-fixtures/src/validate.ts
+++ b/packages/graphql-validate-fixtures/src/validate.ts
@@ -261,9 +261,9 @@ function validateValueAgainstObjectFieldDescription(
             return;
           }
 
-          const isGuaranteedTypeMatch = fragment.possibleTypes.includes(
-            makeTypeNullable(type),
-          );
+          const isGuaranteedTypeMatch = (
+            fragment.possibleTypes as GraphQLType[]
+          ).includes(makeTypeNullable(type));
 
           fragmentFields.push(
             isGuaranteedTypeMatch

--- a/yarn.lock
+++ b/yarn.lock
@@ -8322,10 +8322,15 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.8.2.tgz#800184b1addb20b3010dc06cb70877703a5fff20"
   integrity sha512-hYo8kTGzxePFJtMGC7Y4cbypwifMphIJJ7n4TDcVUAfviRwQBnmZAbfZlC+XFwWDUaR7raEDQPxWctpccmE0JQ==
 
-"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", "graphql@>=14.5.0 <16.0.0", graphql@^15.4.0:
+"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0":
   version "15.5.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
   integrity sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==
+
+"graphql@>=14.5.0 <17.0.0", graphql@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
+  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
 
 handlebars@*, handlebars@^4.4.3, handlebars@^4.7.7:
   version "4.7.7"


### PR DESCRIPTION
## Description

Update `graphql` support to allow for using v16.

graphql v16 was released almost three years ago, this is very overdue. 
It was never a priority as everything worked fine at runtime before (checkout-web has had a resolution to force graphql v16 while using these packages for months). This is change is mostly to shut up package managers that grumble about mismatched peer-dependency versions when you're using v16 for other stuff.


### Testing

I've updated the installed version of graphql to v16.8.1.

You can test in older versions by adding `"graphql": "15.2.0"` to the resolutions key then run `yarn && yarn type-check --clean && yarn type-check && yarn test` to prove that type-check and tests pass.

It seems that less that 15.2.0 doesn't actually pass type-checking, there's one error in `graphql-persisted` but literally nobody uses that package anyway - I suspect that is a result of our move to `@apollo/client` as part of the Apollo 3 work last year, which dropped support for graphql pre-15.2.0. I don't think it's worth adjusting the minimum versions for that.