### PR TITLE
feat: option to format percentage without percentage sign

### DIFF
--- a/.changeset/grumpy-socks-press.md
+++ b/.changeset/grumpy-socks-press.md
@@ -1,0 +1,5 @@
+---
+'@shopify/react-i18n': minor
+---
+
+Option to format percentage without percentage sign

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -134,7 +134,9 @@ The provided `i18n` object exposes many useful methods for internationalizing yo
   - if `form: 'explicit'` is given, then the result will be the same as for `short`, but will append the ISO 4217 code if it is not already present
   - if `form` is omitted, or if `form: 'auto'` is given, then `explicit` will be selected if the `currency` option does not match the `defaultCurrency`, otherwise `short` is selected. If either `currency` or `defaultCurrency` is not defined then `short` is selected.
 - `unformatCurrency()`: converts a localized currency string to a currency string parseable by JavaScript. Example: `€ 1,25 => 1.25`
-- `formatPercentage()`: formats a number as a percentage according to the locale. Convenience function that simply _auto-assigns_ the `as` option to `percent` and calls `formatNumber()`.
+- `formatPercentage()`: formats a number as a percentage according to the locale.
+  - if `percentageSignDisplay: 'never'` is given, then the percentage sign will be omitted. Example: `0.5 => 50`
+  - if `percentageSignDisplay` is omitted, or if `percentageSignDisplay: 'auto'` is given, then the number will be formatted `as: percent`. Example: `0.5 => 50%`
 - `formatDate()`: formats a date according to the locale. The `defaultTimezone` value supplied to the i18n `I18nContext.Provider` component will be used when no custom `timezone` is provided. Assign the `style` option to a `DateStyle` value to use common formatting options.
   - `DateStyle.Long`: e.g., `Thursday, December 20, 2012`
   - `DateStyle.Short`: e.g., `Dec 20, 2012`

--- a/packages/react-i18n/src/tests/i18n.test.ts
+++ b/packages/react-i18n/src/tests/i18n.test.ts
@@ -1390,10 +1390,14 @@ describe('I18n', () => {
   describe('#formatPercentage()', () => {
     it('formats the number as a percentage', () => {
       const i18n = new I18n(defaultTranslations, defaultDetails);
-      const expected = Intl.NumberFormat(defaultDetails.locale, {
-        style: 'percent',
-      }).format(50);
-      expect(i18n.formatPercentage(50)).toBe(expected);
+      expect(i18n.formatPercentage(0.5)).toBe('50%');
+    });
+
+    it('formats the number as a percentage omitting the percentage symbol', () => {
+      const i18n = new I18n(defaultTranslations, defaultDetails);
+      expect(i18n.formatPercentage(0.5, {percentageSignDisplay: 'never'})).toBe(
+        '50',
+      );
     });
   });
 


### PR DESCRIPTION
## Description

Part of https://github.com/Shopify/quilt/issues/2822

Add new option that can be passed to `formatPercentage` to omit the percentage sign. Default behavior if unspecified will remain the same, which prevents this from being a breaking change.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
