### PR TITLE
fix: unknown type in ExecutionResult

### DIFF
--- a/.changeset/rich-papayas-clean.md
+++ b/.changeset/rich-papayas-clean.md
@@ -1,0 +1,8 @@
+---
+'@shopify/graphql-testing': patch
+---
+
+MockGraphQLResponse should allow an ExecutionResult containing any data.
+GraphQL v15 defaulted ExecutionResult's data to be an object containing any keys
+but v16 narrowed that down to use `unknown` instead of `any`. This change
+explicitly uses the default behaviour of allowing any from v15.

--- a/packages/graphql-testing/src/types.ts
+++ b/packages/graphql-testing/src/types.ts
@@ -6,7 +6,9 @@ export interface FindOptions {
   mutation?: DocumentNode;
 }
 
-export type MockGraphQLResponse = Error | ExecutionResult['data'];
+export type MockGraphQLResponse =
+  | Error
+  | ExecutionResult<{[key: string]: any}>['data'];
 export type MockGraphQLFunction = (
   request: GraphQLRequest,
 ) => MockGraphQLResponse;


### PR DESCRIPTION
## Description

The Collective (`merchant-to-merchant`) team was trying to [upgrade our graphql dependency](https://github.com/Shopify/merchant-to-merchant/pull/15185) to v16+ and were not able to due to failing typechecks.
The change in [this PR](https://github.com/Shopify/quilt/pull/2778/files#diff-1fff474cb21f6f65d6c5d2be3e8164345ae406da083352db9da72ce2ba7f8389L9) from the `@shopify/graphql-testing` library was causing the typechecks to fail. The `ExecutionResult` type from graphql has a new definition is v16, which causes our `fillGraphQL` type to complain with this error:

| Failure point | Error message |
| ----- | ----- |
| ![](https://screenshot.click/30-36-zq609-9fiul.png) | ![](https://github.com/user-attachments/assets/ba91bc7e-f799-4684-9e63-a321a0b4a82f) |

Here is the difference between the types in the two versions which caused the types to complain.

| graphql v15.8.0 | graphql v16.9.0 |
| ----- | ----- |
| ![](https://screenshot.click/30-32-v18eo-28x8p.png) | ![](https://screenshot.click/30-34-u4800-p5nal.png) |

To fix the issue, we had to pass in `<{[key: string]: any}>` as the generic type for `ExecutionResult`, inside the `graphql-testing` package


### Tophatting
I tested this change in the merchant-to-merchant repo and we were able to successfully run our type-checks again. Thanks @BPScott for helping me out on this one 🙏 

![](https://screenshot.click/30-05-9ubnw-ep3mn.png)