### PR TITLE
Downgrade the release type of the graphql v16 change to patch

### DIFF
--- a/.changeset/empty-spiders-sparkle.md
+++ b/.changeset/empty-spiders-sparkle.md
@@ -1,11 +1,11 @@
 ---
-'graphql-fixtures': minor
-'graphql-mini-transforms': minor
-'@shopify/graphql-testing': minor
-'graphql-tool-utilities': minor
-'graphql-typed': minor
-'graphql-typescript-definitions': minor
-'graphql-validate-fixtures': minor
+'graphql-fixtures': patch
+'graphql-mini-transforms': patch
+'@shopify/graphql-testing': patch
+'graphql-tool-utilities': patch
+'graphql-typed': patch
+'graphql-typescript-definitions': patch
+'graphql-validate-fixtures': patch
 ---
 
 Add graphql `^16.0.0` as an allowable graphql dependency version


### PR DESCRIPTION

## Description

This avoids changesets wanting to release peer-dependants of graphql-typed (graphql-fixtures and graphql-typescript-definitions) as major versions.

If changesets sees a minor change to a peerDependant package, then it wants to bump the major version of the package. For instance, because graphql-typed has a minor bump, it wants to do a major bump of graphql-fixtures and graphql-typescript-definitions as those packages have a peer dependency on graphql-typed.

By downgrading the bump type of graphq-typed to patch, then its two dependants will remain as minor bumps themselves. You can see this by comparing `yarn changeset status` on main / on this PR.

