### PR TITLE
Add missing compilerOptions.lib necessary for tsd-lite to test types consistently

### DIFF
--- a/packages/useful-types/test-d/tsconfig.json
+++ b/packages/useful-types/test-d/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "lib": ["dom", "dom.iterable", "es2022"]
   },
   "references": [{"path": ".."}]
 }


### PR DESCRIPTION
Under some circumstances, tsd-lite will throw errors while testing such as:

```
❯ yarn run jest packages/useful-types/test-d/types.test-d.ts
 FAIL   useful-types  packages/useful-types/test-d/types.test-d.ts
  ✕ tsd typecheck (2562 ms)

  ● tsd typecheck

    Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

    > 29 |   seenReferences?: WeakMap<object, boolean>,
         |                    ^

      at node_modules/.pnpm/@jest+expect-utils@29.7.0/node_modules/@jest/expect-utils/build/index.d.ts:29:20
```

I think it has to do with which version of a transitive dependency is installed.

Either way; the `compilerOptions.lib` option fixes it, and it should have always been there. This PR adds it.

NOTE: I skipped changelog as this is a purely internal test thing only and doesn't require a release.