### PR TITLE
Add support for omitting GraphQL source text

### DIFF
--- a/.changeset/lucky-mayflies-double.md
+++ b/.changeset/lucky-mayflies-double.md
@@ -1,0 +1,5 @@
+---
+'graphql-mini-transforms': minor
+---
+
+Add support for omitting GraphQL source text

--- a/packages/graphql-mini-transforms/README.md
+++ b/packages/graphql-mini-transforms/README.md
@@ -59,7 +59,10 @@ fragment ProductVariantId on ProductVariant {
 
 #### Options
 
-This loader accepts a single option, `simple`. This option changes the shape of the value exported from `.graphql` files. By default, a `graphql-typed` `DocumentNode` is exported, but when `simple` is set to `true`, a `SimpleDocument` is exported instead. This representation of GraphQL documents is smaller than a full `DocumentNode`, but generally won’t work with normalized GraphQL caches.
+This loader accepts a single option, `format`. This option changes the shape of the value exported from `.graphql` files. By default, a `graphql-typed` `DocumentNode` is exported, but you can also provide these alternative formats instead:
+
+- `simple`: a `SimpleDocument` is exported instead. This representation of GraphQL documents is smaller than a full `DocumentNode`, but generally won’t work with normalized GraphQL caches like the one used in Apollo Client.
+- `simple-persisted`: like `simple`, but with the `source` property removed. This means that the original document will not be present in your JavaScript at all. This option is only appropriate for apps using “persisted queries”, where only a hash of the query (available as the `id` property) is sent to the server.
 
 ```js
 module.exports = {
@@ -69,14 +72,14 @@ module.exports = {
         test: /\.(graphql|gql)$/,
         use: 'graphql-mini-transforms/webpack-loader',
         exclude: /node_modules/,
-        options: {simple: true},
+        options: {format: 'simple'},
       },
     ],
   },
 };
 ```
 
-If this option is set to `true`, you should also use the `jest-simple` transformer for Jest, and the `--export-format simple` flag for `graphql-typescript-definitions`.
+If this option is set to `simple` or `simple-persisted`, you should also use the `jest-simple` transformer for Jest, and the `--export-format simple` flag for `graphql-typescript-definitions`.
 
 ### Rollup / Vite
 
@@ -97,7 +100,7 @@ export default {
 };
 ```
 
-Like the Webpack loader, you can provide a `simple: true` option to enable the `SimpleDocument` export format:
+Like the Webpack loader, you can provide a `format` option to control the way documents are exported from `.graphql` files:
 
 ```js
 // rollup.config.mjs
@@ -108,7 +111,7 @@ export default {
   // ...
   // Other Rollup config
   // ...
-  plugins: [graphql({simple: true})],
+  plugins: [graphql({format: 'simple'})],
 };
 ```
 
@@ -139,7 +142,7 @@ module.exports = {
 };
 ```
 
-If you want to get the same output as the `simple` option of the webpack loader, you can instead use the `jest-simple` loader transformer:
+If you want to get the same output as the `format: 'simple'` option of the webpack loader, you can instead use the `jest-simple` loader transformer:
 
 ```js
 module.exports = {

--- a/packages/graphql-mini-transforms/src/rollup.ts
+++ b/packages/graphql-mini-transforms/src/rollup.ts
@@ -4,9 +4,23 @@ import {parse} from 'graphql';
 import type {DocumentNode} from 'graphql';
 import type {Plugin, PluginContext} from 'rollup';
 
-import {cleanDocument, extractImports, toSimpleDocument} from './document';
+import {cleanDocument, extractImports, formatDocument} from './document';
+import type {OutputFormat} from './document';
 
-export function graphql({simple = false}: {simple?: boolean} = {}): Plugin {
+interface Options {
+  /** @deprecated Use `format: 'simple'` instead. */
+  simple?: boolean;
+
+  /**
+   * Controls the runtime code that will be generated for the GraphQL document.
+   */
+  format?: OutputFormat;
+}
+
+export function graphql({
+  simple = false,
+  format = simple ? 'simple' : 'document',
+}: Options = {}): Plugin {
   return {
     name: '@shopify/graphql-mini-transforms',
     async transform(code, id) {
@@ -30,8 +44,7 @@ export function graphql({simple = false}: {simple?: boolean} = {}): Plugin {
       );
 
       const document = cleanDocument(loadedDocument);
-
-      const exported = simple ? toSimpleDocument(document) : document;
+      const exported = formatDocument(document, format);
 
       return {code: `export default ${JSON.stringify(exported)}`, map: null};
     },

--- a/packages/graphql-mini-transforms/src/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/src/tests/webpack.test.ts
@@ -221,7 +221,7 @@ describe('graphql-mini-transforms/webpack', () => {
       expect(
         await extractDocumentExport(
           originalSource,
-          createLoaderContext({query: {simple: true}}),
+          createLoaderContext({query: {format: 'simple'}}),
         ),
       ).toHaveProperty('source', expectedSource);
     });
@@ -229,7 +229,7 @@ describe('graphql-mini-transforms/webpack', () => {
     it('has an id property that is a sha256 hash of the query document', async () => {
       const result = await extractDocumentExport(
         `query Shop { shop { id } }`,
-        createLoaderContext({query: {simple: true}}),
+        createLoaderContext({query: {format: 'simple'}}),
       );
 
       expect(result).toHaveProperty(
@@ -241,7 +241,7 @@ describe('graphql-mini-transforms/webpack', () => {
     it('has a name property that is the name of the first operation', async () => {
       const result = await extractDocumentExport(
         `query Shop { shop { id } }`,
-        createLoaderContext({query: {simple: true}}),
+        createLoaderContext({query: {format: 'simple'}}),
       );
 
       expect(result).toHaveProperty('name', 'Shop');
@@ -250,10 +250,27 @@ describe('graphql-mini-transforms/webpack', () => {
     it('has an undefined name when there are no named operations', async () => {
       const result = await extractDocumentExport(
         `query { shop { id } }`,
-        createLoaderContext({query: {simple: true}}),
+        createLoaderContext({query: {format: 'simple'}}),
       );
 
       expect(result).not.toHaveProperty('name');
+    });
+  });
+
+  describe('simple-persisted', () => {
+    it('provides a simple representation of the GraphQL document, with the source set to an empty string', async () => {
+      const simpleResult = await extractDocumentExport(
+        `query Shop { shop { id } }`,
+        createLoaderContext({query: {format: 'simple'}}),
+      );
+      const persistedResult = await extractDocumentExport(
+        `query Shop { shop { id } }`,
+        createLoaderContext({query: {format: 'simple-persisted'}}),
+      );
+
+      const expected = {...simpleResult, source: ''};
+
+      expect(persistedResult).toStrictEqual(expected);
     });
   });
 });


### PR DESCRIPTION
## Description

This PR adds a new format for GraphQL documents that `graphql-mini-transforms` can output: `simple-persisted`. This is like the "simple" outputs I added in https://github.com/Shopify/quilt/pull/2597, but it removes the `source` field, so that the original document source is not present in the resulting build outputs. This will be used by Checkout, which already used the "simple" format, and which uses persisted queries in production as a performance optimization.

Previously, I added the "simple" format as a boolean `simple` option. Since this is a third format the library can output, I deprecated that `simple` option and introduced a new `format` option. The new option is implemented in a backwards-compatible way, so I am just marking this as a minor API change.

You might notice that I didn't add an associated Jest plugin for this new format. This was intentional: I suspect all clients will still want to include `source`s in development and test. In these environments, it's typically hard to coordinate server and client properly, and you often want the debuggability and mock-ability that having the original GraphQL document allows.
