### PR TITLE
fix:loader-module-webpack

### DIFF
--- a/.changeset/spicy-panthers-prove.md
+++ b/.changeset/spicy-panthers-prove.md
@@ -1,0 +1,6 @@
+---
+'@shopify/web-worker': minor
+---
+
+- Allow `output.chunkFilename` to be a function or string.
+- `compiler.options.output.filename` and `compiler.options.output.chunkFilename` now default to `[name].js` when undefined.

--- a/packages/web-worker/src/webpack-parts/loader.ts
+++ b/packages/web-worker/src/webpack-parts/loader.ts
@@ -78,18 +78,17 @@ export function pitch(this: LoaderContext<Options>, request: string) {
       wrapperContent = cachedContent;
     } else if (cachedContent == null) {
       try {
-        if (this.fs?.readFileSync) { 
+        if (this.fs?.readFileSync) {
           wrapperContent = this.fs.readFileSync(wrapperModule).toString();
           moduleWrapperCache.set(wrapperModule, wrapperContent ?? false);
         } else {
-          throw new Error("readFileSync is undefined");
+          throw new Error('readFileSync is undefined');
         }
       } catch (error) {
         moduleWrapperCache.set(wrapperModule, false);
       }
     }
   }
-
 
   if (wrapperContent) {
     plugin.virtualModules.writeModule(

--- a/packages/web-worker/src/webpack-parts/loader.ts
+++ b/packages/web-worker/src/webpack-parts/loader.ts
@@ -96,9 +96,9 @@ export function pitch(this: LoaderContext<Options>, request: string) {
   const workerOptions = {
     filename:
       plugin.options.filename ??
-      addWorkerSubExtension(compiler.options.output.filename ?? '[worker].js'),
+      addWorkerSubExtension(compiler.options.output.filename ?? '[name].js'),
     chunkFilename: addWorkerSubExtension(
-      compiler.options.output.chunkFilename ?? '[worker].js',
+      compiler.options.output.chunkFilename ?? '[name].js',
     ),
     globalObject: (plugin && plugin.options.globalObject) || 'self',
   };

--- a/packages/web-worker/src/webpack-parts/loader.ts
+++ b/packages/web-worker/src/webpack-parts/loader.ts
@@ -78,13 +78,18 @@ export function pitch(this: LoaderContext<Options>, request: string) {
       wrapperContent = cachedContent;
     } else if (cachedContent == null) {
       try {
-        wrapperContent = this.fs.readFileSync(wrapperModule).toString();
-        moduleWrapperCache.set(wrapperModule, wrapperContent ?? false);
+        if (this.fs?.readFileSync) { 
+          wrapperContent = this.fs.readFileSync(wrapperModule).toString();
+          moduleWrapperCache.set(wrapperModule, wrapperContent ?? false);
+        } else {
+          throw new Error("readFileSync is undefined");
+        }
       } catch (error) {
         moduleWrapperCache.set(wrapperModule, false);
       }
     }
   }
+
 
   if (wrapperContent) {
     plugin.virtualModules.writeModule(


### PR DESCRIPTION
## Description

Fixes (issue #2807)

This PR addresses an issue with the webpack loader in ```@shopify/web-worker``` where ```output.chunkFilename``` could be either a string or a function returning a string. 
The loader previously assumed it was always a string, leading to ```TypeError: file.includes is not a function errors.```
The solution now checks if output.chunkFilename is a function and handles it correctly.

Changes Made
- Default Values: Default values [worker].js are provided for compiler.options.output.filename and compiler.options.output.chunkFilename in case they are undefined.
- Type Handling in addWorkerSubExtension:
- If file is a string, the function directly performs the replacement to add the .worker suffix.
- If file is a function, the function wraps it in another function that performs the replacement on its return value.