### PR TITLE
Teach graphql typegen how to create string unions

### DIFF
--- a/.changeset/metal-llamas-behave.md
+++ b/.changeset/metal-llamas-behave.md
@@ -1,0 +1,5 @@
+---
+'graphql-typescript-definitions': minor
+---
+
+Add `--enum-style=type` option to allow codegen to generate string union types from grahpql enums

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -190,7 +190,7 @@ Note that the above example assumes that you specify the `--add-typename` argume
 
 #### Schema Types
 
-Input types (enums, input objects, and custom scalars) are generated once, in a central location, and imported within each typing file. You can use these definitions to reference the schema types in other application code as well; in particular, GraphQL enums are turned into corresponding TypeScript `enum`s. The schema types directory is specified using the `--schema-types-path` argument (detailed below), and the format for the generated enums can be specified using the `--enum-format` option.
+Input types (enums, input objects, and custom scalars) are generated once, in a central location, and imported within each typing file. You can use these definitions to reference the schema types in other application code as well. If `--enum-style=enum` (the default) is set then GraphQL enums are turned into corresponding TypeScript `enum`s, else if `--enum-style=type` is set then GraphQL enums are created as string union types. The schema types directory is specified using the `--schema-types-path` argument (detailed below), and the format for the generated typescript enums can be specified using the `--enum-format` option.
 
 ### CLI
 
@@ -209,6 +209,8 @@ As noted above, the configuration of your schema and GraphQL documents is done v
 - `--enum-format`: specifies output format for enum types (default = `undefined`)
   - Options: `camel-case`, `pascal-case`, `snake-case`, `screaming-snake-case`
   - `undefined` results in using the unchanged name from the schema (verbatim)
+- `--enum-style`: specifies if the graphql enum types should be created as typescript enums or string unions types. (default = 'enum')
+  - Options: `enum` (exports typescript enums), `type` (exports a string union type, that has no runtime impact)
 - `--custom-scalars`: specifies custom types to use in place of scalar types in your GraphQL schema. See below for details.
 
 #### Examples
@@ -283,6 +285,7 @@ As with the CLI, you can pass options to customize the build and behavior:
 
 - `watch`
 - `enumFormat` (use the exported `EnumFormat` enum)
+- `enumStyle` (use the exported `EnumStyle` enum)
 - `graphQLFiles`
 - `schemaPath`
 - `schemaTypesPath`

--- a/packages/graphql-typescript-definitions/src/cli.ts
+++ b/packages/graphql-typescript-definitions/src/cli.ts
@@ -3,7 +3,7 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
 
-import {EnumFormat, ExportFormat} from './types';
+import {EnumFormat, EnumStyle, ExportFormat} from './types';
 
 import type {SchemaBuild, DocumentBuild} from '.';
 import {Builder} from '.';
@@ -56,6 +56,12 @@ const argv = yargs
       EnumFormat.ScreamingSnakeCase,
     ],
   })
+  .option('enum-style', {
+    required: false,
+    describe:
+      'The style used for generating enums - as typescript enums or as string union types',
+    choices: [EnumStyle.Enum, EnumStyle.Type],
+  })
   .option('custom-scalars', {
     required: false,
     default: '{}',
@@ -70,6 +76,7 @@ const builder = new Builder({
   schemaTypesPath: argv['schema-types-path'],
   addTypename: argv['add-typename'],
   enumFormat: argv['enum-format'],
+  enumStyle: argv['enum-style'],
   customScalars: normalizeCustomScalars(argv['custom-scalars']),
   exportFormat: argv['export-format'],
 });

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -26,12 +26,12 @@ import type {GraphQLFilesystem} from './filesystem';
 import {AbstractGraphQLFilesystem} from './filesystem';
 import type {PrintDocumentOptions, PrintSchemaOptions} from './print';
 import {printDocument, generateSchemaTypes} from './print';
-import {EnumFormat, ExportFormat} from './types';
+import {EnumFormat, EnumStyle, ExportFormat} from './types';
 
 const {mkdirp, readFile, writeFile} = fsExtra;
 
 export type {GraphQLFilesystem};
-export {AbstractGraphQLFilesystem, EnumFormat, ExportFormat};
+export {AbstractGraphQLFilesystem, EnumFormat, EnumStyle, ExportFormat};
 
 export interface Options extends PrintDocumentOptions, PrintSchemaOptions {
   addTypename: boolean;

--- a/packages/graphql-typescript-definitions/src/types.ts
+++ b/packages/graphql-typescript-definitions/src/types.ts
@@ -5,6 +5,11 @@ export enum EnumFormat {
   ScreamingSnakeCase = 'screaming-snake-case',
 }
 
+export enum EnumStyle {
+  Enum = 'enum',
+  Type = 'type',
+}
+
 export enum ExportFormat {
   Document = 'document',
   TypedDocumentNode = 'typedDocumentNode',


### PR DESCRIPTION
This branch is based atop #2778. Once that's merged I'll rebase.

## Description

- Add enumStyle option to graphql typegen. This defaults to "enum" -
  which uses the current behaviour of creating a typescript enum for
each graphql enum. Setting it to "type" will create a typescript type
that is a union type containing the possible string values.
- Adjust the ordering of the enums so they're generated in schema order

Imagine you've got a grahpql schema containing

```
enum Gandalf {
  WHITE
  GREY
}
```


By default (or if you specify `--export-style=enum`) you'll get generated code that looks the following:

```ts
// index.ts
import { Gandalf } from "./Gandalf";
import { Permissions } from "./Permissions";
export { Gandalf };
export { Permissions };

// Gandalf.ts
export enum Gandalf {
  WHITE = "WHITE",
  GREY = "GREY",
}

// Permissions.ts
export enum Permissions {
  SHALL_PASS = "SHALL_PASS",
  SHALL_NOT_PASS = "SHALL_NOT_PASS",
}
```


If you specify `--export-style=type` you'll get get generated code that looks like the following. Note that only an index file is created:

```ts
// index.ts
export type Gandalf = "WHITE | "GREY";
export type Permissions = "SHALL_PASS" | "SHALL_NOT_PASS";
```