### PR TITLE
Use absolute import path when importing apollo-codegen legacyIR

### DIFF
--- a/.changeset/strange-dingos-confess.md
+++ b/.changeset/strange-dingos-confess.md
@@ -1,0 +1,5 @@
+---
+'graphql-tool-utilities': patch
+---
+
+Fix import of apollo-codegen-core when using the mjs version of the package

--- a/packages/graphql-tool-utilities/src/ast.ts
+++ b/packages/graphql-tool-utilities/src/ast.ts
@@ -8,7 +8,8 @@ import type {
   LegacyInlineFragment,
   LegacyOperation,
 } from 'apollo-codegen-core/lib/compiler/legacyIR';
-import {compileToLegacyIR as compileToIR} from 'apollo-codegen-core/lib/compiler/legacyIR';
+// Explicit js extension as it is required for the esm build
+import {compileToLegacyIR as compileToIR} from 'apollo-codegen-core/lib/compiler/legacyIR.js';
 
 export enum OperationType {
   Query = 'query',


### PR DESCRIPTION
## Description

Fixes import error when using the mjs version of the graphql-tool-utilities package with node


## Grumble

The graphql packages should probably have always been commonjs only, but it's about 4 years too late for that.