### PR TITLE
Add GraphQL operation type

### DIFF
--- a/.changeset/clean-pumpkins-sin.md
+++ b/.changeset/clean-pumpkins-sin.md
@@ -1,0 +1,6 @@
+---
+'graphql-mini-transforms': minor
+'graphql-typed': minor
+---
+
+Add `type` field to `SimpleDocument` type

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -101,6 +101,7 @@ export function toSimpleDocument<
 ): SimpleDocument<Data, Variables, DeepPartial> {
   return {
     id: document.id,
+    type: operationTypeForDocument(document),
     name: operationNameForDocument(document),
     source: includeSource ? document.loc?.source?.body! : '',
   };
@@ -118,6 +119,13 @@ export function formatDocument(document: DocumentNode, format: OutputFormat) {
       return toSimpleDocument(document, {includeSource: false});
     }
   }
+}
+
+function operationTypeForDocument(document: DocumentNode) {
+  return document.definitions.find(
+    (definition): definition is OperationDefinitionNode =>
+      definition.kind === 'OperationDefinition',
+  )?.operation;
 }
 
 function operationNameForDocument(document: DocumentNode) {

--- a/packages/graphql-mini-transforms/src/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/src/tests/webpack.test.ts
@@ -238,6 +238,15 @@ describe('graphql-mini-transforms/webpack', () => {
       );
     });
 
+    it('has a type property that is the operation type of the first operation in the document', async () => {
+      const result = await extractDocumentExport(
+        `query Shop { shop { id } }`,
+        createLoaderContext({query: {format: 'simple'}}),
+      );
+
+      expect(result).toHaveProperty('type', 'query');
+    });
+
     it('has a name property that is the name of the first operation', async () => {
       const result = await extractDocumentExport(
         `query Shop { shop { id } }`,

--- a/packages/graphql-typed/src/index.ts
+++ b/packages/graphql-typed/src/index.ts
@@ -22,6 +22,7 @@ export interface DocumentNode<Data = {}, Variables = {}, DeepPartial = {}>
 export interface SimpleDocument<Data = {}, Variables = {}, DeepPartial = {}>
   extends GraphQLOperation<Data, Variables, DeepPartial> {
   readonly id: string;
+  readonly type?: 'query' | 'mutation' | 'subscription';
   readonly name?: string;
   readonly source: string;
 }


### PR DESCRIPTION
## Description

This PR adds a `type` property to GraphQL operations using our "simple" and "simple-persisted" GraphQL output formats. This field extracts the operation type of the original document, so a consumer can easily tell if this is a query, mutation, or subscription. I need this for my work to [add persisted queries to checkout](https://github.com/Shopify/checkout-web/pull/34777), so that we can correctly switch between `GET` and `POST` requests, depending on whether we have a query or mutation.
