### PR TITLE
Fix typing of vite graphql mini transform

### DIFF
--- a/.changeset/empty-goats-divide.md
+++ b/.changeset/empty-goats-divide.md
@@ -1,0 +1,5 @@
+---
+'graphql-mini-transforms': patch
+---
+
+Fix typing of "enforce" in vite transform

--- a/packages/graphql-mini-transforms/src/vite.ts
+++ b/packages/graphql-mini-transforms/src/vite.ts
@@ -1,5 +1,5 @@
 import {graphql as rollupGraphQL} from './rollup';
 
 export function graphql(...args: Parameters<typeof rollupGraphQL>) {
-  return {...rollupGraphQL(...args), enforce: 'pre'};
+  return {...rollupGraphQL(...args), enforce: 'pre' as const};
 }


### PR DESCRIPTION
## Description

The Vite transform causes a type-check error when you try to use it in a Vite config's plugins array.

This is because Vite wants `enforce` to be "pre" or "post". Without the `as const` we the type of enforce is `string` which is too wide.

