### PR TITLE
Move @shopify/network to dependencies in react-performance

### DIFF
--- a/.changeset/empty-islands-grin.md
+++ b/.changeset/empty-islands-grin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-performance': major
+---
+
+Move @shopify/network to a dependency, not devDependency

--- a/.changeset/empty-islands-grin.md
+++ b/.changeset/empty-islands-grin.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/react-performance': major
+'@shopify/react-performance': patch
 ---
 
 Move @shopify/network to a dependency, not devDependency

--- a/packages/react-performance/package.json
+++ b/packages/react-performance/package.json
@@ -24,14 +24,14 @@
     "node": ">=18.12.0"
   },
   "dependencies": {
-    "@shopify/performance": "^4.3.0"
+    "@shopify/performance": "^4.3.0",
+    "@shopify/network": "^3.3.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0 <19.0.0"
   },
   "devDependencies": {
-    "@shopify/jest-dom-mocks": "^5.2.0",
-    "@shopify/network": "^3.3.0"
+    "@shopify/jest-dom-mocks": "^5.2.0"
   },
   "files": [
     "build/",


### PR DESCRIPTION
## Description

The `@shopify/network` package is currently listed as a `devDependency` for the `@shopify/react-performance` package. I think this is incorrect as the package is referenced from from [performanceReport](https://github.com/Shopify/quilt/blob/75ea9fe52b65f001b238d3d21e76c3181badfe6c/packages/react-performance/src/performance-report.ts#L4) file.

I have moved the package from `devDependency` to `dependency` to resolve.

**That said**, if we look at the _usage_ of the package in the file, it's simply to reference two constants, so I wonder if we're more comfortable/pragmatic in simply inlining these definitions?

- `Header.ContentType`

https://github.com/Shopify/quilt/blob/75ea9fe52b65f001b238d3d21e76c3181badfe6c/packages/react-performance/src/performance-report.ts#L46

- `Method.Post`

https://github.com/Shopify/quilt/blob/75ea9fe52b65f001b238d3d21e76c3181badfe6c/packages/react-performance/src/performance-report.ts#L44
